### PR TITLE
fix(web): wire decoder backpressure through Worker to ConnectionManager

### DIFF
--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -305,6 +305,10 @@ function handleWebGpuLost() {
             if (decodeErrorTimer) { clearTimeout(decodeErrorTimer); decodeErrorTimer = null; }
             onFallbackNeeded?.('hls');
           }
+        } else if (msg.type === 'backpressure') {
+          if (cm) {
+            cm.setPaused(msg.paused);
+          }
         }
       };
 

--- a/web/src/lib/webcodecs-player/worker.ts
+++ b/web/src/lib/webcodecs-player/worker.ts
@@ -94,6 +94,11 @@ async function handleCodecInfo(data: {
     self.postMessage({ type: 'error', error: err.message });
   });
 
+  // Set backpressure callback — forward to main thread so ConnectionManager can skip frames
+  decoder.onBackpressure((paused: boolean) => {
+    self.postMessage({ type: 'backpressure', paused });
+  });
+
   try {
     await decoder.configure({
       codec: data.codec as any,


### PR DESCRIPTION
## Problem

WebSocket (wss) live preview freezes the browser.

## Root Cause

**Broken backpressure circuit.** The Decoder detects overload (pending decode ≥ 5) and fires `onBackpressure`, but the callback was **never wired through the Worker** to the WasmPlayer. `ConnectionManager.setPaused()` was **never called**.

Without backpressure signaling, every WebSocket frame was parsed + `postMessage`'d to the Worker even when the decoder was already backed up. This flooded the main thread with wasted frame processing → main thread gets busier → Worker receives frames slower → decoder stays backlogged → **vicious cycle → browser freezes**.

## Fix

Two changes complete the backpressure circuit:

1. **`worker.ts`** — Register `decoder.onBackpressure()` callback that posts `{ type: 'backpressure', paused }` to the main thread
2. **`WasmPlayer.svelte`** — Handle `'backpressure'` messages from Worker → call `cm.setPaused(msg.paused)`

Now when the decoder is overloaded, frames are dropped at the ConnectionManager level **before** wasting CPU on `decodeVideoFrame()` parsing and `postMessage()` serialization.

## Data Flow

```
Before (broken):
  WebSocket → ConnectionManager(never paused) → postMessage → Decoder(drops frames)
                        ↑                                              ↑
                  _paused always false                          wasted CPU every frame

After (fixed):
  WebSocket → ConnectionManager(setPaused when full) → postMessage → Decoder(healthy)
                  ↑                                                                       │
                  └──── 'backpressure' message ─── WasmPlayer ──────────────────────────┘
```

## Testing

- ✅ Frontend build passes
- ✅ All 121 unit tests pass (connection + decoder)
- ✅ Deployed to Banana Pi M5 (production) — browser responsive, WebSocket streams active
- ✅ Deployed to Docker VM (clean state) — browser responsive, graceful HLS fallback
- ✅ 60-second continuous monitoring — **no browser freeze**

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)