### PR TITLE
fix: v0.7.0 release fixes — VAAPI fallback, test isolation, README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ For detailed setup, see [Getting Started](docs/en/getting-started.md).
 - Atomic configuration with validation
 
 ### 🤖 Smart Features
-- AI detection with ONNX Runtime inference
 - Multi-layer camera health monitoring
 - Auto-remediation for connection issues
 - SSE-based real-time event system

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,7 +35,6 @@
 - **视频转码**：基于 FFmpeg 的硬件转码，H.265→H.264 转换
 - **延时摄影**：定时快照延时录像
 - **WebSocket 流**：实时二进制帧流
-- **AI 检测**：ONNX Runtime 推理，浏览器端目标检测
 - **事件系统**：基于 SSE 的实时事件流
 
 ## 开发路线
@@ -192,7 +191,7 @@ make docker-release
 ```
 cmd/mibee-nvr/       # 程序入口
 internal/            # 核心模块（29 个）
-  ai/               # ONNX Runtime AI 推理
+  ai/               # AI 配置 + ROI 区域（浏览器端推理，无后端推理）
   api/              # REST API
   camera/           # 摄像头管理
   cleanup/          # 保留策略 + 磁盘清理

--- a/internal/transcoding/downloader_test.go
+++ b/internal/transcoding/downloader_test.go
@@ -108,6 +108,7 @@ func serveTarGz(t *testing.T, archive []byte) *httptest.Server {
 
 // TestGetFFmpegStatus_NotInstalled verifies status when no FFmpeg exists.
 func TestGetFFmpegStatus_NotInstalled(t *testing.T) {
+	t.Setenv("PATH", "") // isolate from system FFmpeg
 	d := newTestDownloader(t)
 
 	status := d.GetFFmpegStatus()
@@ -141,6 +142,7 @@ func TestGetFFmpegStatus_Available(t *testing.T) {
 
 // TestGetFFmpegStatus_Downloading verifies status returns in-progress state.
 func TestGetFFmpegStatus_Downloading(t *testing.T) {
+	t.Setenv("PATH", "") // isolate from system FFmpeg
 	d := newTestDownloader(t)
 
 	d.mu.Lock()

--- a/internal/transcoding/manager_test.go
+++ b/internal/transcoding/manager_test.go
@@ -438,6 +438,7 @@ exit 0
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PATH", "") // isolate from system FFmpeg
 			mgr := tt.setup(t)
 			mgr.updateFFmpegStatus()
 

--- a/internal/transcoding/probe.go
+++ b/internal/transcoding/probe.go
@@ -246,6 +246,16 @@ var videoDeviceExists = func() bool {
 	return len(matches) > 0
 }
 
+// vaapiDeviceExists checks for DRI render devices (e.g. /dev/dri/renderD128).
+// VAAPI encoders are compiled into many FFmpeg builds but require a GPU
+// device. Without this check, the probe selects VAAPI even in Docker containers
+// that lack GPU passthrough, causing runtime encode failures (exit code 234).
+// Overridden in tests.
+var vaapiDeviceExists = func() bool {
+	matches, _ := filepath.Glob("/dev/dri/renderD*")
+	return len(matches) > 0
+}
+
 // testEncoder checks if an encoder is available via ffmpeg -encoders list parsing.
 // For V4L2M2M encoders, also verifies /dev/video* device existence AND does a smoke test
 // (encoders may be listed but the device may only support decode, not encode).
@@ -268,6 +278,16 @@ func testEncoder(ffmpegPath, encoder string) bool {
 		// Device exists but may only support decode. Smoke test: encode 1 frame.
 		if !smokeTestEncoder(ffmpegPath, encoder) {
 			slog.Debug("V4L2M2M encoder smoke test failed — device likely lacks encode support", "encoder", encoder)
+			return false
+		}
+	}
+
+	// VAAPI encoders are compiled into FFmpeg on most Linux distros but the GPU
+	// device (/dev/dri/renderD128) may not be accessible (e.g. Docker without GPU
+	// passthrough). Verify device existence to avoid runtime failures.
+	if strings.Contains(encoder, "vaapi") {
+		if !vaapiDeviceExists() {
+			slog.Debug("VAAPI encoder listed but no DRI render device — falling back", "encoder", encoder)
 			return false
 		}
 	}


### PR DESCRIPTION
## Pre-release fixes for v0.7.0

### Issues fixed
- **VAAPI fallback bug**: Hardware probe selected VAAPI based on FFmpeg's `-encoders` list (compiled-in) without verifying the GPU device was accessible. In Docker/VM environments without GPU passthrough, FFmpeg crashed with exit code 234 and no software fallback occurred. Added `vaapiDeviceExists()` check.
- **6 failing transcoding tests (CI blocker)**: `GetFFmpegStatus()` checks system PATH first, shadowing test-configured statuses on machines with FFmpeg installed (including CI). Added `t.Setenv("PATH", "")` isolation.
- **Stale README**: AI module was removed (commit 799da87) but README still advertised ONNX Runtime inference.

### Verification
- ✅ All 3016 tests pass (was 3010 pass + 6 fail)
- ✅ `go build ./...` + `go vet ./...` clean
- ✅ Runtime tested on Docker VM: H.265 recording, merge (20 segments → 594s), timelapse keyframe extraction, transcoding queue all verified