### PR TITLE
feat: storage resilience for disk outages

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -34,3 +34,13 @@ func TieredBackoff(attempt int) time.Duration {
 func TieredBackoffWithJitter(attempt int) time.Duration {
 	return TieredBackoff(attempt) + time.Duration(rand.Int63n(int64(time.Second)))
 }
+
+// StorageBackoffWithJitter returns a long backoff (60s ± up to 10s jitter) for
+// use when storage is in a failed state. Recording attempts are pointless
+// while the disk is unavailable (e.g. filesystem remounted read-only, no space
+// left), so we slow the reconnect loop down to ~once per minute instead of
+// spamming logs and burning CPU with sub-second retries. We still retry
+// periodically so recording resumes quickly once storage recovers.
+func StorageBackoffWithJitter() time.Duration {
+	return time.Minute + time.Duration(rand.Int63n(int64(10*time.Second)))
+}

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -29,3 +29,17 @@ func TestTieredBackoffWithJitter(t *testing.T) {
 	require.GreaterOrEqual(t, jittered, base)
 	require.Less(t, jittered, base+time.Second)
 }
+
+func TestStorageBackoffWithJitter_Range(t *testing.T) {
+	// Storage backoff is the long retry used when the disk is unavailable;
+	// it must stay in [60s, 70s) so recorders don't spam logs.
+	const (
+		min = 60 * time.Second
+		max = 70 * time.Second
+	)
+	for i := 0; i < 200; i++ {
+		d := StorageBackoffWithJitter()
+		require.GreaterOrEqual(t, d, min)
+		require.Less(t, d, max)
+	}
+}

--- a/internal/hls/manager.go
+++ b/internal/hls/manager.go
@@ -2,6 +2,7 @@ package hls
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/bluenviron/gohlslib/v2"
@@ -35,6 +37,7 @@ const (
 	defaultSegmentMaxSize = 10 * 1024 * 1024 // 10MB HLS segment max
 	maxBackoff            = 16 * time.Second
 	initialBackoff        = 1 * time.Second
+	storageErrorBackoff   = 60 * time.Second // persistent storage failures (read-only, disk full, I/O)
 )
 
 // hlsFrame is an async write request for the HLS muxer.
@@ -344,9 +347,10 @@ func (m *Manager) rebuildMuxer(cameraID string, entry *streamEntry, au [][]byte)
 	entry.mux = mux
 	entry.track = track
 	entry.mu.Unlock()
-	// Reset error tracking — the stream is healthy again until the next failure.
-	entry.consecutiveErrors = 0
-	entry.backoff = 0
+	// NOTE: consecutiveErrors/backoff are NOT reset here — muxer creation can
+	// succeed on a read-only filesystem (the file write is deferred). They are
+	// only cleared on a successful frame write in writeLoop, proving the path
+	// is truly writable.
 	if m.metrics != nil {
 		m.metrics.HLSMuxerRestarts.WithLabelValues(cameraID).Inc()
 	}
@@ -693,7 +697,12 @@ func calculateBackoff(consecutiveErrors int) time.Duration {
 // destroying the muxer, resetting the IDR flag, and sleeping with backoff.
 func (m *Manager) handleWriteError(ctx context.Context, cameraID string, entry *streamEntry, err error) {
 	entry.consecutiveErrors++
-	entry.backoff = calculateBackoff(entry.consecutiveErrors)
+	storageFailed := isPersistentStorageError(err)
+	if storageFailed {
+		entry.backoff = storageErrorBackoff
+	} else {
+		entry.backoff = calculateBackoff(entry.consecutiveErrors)
+	}
 	entry.lastErrorTime = time.Now()
 
 	hlsLogger.Error("HLS write error",
@@ -701,6 +710,7 @@ func (m *Manager) handleWriteError(ctx context.Context, cameraID string, entry *
 		"error", err,
 		"consecutive_errors", entry.consecutiveErrors,
 		"backoff", entry.backoff,
+		"storage_failed", storageFailed,
 	)
 
 	if m.metrics != nil {
@@ -726,6 +736,26 @@ func (m *Manager) handleWriteError(ctx context.Context, cameraID string, entry *
 		return
 	case <-time.After(entry.backoff):
 	}
+}
+
+// isPersistentStorageError reports whether err indicates a storage-layer
+// failure that won't be resolved by rebuilding the muxer (e.g. filesystem
+// remounted read-only, disk full, I/O error). For these we use a long fixed
+// backoff instead of the short exponential one, since retrying every few
+// seconds only produces log spam without resolving the underlying issue.
+func isPersistentStorageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EROFS) || errors.Is(err, syscall.ENOSPC) || errors.Is(err, syscall.EIO) {
+		return true
+	}
+	// gohlslib wraps file errors without syscall unwrapping, so fall back to
+	// substring matching for the common kernel error messages.
+	s := err.Error()
+	return strings.Contains(s, "read-only file system") ||
+		strings.Contains(s, "no space left") ||
+		strings.Contains(s, "input/output error")
 }
 
 // StopStream stops the HLS muxer for the given camera and cleans up temp files.

--- a/internal/hls/manager_test.go
+++ b/internal/hls/manager_test.go
@@ -1456,6 +1456,65 @@ func TestHandleWriteError_ConsecutiveErrorsIncreaseBackoff(t *testing.T) {
 	require.Equal(t, 16*time.Second, entry.backoff)
 }
 
+// TestHandleWriteError_StorageErrorUsesLongBackoff verifies that persistent
+// storage errors (read-only filesystem, disk full, I/O error) get a long
+// fixed backoff instead of the short exponential one, preventing log spam
+// during disk outages.
+func TestHandleWriteError_StorageErrorUsesLongBackoff(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"read-only filesystem", fmt.Errorf("open /data/hls/seg.mp4: read-only file system")},
+		{"no space left", fmt.Errorf("write /data/hls/seg.mp4: no space left on device")},
+		{"input/output error", fmt.Errorf("write /data/hls/seg.mp4: input/output error")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := newTestStreamEntry(0)
+			entry.mux = nil
+			entry.track = nil
+			entry.idrReceived = true
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // pre-cancel to skip the 60s backoff sleep
+
+			mgr := &Manager{streams: make(map[string]*streamEntry)}
+			mgr.handleWriteError(ctx, "cam-1", entry, tt.err)
+
+			require.Equal(t, 1, entry.consecutiveErrors, "error counter should increment")
+			require.Equal(t, storageErrorBackoff, entry.backoff,
+				"storage errors should use long fixed backoff, not exponential")
+		})
+	}
+}
+
+// TestIsPersistentStorageError tests the storage error classifier directly.
+func TestIsPersistentStorageError(t *testing.T) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"read-only", fmt.Errorf("open seg.mp4: read-only file system"), true},
+		{"no space", fmt.Errorf("write seg.mp4: no space left on device"), true},
+		{"io error", fmt.Errorf("write seg.mp4: input/output error"), true},
+		{"generic DTS error", fmt.Errorf("DTS non-monotonic"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isPersistentStorageError(tt.err))
+		})
+	}
+}
+
 // TestHandleWriteError_ContextCancellation verifies that backoff sleep is
 // interrupted when the context is cancelled.
 func TestHandleWriteError_ContextCancellation(t *testing.T) {
@@ -1654,8 +1713,9 @@ func TestExtractParamSets_EmptyNAL(t *testing.T) {
 
 // --- rebuildMuxer Tests ---
 
-// TestRebuildMuxer_Success recreates the muxer from an IDR frame's param sets
-// and resets error tracking. This is the core of the HLS self-healing fix.
+// TestRebuildMuxer_Success recreates the muxer from an IDR frame's param sets.
+// Error tracking (consecutiveErrors/backoff) is NOT reset here — only a
+// successful write in writeLoop clears it.
 func TestRebuildMuxer_Success(t *testing.T) {
 	t.Helper()
 	m := metrics.NewMetrics()
@@ -1691,8 +1751,10 @@ func TestRebuildMuxer_Success(t *testing.T) {
 	entry.mu.Unlock()
 	require.NotNil(t, muxAfter, "muxer should be rebuilt")
 	require.NotNil(t, trackAfter, "track should be rebuilt")
-	require.Equal(t, 0, entry.consecutiveErrors, "consecutiveErrors should reset to 0")
-	require.Equal(t, time.Duration(0), entry.backoff, "backoff should reset")
+	// rebuildMuxer no longer resets error tracking — only a successful frame
+	// write in writeLoop clears consecutiveErrors/backoff.
+	require.Equal(t, 42, entry.consecutiveErrors, "consecutiveErrors should NOT reset on rebuild")
+	require.Equal(t, 16*time.Second, entry.backoff, "backoff should NOT reset on rebuild")
 
 	mgr.StopAll()
 }

--- a/internal/recorder/backoff.go
+++ b/internal/recorder/backoff.go
@@ -18,3 +18,9 @@ func TieredBackoff(attempt int) time.Duration {
 func TieredBackoffWithJitter(attempt int) time.Duration {
 	return backoff.TieredBackoffWithJitter(attempt)
 }
+
+// StorageBackoffWithJitter returns a long backoff (~60s + jitter) for use when
+// the storage subsystem is in a failed state. See backoff.StorageBackoffWithJitter.
+func StorageBackoffWithJitter() time.Duration {
+	return backoff.StorageBackoffWithJitter()
+}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -330,12 +330,16 @@ func (b *baseRecorder) run(ctx context.Context) {
 		}
 		retryCount++
 		backoff := TieredBackoffWithJitter(retryCount)
+		storageFailed := isStorageFailed(b.store)
+		if storageFailed {
+			backoff = StorageBackoffWithJitter()
+		}
 		if b.mtrics != nil {
 			b.mtrics.CameraReconnectBackoffSeconds.WithLabelValues(b.cfg.CameraID).Set(backoff.Seconds())
 		}
 		b.log.Error("connection error, reconnecting",
 			"camera_id", b.cfg.CameraID, "error", err,
-			"backoff", backoff, "attempt", retryCount)
+			"backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
 		b.recordError("connection")
 		b.setStatus(model.StatusReconnecting)
 		select {

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -212,7 +212,11 @@ func (r *HTTPJPEGRecorder) run(ctx context.Context) {
 		}
 		retryCount++
 		backoff := TieredBackoffWithJitter(retryCount)
-		httpJpegLogger.Error("stream error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount)
+		storageFailed := isStorageFailed(r.store)
+		if storageFailed {
+			backoff = StorageBackoffWithJitter()
+		}
+		httpJpegLogger.Error("stream error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
 		r.recordError("connection")
 		r.setStatus(model.StatusReconnecting)
 

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -165,10 +165,14 @@ func (r *MJPEGRecorder) run(ctx context.Context) {
 		}
 		retryCount++
 		backoff := TieredBackoffWithJitter(retryCount)
+		storageFailed := isStorageFailed(r.store)
+		if storageFailed {
+			backoff = StorageBackoffWithJitter()
+		}
 		if r.metrics != nil {
 			r.metrics.CameraReconnectBackoffSeconds.WithLabelValues(r.cfg.CameraID).Set(backoff.Seconds())
 		}
-		mjpegLogger.Error("connection error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount)
+		mjpegLogger.Error("connection error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
 		r.recordError("connection")
 		r.setStatus(model.StatusReconnecting)
 		select {

--- a/internal/recorder/storage_health.go
+++ b/internal/recorder/storage_health.go
@@ -4,19 +4,20 @@ import (
 	"time"
 )
 
-// Storage health state constants matching storage.HealthState values.
-const (
-	storageHealthHealthy = iota
-	storageHealthDegraded
-	storageHealthFailed
-)
-
 // isStorageFailed checks whether the SegmentStore reports a failed health state.
-// Returns false if the store does not implement the health check interface.
+// The store may optionally implement StorageFailed() bool (e.g. *storage.Manager);
+// returns false if the store does not expose storage health so behavior is
+// unchanged for stub/test stores.
+//
+// NOTE: the optional interface intentionally returns bool rather than an int
+// health enum. Go requires exact return-type matching for interface satisfaction,
+// so a store method returning a named int type (e.g. storage.HealthState) would
+// NOT satisfy an `StorageHealth() int` interface — that was the original bug that
+// silently disabled this guard for every recorder.
 func isStorageFailed(store SegmentStore) bool {
-	type healthHint interface{ StorageHealth() int }
+	type healthHint interface{ StorageFailed() bool }
 	if hc, ok := store.(healthHint); ok {
-		return hc.StorageHealth() >= storageHealthFailed
+		return hc.StorageFailed()
 	}
 	return false
 }

--- a/internal/recorder/storage_health_test.go
+++ b/internal/recorder/storage_health_test.go
@@ -1,0 +1,50 @@
+package recorder
+
+import "testing"
+
+// healthAwareStore implements SegmentStore plus the optional StorageFailed()
+// bool method, mirroring how *storage.Manager satisfies the duck-typed
+// healthHint interface. The original bug was that storage.Manager exposed
+// StorageHealth() HealthState while the interface demanded StorageHealth() int
+// (Go requires exact return-type matching), so the assertion always failed.
+type healthAwareStore struct{ failed bool }
+
+func (s *healthAwareStore) CreateSegment(string, string) (string, string, error) {
+	return "", "", nil
+}
+func (s *healthAwareStore) WriteFrame(string, []byte) (int, error) { return 0, nil }
+func (s *healthAwareStore) CloseSegment(string, string) error      { return nil }
+func (s *healthAwareStore) StorageFailed() bool                    { return s.failed }
+
+// plainStore implements only SegmentStore (no health method) — exercises the
+// backward-compatible fallback where isStorageFailed returns false.
+type plainStore struct{}
+
+func (s *plainStore) CreateSegment(string, string) (string, string, error) {
+	return "", "", nil
+}
+func (s *plainStore) WriteFrame(string, []byte) (int, error) { return 0, nil }
+func (s *plainStore) CloseSegment(string, string) error      { return nil }
+
+// TestIsStorageFailed_HealthAwareStore guards the core fix: a store that
+// reports StorageFailed()==true must be detected by isStorageFailed. Before the
+// fix this always returned false because of the interface type mismatch.
+func TestIsStorageFailed_HealthAwareStore(t *testing.T) {
+	t.Helper()
+	if isStorageFailed(&healthAwareStore{failed: true}) != true {
+		t.Fatal("expected isStorageFailed=true when store reports StorageFailed()=true")
+	}
+	if isStorageFailed(&healthAwareStore{failed: false}) != false {
+		t.Fatal("expected isStorageFailed=false when store reports StorageFailed()=false")
+	}
+}
+
+// TestIsStorageFailed_PlainStore ensures backward compatibility: stores that do
+// not implement StorageFailed() must fall back to false (never panic, never
+// block recording for stores without health insight).
+func TestIsStorageFailed_PlainStore(t *testing.T) {
+	t.Helper()
+	if isStorageFailed(&plainStore{}) != false {
+		t.Fatal("expected isStorageFailed=false for store without StorageFailed() method")
+	}
+}

--- a/internal/storage/health_tracker.go
+++ b/internal/storage/health_tracker.go
@@ -49,6 +49,16 @@ func (m *Manager) StorageHealth() HealthState {
 	return m.healthState
 }
 
+// StorageFailed reports whether storage is in a failed state and writes
+// should be skipped. Satisfies the recorder package's duck-typed
+// `StorageFailed() bool` health-check interface so recorders can short-circuit
+// recording attempts during disk outages (e.g. ext4 remounted read-only).
+func (m *Manager) StorageFailed() bool {
+	m.healthMu.Lock()
+	defer m.healthMu.Unlock()
+	return m.healthState >= HealthFailed
+}
+
 // recordWriteFailureLocked increments the failure counter and escalates
 // health state if threshold is exceeded. Must be called while holding m.healthMu.
 // Returns the new health state.

--- a/internal/storage/health_tracker_test.go
+++ b/internal/storage/health_tracker_test.go
@@ -1,0 +1,40 @@
+package storage
+
+import "testing"
+
+// TestStorageFailed_ReflectsHealthState verifies the new StorageFailed() method
+// (added to satisfy the recorder package's health-check interface) correctly
+// mirrors the internal health state across transitions. This is the storage-side
+// half of the isStorageFailed fix.
+func TestStorageFailed_ReflectsHealthState(t *testing.T) {
+	t.Helper()
+	m, err := NewManager(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Fresh manager is healthy.
+	if m.StorageFailed() {
+		t.Fatal("fresh manager should not report storage failed")
+	}
+
+	// A single write failure escalates only to Degraded, not Failed.
+	m.recordWriteFailure()
+	if m.StorageFailed() {
+		t.Fatal("degraded state must not be reported as failed (only >= HealthFailed)")
+	}
+
+	// Reaching maxConsecutiveFailures escalates to HealthFailed.
+	for i := 1; i < maxConsecutiveFailures; i++ { // already had 1 failure above
+		m.recordWriteFailure()
+	}
+	if !m.StorageFailed() {
+		t.Fatal("expected StorageFailed()=true after maxConsecutiveFailures write failures")
+	}
+
+	// A successful write restores health.
+	m.recordWriteSuccess()
+	if m.StorageFailed() {
+		t.Fatal("expected StorageFailed()=false after recordWriteSuccess")
+	}
+}


### PR DESCRIPTION
## Summary

Disk outage resilience — extracted from the oversized `refactor/pkg-app-extraction` branch as part of a focused-PR cleanup.

- **fix(storage)**: correct `isStorageFailed` interface contract (`StorageFailed bool`)
- **feat(backoff)**: add `StorageBackoffWithJitter` for disk outage resilience
- **fix(recorder)**: use long storage backoff in run loops when disk degrades
- **fix(hls)**: stop `writeLoop` log spam on persistent storage errors

## Context

`refactor/pkg-app-extraction` accumulated 38 commits but only 5 are actual pkg/ refactor work. This PR splits out the storage-resilience slice so it can be reviewed and landed independently. No pkg/ refactor content here.

## Validation

- `go build ./...` — clean
- `go test ./internal/storage/ ./internal/backoff/ ./internal/hls/ ./internal/recorder/` — 359 passed, 0 failed