### PR TITLE
refactor: extract pkg/ public extension API (app + camera + streamhub + eventbus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ plugins-*.png
 # Private documentation (not committed to remote)
 docs/private/
 
+# Cross-team collaboration (private, do NOT commit)
+docs/MiBee-Projects/
+
 # IDE / Editor
 .vscode/
 .idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/MiBee-Projects"]
-	path = docs/MiBee-Projects
-	url = ssh://gitea@192.168.63.10:2222/home-lab/MiBee-Projects.git

--- a/internal/camera/adapter.go
+++ b/internal/camera/adapter.go
@@ -1,0 +1,117 @@
+package camera
+
+import (
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	pkgcamera "github.com/Mi-Bee-Studio/MiBeeNvr/pkg/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
+)
+
+// Compile-time assertions.
+//
+// *CameraManager satisfies pkg/app.Service via Name + Start + Stop.
+// *publicAdapter (not *CameraManager) satisfies pkg/camera.Manager —
+// the wrapper is required because pkg/camera.Manager.Status(id) collides
+// in name with the legacy CameraManager.Status() (no args, returns map).
+var (
+	_ interface{ Name() string } = (*CameraManager)(nil)
+	_ pkgcamera.Manager          = (*publicAdapter)(nil)
+)
+
+// Name returns the service identifier used by pkg/app.App.
+// *CameraManager satisfies pkg/app.Service via Name + Start + Stop.
+func (cm *CameraManager) Name() string { return "camera" }
+
+// AsPublic returns a read-only wrapper that satisfies pkg/camera.Manager.
+//
+// The wrapper exists because pkg/camera.Manager.Status(id) collides in
+// name with the existing CameraManager.Status() (which returns the
+// status map for all cameras). Rather than rename the legacy method,
+// we expose a separate adapter for out-of-module consumers.
+//
+// Register with pkg/app.App for typed retrieval:
+//
+//	camMgr := camera.NewCameraManager(...)
+//	a.Register(camMgr)                       // lifecycle (Start/Stop)
+//	a.RegisterValue("camera-manager", camMgr.AsPublic())  // pkg/camera.Manager
+func (cm *CameraManager) AsPublic() pkgcamera.Manager {
+	return &publicAdapter{cm: cm}
+}
+
+// publicAdapter wraps *CameraManager to satisfy pkg/camera.Manager.
+type publicAdapter struct {
+	cm *CameraManager
+}
+
+// List implements pkg/camera.Manager.
+func (a *publicAdapter) List() []pkgcamera.Camera {
+	a.cm.mu.RLock()
+	defer a.cm.mu.RUnlock()
+	out := make([]pkgcamera.Camera, 0, len(a.cm.cfg.Cameras))
+	for i := range a.cm.cfg.Cameras {
+		out = append(out, cameraView{cfg: &a.cm.cfg.Cameras[i]})
+	}
+	return out
+}
+
+// Get implements pkg/camera.Manager.
+func (a *publicAdapter) Get(id string) (pkgcamera.Camera, error) {
+	a.cm.mu.RLock()
+	defer a.cm.mu.RUnlock()
+	for i := range a.cm.cfg.Cameras {
+		if a.cm.cfg.Cameras[i].ID == id {
+			return cameraView{cfg: &a.cm.cfg.Cameras[i]}, nil
+		}
+	}
+	return nil, pkgcamera.NewNotFoundError(id)
+}
+
+// Status implements pkg/camera.Manager.
+//
+// Runtime status is derived from the recorder's current state plus any
+// error detail recorded for the camera. FPS and BitrateKbps are left
+// zero in this v0.1 adapter; wiring them to metrics is deferred.
+func (a *publicAdapter) Status(id string) (pkgcamera.Status, error) {
+	cfg := a.cm.GetCameraConfig(id)
+	if cfg == nil {
+		return pkgcamera.Status{}, pkgcamera.NewNotFoundError(id)
+	}
+
+	rs := a.cm.CameraStatus(id)
+	s := pkgcamera.Status{
+		ID:        id,
+		Online:    rs == model.StatusRecording || rs == model.StatusReconnecting,
+		Recording: rs == model.StatusRecording,
+	}
+	if detail := a.cm.GetErrorDetail(id); detail != nil {
+		s.Error = detail.Message
+	}
+	return s, nil
+}
+
+// Hub implements pkg/camera.Manager.
+//
+// Returns the frame distribution hub for the camera. The returned Hub
+// is shared across all callers; each must Subscribe under a unique
+// consumerID. The underlying *model.StreamHub is wrapped via
+// model.NewHubAdapter to satisfy the pkg/streamhub.Hub interface.
+func (a *publicAdapter) Hub(id string) (streamhub.Hub, error) {
+	h := a.cm.GetHub(id)
+	if h == nil {
+		return nil, pkgcamera.NewNotFoundError(id)
+	}
+	return model.NewHubAdapter(h), nil
+}
+
+// cameraView adapts a *config.CameraConfig to the pkg/camera.Camera
+// interface. It is a thin read-only view; mutations to the underlying
+// config are visible through the adapter.
+type cameraView struct {
+	cfg *config.CameraConfig
+}
+
+func (c cameraView) ID() string         { return c.cfg.ID }
+func (c cameraView) Name() string       { return c.cfg.Name }
+func (c cameraView) Protocol() string   { return c.cfg.Protocol }
+func (c cameraView) Encoding() string   { return c.cfg.Encoding }
+func (c cameraView) AudioEnabled() bool { return c.cfg.AudioEnabled }

--- a/internal/model/adapter.go
+++ b/internal/model/adapter.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	pkgstreamhub "github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
+)
+
+// Compile-time assertion that *HubAdapter satisfies pkg/streamhub.Hub.
+var _ pkgstreamhub.Hub = (*HubAdapter)(nil)
+
+// HubAdapter wraps *StreamHub to satisfy pkg/streamhub.Hub.
+//
+// StreamHub's native callback types (model.FrameCallback,
+// model.AudioCallback) are structurally similar but not identical to
+// pkg/streamhub's types — model.AudioCallback uses AudioCodec (a
+// defined string type) while pkg/streamhub uses plain string. The
+// adapter bridges these via zero-cost type conversions.
+//
+// Construct with NewHubAdapter; do not allocate directly.
+type HubAdapter struct {
+	Hub *StreamHub
+}
+
+// NewHubAdapter wraps h as a pkg/streamhub.Hub.
+// Returns nil if h is nil so callers can pass through directly.
+func NewHubAdapter(h *StreamHub) pkgstreamhub.Hub {
+	if h == nil {
+		return nil
+	}
+	return &HubAdapter{Hub: h}
+}
+
+// Subscribe registers a video frame callback. The pkg-streamhub
+// callback is converted to the internal FrameCallback signature.
+func (a *HubAdapter) Subscribe(consumerID string, cb pkgstreamhub.FrameCallback) error {
+	return a.Hub.Subscribe(consumerID, FrameCallback(cb))
+}
+
+// Unsubscribe removes the video consumer. Idempotent.
+func (a *HubAdapter) Unsubscribe(consumerID string) {
+	a.Hub.Unsubscribe(consumerID)
+}
+
+// SubscribeAudio registers an audio frame callback. The pkg-streamhub
+// callback (which receives a plain string codec) is bridged to the
+// internal AudioCallback (which receives AudioCodec).
+func (a *HubAdapter) SubscribeAudio(consumerID string, cb pkgstreamhub.AudioCallback) error {
+	return a.Hub.SubscribeAudio(consumerID, func(pts int64, codec AudioCodec, data []byte) {
+		cb(pts, string(codec), data)
+	})
+}
+
+// UnsubscribeAudio removes the audio consumer. Idempotent.
+func (a *HubAdapter) UnsubscribeAudio(consumerID string) {
+	a.Hub.UnsubscribeAudio(consumerID)
+}
+
+// Sends returns the count of frames delivered to the consumer.
+func (a *HubAdapter) Sends(consumerID string) int64 {
+	return a.Hub.Sends(consumerID)
+}
+
+// Drops returns the count of frames dropped for the consumer.
+func (a *HubAdapter) Drops(consumerID string) int64 {
+	return a.Hub.Drops(consumerID)
+}
+
+// ConsumerCount returns the current number of video subscribers.
+func (a *HubAdapter) ConsumerCount() int {
+	return a.Hub.ConsumerCount()
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -37,6 +37,7 @@ type App struct {
 	mu       sync.Mutex
 	services map[string]Service
 	order    []string // registration order, for deterministic start/stop
+	values   map[string]any // typed values for retrieval via Value()
 	started  bool
 	stopped  bool
 }
@@ -45,6 +46,7 @@ type App struct {
 func New() *App {
 	return &App{
 		services: make(map[string]Service),
+		values:   make(map[string]any),
 	}
 }
 
@@ -76,6 +78,7 @@ func (a *App) Register(s Service) error {
 		return fmt.Errorf("app: service %q already registered", name)
 	}
 	a.services[name] = s
+	a.values[name] = s // also expose for typed retrieval
 	a.order = append(a.order, name)
 	slog.Debug("app: registered service", "name", name)
 	return nil
@@ -83,16 +86,54 @@ func (a *App) Register(s Service) error {
 
 // Get returns the Service with the given name, or nil if not registered.
 //
-// The caller is expected to type-assert the result to a specific interface
+// The returned Service can be type-asserted to a specific interface
 // exposed by a sibling pkg/ package (e.g., pkg/camera.Manager):
-//
 //	camSvc := a.Get("camera")
 //	if camSvc == nil { return errors.New("camera service not registered") }
 //	camMgr := camSvc.(camera.Manager)
+//
+// For values that are not lifecycle Services (e.g., wrapper adapters),
+// use Value() instead.
 func (a *App) Get(name string) Service {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.services[name]
+}
+
+// RegisterValue stores an arbitrary value under name, retrievable via Value.
+// Unlike Register, this does NOT add the value to the service lifecycle.
+// Use it to expose typed handles (e.g., a pkg/camera.Manager wrapper) for
+// out-of-module consumers when the underlying concrete type cannot satisfy
+// both pkg/app.Service and the public interface simultaneously
+// (e.g., due to method-name conflicts).
+//
+// Returns an error if name is already used by either a Service or a value,
+// or if Start has already been called.
+func (a *App) RegisterValue(name string, v any) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.started {
+		return fmt.Errorf("app: cannot register value %q after Start", name)
+	}
+	if _, exists := a.services[name]; exists {
+		return fmt.Errorf("app: name %q already registered as service", name)
+	}
+	if _, exists := a.values[name]; exists {
+		return fmt.Errorf("app: value %q already registered", name)
+	}
+	a.values[name] = v
+	slog.Debug("app: registered value", "name", name)
+	return nil
+}
+
+// Value returns the value registered under name, or nil if not registered.
+// The caller is expected to type-assert:
+//
+	//	m := a.Value("camera-manager").(camera.Manager)
+func (a *App) Value(name string) any {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.values[name]
 }
 
 // Services returns the names of all registered services in registration order.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1,0 +1,189 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// Service is a lifecycle-managed component of the App.
+//
+// Implementations should be safe for concurrent use after Start returns.
+// Stop must be idempotent (safe to call multiple times) and should release
+// all goroutines, file handles, and network resources held by the service.
+type Service interface {
+	// Name uniquely identifies the service in the App's registry.
+	// Two services with the same Name cannot coexist.
+	Name() string
+
+	// Start begins the service's operation. It must return promptly;
+	// long-running work should run on goroutines that honor ctx cancellation.
+	// Returning a non-nil error aborts the App start and triggers rollback.
+	Start(ctx context.Context) error
+
+	// Stop terminates the service gracefully. It must release all resources.
+	// It is called in reverse registration order during App.Stop.
+	Stop() error
+}
+
+// App is the root application orchestrator.
+//
+// It manages a set of Services with deterministic start (registration order)
+// and stop (reverse registration order) sequencing. App is safe for
+// concurrent use after construction.
+type App struct {
+	mu       sync.Mutex
+	services map[string]Service
+	order    []string // registration order, for deterministic start/stop
+	started  bool
+	stopped  bool
+}
+
+// New creates an empty App ready for service registration.
+func New() *App {
+	return &App{
+		services: make(map[string]Service),
+	}
+}
+
+// Register adds a Service to the App.
+//
+// Returns an error if:
+//   - the service is nil,
+//   - another service with the same Name is already registered,
+//   - Start has already been called (registration after Start is forbidden).
+//
+// Register must be called before Start. The Pro extension path:
+// call RunFree → Register Pro services → Start.
+func (a *App) Register(s Service) error {
+	if s == nil {
+		return errors.New("app: cannot register nil service")
+	}
+	name := s.Name()
+	if name == "" {
+		return errors.New("app: service Name() cannot be empty")
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.started {
+		return fmt.Errorf("app: cannot register service %q after Start", name)
+	}
+	if _, exists := a.services[name]; exists {
+		return fmt.Errorf("app: service %q already registered", name)
+	}
+	a.services[name] = s
+	a.order = append(a.order, name)
+	slog.Debug("app: registered service", "name", name)
+	return nil
+}
+
+// Get returns the Service with the given name, or nil if not registered.
+//
+// The caller is expected to type-assert the result to a specific interface
+// exposed by a sibling pkg/ package (e.g., pkg/camera.Manager):
+//
+//	camSvc := a.Get("camera")
+//	if camSvc == nil { return errors.New("camera service not registered") }
+//	camMgr := camSvc.(camera.Manager)
+func (a *App) Get(name string) Service {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.services[name]
+}
+
+// Services returns the names of all registered services in registration order.
+// The returned slice is a copy; callers may mutate it freely.
+func (a *App) Services() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.order))
+	copy(out, a.order)
+	return out
+}
+
+// Start starts all registered services in registration order.
+//
+// If any service fails to start, already-started services are stopped in
+// reverse order before returning the error (rollback). Start is idempotent
+// in the failure sense: a second call after success returns nil; a second
+// call after failure returns the original error.
+func (a *App) Start(ctx context.Context) error {
+	a.mu.Lock()
+	if a.started {
+		a.mu.Unlock()
+		return nil
+	}
+	a.started = true
+	order := make([]string, len(a.order))
+	copy(order, a.order)
+	a.mu.Unlock()
+
+	var started []string
+	for _, name := range order {
+		s := a.services[name]
+		slog.Info("app: starting service", "name", name)
+		if err := s.Start(ctx); err != nil {
+			slog.Error("app: service failed to start",
+				"name", name, "error", err)
+			// Rollback in reverse order.
+			for i := len(started) - 1; i >= 0; i-- {
+				rbName := started[i]
+				if rbErr := a.services[rbName].Stop(); rbErr != nil {
+					slog.Error("app: service failed to stop during rollback",
+						"name", rbName, "error", rbErr)
+				}
+			}
+			return fmt.Errorf("app: start service %q: %w", name, err)
+		}
+		started = append(started, name)
+	}
+	slog.Info("app: all services started",
+		"count", len(started))
+	return nil
+}
+
+// Stop stops all registered services in reverse registration order.
+//
+// Stop is idempotent: repeated calls return nil. Errors from individual
+// services are logged; the first non-nil error is returned to the caller
+// after all services have been stopped.
+func (a *App) Stop() error {
+	a.mu.Lock()
+	if a.stopped {
+		a.mu.Unlock()
+		return nil
+	}
+	a.stopped = true
+	order := make([]string, len(a.order))
+	copy(order, a.order)
+	a.mu.Unlock()
+
+	var firstErr error
+	for i := len(order) - 1; i >= 0; i-- {
+		name := order[i]
+		s := a.services[name]
+		slog.Info("app: stopping service", "name", name)
+		if err := s.Stop(); err != nil {
+			slog.Error("app: service failed to stop",
+				"name", name, "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("app: stop service %q: %w", name, err)
+			}
+		}
+	}
+	if firstErr == nil {
+		slog.Info("app: all services stopped", "count", len(order))
+	}
+	return firstErr
+}
+
+// Started reports whether Start has been called successfully.
+func (a *App) Started() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.started && !a.stopped
+}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -1,0 +1,276 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// fakeService is a minimal Service implementation for tests.
+type fakeService struct {
+	name      string
+	startErr  error
+	stopErr   error
+	startCnt  int
+	stopCnt   int
+	startSlow bool
+	mu        sync.Mutex
+}
+
+func (f *fakeService) Name() string { return f.name }
+
+func (f *fakeService) Start(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.startCnt++
+	if f.startErr != nil {
+		return f.startErr
+	}
+	return nil
+}
+
+func (f *fakeService) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopCnt++
+	return f.stopErr
+}
+
+func (f *fakeService) starts() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.startCnt
+}
+
+func (f *fakeService) stops() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stopCnt
+}
+
+func TestNew_Empty(t *testing.T) {
+	t.Helper()
+	a := New()
+	if got := len(a.Services()); got != 0 {
+		t.Errorf("Services() = %v, want empty", got)
+	}
+	if a.Started() {
+		t.Error("Started() = true on new App, want false")
+	}
+}
+
+func TestRegister_Success(t *testing.T) {
+	t.Helper()
+	a := New()
+	s := &fakeService{name: "alpha"}
+	if err := a.Register(s); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if got := a.Services(); len(got) != 1 || got[0] != "alpha" {
+		t.Errorf("Services() = %v, want [alpha]", got)
+	}
+	if a.Get("alpha") != s {
+		t.Error("Get returned wrong service")
+	}
+}
+
+func TestRegister_Nil(t *testing.T) {
+	t.Helper()
+	a := New()
+	if err := a.Register(nil); err == nil {
+		t.Error("Register(nil) = nil, want error")
+	}
+}
+
+func TestRegister_EmptyName(t *testing.T) {
+	t.Helper()
+	a := New()
+	s := &fakeService{name: ""}
+	if err := a.Register(s); err == nil {
+		t.Error("Register with empty Name = nil, want error")
+	}
+}
+
+func TestRegister_Duplicate(t *testing.T) {
+	t.Helper()
+	a := New()
+	if err := a.Register(&fakeService{name: "alpha"}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := a.Register(&fakeService{name: "alpha"})
+	if err == nil {
+		t.Error("second Register = nil, want duplicate error")
+	}
+}
+
+func TestRegister_AfterStart(t *testing.T) {
+	t.Helper()
+	a := New()
+	_ = a.Register(&fakeService{name: "alpha"})
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	err := a.Register(&fakeService{name: "beta"})
+	if err == nil {
+		t.Error("Register after Start = nil, want error")
+	}
+}
+
+func TestStart_Order(t *testing.T) {
+	t.Helper()
+	a := New()
+	s1 := &fakeService{name: "first"}
+	s2 := &fakeService{name: "second"}
+	s3 := &fakeService{name: "third"}
+	_ = a.Register(s1)
+	_ = a.Register(s2)
+	_ = a.Register(s3)
+
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !a.Started() {
+		t.Error("Started() = false, want true")
+	}
+	for _, s := range []*fakeService{s1, s2, s3} {
+		if s.starts() != 1 {
+			t.Errorf("%q started %d times, want 1", s.name, s.starts())
+		}
+	}
+}
+
+func TestStop_ReverseOrder(t *testing.T) {
+	t.Helper()
+	a := New()
+
+	svcs := make([]*fakeService, 0, 3)
+	for _, name := range []string{"a", "b", "c"} {
+		s := &fakeService{name: name}
+		svcs = append(svcs, s)
+		_ = a.Register(s)
+	}
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// All services stopped exactly once.
+	for _, s := range svcs {
+		if s.stops() != 1 {
+			t.Errorf("%q stopped %d times, want 1", s.name, s.stops())
+		}
+	}
+}
+
+func TestStop_BeforeStart(t *testing.T) {
+	t.Helper()
+	a := New()
+	_ = a.Register(&fakeService{name: "alpha"})
+	if err := a.Stop(); err != nil {
+		t.Errorf("Stop before Start = %v, want nil", err)
+	}
+}
+
+func TestStop_Idempotent(t *testing.T) {
+	t.Helper()
+	a := New()
+	s := &fakeService{name: "alpha"}
+	_ = a.Register(s)
+	_ = a.Start(context.Background())
+	if err := a.Stop(); err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if err := a.Stop(); err != nil {
+		t.Errorf("second Stop: %v, want nil", err)
+	}
+	if s.stops() != 1 {
+		t.Errorf("stopped %d times after double Stop, want 1", s.stops())
+	}
+}
+
+func TestStart_RollbackOnError(t *testing.T) {
+	t.Helper()
+	a := New()
+	s1 := &fakeService{name: "ok1"}
+	s2 := &fakeService{name: "fails", startErr: errors.New("boom")}
+	s3 := &fakeService{name: "never"}
+	_ = a.Register(s1)
+	_ = a.Register(s2)
+	_ = a.Register(s3)
+
+	err := a.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start = nil, want error from failing service")
+	}
+	if s1.starts() != 1 {
+		t.Errorf("ok1 started %d, want 1", s1.starts())
+	}
+	if s1.stops() != 1 {
+		t.Errorf("ok1 stopped %d, want 1 (rollback)", s1.stops())
+	}
+	if s2.starts() != 1 {
+		t.Errorf("fails started %d, want 1", s2.starts())
+	}
+	if s3.starts() != 0 {
+		t.Errorf("never started %d, want 0", s3.starts())
+	}
+}
+
+func TestStart_AlreadyStarted(t *testing.T) {
+	t.Helper()
+	a := New()
+	s := &fakeService{name: "alpha"}
+	_ = a.Register(s)
+	if err := a.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := a.Start(context.Background()); err != nil {
+		t.Errorf("second Start: %v, want nil (idempotent)", err)
+	}
+	if s.starts() != 1 {
+		t.Errorf("started %d after double Start, want 1", s.starts())
+	}
+}
+
+func TestGet_Unknown(t *testing.T) {
+	t.Helper()
+	a := New()
+	if got := a.Get("missing"); got != nil {
+		t.Errorf("Get(missing) = %v, want nil", got)
+	}
+}
+
+func TestStop_PropagatesFirstError(t *testing.T) {
+	t.Helper()
+	a := New()
+	s1 := &fakeService{name: "alpha", stopErr: errors.New("alpha-fail")}
+	s2 := &fakeService{name: "beta", stopErr: errors.New("beta-fail")}
+	_ = a.Register(s1)
+	_ = a.Register(s2)
+	_ = a.Start(context.Background())
+
+	err := a.Stop()
+	if err == nil {
+		t.Fatal("Stop = nil, want error")
+	}
+	// First error in reverse order is from beta (stopped first).
+	if err.Error() == "" {
+		t.Errorf("Error message empty: %v", err)
+	}
+}
+
+// TestServices_ReturnsCopy verifies the caller cannot mutate App's internal
+// slice via the returned value.
+func TestServices_ReturnsCopy(t *testing.T) {
+	t.Helper()
+	a := New()
+	_ = a.Register(&fakeService{name: "alpha"})
+	svcs := a.Services()
+	svcs[0] = "mutated"
+	if got := a.Services(); got[0] != "alpha" {
+		t.Errorf("internal slice mutated via returned copy: %v", got)
+	}
+}

--- a/pkg/app/doc.go
+++ b/pkg/app/doc.go
@@ -1,0 +1,37 @@
+// Package app provides the root application orchestrator for MiBee NVR.
+//
+// # Design
+//
+// The App owns a set of Service implementations and manages their lifecycle
+// with deterministic start/stop ordering. Services register dependencies
+// (other managers, hubs, config) at construction time; once Start is called
+// no further registration is allowed.
+//
+// # Open source vs commercial integration
+//
+// Public main and commercial MiBeeNvrP2P both construct the App via RunFree,
+// which wires all open-source services. Commercial callers obtain the App,
+// type-assert services to the interfaces exposed in sibling pkg/ packages,
+// and Register() their own services before Start().
+//
+// Example (public main):
+//
+//	a, err := app.RunFree(cfg, configPath)
+//	if err != nil { return err }
+//	if err := a.Start(ctx); err != nil { return err }
+//
+// Example (commercial main):
+//
+//	a, err := app.RunFree(cfg, configPath)
+//	if err != nil { return err }
+//	camSvc := a.Get("camera").(camera.Manager)
+//	p2pSvc := p2p.New(camSvc, a.Get("eventbus").(eventbus.Bus))
+//	if err := a.Register(p2pSvc); err != nil { return err }
+//	if err := a.Start(ctx); err != nil { return err }
+//
+// # Conventions
+//
+// Service implementations live in internal/* and adapt themselves to this
+// interface via an AsService() method (see internal/camera/adapter.go). They
+// must be safe for concurrent use after Start returns.
+package app

--- a/pkg/app/doc.go
+++ b/pkg/app/doc.go
@@ -7,10 +7,10 @@
 // (other managers, hubs, config) at construction time; once Start is called
 // no further registration is allowed.
 //
-// # Open source vs commercial integration
+// # Extensibility
 //
-// Public main and commercial MiBeeNvrP2P both construct the App via RunFree,
-// which wires all open-source services. Commercial callers obtain the App,
+// Public main and third-party extensions both construct the App via RunFree,
+// which wires all open-source services. External callers obtain the App,
 // type-assert services to the interfaces exposed in sibling pkg/ packages,
 // and Register() their own services before Start().
 //
@@ -20,13 +20,13 @@
 //	if err != nil { return err }
 //	if err := a.Start(ctx); err != nil { return err }
 //
-// Example (commercial main):
+// Example (third-party extension):
 //
 //	a, err := app.RunFree(cfg, configPath)
 //	if err != nil { return err }
 //	camSvc := a.Get("camera").(camera.Manager)
-//	p2pSvc := p2p.New(camSvc, a.Get("eventbus").(eventbus.Bus))
-//	if err := a.Register(p2pSvc); err != nil { return err }
+//	extSvc := myextension.New(camSvc, a.Get("eventbus").(eventbus.Bus))
+//	if err := a.Register(extSvc); err != nil { return err }
 //	if err := a.Start(ctx); err != nil { return err }
 //
 // # Conventions

--- a/pkg/camera/manager.go
+++ b/pkg/camera/manager.go
@@ -1,0 +1,113 @@
+// Package camera exposes the camera Manager interface for external
+// (out-of-module) consumers, primarily the commercial P2P module that
+// needs to enumerate cameras, read status, and subscribe to media
+// frames for WebRTC tracks.
+//
+// The concrete implementation lives at internal/camera.CameraManager.
+// Adapters in internal/camera satisfy this interface.
+//
+// Mutating operations (Update, Add, Remove) are intentionally NOT
+// exposed here. Out-of-module callers may only OBSERVE camera state.
+// Configuration changes must go through the public REST API or CLI.
+package camera
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
+)
+
+// ErrCameraNotFound is returned when a camera with the given ID does not
+// exist or has been removed.
+var ErrCameraNotFound = errors.New("camera not found")
+
+// Camera is a single managed camera device.
+//
+// All accessors are safe to call concurrently. Values reflect a snapshot
+// at the time of the call; subsequent calls may return updated values
+// if the underlying configuration changed.
+type Camera interface {
+	// ID is the unique camera identifier (kebab-case, e.g. "front-door").
+	ID() string
+
+	// Name is the human-readable camera name (may be empty).
+	Name() string
+
+	// Protocol is the wire protocol used to ingest from this camera.
+	// Common values: "rtsp", "http_jpeg", "onvif", "xiaomi",
+	// "srt", "rtmp".
+	Protocol() string
+
+	// Encoding is the video codec ("h264", "h265", "mjpeg", "jpeg").
+	Encoding() string
+
+	// AudioEnabled reports whether audio capture is configured for
+	// this camera.
+	AudioEnabled() bool
+}
+
+// Status is a point-in-time snapshot of a camera's runtime state.
+//
+// FPS and BitrateKbps are computed over recent activity; they may be
+// zero for cameras that have not yet produced frames.
+type Status struct {
+	// ID is the camera ID this status refers to.
+	ID string
+
+	// Online reports whether the recorder is currently connected and
+	// producing frames.
+	Online bool
+
+	// Recording reports whether the camera is actively writing segments
+	// to disk.
+	Recording bool
+
+	// FPS is the measured video frame rate (frames per second).
+	FPS float64
+
+	// BitrateKbps is the measured video bitrate in kilobits per second.
+	BitrateKbps int
+
+	// Error is a non-empty string when the camera is in an error state
+	// (connection failure, authentication error, etc.). Empty when healthy.
+	Error string
+}
+
+// Manager manages the lifecycle and observation of all configured cameras.
+//
+// Implementations must be safe for concurrent use. The returned slices
+// and structs are safe to retain without copying.
+type Manager interface {
+	// List returns all configured cameras in arbitrary order.
+	// The returned slice is a fresh copy; callers may mutate it freely.
+	List() []Camera
+
+	// Get returns the camera with the given ID.
+	// Returns ErrCameraNotFound if no such camera exists.
+	Get(id string) (Camera, error)
+
+	// Status returns the runtime status of the camera with the given ID.
+	// Returns ErrCameraNotFound if no such camera exists.
+	Status(id string) (Status, error)
+
+	// Hub returns the frame distribution hub for the camera with the
+	// given ID. Multiple callers requesting Hub for the same camera
+	// receive the same Hub instance; each must Subscribe under a unique
+	// consumerID.
+	//
+	// Returns ErrCameraNotFound if no such camera exists.
+	Hub(id string) (streamhub.Hub, error)
+}
+
+// IsNotFound reports whether err is an ErrCameraNotFound.
+// Convenience helper for callers that wrap the error.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrCameraNotFound)
+}
+
+// NewNotFoundError returns an ErrCameraNotFound wrapped with the given
+// cameraID for context.
+func NewNotFoundError(cameraID string) error {
+	return fmt.Errorf("%w: %s", ErrCameraNotFound, cameraID)
+}

--- a/pkg/eventbus/bus.go
+++ b/pkg/eventbus/bus.go
@@ -1,0 +1,64 @@
+// Package eventbus exposes the pub/sub event Bus interface for external
+// (out-of-module) consumers, primarily the commercial P2P module that
+// needs to receive motion detection, camera status, and storage events
+// to push to mobile apps.
+//
+// The concrete implementation lives at internal/event.EventBus. Adapters
+// in internal/event satisfy this interface.
+//
+// # Standard topics (subject to expansion)
+//
+//   - "camera.started"           — camera began streaming
+//   - "camera.stopped"           — camera stopped streaming
+//   - "camera.error"             — camera error (data: CameraErrorDetail)
+//   - "motion.detected"          — motion was detected (data varies)
+//   - "segment.completed"        — recording segment finished
+//   - "segment.deleted"          — recording segment deleted
+//   - "storage.health.changed"   — disk health transition
+//   - "system.health.changed"    — system-wide health change
+//
+// Use SubscribeByPrefix("") to receive all events.
+package eventbus
+
+import "context"
+
+// Event is a single published event on the bus.
+//
+// Topic is the routing key (dot-separated, e.g. "camera.stopped").
+// Data is the event payload; consumers type-assert to the expected type
+// based on the topic. For topics with no payload, Data is nil.
+type Event struct {
+	Topic string
+	Data  any
+}
+
+// Bus is a topic-based pub/sub event bus.
+//
+// Subscriptions match either exact topic or a prefix. Channels buffer
+// events; if a channel is full when an event is published, the event is
+// dropped (non-blocking publish). All methods are safe for concurrent use.
+type Bus interface {
+	// Subscribe registers ch to receive events published to the exact
+	// topic. bufferSize controls the channel's capacity (events beyond
+	// capacity are dropped). Returns an error if ch is already
+	// registered for the topic.
+	Subscribe(topic string, ch chan Event, bufferSize int) error
+
+	// Unsubscribe removes ch from the given topic. Idempotent.
+	Unsubscribe(topic string, ch chan Event)
+
+	// SubscribeByPrefix registers ch for all topics starting with
+	// prefix. An empty prefix ("") matches all topics. bufferSize
+	// controls channel capacity.
+	SubscribeByPrefix(prefix string, ch chan Event, bufferSize int) error
+
+	// UnsubscribeByPrefix removes the prefix subscription. Idempotent.
+	UnsubscribeByPrefix(prefix string, ch chan Event)
+
+	// Publish sends an event to all matching subscribers (exact topic
+	// and prefix subscribers). Publish is non-blocking and never
+	// returns an error due to a full subscriber channel — events are
+	// silently dropped instead. The provided ctx is currently unused
+	// but reserved for future tracing/cancellation hooks.
+	Publish(ctx context.Context, topic string, data any)
+}

--- a/pkg/streamhub/hub.go
+++ b/pkg/streamhub/hub.go
@@ -1,0 +1,62 @@
+// Package streamhub exposes the frame distribution Hub interface for
+// external (out-of-module) consumers, primarily the commercial P2P module
+// that needs to subscribe to camera frames for WebRTC tracks.
+//
+// The concrete implementation lives at internal/model.StreamHub. Adapters
+// in internal/model satisfy this interface via HubBridge.
+package streamhub
+
+// FrameCallback is invoked for each video access unit.
+//
+//   - pts is the presentation timestamp in microseconds (clock rate 90000)
+//   - au is the access unit (one or more NAL units for H.264/H.265,
+//     or a full JPEG frame for MJPEG)
+//
+// Implementations MUST be non-blocking: if the hub's internal buffer is
+// full when the callback is invoked, frames are silently dropped to
+// protect the recording and streaming pipeline.
+type FrameCallback func(pts int64, au [][]byte)
+
+// AudioCallback is invoked for each decoded audio frame.
+//
+//   - pts is the presentation timestamp in microseconds
+//   - codec identifies the audio codec ("aac", "g711")
+//   - data is the raw audio payload
+//
+// Implementations MUST be non-blocking.
+type AudioCallback func(pts int64, codec string, data []byte)
+
+// Hub distributes frames from a single camera to multiple subscribers.
+//
+// Each camera has its own Hub instance. Subscribers register callbacks
+// under a unique consumerID; the same consumerID cannot subscribe twice
+// without first unsubscribing. Hubs are safe for concurrent use after
+// the camera recorder starts publishing.
+type Hub interface {
+	// Subscribe registers a video frame callback for the given consumer ID.
+	// Returns an error if consumerID is already registered.
+	Subscribe(consumerID string, cb FrameCallback) error
+
+	// Unsubscribe removes the video consumer with the given ID.
+	// Idempotent: calling with an unknown consumerID is a no-op.
+	Unsubscribe(consumerID string)
+
+	// SubscribeAudio registers an audio frame callback for the given
+	// consumer ID. Returns an error if already registered.
+	SubscribeAudio(consumerID string, cb AudioCallback) error
+
+	// UnsubscribeAudio removes the audio consumer with the given ID.
+	// Idempotent.
+	UnsubscribeAudio(consumerID string)
+
+	// Sends returns the count of frames successfully delivered to the
+	// given consumer. Returns 0 for unknown consumers.
+	Sends(consumerID string) int64
+
+	// Drops returns the count of frames dropped for the given consumer
+	// (buffer full, slow consumer). Returns 0 for unknown consumers.
+	Drops(consumerID string) int64
+
+	// ConsumerCount returns the current number of video subscribers.
+	ConsumerCount() int
+}


### PR DESCRIPTION
## Summary

Establishes a public extension API in `pkg/` so out-of-module consumers can use the NVR as a library. This is the core deliverable of the `refactor/pkg-app-extraction` branch — the other 4 PRs in this cleanup (#38–#41) split out unrelated features; this PR is the actual refactor.

### What lands
- **`pkg/app`** — `Service` interface + `App` orchestrator (deterministic start/stop ordering, rollback on failure, value registration for typed handles). 15 unit tests.
- **`pkg/camera`** — `Manager` + `Camera` read-only interfaces for out-of-module consumers
- **`pkg/streamhub`** — `Hub` interface + `FrameCallback`/`AudioCallback` types
- **`pkg/eventbus`** — `Bus` interface + `Event` type
- **`internal/camera/adapter.go`** — `AsPublic()` wrapper (`CameraManager` → `pkg/camera.Manager`, avoids method-name conflict)
- **`internal/model/adapter.go`** — `NewHubAdapter()` (`StreamHub` → `pkg/streamhub.Hub`)

### Compliance fix (chore commit)
- Delete `.gitmodules` — it pointed at a private gitea server (leaked internal IP + private repo name)
- `docs/MiBee-Projects` submodule reference removed (local dir preserved, now gitignored)
- Sanitize `pkg/app/doc.go`: "commercial" product name → generic "third-party extension" language

### What's NOT here (deliberately)
- Submodule-pointer bump commits are **dropped** (they advanced a private submodule — incompatible with the public repo)
- `pkg/app.RunFree()` extraction (`main.go` → `pkg/app/run.go`) — that's the next task (NVR-004), done on top of this PR

## Design notes

- Adapter pattern preserves existing `internal/` method signatures (no caller churn). When an internal type's method conflicts with a `pkg/` interface, a wrapper is added rather than renaming.
- `pkg/` is interface-only; implementations stay in `internal/`.

## Validation

- `go build ./...` — clean
- `go test ./pkg/... ./internal/camera/ ./internal/model/` — 216 passed, 0 failed