### PR TITLE
feat(cli): repair fragments — clean up merge-dead segments

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -41,6 +41,8 @@ func runRepair() int {
 		return runRepairDuration()
 	case "merge-status":
 		return runRepairMergeStatus()
+	case "fragments":
+		return runRepairFragments()
 	case "--help", "-h":
 		printRepairUsage()
 		return 0
@@ -366,6 +368,245 @@ func runRepairMergeStatus() int {
 	return 0
 }
 
+// ---------------------------------------------------------------------------
+// repair fragments — clean up segments the merge engine gave up on
+// ---------------------------------------------------------------------------
+
+// deadMergeStatuses are the merge_status values that mean the merge engine has
+// permanently given up on a segment. These accumulate as debris that rolling
+// merge will never retry (rolling.go marks them "incompatible so we don't retry
+// forever"). Live states (pending/merged/merging) must never be matched — the
+// CLI refuses them to avoid clobbering in-flight merges.
+var deadMergeStatuses = map[string]bool{
+	model.MergeStatusIncompatible: true,
+	model.MergeStatusFailed:       true,
+	model.MergeStatusDark:         true,
+}
+
+func runRepairFragments() int {
+	opts := parseRepairFlags(3)
+	if opts.configPath == "__help__" {
+		printRepairFragmentsUsage()
+		return 0
+	}
+
+	// Parse fragments-specific flags (in addition to the shared flags already
+	// parsed by parseRepairFlags: --execute/--dry-run/--camera/--limit/--config).
+	var statusStr string
+	var retry, forceDelete bool
+	for i := 3; i < len(os.Args); i++ {
+		switch os.Args[i] {
+		case "--retry":
+			retry = true
+		case "--force-delete":
+			forceDelete = true
+		case "--status":
+			if i+1 < len(os.Args) {
+				i++
+				statusStr = os.Args[i]
+			}
+		case "--help", "-h":
+			printRepairFragmentsUsage()
+			return 0
+		}
+	}
+
+	// Default status: incompatible (the most common debris). Comma-separated list allowed.
+	if statusStr == "" {
+		statusStr = model.MergeStatusIncompatible
+	}
+	statuses := splitCSV(statusStr)
+	for _, s := range statuses {
+		if !deadMergeStatuses[s] {
+			fmt.Fprintf(os.Stderr, "Error: --status %q is not a dead merge status.\n", s)
+			fmt.Fprintf(os.Stderr, "Allowed (segments the merge engine gave up on): incompatible, failed, dark.\n")
+			fmt.Fprintf(os.Stderr, "Live statuses (pending/merged/merging) are never cleared — they are still being processed.\n")
+			return 1
+		}
+	}
+	if retry && forceDelete {
+		fmt.Fprintln(os.Stderr, "Error: --retry and --force-delete are mutually exclusive.")
+		fmt.Fprintln(os.Stderr, "  --retry         reset to pending (give the merge engine another chance)")
+		fmt.Fprintln(os.Stderr, "  --force-delete  delete the DB row + file permanently")
+		return 1
+	}
+
+	db, _, err := openDBFromConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx, cancel := setupSignalHandler()
+	defer cancel()
+
+	mode := "DRY RUN (no changes)"
+	if !opts.dryRun {
+		mode = "EXECUTE"
+	}
+	action := "report only"
+	switch {
+	case retry:
+		action = "reset to pending (retry merge)"
+	case forceDelete:
+		action = "delete DB row + file"
+	}
+	fmt.Printf("repair fragments — %s — %s\n", mode, action)
+	fmt.Printf("  status filter: %s\n", statusStr)
+	if opts.cameraID != "" {
+		fmt.Printf("  camera:        %s\n", opts.cameraID)
+	}
+	if opts.limit > 0 {
+		fmt.Printf("  limit:         %d\n", opts.limit)
+	}
+	fmt.Println()
+
+	recs, err := db.ListRecordingsByMergeStatus(ctx, statuses, opts.cameraID, opts.limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing fragments: %v\n", err)
+		return 1
+	}
+	if len(recs) == 0 {
+		fmt.Println("No matching fragments found. Nothing to do.")
+		return 0
+	}
+
+	// Per-camera summary (count / total duration / total size).
+	type camStat struct {
+		count int
+		dur   float64
+		size  int64
+	}
+	byCam := map[string]*camStat{}
+	var totalDur float64
+	var totalSize int64
+	for _, r := range recs {
+		s := byCam[r.CameraID]
+		if s == nil {
+			s = &camStat{}
+			byCam[r.CameraID] = s
+		}
+		s.count++
+		s.dur += r.Duration
+		s.size += r.FileSize
+		totalDur += r.Duration
+		totalSize += r.FileSize
+	}
+	fmt.Printf("Found %d fragments across %d camera(s):\n\n", len(recs), len(byCam))
+	for cam, s := range byCam {
+		fmt.Printf("  %-40s %4d segments  %7.1f min  %6.2f GB\n", cam, s.count, s.dur/60, float64(s.size)/1024/1024/1024)
+	}
+	fmt.Printf("  %-40s %4d segments  %7.1f min  %6.2f GB\n", "TOTAL", len(recs), totalDur/60, float64(totalSize)/1024/1024/1024)
+	fmt.Println()
+
+	// Dry-run stops here (report only). --execute + (--retry|--force-delete) applies.
+	if !opts.dryRun && !retry && !forceDelete {
+		fmt.Println("No action specified. Re-run with --retry or --force-delete (and --execute) to act.")
+		fmt.Println("Dry run — no changes made.")
+		return 0
+	}
+	if opts.dryRun {
+		fmt.Println("Dry run — no changes made. Re-run with --execute (and --retry or --force-delete) to act.")
+		return 0
+	}
+
+	// --- Apply: retry (reset to pending) ---
+	if retry {
+		ids := make([]string, len(recs))
+		for i, r := range recs {
+			ids[i] = r.ID
+		}
+		// Chunk the reset to stay under SQLite's variable limit and bound lock time.
+		const chunkSize = 500
+		reset := 0
+		failed := 0
+		for start := 0; start < len(ids); start += chunkSize {
+			if ctx.Err() != nil {
+				break
+			}
+			end := start + chunkSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			chunk := ids[start:end]
+			if err := db.SetMergeStatus(ctx, chunk, model.MergeStatusPending); err != nil {
+				fmt.Fprintf(os.Stderr, "  reset failed for batch [%d:%d]: %v\n", start, end, err)
+				failed += len(chunk)
+				continue
+			}
+			reset += len(chunk)
+			fmt.Printf("  reset %d/%d to pending\n", reset, len(ids))
+		}
+		fmt.Println()
+		fmt.Printf("Summary: %d reset to pending, %d failed (of %d total)\n", reset, failed, len(recs))
+		if reset > 0 {
+			fmt.Println("The merge engine will retry these. If they fail again they'll be re-marked")
+			fmt.Println("incompatible — then re-run with --force-delete --execute to reclaim the space.")
+		}
+		return 0
+	}
+
+	// --- Apply: force-delete (DB row + file) ---
+	deleted := 0
+	deleteFailed := 0
+	var freedBytes int64
+	for i, r := range recs {
+		if ctx.Err() != nil {
+			break
+		}
+		// Delete the DB row first (source of truth), then best-effort the file.
+		if err := db.DeleteRecording(ctx, r.ID); err != nil {
+			fmt.Fprintf(os.Stderr, "  [%d/%d] DB DELETE FAILED %s: %v\n", i+1, len(recs), r.ID, err)
+			deleteFailed++
+			continue
+		}
+		freedBytes += r.FileSize
+		deleted++
+		// Best-effort file removal. FilePath may be a directory (MJPEG) or a file;
+		// either way os.RemoveAll handles both. Ignore errors — the DB row is gone,
+		// and an orphan file will be swept by the cleanup manager's orphan pass.
+		if r.FilePath != "" {
+			_ = os.RemoveAll(r.FilePath)
+		}
+		if deleted%50 == 0 || deleted == len(recs) {
+			fmt.Printf("  [%d/%d] deleted\n", deleted, len(recs))
+		}
+		// Throttle: avoid IO spikes on RPi/SD-card during large deletes.
+		select {
+		case <-time.After(20 * time.Millisecond):
+		case <-ctx.Done():
+		}
+	}
+	fmt.Println()
+	fmt.Printf("Summary: %d deleted (%.2f GB freed), %d failed (of %d total)\n",
+		deleted, float64(freedBytes)/1024/1024/1024, deleteFailed, len(recs))
+	return 0
+}
+
+// splitCSV splits a comma-separated string, trimming whitespace and dropping empties.
+func splitCSV(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			field := s[start:i]
+			// trim spaces
+			for len(field) > 0 && (field[0] == ' ' || field[0] == '\t') {
+				field = field[1:]
+			}
+			for len(field) > 0 && (field[len(field)-1] == ' ' || field[len(field)-1] == '\t') {
+				field = field[:len(field)-1]
+			}
+			if field != "" {
+				out = append(out, field)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}
+
 // estimateMJpegDirDuration estimates the duration of an MJPEG frame-directory
 // recording. ESP32 MiBeeCam stores JPEG frames in a directory (not a single MP4).
 // We count .jpg/.jpeg files in the directory and multiply by a nominal frame
@@ -418,6 +659,7 @@ allows concurrent access).
 Subcommands:
   duration       Fix recordings stuck at duration=0 by re-probing video files
   merge-status   Reset merge_status for recordings whose merged file is missing
+  fragments      Clean up segments the merge engine gave up on (incompatible/failed)
 
 Common options:
   --dry-run      Report what would change without modifying (default)
@@ -468,6 +710,60 @@ tool to avoid the per-boot full-table scan + per-file stat overhead.
 Options:
   --execute         Actually reset stale statuses (default: dry-run, report only)
   --dry-run         Report only, no changes (default)
+  --config <path>   Config file path (default: mibee-nvr.yaml)
+  --help, -h        Show this help
+`)
+}
+
+func printRepairFragmentsUsage() {
+	fmt.Print(`Usage: mibee-nvr repair fragments [options]
+
+Clean up recording segments the merge engine has permanently given up on.
+When MergeMP4Segments fails (e.g. SPS/PPS differ between segments after a
+camera reconnect), the rolling/periodic merge marks those segments
+merge_status='incompatible' so it doesn't retry forever. These accumulate as
+debris that will never be merged — they still occupy disk space and clutter
+the timeline. This command surfaces and clears them.
+
+By default it reports only (dry-run). Use one of the action flags with
+--execute to act:
+
+  --retry           Reset matched segments to 'pending', giving the merge
+                    engine another chance. Use this first — if the segments
+                    are actually fine and the failure was transient, they'll
+                    merge successfully and the debris clears itself.
+  --force-delete    Delete the DB row AND the underlying file permanently.
+                    Use this when --retry has already been tried and the
+                    segments still come back incompatible (genuinely corrupt
+                    / unplayable debris). Reclaims the disk space.
+
+Examples:
+  # See what debris exists and how much space it uses (no changes)
+  mibee-nvr repair fragments --config /path/to/mibee-nvr.yaml
+
+  # Give the merge engine another chance on a few segments first
+  mibee-nvr repair fragments --retry --execute --camera <id> --limit 5
+  # (watch the logs — if they merge, great; if they flip back to
+  #  incompatible, they're genuinely corrupt and should be deleted)
+
+  # Delete all incompatible debris across all cameras
+  mibee-nvr repair fragments --force-delete --execute
+
+  # Also include 'failed' and 'dark' segments (comma-separated)
+  mibee-nvr repair fragments --status incompatible,failed,dark --force-delete --execute
+
+Live merge states (pending/merged/merging) are NEVER matched — the tool
+refuses --status values that the merge engine is still actively processing.
+
+Options:
+  --execute         Actually apply the action (default: dry-run, report only)
+  --dry-run         Report only, no changes (default)
+  --retry           Reset matched segments to pending (merge engine retries)
+  --force-delete    Delete DB row + file permanently (mutually exclusive with --retry)
+  --status <list>   Comma-separated merge statuses to match
+                    (default: incompatible; allowed: incompatible, failed, dark)
+  --camera <id>     Only process this camera
+  --limit <n>       Max segments to process (0 = no limit; bounds IO on RPi)
   --config <path>   Config file path (default: mibee-nvr.yaml)
   --help, -h        Show this help
 `)

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -379,6 +379,50 @@ func (d *DB) ListMergedRecordingsForValidation(ctx context.Context) ([]*model.Re
 	return result, rows.Err()
 }
 
+// ListRecordingsByMergeStatus returns recordings matching one of the given
+// merge_status values (e.g. "incompatible", "failed", "dark"). Used by the
+// `repair fragments` CLI to surface segments the merge engine permanently gave
+// up on — those accumulate as un-mergeable debris that rolling merge will never
+// retry (rolling.go marks them "incompatible so we don't retry forever").
+//
+// cameraID == "" matches all cameras; limit <= 0 means no limit.
+// Results are ordered by started_at ASC so dry-run output reads chronologically.
+func (d *DB) ListRecordingsByMergeStatus(ctx context.Context, statuses []string, cameraID string, limit int) ([]*model.Recording, error) {
+	if len(statuses) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(statuses))
+	args := make([]any, 0, len(statuses)+2)
+	for i, s := range statuses {
+		placeholders[i] = "?"
+		args = append(args, s)
+	}
+	q := "SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merged, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived FROM recordings WHERE merge_status IN (" +
+		strings.Join(placeholders, ",") + ")"
+	if cameraID != "" {
+		q += " AND camera_id=?"
+		args = append(args, cameraID)
+	}
+	q += " ORDER BY started_at ASC"
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	}
+	rows, err := d.readConn().QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	recs, err := scanRecordingRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*model.Recording, len(recs))
+	for i := range recs {
+		result[i] = &recs[i]
+	}
+	return result, nil
+}
+
 // ResetMergeStatus clears merge_status and merge_path for a recording, reverting
 // it to its unmerged state so playback falls back to original frames.
 func (d *DB) ResetMergeStatus(ctx context.Context, id string) error {

--- a/internal/storage/db_merge_test.go
+++ b/internal/storage/db_merge_test.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListRecordingsByMergeStatus verifies the query used by `repair fragments`
+// to find segments the merge engine gave up on. Covers status filtering, camera
+// filtering, limit, and the empty-input no-op.
+func TestListRecordingsByMergeStatus(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_merge.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	now := time.Now().UTC()
+	// Insert 5 recordings across 2 cameras; we'll set distinct merge_status values.
+	recs := []*model.Recording{
+		{ID: "incompat-a", CameraID: "camA", FilePath: "/a1.mp4", Format: model.FormatH264, StartedAt: now, Duration: 11, FileSize: 100},
+		{ID: "incompat-b", CameraID: "camA", FilePath: "/a2.mp4", Format: model.FormatH264, StartedAt: now.Add(time.Second), Duration: 9, FileSize: 100},
+		{ID: "failed-a", CameraID: "camA", FilePath: "/a3.mp4", Format: model.FormatH264, StartedAt: now.Add(2 * time.Second), Duration: 7, FileSize: 100},
+		{ID: "incompat-c", CameraID: "camB", FilePath: "/b1.mp4", Format: model.FormatH264, StartedAt: now.Add(3 * time.Second), Duration: 13, FileSize: 100},
+		{ID: "pending-a", CameraID: "camA", FilePath: "/a4.mp4", Format: model.FormatH264, StartedAt: now.Add(4 * time.Second), Duration: 31, FileSize: 100},
+	}
+	for _, r := range recs {
+		require.NoError(t, db.InsertRecording(ctx, r))
+	}
+	// pending-a stays pending (InsertRecording default). Set the others.
+	require.NoError(t, db.SetMergeStatus(ctx, []string{"incompat-a", "incompat-b", "incompat-c"}, model.MergeStatusIncompatible))
+	require.NoError(t, db.SetMergeStatus(ctx, []string{"failed-a"}, model.MergeStatusFailed))
+
+	// 1. Filter by incompatible only — should return 3, ordered by started_at ASC.
+	t.Run("incompatible only", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusIncompatible}, "", 0)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		// ASC ordering: incompat-a (now) < incompat-b (+1s) < incompat-c (+3s)
+		require.Equal(t, "incompat-a", got[0].ID)
+		require.Equal(t, "incompat-b", got[1].ID)
+		require.Equal(t, "incompat-c", got[2].ID)
+		// Full row populated (FilePath needed by --force-delete to remove files).
+		require.Equal(t, "/a1.mp4", got[0].FilePath)
+		require.Equal(t, model.FormatH264, got[0].Format)
+	})
+
+	// 2. Multiple statuses: incompatible + failed = 4 (excludes pending-a).
+	t.Run("incompatible+failed", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusIncompatible, model.MergeStatusFailed}, "", 0)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+	})
+
+	// 3. Camera filter: camA incompatible = 2 (a, b); camB = 1 (c).
+	t.Run("camera filter", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusIncompatible}, "camA", 0)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		for _, r := range got {
+			require.Equal(t, "camA", r.CameraID)
+		}
+	})
+
+	// 4. Limit caps the result.
+	t.Run("limit", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusIncompatible}, "", 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	})
+
+	// 5. Pending is never returned by an incompatible query (the CLI relies on
+	//    this to avoid touching live segments the merge engine is still working on).
+	t.Run("excludes pending", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusIncompatible}, "", 0)
+		require.NoError(t, err)
+		for _, r := range got {
+			require.NotEqual(t, "pending-a", r.ID)
+		}
+	})
+
+	// 6. Empty status slice is a no-op (returns nil, nil — no SQL executed).
+	t.Run("empty status no-op", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, nil, "", 0)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	// 7. Non-matching status returns empty.
+	t.Run("no match", func(t *testing.T) {
+		got, err := db.ListRecordingsByMergeStatus(ctx, []string{model.MergeStatusDark}, "", 0)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}


### PR DESCRIPTION
## Summary

When `MergeMP4Segments` fails (e.g. SPS/PPS differ between segments after a camera reconnect), the rolling/periodic merge marks those segments `merge_status='incompatible'` so it doesn't retry forever. They accumulate as debris that will never be merged — still occupying disk space and cluttering the timeline. There was no operational way to clear them.

Adds a new `mibee-nvr repair fragments` subcommand:

- **Dry-run (default)**: lists debris by camera with count/duration/space totals.
- **`--retry`**: resets matched segments to `pending`, giving the merge engine another chance (use first — transient failures may succeed on retry).
- **`--force-delete`**: deletes the DB row + file permanently, reclaiming space (use when `--retry` has been tried and segments still come back incompatible).
- `--status` (default `incompatible`; allowed `incompatible`/`failed`/`dark`), `--camera`, `--limit` filters. Live states (`pending`/`merged`/`merging`) are refused to avoid clobbering in-flight merges.

Follows existing repair CLI conventions: dry-run default, `--execute` to apply, signal handler for graceful interrupt, IO throttle on deletes (20ms/segment — protects RPi SD card).

### Storage
New `ListRecordingsByMergeStatus(ctx, statuses, cameraID, limit)` returns full rows (FilePath etc. needed for deletion), ordered ASC. Mirrors `ListMergedRecordingsForValidation` / `ListZeroDurationRecordings` patterns.

## Production validation (Banana Pi M5)
```
$ mibee-nvr repair fragments --config mibee-nvr.yaml
Found 179 fragments across 3 camera(s):
  cam-4aeeef41   136 segments   757 min   7.92 GB
  cam-3bbed0e1    25 segments   113 min   0.02 GB
  cam-862ad991    18 segments    83 min   0.27 GB
  TOTAL          179 segments   953 min   8.21 GB
```
- ✅ Dry-run correctly identifies debris
- ✅ `--retry --execute --limit 5` reset 5 segments to pending (merge engine will retry)

Stacked on #60 (which it was developed and tested against).

## Test plan
- [x] `TestListRecordingsByMergeStatus`: 8 subtests (status/camera/limit/no-op/excludes-pending/no-match)
- [x] Go tests: 3863 passed
- [x] golangci-lint v2: 0 issues
- [x] Prod dry-run + retry verified