### PR TITLE
fix(merge): stop marking singletons as merged (fake-merged debris)

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -393,13 +393,15 @@ func runRepairFragments() int {
 	// Parse fragments-specific flags (in addition to the shared flags already
 	// parsed by parseRepairFlags: --execute/--dry-run/--camera/--limit/--config).
 	var statusStr string
-	var retry, forceDelete bool
+	var retry, forceDelete, resetFakeMerged bool
 	for i := 3; i < len(os.Args); i++ {
 		switch os.Args[i] {
 		case "--retry":
 			retry = true
 		case "--force-delete":
 			forceDelete = true
+		case "--reset-fake-merged":
+			resetFakeMerged = true
 		case "--status":
 			if i+1 < len(os.Args) {
 				i++
@@ -409,6 +411,18 @@ func runRepairFragments() int {
 			printRepairFragmentsUsage()
 			return 0
 		}
+	}
+
+	// --reset-fake-merged is a distinct operation mode: it targets segments
+	// marked merged but never actually merged (empty merge_path), resetting
+	// them to pending so the merge engine re-queues them. It does not use
+	// --status/--retry/--force-delete.
+	if resetFakeMerged {
+		if statusStr != "" || retry || forceDelete {
+			fmt.Fprintln(os.Stderr, "Error: --reset-fake-merged cannot be combined with --status/--retry/--force-delete.")
+			return 1
+		}
+		return runRepairFragmentsResetFakeMerged(opts)
 	}
 
 	// Default status: incompatible (the most common debris). Comma-separated list allowed.
@@ -584,6 +598,118 @@ func runRepairFragments() int {
 	return 0
 }
 
+// runRepairFragmentsResetFakeMerged handles `repair fragments --reset-fake-merged`:
+// finds segments marked merge_status='merged' but with an empty merge_path (the
+// rolling merge singleton fast-path marked them merged without actually merging),
+// and resets them to pending so the merge engine re-queues them for a real merge.
+//
+// This is the cleanup companion to the singleton-bug fix in rolling.go: existing
+// deployments already have thousands of these fake-merged fragments accumulated
+// before the fix. After resetting, a service restart (or waiting for periodic
+// merge) will re-merge them into proper long recordings.
+func runRepairFragmentsResetFakeMerged(opts repairOpts) int {
+	db, _, err := openDBFromConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx, cancel := setupSignalHandler()
+	defer cancel()
+
+	mode := "DRY RUN (no changes)"
+	if !opts.dryRun {
+		mode = "EXECUTE"
+	}
+	fmt.Printf("repair fragments --reset-fake-merged — %s\n", mode)
+	fmt.Printf("  target: merge_status='merged' with empty merge_path (never actually merged)\n")
+	if opts.cameraID != "" {
+		fmt.Printf("  camera: %s\n", opts.cameraID)
+	}
+	if opts.limit > 0 {
+		fmt.Printf("  limit:  %d\n", opts.limit)
+	}
+	fmt.Println()
+
+	recs, err := db.ListFakeMergedRecordings(ctx, opts.cameraID, opts.limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing fake-merged recordings: %v\n", err)
+		return 1
+	}
+	if len(recs) == 0 {
+		fmt.Println("No fake-merged recordings found. Nothing to do.")
+		return 0
+	}
+
+	// Per-camera summary (count / total duration / total size).
+	type camStat struct {
+		count int
+		dur   float64
+		size  int64
+	}
+	byCam := map[string]*camStat{}
+	var totalDur float64
+	var totalSize int64
+	for _, r := range recs {
+		s := byCam[r.CameraID]
+		if s == nil {
+			s = &camStat{}
+			byCam[r.CameraID] = s
+		}
+		s.count++
+		s.dur += r.Duration
+		s.size += r.FileSize
+		totalDur += r.Duration
+		totalSize += r.FileSize
+	}
+	fmt.Printf("Found %d fake-merged recordings across %d camera(s):\n\n", len(recs), len(byCam))
+	for cam, s := range byCam {
+		fmt.Printf("  %-40s %4d segments  %7.1f min  %6.2f GB\n", cam, s.count, s.dur/60, float64(s.size)/1024/1024/1024)
+	}
+	fmt.Printf("  %-40s %4d segments  %7.1f min  %6.2f GB\n", "TOTAL", len(recs), totalDur/60, float64(totalSize)/1024/1024/1024)
+	fmt.Println()
+
+	if opts.dryRun {
+		fmt.Println("Dry run — no changes made. Re-run with --execute to reset these to pending.")
+		fmt.Println("After resetting, restart the service (or wait for periodic merge) to re-merge them.")
+		return 0
+	}
+
+	// Reset to pending in chunks (SetMergeStatus batches internally).
+	ids := make([]string, len(recs))
+	for i, r := range recs {
+		ids[i] = r.ID
+	}
+	const chunkSize = 500
+	reset := 0
+	failed := 0
+	for start := 0; start < len(ids); start += chunkSize {
+		if ctx.Err() != nil {
+			break
+		}
+		end := start + chunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		if err := db.SetMergeStatus(ctx, chunk, model.MergeStatusPending); err != nil {
+			fmt.Fprintf(os.Stderr, "  reset failed for batch [%d:%d]: %v\n", start, end, err)
+			failed += len(chunk)
+			continue
+		}
+		reset += len(chunk)
+		fmt.Printf("  reset %d/%d to pending\n", reset, len(ids))
+	}
+	fmt.Println()
+	fmt.Printf("Summary: %d reset to pending, %d failed (of %d total)\n", reset, failed, len(recs))
+	if reset > 0 {
+		fmt.Println("Restart the service (or wait for the next periodic merge cycle) to re-merge these")
+		fmt.Println("into proper long recordings. They will now appear as pending on the timeline.")
+	}
+	return 0
+}
+
 // splitCSV splits a comma-separated string, trimming whitespace and dropping empties.
 func splitCSV(s string) []string {
 	var out []string
@@ -752,20 +878,36 @@ Examples:
   # Also include 'failed' and 'dark' segments (comma-separated)
   mibee-nvr repair fragments --status incompatible,failed,dark --force-delete --execute
 
-Live merge states (pending/merged/merging) are NEVER matched — the tool
-refuses --status values that the merge engine is still actively processing.
+Live merge states (pending/merged/merging) are NEVER matched by --status — the
+tool refuses values that the merge engine is still actively processing.
+
+--reset-fake-merged is a separate operation mode for a different class of debris:
+recordings marked merge_status='merged' but with an empty merge_path. These were
+marked "merged" by the rolling merge singleton fast-path (a batch with <2 valid
+segments) without actually being merged, permanently ejecting them from the merge
+queue. They show up as thousands of un-merged short fragments on the timeline.
+Resetting them to pending re-queues them for a real merge.
+
+  # Find fake-merged fragments (merged but never actually merged)
+  mibee-nvr repair fragments --reset-fake-merged
+
+  # Reset them to pending, then restart the service to re-merge
+  mibee-nvr repair fragments --reset-fake-merged --execute
+  sudo systemctl restart mibee-nvr
 
 Options:
-  --execute         Actually apply the action (default: dry-run, report only)
-  --dry-run         Report only, no changes (default)
-  --retry           Reset matched segments to pending (merge engine retries)
-  --force-delete    Delete DB row + file permanently (mutually exclusive with --retry)
-  --status <list>   Comma-separated merge statuses to match
-                    (default: incompatible; allowed: incompatible, failed, dark)
-  --camera <id>     Only process this camera
-  --limit <n>       Max segments to process (0 = no limit; bounds IO on RPi)
-  --config <path>   Config file path (default: mibee-nvr.yaml)
-  --help, -h        Show this help
+  --execute              Actually apply the action (default: dry-run, report only)
+  --dry-run              Report only, no changes (default)
+  --retry                Reset matched segments to pending (merge engine retries)
+  --force-delete         Delete DB row + file permanently (mutually exclusive with --retry)
+  --reset-fake-merged    Reset merged-but-not-actually-merged segments to pending
+                         (separate mode; cannot combine with --status/--retry/--force-delete)
+  --status <list>        Comma-separated merge statuses to match
+                         (default: incompatible; allowed: incompatible, failed, dark)
+  --camera <id>          Only process this camera
+  --limit <n>            Max segments to process (0 = no limit; bounds IO on RPi)
+  --config <path>        Config file path (default: mibee-nvr.yaml)
+  --help, -h             Show this help
 `)
 }
 

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -461,15 +461,9 @@ func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID stri
 				valid = append(valid, rec)
 			}
 			if len(valid) < 2 {
-				for _, rec := range valid {
-					if err := storage.RetryOnBusy(ctx, func() error {
-						return r.db.SetMergeStatus(ctx, []string{rec.ID}, model.MergeStatusMerged)
-					}); err != nil {
-						rollingLogger.Warn("backfill: failed to mark singleton",
-							"camera_id", cameraID, "recording_id", rec.ID, "error", err)
-					}
-					merged++
-				}
+				// Not enough segments to merge — leave pending (see comment in
+				// backfillBatchFormat). Marking singletons merged permanently
+				// ejected them from the merge queue.
 				continue
 			}
 
@@ -650,16 +644,18 @@ func (r *RollingMergeCoordinator) backfillBatchFormat(ctx context.Context, camer
 			valid = append(valid, rec)
 		}
 		if len(valid) < 2 {
-			// Not enough segments to merge — mark singletons as merged.
-			for _, rec := range valid {
-				if err := storage.RetryOnBusy(ctx, func() error {
-					return r.db.SetMergeStatus(ctx, []string{rec.ID}, model.MergeStatusMerged)
-				}); err != nil {
-					rollingLogger.Warn("backfill: failed to mark singleton",
-						"camera_id", cameraID, "recording_id", rec.ID, "error", err)
-				}
-				merged++
-			}
+			// Not enough segments to merge in this batch. Leave them pending —
+			// do NOT mark as merged. Marking singletons merged (the old behavior)
+			// permanently ejected them from the merge queue: backfill only selects
+			// pending segments, so a segment marked merged here would never be
+			// retried even when adjacent segments arrive later. This produced
+			// thousands of "fake merged" 30s fragments that cluttered the timeline
+			// (merge_status=merged but merge_path empty — never actually merged).
+			// Keeping them pending means the next backfill/periodic merge will
+			// reconsider them alongside any new neighbors.
+			rollingLogger.Debug("backfill: batch has <2 valid segments, leaving pending",
+				"camera_id", cameraID, "format", format,
+				"valid", len(valid), "missing", len(batch)-len(valid))
 			continue
 		}
 

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -474,16 +474,19 @@ func TestBackfillCamera_IncludeFailed(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, withFailed, 1, "failed segment should be included with includeFailed=true")
 
-	// Backfill with includeFailed=true should reset and merge it.
+	// Backfill with includeFailed=true resets it to pending. With only 1 segment
+	// there's nothing to merge — it's left pending (singleton fast-path removed:
+	// a lone segment is not falsely marked merged). It will merge when a neighbor
+	// arrives in a future backfill.
 	merged, err := r.BackfillCamera(context.Background(), cameraID, true)
 	require.NoError(t, err)
-	require.Equal(t, 1, merged, "should merge the previously-failed segment")
+	require.Equal(t, 0, merged, "single segment is not merged (left pending for retry with future neighbors)")
 
-	// Verify it's now merged.
+	// Verify it's now pending (reset from failed), NOT falsely merged.
 	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
-	require.Equal(t, model.MergeStatusMerged, recs[0].MergeStatus, "should be marked merged")
+	require.Equal(t, model.MergeStatusPending, recs[0].MergeStatus, "should be reset to pending, not falsely merged")
 }
 
 // ---------------------------------------------------------------------------
@@ -519,27 +522,21 @@ func TestBackfillCamera_MissingFileSkipped(t *testing.T) {
 	}
 	require.NoError(t, env.db.InsertRecording(context.Background(), missingRec))
 
-	// Backfill should skip the missing file and merge the good one.
+	// Backfill should skip the missing file. With only 1 valid segment left,
+	// there's nothing to merge — the singleton is left pending (NOT marked
+	// merged, which would permanently eject it from the merge queue — see the
+	// fake-merged bug fix in backfillMP4/backfillBatchFormat).
 	merged, err := r.BackfillCamera(context.Background(), cameraID, false)
 	require.NoError(t, err)
-	require.Equal(t, 1, merged, "should merge only the good segment")
+	require.Equal(t, 0, merged, "single valid segment is not merged (left pending for retry)")
 
-	// Verify: good segment merged, missing segment still pending (or gone).
+	// Verify: both segments remain pending — neither is falsely marked merged.
 	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
 	require.NoError(t, err)
-	// The good segment should be marked merged (status), the missing one should NOT be merged.
-	hasGoodMerged := false
-	hasPendingMissing := false
 	for _, rec := range recs {
-		if rec.ID == "good-rec" && rec.MergeStatus == model.MergeStatusMerged {
-			hasGoodMerged = true
-		}
-		if rec.ID == "missing-rec" && rec.MergeStatus != model.MergeStatusMerged {
-			hasPendingMissing = true
-		}
+		require.NotEqual(t, model.MergeStatusMerged, rec.MergeStatus,
+			"segment %s must not be marked merged (singleton fast-path removed)", rec.ID)
 	}
-	require.True(t, hasGoodMerged, "good segment should be marked merged")
-	require.True(t, hasPendingMissing, "missing-file segment should NOT be merged")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -423,6 +423,44 @@ func (d *DB) ListRecordingsByMergeStatus(ctx context.Context, statuses []string,
 	return result, nil
 }
 
+// ListFakeMergedRecordings returns recordings marked merge_status='merged' but
+// with an empty merge_path — i.e. segments that were marked "merged" by the
+// rolling merge singleton fast-path (when a batch had <2 valid segments) but
+// were never actually merged. These permanently fell out of the merge queue
+// (backfill only selects pending), accumulating as thousands of un-merged
+// short fragments that clutter the timeline.
+//
+// cameraID == "" matches all cameras; limit <= 0 means no limit.
+// Ordered by started_at ASC for chronological dry-run output.
+//
+// Reset these to pending (via SetMergeStatus) to re-queue them for merging.
+func (d *DB) ListFakeMergedRecordings(ctx context.Context, cameraID string, limit int) ([]*model.Recording, error) {
+	q := "SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merged, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived FROM recordings WHERE merge_status='merged' AND (merge_path IS NULL OR merge_path='')"
+	args := []any{}
+	if cameraID != "" {
+		q += " AND camera_id=?"
+		args = append(args, cameraID)
+	}
+	q += " ORDER BY started_at ASC"
+	if limit > 0 {
+		q += fmt.Sprintf(" LIMIT %d", limit)
+	}
+	rows, err := d.readConn().QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	recs, err := scanRecordingRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*model.Recording, len(recs))
+	for i := range recs {
+		result[i] = &recs[i]
+	}
+	return result, nil
+}
+
 // ResetMergeStatus clears merge_status and merge_path for a recording, reverting
 // it to its unmerged state so playback falls back to original frames.
 func (d *DB) ResetMergeStatus(ctx context.Context, id string) error {

--- a/internal/storage/db_merge_test.go
+++ b/internal/storage/db_merge_test.go
@@ -100,3 +100,62 @@ func TestListRecordingsByMergeStatus(t *testing.T) {
 		require.Empty(t, got)
 	})
 }
+
+// TestListFakeMergedRecordings verifies the query behind `repair fragments
+// --reset-fake-merged`: recordings marked merged but with an empty merge_path
+// (never actually merged by the singleton fast-path bug).
+func TestListFakeMergedRecordings(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_fake.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	now := time.Now().UTC()
+	// Three recordings: a real merge (has merge_path), a fake merge (no path),
+	// and a pending one. Only the fake merge should be returned.
+	recs := []*model.Recording{
+		{ID: "real-merged", CameraID: "camA", FilePath: "/src1.mp4", Format: model.FormatH264, StartedAt: now, Duration: 30, FileSize: 100},
+		{ID: "fake-merged", CameraID: "camA", FilePath: "/src2.mp4", Format: model.FormatH264, StartedAt: now.Add(time.Second), Duration: 30, FileSize: 100},
+		{ID: "pending-one", CameraID: "camA", FilePath: "/src3.mp4", Format: model.FormatH264, StartedAt: now.Add(2 * time.Second), Duration: 30, FileSize: 100},
+	}
+	for _, r := range recs {
+		require.NoError(t, db.InsertRecording(ctx, r))
+	}
+	// real-merged: mark merged WITH a merge_path (real merge output).
+	require.NoError(t, db.SetMergeResult(ctx, "real-merged", "/merged/output.mp4", "go"))
+	// fake-merged: mark merged but SetMergeStatus leaves merge_path empty (the bug).
+	require.NoError(t, db.SetMergeStatus(ctx, []string{"fake-merged"}, model.MergeStatusMerged))
+	// pending-one stays pending.
+
+	// 1. Only fake-merged is returned.
+	got, err := db.ListFakeMergedRecordings(ctx, "", 0)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "fake-merged", got[0].ID)
+	require.Equal(t, "", got[0].MergePath, "fake-merged has empty merge_path")
+
+	// 2. Camera filter works.
+	t.Run("camera filter", func(t *testing.T) {
+		got, err := db.ListFakeMergedRecordings(ctx, "camA", 0)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+	})
+
+	// 3. Non-matching camera returns empty.
+	t.Run("other camera", func(t *testing.T) {
+		got, err := db.ListFakeMergedRecordings(ctx, "camB", 0)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	// 4. After resetting fake-merged to pending, it's no longer returned.
+	t.Run("after reset to pending", func(t *testing.T) {
+		require.NoError(t, db.SetMergeStatus(ctx, []string{"fake-merged"}, model.MergeStatusPending))
+		got, err := db.ListFakeMergedRecordings(ctx, "", 0)
+		require.NoError(t, err)
+		require.Empty(t, got, "once reset to pending, it's no longer fake-merged")
+	})
+}


### PR DESCRIPTION
## Summary

The rolling merge backfill had a singleton fast-path that **permanently broke merging** for ~34% of recordings in production.

### The bug
When a backfill batch had `<2` valid segments (file temporarily unavailable, or a window-edge orphan), the code marked those lone segments `merge_status='merged'` to "mark them processed". But backfill only selects `pending` segments — so a segment marked `merged` here **permanently fell out of the merge queue** and would never be reconsidered, even when adjacent segments arrived later.

### Production impact
4647 "fake merged" fragments accumulated (34% of 13751 total recordings): `merge_status='merged'` but `merge_path` empty (never actually merged). Mostly ESP32 AVI/MJPEG 30s segments + H265 fragments. They showed up on the timeline as thousands of un-merged short clips — the user saw "4000+ recordings on July 18" when most were 30s fragments that should have been merged into a few long recordings.

### Fix
1. **rolling.go**: leave singletons `pending` instead of marking them `merged`. The next backfill/periodic merge reconsiders them alongside new neighbors. Applied to both `backfillMP4` (H264/H265) and `backfillBatchFormat` (AVI/MJPEG).
2. **`repair fragments --reset-fake-merged`**: cleanup for existing deployed databases — resets merged-but-no-merge_path recordings to pending so the merge engine re-queues them. New storage method `ListFakeMergedRecordings`.

## Test plan
- [x] Go tests: 3867 passed (49 packages)
- [x] golangci-lint v2: 0 issues
- [x] TestListFakeMergedRecordings: 4 subtests
- [x] Updated 2 backfill tests whose assertions encoded the old singleton-marked-merged behavior
- [ ] Prod validation: `repair fragments --reset-fake-merged` dry-run → should find ~4647 fake-merged; execute → restart → verify timeline shows fewer, longer recordings