### PR TITLE
feat(cli): repair fragments --max-duration for --reset-fake-merged

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -394,6 +394,7 @@ func runRepairFragments() int {
 	// parsed by parseRepairFlags: --execute/--dry-run/--camera/--limit/--config).
 	var statusStr string
 	var retry, forceDelete, resetFakeMerged bool
+	var maxDurationSec float64
 	for i := 3; i < len(os.Args); i++ {
 		switch os.Args[i] {
 		case "--retry":
@@ -402,6 +403,16 @@ func runRepairFragments() int {
 			forceDelete = true
 		case "--reset-fake-merged":
 			resetFakeMerged = true
+		case "--max-duration":
+			if i+1 < len(os.Args) {
+				i++
+				if v, err := parseFloat(os.Args[i]); err == nil && v > 0 {
+					maxDurationSec = v
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: invalid --max-duration %q (must be a positive number of seconds)\n", os.Args[i])
+					return 1
+				}
+			}
 		case "--status":
 			if i+1 < len(os.Args) {
 				i++
@@ -422,7 +433,7 @@ func runRepairFragments() int {
 			fmt.Fprintln(os.Stderr, "Error: --reset-fake-merged cannot be combined with --status/--retry/--force-delete.")
 			return 1
 		}
-		return runRepairFragmentsResetFakeMerged(opts)
+		return runRepairFragmentsResetFakeMerged(opts, maxDurationSec)
 	}
 
 	// Default status: incompatible (the most common debris). Comma-separated list allowed.
@@ -607,7 +618,7 @@ func runRepairFragments() int {
 // deployments already have thousands of these fake-merged fragments accumulated
 // before the fix. After resetting, a service restart (or waiting for periodic
 // merge) will re-merge them into proper long recordings.
-func runRepairFragmentsResetFakeMerged(opts repairOpts) int {
+func runRepairFragmentsResetFakeMerged(opts repairOpts, maxDurationSec float64) int {
 	db, _, err := openDBFromConfig(opts.configPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -624,6 +635,9 @@ func runRepairFragmentsResetFakeMerged(opts repairOpts) int {
 	}
 	fmt.Printf("repair fragments --reset-fake-merged — %s\n", mode)
 	fmt.Printf("  target: merge_status='merged' with empty merge_path (never actually merged)\n")
+	if maxDurationSec > 0 {
+		fmt.Printf("  max-duration: %.0fs (only short singleton fragments; long recordings left alone)\n", maxDurationSec)
+	}
 	if opts.cameraID != "" {
 		fmt.Printf("  camera: %s\n", opts.cameraID)
 	}
@@ -632,7 +646,7 @@ func runRepairFragmentsResetFakeMerged(opts repairOpts) int {
 	}
 	fmt.Println()
 
-	recs, err := db.ListFakeMergedRecordings(ctx, opts.cameraID, opts.limit)
+	recs, err := db.ListFakeMergedRecordings(ctx, opts.cameraID, opts.limit, maxDurationSec)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error listing fake-merged recordings: %v\n", err)
 		return 1
@@ -902,6 +916,10 @@ Options:
   --force-delete         Delete DB row + file permanently (mutually exclusive with --retry)
   --reset-fake-merged    Reset merged-but-not-actually-merged segments to pending
                          (separate mode; cannot combine with --status/--retry/--force-delete)
+  --max-duration <sec>   Only match segments shorter than this (with --reset-fake-merged).
+                         Targets singleton fragments while leaving long already-merged
+                         recordings (which legitimately have an empty merge_path) untouched.
+                         Recommended: 300 (5min) — singleton fragments are typically ≤60s.
   --status <list>        Comma-separated merge statuses to match
                          (default: incompatible; allowed: incompatible, failed, dark)
   --camera <id>          Only process this camera
@@ -916,4 +934,11 @@ func parseInt(s string) (int, error) {
 	var n int
 	_, err := fmt.Sscanf(s, "%d", &n)
 	return n, err
+}
+
+// parseFloat parses a float (e.g. "300" seconds) without importing strconv.
+func parseFloat(s string) (float64, error) {
+	var f float64
+	_, err := fmt.Sscanf(s, "%f", &f)
+	return f, err
 }

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -431,15 +431,22 @@ func (d *DB) ListRecordingsByMergeStatus(ctx context.Context, statuses []string,
 // short fragments that clutter the timeline.
 //
 // cameraID == "" matches all cameras; limit <= 0 means no limit.
+// maxDurationSec > 0 restricts to recordings with duration <= that value (used
+// to target singleton fragments while leaving long already-merged recordings
+// alone — some merged outputs legitimately have an empty merge_path).
 // Ordered by started_at ASC for chronological dry-run output.
 //
 // Reset these to pending (via SetMergeStatus) to re-queue them for merging.
-func (d *DB) ListFakeMergedRecordings(ctx context.Context, cameraID string, limit int) ([]*model.Recording, error) {
+func (d *DB) ListFakeMergedRecordings(ctx context.Context, cameraID string, limit int, maxDurationSec float64) ([]*model.Recording, error) {
 	q := "SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merged, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived FROM recordings WHERE merge_status='merged' AND (merge_path IS NULL OR merge_path='')"
 	args := []any{}
 	if cameraID != "" {
 		q += " AND camera_id=?"
 		args = append(args, cameraID)
+	}
+	if maxDurationSec > 0 {
+		q += " AND duration <= ?"
+		args = append(args, maxDurationSec)
 	}
 	q += " ORDER BY started_at ASC"
 	if limit > 0 {

--- a/internal/storage/db_merge_test.go
+++ b/internal/storage/db_merge_test.go
@@ -131,7 +131,7 @@ func TestListFakeMergedRecordings(t *testing.T) {
 	// pending-one stays pending.
 
 	// 1. Only fake-merged is returned.
-	got, err := db.ListFakeMergedRecordings(ctx, "", 0)
+	got, err := db.ListFakeMergedRecordings(ctx, "", 0, 0)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, "fake-merged", got[0].ID)
@@ -139,22 +139,36 @@ func TestListFakeMergedRecordings(t *testing.T) {
 
 	// 2. Camera filter works.
 	t.Run("camera filter", func(t *testing.T) {
-		got, err := db.ListFakeMergedRecordings(ctx, "camA", 0)
+		got, err := db.ListFakeMergedRecordings(ctx, "camA", 0, 0)
 		require.NoError(t, err)
 		require.Len(t, got, 1)
 	})
 
 	// 3. Non-matching camera returns empty.
 	t.Run("other camera", func(t *testing.T) {
-		got, err := db.ListFakeMergedRecordings(ctx, "camB", 0)
+		got, err := db.ListFakeMergedRecordings(ctx, "camB", 0, 0)
 		require.NoError(t, err)
 		require.Empty(t, got)
 	})
 
-	// 4. After resetting fake-merged to pending, it's no longer returned.
+	// 4. maxDuration filter: only returns fragments with duration <= the threshold.
+	// Useful for targeting singleton debris while leaving long already-merged
+	// recordings (which legitimately have an empty merge_path) untouched.
+	t.Run("maxDuration filter", func(t *testing.T) {
+		// fake-merged has duration=30s. A 60s threshold includes it; a 10s
+		// threshold (below 30s) excludes it.
+		got, err := db.ListFakeMergedRecordings(ctx, "", 0, 60)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "30s fragment passes a 60s threshold")
+		got, err = db.ListFakeMergedRecordings(ctx, "", 0, 10)
+		require.NoError(t, err)
+		require.Empty(t, got, "30s fragment excluded by a 10s threshold")
+	})
+
+	// 5. After resetting fake-merged to pending, it's no longer returned.
 	t.Run("after reset to pending", func(t *testing.T) {
 		require.NoError(t, db.SetMergeStatus(ctx, []string{"fake-merged"}, model.MergeStatusPending))
-		got, err := db.ListFakeMergedRecordings(ctx, "", 0)
+		got, err := db.ListFakeMergedRecordings(ctx, "", 0, 0)
 		require.NoError(t, err)
 		require.Empty(t, got, "once reset to pending, it's no longer fake-merged")
 	})


### PR DESCRIPTION
## Summary

Follow-up to #62. The `--reset-fake-merged` query matched two populations:
1. **Singleton fragments (≤60s)** — the debris from the fixed singleton-marking bug, should be reset.
2. **Long already-merged recordings (10min–2h)** — legitimate merged outputs with an empty merge_path (a historical quirk). Resetting these wastes IO and they're already proper recordings.

Adds `--max-duration <sec>` to scope the reset to short fragments only. Production data showed 4701 fake-merged recordings / 164 GB, but most of the 164 GB was long recordings (cam-5b24e253: 69 recordings >10min). With `--max-duration 300`, only the ~3500 actual singleton fragments get reset.

## Test plan
- [x] Go tests: 210 passed (storage)
- [x] TestListFakeMergedRecordings/maxDuration_filter subtest
- [ ] Prod: `repair fragments --reset-fake-merged --max-duration 300` dry-run