### PR TITLE
docs: de-emphasize Raspberry Pi in marketing positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Svelte](https://img.shields.io/badge/Svelte-FF3E00?style=flat&logo=svelte&logoColor=white)](https://svelte.dev/)
 [![SQLite](https://img.shields.io/badge/SQLite-003B57?style=flat&logo=sqlite&logoColor=white)](https://www.sqlite.org/)
 [![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)](https://www.docker.com/)
-[![Raspberry Pi](https://img.shields.io/badge/Raspberry_Pi-A22846?style=flat&logo=raspberrypi&logoColor=white)](https://www.raspberrypi.com/)
+[![ARM](https://img.shields.io/badge/ARM-0091BD?style=flat&logo=arm&logoColor=white)](https://www.arm.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat)](LICENSE)
 
-> **Turn any Raspberry Pi into a professional NVR in 60 seconds.**  
-> Single binary, zero dependencies, no cloud required. Runs on Raspberry Pi 3B with 512MB memory budget.
+> **Turn any low-power ARM device into a professional NVR in 60 seconds.**  
+> Single binary, zero dependencies, no cloud required. Runs on low-power ARM devices with a 512MB memory budget.
 
 > [**中文**](README.zh.md) — [English](README.md)
 
@@ -82,7 +82,7 @@ For detailed setup, see [Getting Started](docs/en/getting-started.md).
 ## Why MiBee NVR?
 
 - **Single Binary**: Zero dependencies, embedded Svelte 5 SPA, `CGO_ENABLED=0`
-- **Raspberry Pi 3B Ready**: Runs on 1GB RAM with 512MB memory budget
+- **Low-Power ARM Ready**: Runs on 1GB RAM with a 512MB memory budget (validated on Raspberry Pi 3B as the minimum baseline)
 - **Multi-Protocol Streaming**: HLS, WebRTC, HTTP-FLV, RTMP, SRT, WebSocket
 - **No Cloud Required**: Self-hosted, no subscriptions, no vendor lock-in
 - **Modern Web UI**: Dark/light themes, i18n support, responsive design

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,12 +6,12 @@
 [![Svelte](https://img.shields.io/badge/Svelte-FF3E00?style=flat&logo=svelte&logoColor=white)](https://svelte.dev/)
 [![SQLite](https://img.shields.io/badge/SQLite-003B57?style=flat&logo=sqlite&logoColor=white)](https://www.sqlite.org/)
 [![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white)](https://www.docker.com/)
-[![Raspberry Pi](https://img.shields.io/badge/Raspberry_Pi-A22846?style=flat&logo=raspberrypi&logoColor=white)](https://www.raspberrypi.com/)
+[![ARM](https://img.shields.io/badge/ARM-0091BD?style=flat&logo=arm&logoColor=white)](https://www.arm.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat)](LICENSE)
 
 轻量级、易上手的网络视频录像机，单文件部署，零配置烦恼——下载即用。
 
-专为树莓派及低功耗设备打造。支持主流协议：**RTSP**（H.264/H.265/MJPEG）、**HTTP JPEG**、**HLS** 直播流、**ONVIF** 设备发现、**WebRTC**（WHEP）、**HTTP-FLV**、**RTMP** 接入、**SRT** 接收器。
+专为低功耗 ARM 设备打造（在树莓派 3B 上验证最低配置）。支持主流协议：**RTSP**（H.264/H.265/MJPEG）、**HTTP JPEG**、**HLS** 直播流、**ONVIF** 设备发现、**WebRTC**（WHEP）、**HTTP-FLV**、**RTMP** 接入、**SRT** 接收器。
 
 [**English**](README.md)
 

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -248,7 +248,7 @@ tar xzf nvr-backup-20240101.tar.gz
 docker compose up -d
 ```
 
-#### Running on Raspberry Pi
+#### Running on ARM SBCs (e.g. Raspberry Pi)
 
 Raspberry Pi requires the ARM64 image:
 
@@ -453,7 +453,7 @@ server {
 }
 ```
 
-## RPi 3B Notes
+## Low-Memory Device Notes (e.g. RPi 3B)
 
 The Raspberry Pi 3B has 905MB RAM. For stable operation:
 

--- a/docs/en/docker-hardware-transcoding.md
+++ b/docs/en/docker-hardware-transcoding.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Hardware passthrough is essential for optimal transcoding performance in Docker containers. MiBee NVR supports multiple hardware acceleration paths: V4L2 M2M for Raspberry Pi, VAAPI for Intel/AMD GPUs, and NVENC for NVIDIA GPUs. This guide explains how to configure Docker to expose hardware devices to the container for maximum transcoding efficiency.
+Hardware passthrough is essential for optimal transcoding performance in Docker containers. MiBee NVR supports multiple hardware acceleration paths: VAAPI for Intel/AMD GPUs, NVENC for NVIDIA GPUs, and V4L2 M2M for Raspberry Pi. This guide explains how to configure Docker to expose hardware devices to the container for maximum transcoding efficiency.
 
 ## Raspberry Pi V4L2 M2M
 

--- a/docs/zh/deployment.md
+++ b/docs/zh/deployment.md
@@ -248,7 +248,7 @@ tar xzf nvr-backup-20240101.tar.gz
 docker compose up -d
 ```
 
-#### 在树莓派上使用 Docker
+#### 在 ARM 开发板上使用 Docker（如树莓派）
 
 树莓派需要使用 ARM64 架构镜像：
 
@@ -453,7 +453,7 @@ server {
 }
 ```
 
-## 树莓派 3B 注意事项
+## 低内存设备注意事项（如树莓派 3B）
 
 树莓派 3B 仅有 905MB 内存。为保证稳定运行：
 

--- a/docs/zh/docker-hardware-transcoding.md
+++ b/docs/zh/docker-hardware-transcoding.md
@@ -2,7 +2,7 @@
 
 ## 概述
 
-硬件直通对于 Docker 容器中的最佳转码性能至关重要。MiBee NVR 支持多种硬件加速路径：树莓派的 V4L2 M2M、Intel/AMD GPU 的 VAAPI，以及 NVIDIA GPU 的 NVENC。本指南介绍如何配置 Docker 以将硬件设备暴露给容器，以实现最大转码效率。
+硬件直通对于 Docker 容器中的最佳转码性能至关重要。MiBee NVR 支持多种硬件加速路径：Intel/AMD GPU 的 VAAPI、NVIDIA GPU 的 NVENC，以及树莓派的 V4L2 M2M。本指南介绍如何配置 Docker 以将硬件设备暴露给容器，以实现最大转码效率。
 
 ## 树莓派 V4L2 M2M
 


### PR DESCRIPTION
## Summary

The project has grown from a Raspberry-Pi-only NVR into a **cross-platform NVR** — x86 servers, Banana Pi, Synology NAS, Raspberry Pi, etc. are all target platforms now. But the README still led with Raspberry Pi as the flagship identity, giving users the impression it only runs on RPi. This PR demotes RPi from "the protagonist" to "one of many supported low-power ARM platforms."

Two motivations (both addressed):
1. **Product positioning expansion** — RPi is no longer the only target hardware.
2. **Eliminate the "RPi-only" misconception** — users hesitated to deploy on x86/NAS after reading the slogan.

## Scope

**Marketing surface only** — the first impression a new visitor gets. Technical constraint docs (where RPi 3B is the minimum-end validation baseline) are intentionally **untouched**.

## Changes (6 files, +12/-12)

### README.md
- **Badge**: `Raspberry Pi` → generic `ARM` (`logo=arm`, ARM blue `#0091BD`, links to arm.com)
- **Hero slogan**: `Turn any Raspberry Pi into a professional NVR...` → `Turn any low-power ARM device into a professional NVR...`
- **Sub-slogan**: `Runs on Raspberry Pi 3B with 512MB memory budget` → `Runs on low-power ARM devices with a 512MB memory budget`
- **"Why MiBee NVR?" bullet**: `Raspberry Pi 3B Ready` → `Low-Power ARM Ready: Runs on 1GB RAM with a 512MB memory budget (validated on Raspberry Pi 3B as the minimum baseline)`

### README.zh.md
- **Badge**: same ARM badge as EN
- **Positioning line**: `专为树莓派及低功耗设备打造` → `专为低功耗 ARM 设备打造（在树莓派 3B 上验证最低配置）`

### docs/en/deployment.md + docs/zh/deployment.md (section headers only, bodies unchanged)
- `#### Running on Raspberry Pi` → `#### Running on ARM SBCs (e.g. Raspberry Pi)`
- `## RPi 3B Notes` → `## Low-Memory Device Notes (e.g. RPi 3B)`
- (zh equivalents)

### docs/en/docker-hardware-transcoding.md + docs/zh/ (overview sentence only)
- Reorder capability list: ~~`V4L2 M2M for Raspberry Pi, VAAPI..., NVENC...`~~ → `VAAPI for Intel/AMD GPUs, NVENC for NVIDIA GPUs, and V4L2 M2M for Raspberry Pi` (generic GPU paths first, RPi-specific path last)

## Intentionally KEPT (technical surface)

These all reference RPi 3B as the **minimum-end validation baseline** — demoting them would lose valuable engineering constraint info:

- **configuration.md** (en+zh, ~14 mentions): all `# RPi constraint` / `# RPi 限制` annotations on config defaults (`max_streams=4`, `segment_duration<=30s`, `scan_interval>=30`, etc.)
- **deployment.md bodies** (en+zh): 905MB RAM note, `MemoryMax=512M`, `memory: 512m`, USB ext4 guidance, RPi 3B stable-operation checklist
- **storage-optimization.md / storage-research.md**: the canonical RPi 3B storage/IO performance baseline
- **architecture.md / relay-guide.md / camera-guide.md**: memory-footprint comparisons (`~5-10MB on RPi 3B`)
- **transcoding.md / metrics.md / timelapse.md / wasm-player-design.md**: resource-budget rationale
- **getting-started.md / troubleshooting.md**: RPi 3B optimized-config blocks & troubleshooting
- **AGENTS.md** (~20 mentions): gitignored dev-internal constraints (RPi 3B validation gate, `RPi_HOST` make var, engineering constraints) — never published, untouched
- **README download/cross-compile comments** (`# ARM64 (Raspberry Pi 4/5, etc.)`): RPi as install example is accurate and useful
- **onvif-guide.md**: `OV5647 Raspberry Pi Camera` — real test-camera product name
- **mediamtx-guide.md**: `rpicam-vid` / `rpiCamera` — MediaMTX literal identifiers, not project positioning

## Verification

```
README.md remaining RPi: 4 (all technical — download comments + "validated on RPi 3B" parenthetical)
README.zh.md remaining RPi: 3 (all technical)
AGENTS.md changed: 0 files
Technical content intact: 905MB / 512m / MemoryMax=512M / 30s all verified present
```

Total RPi mentions in docs (en+zh) unchanged at ~56 — only marketing phrasing moved.

## Test plan
- [x] No code changes — docs-only PR
- [x] grep verification: marketing surface neutralized, technical surface intact
- [x] ARM badge URL verified to render (`https://img.shields.io/badge/ARM-0091BD?style=flat&logo=arm&logoColor=white` → 200, logo SVG present)
- [ ] CI green (lint/build/test + frontend build)

No issue linked — this is a proactive positioning refactor, not a bug fix.

🤖 Generated with assistance from ZCode
