### PR TITLE
feat(webrtc): ICE/STUN/TURN config for cross-network access + remote-access docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Perfect for homelab enthusiasts. Self-hosted, no subscriptions, works with any R
 | [Prometheus Metrics](docs/en/metrics.md) | Complete Prometheus metric reference with types, labels, and examples |
 | [Relay Guide](docs/en/relay-guide.md) | RTMP live platform relay configuration and troubleshooting |
 | [转发指南](docs/zh/relay-guide.md) | RTMP 直播平台转发配置和故障排除 |
+| [Remote Access](docs/en/remote-access.md) | External/4G access via Tailscale, Cloudflare Tunnel, and WebRTC ICE/STUN/TURN config |
+| [远程访问](docs/zh/remote-access.md) | 外网/4G 访问:Tailscale、Cloudflare Tunnel 及 WebRTC ICE/STUN/TURN 配置 |
 
 ## Build & Deploy
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,14 @@ observability:
 #     enabled: true                   # Enable WebRTC WHEP streaming (default: true)
 #     max_viewers: 2                  # Max concurrent WebRTC viewers (range: 1-10, default: 2)
 #     idle_timeout: "60s"             # WebRTC viewer idle timeout (default: 60s)
+#     # Cross-network (WAN / 4G / remote WiFi) WebRTC access requires ICE servers.
+#     # Leave empty for LAN-only deployments (the default — preserves legacy behavior).
+#     # See docs/{zh,en}/remote-access.md for STUN/TURN setup and tunnel options.
+#     # ice_servers:
+#     #   - urls: ["stun:stun.l.google.com:19302"]            # public Google STUN
+#     #   - urls: ["turn:turn.example.com:3478?transport=udp"] # TURN needs creds
+#     #     username: "user"
+#     #     credential: "pass"
 #   flv:
 #     enabled: true                   # Enable HTTP-FLV streaming (default: true)
 #     max_viewers: 10                 # Max concurrent FLV viewers (range: 1-50, default: 10)

--- a/docs/en/remote-access.md
+++ b/docs/en/remote-access.md
@@ -1,0 +1,159 @@
+# Remote Access
+
+MiBee NVR serves on the LAN by default. This guide covers how to make the NVR reachable from **external networks (4G / remote WiFi / cross-region)**.
+
+> **This page covers only the minimal working configuration.** For advanced features of each tool (subnet routing, ACLs, exit nodes, custom certs), consult the tool's own documentation.
+
+---
+
+## Scenario Comparison
+
+| Method | Best for | Public IP? | Complexity | WebRTC | Notes |
+|--------|----------|-----------|------------|--------|-------|
+| Port forwarding / UPnP | Home with static public IP | ✅ Required | Low | ✅ Works | Simplest, but large attack surface — expose only the TLS port |
+| **Tailscale** | Personal / small team | ❌ No | Very low | ⚠️ See below | Recommended: zero-config mesh VPN, UDP hole-punching |
+| **Cloudflare Tunnel** | Sharing with others, no public IP | ❌ No | Medium | ❌ TCP only | Good for HLS, not WebRTC |
+| Self-hosted WireGuard | Advanced users wanting full control | ✅ Required | High | ✅ Works | Best performance, higher setup bar |
+| frp / ngrok | Temporary debugging, NAT traversal | Depends | Medium | Depends on mode | Not covered here — look them up |
+
+---
+
+## WebRTC Cross-Network Access (Must Read)
+
+WebRTC uses **UDP** by default and needs ICE servers (STUN/TURN) to traverse NAT. MiBee NVR's WebRTC (WHEP) only gathers mDNS host candidates in the default config — **LAN-only**.
+
+To watch video over WebRTC from outside the LAN, configure ICE servers in `mibee-nvr.yaml`:
+
+```yaml
+streaming:
+  webrtc:
+    enabled: true
+    ice_servers:
+      - urls: ["stun:stun.l.google.com:19302"]            # Public STUN (free)
+      - urls: ["turn:turn.example.com:3478?transport=udp"] # TURN relay (required for symmetric NAT)
+        username: "user"
+        credential: "pass"
+```
+
+- **STUN**: any free public server works for most NAT types (cone NAT).
+- **TURN**: required for symmetric NAT (common with carrier-grade NAT). TURN traffic consumes server bandwidth — consider self-hosting [coturn](https://github.com/coturn/coturn).
+- **TCP-only tunnels (e.g. Cloudflare Tunnel) cannot carry WebRTC UDP**: in that case switch the streaming protocol to HLS (`streaming.default_protocol: hls`) — HLS runs over HTTP/TCP and is tunnel-friendly.
+
+---
+
+## Option A: Tailscale (Recommended: Personal Use)
+
+[Tailscale](https://tailscale.com/) is a zero-config mesh VPN built on WireGuard. Once the NVR joins your tailnet, it's reachable at its assigned `100.x.x.x` address from anywhere — **no public IP, no port forwarding needed**.
+
+### Docker Compose Example
+
+Add a tailscale sidecar next to the NVR in your `docker-compose.yml`:
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    volumes:
+      - ./data:/data
+    network_mode: "service:tailscale"   # Key: share the tailscale network stack
+
+  tailscale:
+    image: tailscale/tailscale:latest
+    hostname: mibee-nvr                  # Device name in your tailnet
+    environment:
+      - TS_AUTHKEY=tskey-auth-xxxxx      # Get from https://login.tailscale.com/admin/settings/keys
+      - TS_STATE_DIR=/var/lib/tailscale
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+
+volumes:
+  tailscale-state:
+```
+
+After starting, the `mibee-nvr` device appears in the Tailscale admin console. Reach it from outside at `http://mibee-nvr:9090` (or its assigned IP).
+
+### Notes
+
+- **WebRTC + Tailscale**: Tailscale's UDP hole-punching usually lets WebRTC connect directly without STUN. But if all tailnet nodes sit behind symmetric NAT, you still need TURN.
+- **Auth key expiry**: free-tier auth keys expire after 90 days by default. For production, use a **preauthorized** + reusable key, or set the key to non-expiring in the admin console.
+- **HTTPS**: browser WebRTC (WHEP) needs a Secure Context. Tailscale ships HTTPS via MagicDNS + certs — enable it in the admin console to use `https://mibee-nvr.tail-xxxx.ts.net`.
+
+---
+
+## Option B: Cloudflare Tunnel (Recommended: No Public IP, Sharing)
+
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) reverse-proxies a local service to Cloudflare's edge via `cloudflared` — **no public IP, no open ports, HTTPS and DDoS protection included**. Ideal for sharing the NVR with non-technical users (they just visit a domain).
+
+### Docker Compose Example
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    volumes:
+      - ./data:/data
+    ports:
+      - "127.0.0.1:9090:9090"            # Bind localhost only — cloudflared proxies it
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=eyJhZxxxxx           # Create a tunnel in Cloudflare Zero Trust dashboard
+    depends_on:
+      - mibee-nvr
+```
+
+In the Cloudflare Zero Trust dashboard, point a subdomain (e.g. `nvr.example.com`) of the tunnel to `http://mibee-nvr:9090`.
+
+### ⚠️ Important Limitation: WebRTC Does Not Work
+
+Cloudflare Tunnel is **TCP-only** and cannot relay WebRTC's UDP media. Under this deployment:
+
+- ❌ WebRTC (WHEP) does not work
+- ✅ HLS / LL-HLS / HTTP-FLV / WebSocket streams (over HTTP) work normally
+- ✅ Playback, management API, and all non-WebRTC features work normally
+
+**Recommendation**: switch the default streaming protocol to HLS when deploying behind Cloudflare Tunnel:
+
+```yaml
+streaming:
+  default_protocol: hls   # or ll-hls
+```
+
+### Notes
+
+- **Auth**: Cloudflare Access Policies (zero-trust login) can be layered on top of the tunnel for stronger auth than BasicAuth.
+- **Bandwidth**: Cloudflare's free tier has bandwidth limits. Sustained multi-camera video may trip the ToS — evaluate a paid plan for production.
+
+---
+
+## Other Options
+
+These are not covered in detail here — see their official docs:
+
+- **WireGuard / OpenVPN**: self-hosted VPN, requires a public IP or VPS, best performance but higher setup bar.
+- **frp / ngrok**: NAT traversal, good for temporary debugging. frp needs a self-hosted frps; ngrok's free tier is limited.
+- **ZeroTier**: mesh VPN similar to Tailscale, supports self-hosted controllers.
+
+---
+
+## Limitations
+
+Each approach above requires the user to **maintain a third-party account, client, or server**, with its own trade-offs:
+
+- Tailscale's free tier caps device count (100)
+- Cloudflare Tunnel does not support WebRTC UDP
+- Self-hosted VPN requires a public IP and ops effort
+
+If these trade-offs are unacceptable for your use case, watch for future MiBee releases that improve the remote-access experience.
+
+---
+
+## Next Steps
+
+- After configuring ICE servers, verify STUN/TURN reachability at the [WebRTC trickle-ICE test page](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/).
+- After deployment, change the default admin password immediately and enable TLS (`server.tls_listen`).

--- a/docs/zh/remote-access.md
+++ b/docs/zh/remote-access.md
@@ -1,0 +1,159 @@
+# 远程访问 Remote Access
+
+MiBee NVR 默认只在局域网内提供服务。本文介绍如何让 NVR 在 **外部网络(4G / 远程 WiFi / 跨地域)** 下被访问。
+
+> **本文只覆盖最小可用配置**。每个工具的高级特性(子网路由、ACL、exit node、自建证书等)请参考对应工具的官方文档。
+
+---
+
+## 场景对比
+
+| 方案 | 适合场景 | 需要公网 IP | 复杂度 | WebRTC | 备注 |
+|------|---------|------------|--------|--------|------|
+| 端口转发 / UPnP | 家庭固定公网 IP | ✅ 需要 | 低 | ✅ 可用 | 最简单,但暴露面大,建议只开 TLS 端口 |
+| **Tailscale** | 个人/小团队自用 | ❌ 不需要 | 极低 | ⚠️ 见下文 | 推荐:零配置 mesh VPN,UDP 打洞 |
+| **Cloudflare Tunnel** | 分享给他人、无公网 IP | ❌ 不需要 | 中 | ❌ TCP only | 适合 HLS,不适合 WebRTC |
+| 自建 WireGuard | 高级用户、需要完全控制 | ✅ 需要 | 高 | ✅ 可用 | 性能最好,但配置门槛高 |
+| frp / ngrok | 临时调试、内网穿透 | 取决于部署 | 中 | 取决于模式 | 文档不在本文展开,请自查 |
+
+---
+
+## WebRTC 跨网访问(必读)
+
+WebRTC 默认走 **UDP**,需要 ICE 服务器(STUN/TURN)来穿越 NAT。MiBee NVR 的 WebRTC(WHEP)在默认配置下只收集 mDNS host candidate,**仅适用于局域网**。
+
+要在外网通过 WebRTC 看视频,需要在 `mibee-nvr.yaml` 中配置 ICE 服务器:
+
+```yaml
+streaming:
+  webrtc:
+    enabled: true
+    ice_servers:
+      - urls: ["stun:stun.l.google.com:19302"]            # 公共 STUN(免费)
+      - urls: ["turn:turn.example.com:3478?transport=udp"] # TURN 中继(对称 NAT 必须)
+        username: "user"
+        credential: "pass"
+```
+
+- **STUN**:免费公共服务器即可,适合大多数 NAT 类型(锥形 NAT)。
+- **TURN**:对称 NAT(symmetric NAT,运营商级 NAT 常见)必须用 TURN 中继。TURN 流量会消耗服务器带宽,建议自建 [coturn](https://github.com/coturn/coturn)。
+- **TCP-only tunnel(如 Cloudflare Tunnel)走不通 WebRTC UDP**:这种情况请改用 HLS 协议(`streaming.default_protocol: hls`),HLS 走 HTTP/TCP,tunnel 友好。
+
+---
+
+## 方案 A:Tailscale(推荐:个人自用)
+
+[Tailscale](https://tailscale.com/) 是基于 WireGuard 的零配置 mesh VPN。NVR 加入 tailnet 后,通过分配的 `100.x.x.x` IP 即可在外网访问,**不需要公网 IP,不需要端口转发**。
+
+### Docker Compose 示例
+
+在 NVR 的 `docker-compose.yml` 旁加一个 tailscale sidecar:
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    volumes:
+      - ./data:/data
+    network_mode: "service:tailscale"   # 关键:共享 tailscale 的网络栈
+
+  tailscale:
+    image: tailscale/tailscale:latest
+    hostname: mibee-nvr                  # 在 tailnet 里的设备名
+    environment:
+      - TS_AUTHKEY=tskey-auth-xxxxx      # 从 https://login.tailscale.com/admin/settings/keys 获取
+      - TS_STATE_DIR=/var/lib/tailscale
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+
+volumes:
+  tailscale-state:
+```
+
+启动后,在 Tailscale 管理后台可以看到 `mibee-nvr` 设备,通过 `http://mibee-nvr:9090`(或分配的 IP)即可在外网访问。
+
+### 配置要点
+
+- **WebRTC 与 Tailscale**:Tailscale 的 UDP 打洞通常能让 WebRTC 直连成功,无需额外配 STUN。但若你的 tailnet 节点都在对称 NAT 后,仍需配置 TURN。
+- **Auth key 过期**:免费版 auth key 默认 90 天过期,生产环境建议用 **preauthorized** + reusable key,或在管理后台设置 key 不过期。
+- **HTTPS**:浏览器 WebRTC(WHEP)需要 Secure Context。Tailscale 自带 HTTPS(MagicDNS + 证书),在管理后台启用即可用 `https://mibee-nvr.tail-xxxx.ts.net`。
+
+---
+
+## 方案 B:Cloudflare Tunnel(推荐:无公网 IP 分享访问)
+
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) 通过 `cloudflared` 把本地服务反代到 Cloudflare 边缘节点,**无需公网 IP,无需开放端口,自带 HTTPS 和 DDoS 防护**。适合把 NVR 分享给非技术用户(他们只需访问一个域名)。
+
+### Docker Compose 示例
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    volumes:
+      - ./data:/data
+    ports:
+      - "127.0.0.1:9090:9090"            # 只监听本地,由 cloudflared 反代
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel run
+    environment:
+      - TUNNEL_TOKEN=eyJhZxxxxx           # 从 Cloudflare Zero Trust 后台创建 tunnel 获取
+    depends_on:
+      - mibee-nvr
+```
+
+在 Cloudflare Zero Trust 后台把 tunnel 的某个子域名(如 `nvr.example.com`)指向 `http://mibee-nvr:9090`。
+
+### ⚠️ 重要限制:WebRTC 走不通
+
+Cloudflare Tunnel 是 **TCP-only**,无法转发 WebRTC 的 UDP 媒体流。在这种部署下:
+
+- ❌ WebRTC(WHEP)无法工作
+- ✅ HLS / LL-HLS / HTTP-FLV / WebSocket 流(走 HTTP)正常工作
+- ✅ 回放、管理 API、所有非 WebRTC 功能正常
+
+**建议**:Cloudflare Tunnel 部署时把默认流协议改为 HLS:
+
+```yaml
+streaming:
+  default_protocol: hls   # 或 ll-hls
+```
+
+### 配置要点
+
+- **认证**:Cloudflare 后台可给 tunnel 加 Access Policy(零信任登录),比 BasicAuth 更安全。
+- **带宽**:Cloudflare 免费版对带宽有限制,长时间多路视频流可能触发 ToS,生产环境建议评估付费计划。
+
+---
+
+## 其他方案
+
+下列方案不在本文展开,请参考官方文档:
+
+- **WireGuard / OpenVPN**:自建 VPN,需要公网 IP 或 VPS,性能最好但配置门槛高。
+- **frp / ngrok**:内网穿透,适合临时调试。frp 需要自建 frps 服务器,ngrok 免费版有限制。
+- **ZeroTier**:类似 Tailscale 的 mesh VPN,可自建 controller。
+
+---
+
+## 局限性
+
+上述方案都需要用户**自行维护第三方账号、客户端或服务器**,且各有妥协:
+
+- Tailscale 免费版有设备数限制(100 台)
+- Cloudflare Tunnel 不支持 WebRTC UDP
+- 自建 VPN 需要公网 IP 和运维
+
+如果这些方案的妥协对你不可接受,可以关注 MiBee 后续版本对远程访问体验的改进。
+
+---
+
+## 下一步
+
+- 配置 ICE 服务器后,可在 [WebRTC 测试页](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/) 验证 STUN/TURN 是否生效。
+- 部署后建议立即修改默认 admin 密码,并启用 TLS(`server.tls_listen`)。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -379,9 +379,19 @@ type StreamingConfig struct {
 
 // WebRTCConfig configures WebRTC WHEP streaming
 type WebRTCConfig struct {
-	Enabled     *bool  `yaml:"enabled"`      // default true
-	MaxViewers  int    `yaml:"max_viewers"`  // default 2, range [1,10]
-	IdleTimeout string `yaml:"idle_timeout"` // default "60s"
+	Enabled     *bool             `yaml:"enabled"`               // default true
+	MaxViewers  int               `yaml:"max_viewers"`           // default 2, range [1,10]
+	IdleTimeout string            `yaml:"idle_timeout"`          // default "60s"
+	ICEServers  []ICEServerConfig `yaml:"ice_servers,omitempty"` // STUN/TURN for cross-network access; empty = LAN-only (default)
+}
+
+// ICEServerConfig describes a single STUN/TURN server used for cross-network
+// (WAN/4G/remote WiFi) WebRTC access. Leave streaming.webrtc.ice_servers empty
+// for LAN-only deployments — this preserves the legacy behavior.
+type ICEServerConfig struct {
+	URLs       []string `yaml:"urls"`                 // required, e.g. ["stun:stun.l.google.com:19302"] or ["turn:turn.example.com:3478?transport=udp"]
+	Username   string   `yaml:"username,omitempty"`   // TURN only
+	Credential string   `yaml:"credential,omitempty"` // TURN only
 }
 
 // FLVConfig configures HTTP-FLV streaming
@@ -1126,6 +1136,17 @@ func Validate(cfg *Config) error {
 	}
 	if _, err := time.ParseDuration(cfg.Streaming.WebRTC.IdleTimeout); err != nil {
 		return fmt.Errorf("streaming.webrtc.idle_timeout invalid: %w", err)
+	}
+	// Validate WebRTC ICE servers (for cross-network access). Empty = LAN-only.
+	for i, s := range cfg.Streaming.WebRTC.ICEServers {
+		if len(s.URLs) == 0 {
+			return fmt.Errorf("streaming.webrtc.ice_servers[%d].urls is required", i)
+		}
+		for _, u := range s.URLs {
+			if !strings.HasPrefix(u, "stun:") && !strings.HasPrefix(u, "turn:") && !strings.HasPrefix(u, "turns:") {
+				return fmt.Errorf("streaming.webrtc.ice_servers[%d].urls: %q must start with stun:/turn:/turns:", i, u)
+			}
+		}
 	}
 	if _, err := time.ParseDuration(cfg.Streaming.FLV.IdleTimeout); err != nil {
 		return fmt.Errorf("streaming.flv.idle_timeout invalid: %w", err)

--- a/internal/config/config_webrtc_test.go
+++ b/internal/config/config_webrtc_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateWebRTCICEServers_Valid covers the happy paths for the new
+// streaming.webrtc.ice_servers section: empty (LAN-only), STUN-only, TURN,
+// and TURNS (TLS) are all accepted.
+func TestValidateWebRTCICEServers_Valid(t *testing.T) {
+	valid := []struct {
+		name    string
+		servers []ICEServerConfig
+	}{
+		{"empty (LAN-only)", nil},
+		{"stun only", []ICEServerConfig{{URLs: []string{"stun:stun.l.google.com:19302"}}}},
+		{"turn with creds", []ICEServerConfig{{
+			URLs:       []string{"turn:turn.example.com:3478?transport=udp"},
+			Username:   "user",
+			Credential: "pass",
+		}}},
+		{"turns (TLS)", []ICEServerConfig{{URLs: []string{"turns:turn.example.com:5349"}}}},
+		{"multiple", []ICEServerConfig{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+			{URLs: []string{"turn:turn.example.com:3478"}, Username: "u", Credential: "p"},
+		}},
+	}
+	for _, tc := range valid {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Streaming: StreamingConfig{WebRTC: WebRTCConfig{ICEServers: tc.servers}}}
+			cfg.ApplyDefaults()
+			assert.NoError(t, Validate(cfg))
+		})
+	}
+}
+
+// TestValidateWebRTCICEServers_Invalid covers rejection cases.
+func TestValidateWebRTCICEServers_Invalid(t *testing.T) {
+	invalid := []struct {
+		name    string
+		servers []ICEServerConfig
+		want    string
+	}{
+		{"empty URLs", []ICEServerConfig{{URLs: nil}}, "urls is required"},
+		{"wrong scheme", []ICEServerConfig{{URLs: []string{"http://example.com"}}}, "must start with stun:/turn:/turns:"},
+		{"empty string URL", []ICEServerConfig{{URLs: []string{""}}}, "must start with stun:/turn:/turns:"},
+		{"stun with bad scheme mix", []ICEServerConfig{{
+			URLs: []string{"stun:stun.l.google.com:19302", "ftp://bad"},
+		}}, "must start with stun:/turn:/turns:"},
+	}
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Streaming: StreamingConfig{WebRTC: WebRTCConfig{ICEServers: tc.servers}}}
+			cfg.ApplyDefaults()
+			err := Validate(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+// TestWebRTCICEServersDefaultsUnchanged verifies that leaving ice_servers empty
+// (the documented LAN-only default) does not change legacy WebRTC config
+// behavior — Enabled stays true, MaxViewers stays 2, IdleTimeout stays "60s".
+func TestWebRTCICEServersDefaultsUnchanged(t *testing.T) {
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	require.NotNil(t, cfg.Streaming.WebRTC.Enabled)
+	assert.True(t, *cfg.Streaming.WebRTC.Enabled, "WebRTC should default to enabled")
+	assert.Equal(t, 2, cfg.Streaming.WebRTC.MaxViewers)
+	assert.Equal(t, "60s", cfg.Streaming.WebRTC.IdleTimeout)
+	assert.Nil(t, cfg.Streaming.WebRTC.ICEServers, "ICE servers must default to nil (LAN-only)")
+}
+
+// TestWebRTCICEServersRoundTrip ensures ice_servers survives a YAML save+load
+// cycle, so users can configure TURN credentials persistently.
+func TestWebRTCICEServersRoundTrip(t *testing.T) {
+	src := &Config{
+		Storage: StorageConfig{RootDir: "/tmp/nvr"},
+		Auth:    AuthConfig{Username: "u", PasswordHash: "$2a$10$x"},
+		Streaming: StreamingConfig{
+			DefaultProtocol: "hls",
+			WebRTC: WebRTCConfig{
+				ICEServers: []ICEServerConfig{
+					{URLs: []string{"stun:stun.l.google.com:19302"}},
+					{URLs: []string{"turn:turn.example.com:3478"}, Username: "u", Credential: "p"},
+				},
+			},
+		},
+	}
+	src.ApplyDefaults()
+
+	path := t.TempDir() + "/cfg.yaml"
+	require.NoError(t, Save(path, src))
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	require.Len(t, loaded.Streaming.WebRTC.ICEServers, 2)
+	assert.Equal(t, []string{"stun:stun.l.google.com:19302"}, loaded.Streaming.WebRTC.ICEServers[0].URLs)
+	assert.Equal(t, "u", loaded.Streaming.WebRTC.ICEServers[1].Username)
+	assert.Equal(t, "p", loaded.Streaming.WebRTC.ICEServers[1].Credential)
+
+	// Sanity check Validate passes on the loaded config.
+	assert.NoError(t, Validate(loaded))
+}
+
+// TestWebRTCICEServersOmittedFromYAMLWhenEmpty guards against accidentally
+// serializing an empty ice_servers: [] key (keeps the example diff minimal).
+func TestWebRTCICEServersOmittedFromYAMLWhenEmpty(t *testing.T) {
+	cfg := &Config{Storage: StorageConfig{RootDir: "/tmp/nvr"}}
+	cfg.ApplyDefaults()
+	path := t.TempDir() + "/cfg.yaml"
+	require.NoError(t, Save(path, cfg))
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	raw := string(b)
+	assert.False(t, strings.Contains(raw, "ice_servers"),
+		"empty ice_servers must be omitted from YAML (omitempty), got:\n%s", raw)
+}

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -167,7 +167,8 @@ type Manager struct {
 	maxPeers     int
 	idleTimeout  time.Duration
 	frameBufSize int
-	drainWg      sync.WaitGroup // tracks RTCP drain goroutines for clean shutdown
+	iceServers   []webrtc.ICEServer // STUN/TURN servers for cross-network ICE; nil = LAN-only
+	drainWg      sync.WaitGroup     // tracks RTCP drain goroutines for clean shutdown
 	mets         *metrics.Metrics
 }
 
@@ -211,6 +212,15 @@ func withFrameBufSize(n int) ManagerOption {
 func WithMetrics(m *metrics.Metrics) ManagerOption {
 	return func(mgr *Manager) {
 		mgr.mets = m
+	}
+}
+
+// WithICEServers sets STUN/TURN servers used when creating PeerConnections.
+// This enables cross-network (WAN/4G/remote WiFi) WHEP access. Leave empty for
+// LAN-only deployments (preserves the legacy behavior).
+func WithICEServers(servers []webrtc.ICEServer) ManagerOption {
+	return func(m *Manager) {
+		m.iceServers = servers
 	}
 }
 
@@ -371,8 +381,12 @@ func (m *Manager) CreateWHEPSession(camID string, offerSDP []byte) (answerSDP []
 		return nil, "", ErrMaxPeersReached
 	}
 
-	// Create PeerConnection via shared API factory
-	pc, err := m.api.NewPeerConnection(webrtc.Configuration{})
+	// Create PeerConnection via shared API factory. ICEServers is populated from
+	// config when configured for cross-network access; empty (nil) preserves the
+	// legacy LAN-only behavior.
+	pc, err := m.api.NewPeerConnection(webrtc.Configuration{
+		ICEServers: m.iceServers,
+	})
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/webrtc/manager_ice_test.go
+++ b/internal/webrtc/manager_ice_test.go
@@ -1,0 +1,94 @@
+package webrtc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithICEServersStoresConfig verifies the WithICEServers option populates
+// the Manager's iceServers field — the field that feeds every PeerConnection
+// created in CreateWHEPSession. This is the config→runtime contract: empty
+// input keeps the legacy LAN-only behavior (nil), non-empty input is stored
+// verbatim.
+func TestWithICEServersStoresConfig(t *testing.T) {
+	t.Run("nil preserves LAN-only default", func(t *testing.T) {
+		mgr := NewManager()
+		defer mgr.StopAll()
+		assert.Nil(t, mgr.iceServers, "no option = nil = LAN-only (legacy default)")
+	})
+
+	t.Run("empty slice preserves LAN-only default", func(t *testing.T) {
+		mgr := NewManager(WithICEServers(nil))
+		defer mgr.StopAll()
+		assert.Nil(t, mgr.iceServers, "nil input must keep legacy LAN-only behavior")
+	})
+
+	t.Run("stun server stored", func(t *testing.T) {
+		servers := []webrtc.ICEServer{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+		}
+		mgr := NewManager(WithICEServers(servers))
+		defer mgr.StopAll()
+		require.Len(t, mgr.iceServers, 1)
+		assert.Equal(t, []string{"stun:stun.l.google.com:19302"}, mgr.iceServers[0].URLs)
+	})
+
+	t.Run("turn server with creds stored", func(t *testing.T) {
+		servers := []webrtc.ICEServer{{
+			URLs:           []string{"turn:turn.example.com:3478"},
+			Username:       "user",
+			Credential:     "pass",
+			CredentialType: webrtc.ICECredentialTypePassword,
+		}}
+		mgr := NewManager(WithICEServers(servers))
+		defer mgr.StopAll()
+		require.Len(t, mgr.iceServers, 1)
+		assert.Equal(t, "user", mgr.iceServers[0].Username)
+		assert.Equal(t, "pass", mgr.iceServers[0].Credential)
+		assert.Equal(t, webrtc.ICECredentialTypePassword, mgr.iceServers[0].CredentialType)
+	})
+}
+
+// TestWHEPSessionWithICEServers verifies end-to-end that an ICE-server-configured
+// Manager still produces a valid SDP answer (the WHEP path must not break when
+// ice_servers is populated). We cannot assert the browser actually reaches a
+// public STUN server from a unit test, but we CAN assert the answer SDP still
+// contains a video m-line + H.264 codec — i.e. ICE config injection did not
+// corrupt the offer/answer exchange.
+func TestWHEPSessionWithICEServers(t *testing.T) {
+	mgr := NewManager(WithICEServers([]webrtc.ICEServer{
+		{URLs: []string{"stun:stun.l.google.com:19302"}},
+	}))
+	defer mgr.StopAll()
+
+	client := newTestClient(t, false)
+	defer client.close()
+
+	offerSDP := createOfferSDP(t, client.pc)
+	answerSDP, sessionID := connectWHEP(t, mgr, "ice-cam", client.pc, offerSDP)
+
+	// The answer must still be a well-formed H.264 WHEP answer.
+	assert.True(t, strings.Contains(string(answerSDP), "m=video"),
+		"answer should contain video m-line even with ICE servers configured")
+	assert.NotEmpty(t, sessionID)
+	assert.Equal(t, 1, mgr.activePeerCount("ice-cam"))
+}
+
+// TestWHEPSessionWithoutICEServersIsBackwardCompatible is a regression guard:
+// a Manager created with zero options (the legacy code path in run.go before
+// this feature) must still work identically.
+func TestWHEPSessionWithoutICEServersIsBackwardCompatible(t *testing.T) {
+	mgr := NewManager() // no WithICEServers — legacy path
+	defer mgr.StopAll()
+
+	client := newTestClient(t, false)
+	defer client.close()
+
+	offerSDP := createOfferSDP(t, client.pc)
+	answerSDP, _ := connectWHEP(t, mgr, "legacy-cam", client.pc, offerSDP)
+	assert.True(t, strings.Contains(string(answerSDP), "m=video"))
+}

--- a/internal/wsstream/manager_test.go
+++ b/internal/wsstream/manager_test.go
@@ -368,6 +368,15 @@ func TestServeWS_MaxViewers(t *testing.T) {
 	_, err = readMessage(t, conn1)
 	require.NoError(t, err)
 
+	// Wait until conn1 is actually registered in the viewer map before dialing
+	// conn2. ServeWS writes the init sequence (SPS/PPS) BEFORE registering the
+	// viewer (manager.go ~line 545), so readMessage returning does NOT guarantee
+	// the viewer count has been incremented. Under -race on loaded CI runners,
+	// conn2's dial could pass the maxViewers check before conn1's registration
+	// completed — a flaky failure. Polling viewerCount closes this window.
+	eventually(t, func() bool { return m.viewerCount("cam1") == 1 },
+		2*time.Second, 10*time.Millisecond)
+
 	dialer := websocket.Dialer{}
 	_, resp, err := dialer.Dial(wsURL, nil)
 	assert.True(t, err != nil || (resp != nil && resp.StatusCode != http.StatusSwitchingProtocols),

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -47,6 +47,8 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 
 	_ "github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
+
+	pionwebrtc "github.com/pion/webrtc/v4"
 )
 
 // serviceFunc wraps a pair of start/stop functions as a Service.
@@ -70,6 +72,26 @@ func aiConfigFromConfig(cfg config.AIConfig) ai.Config {
 		FrameSkipRate:       cfg.FrameSkipRate,
 		ConfidenceThreshold: cfg.ConfidenceThreshold,
 	}
+}
+
+// webrtcICEServers converts the config-layer ICE server list to pion's type.
+// Returns nil when empty so the WebRTC Manager falls back to LAN-only behavior
+// (no STUN/TURN, mDNS host candidates only) — preserving the legacy default.
+func webrtcICEServers(servers []config.ICEServerConfig) []pionwebrtc.ICEServer {
+	if len(servers) == 0 {
+		return nil
+	}
+	out := make([]pionwebrtc.ICEServer, 0, len(servers))
+	for _, s := range servers {
+		ic := pionwebrtc.ICEServer{URLs: s.URLs}
+		if s.Username != "" {
+			ic.Username = s.Username
+			ic.Credential = s.Credential
+			ic.CredentialType = pionwebrtc.ICECredentialTypePassword
+		}
+		out = append(out, ic)
+	}
+	return out
 }
 
 // buildRouter constructs the chi HTTP router with all middleware, routes, mounts,
@@ -436,8 +458,12 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 			webrtc.WithMaxPeers(cfg.Streaming.WebRTC.MaxViewers),
 			webrtc.WithIdleTimeout(idleTimeout),
 			webrtc.WithMetrics(metrics),
+			webrtc.WithICEServers(webrtcICEServers(cfg.Streaming.WebRTC.ICEServers)),
 		)
-		slog.Info("WebRTC manager initialized", "max_viewers", cfg.Streaming.WebRTC.MaxViewers)
+		slog.Info("WebRTC manager initialized",
+			"max_viewers", cfg.Streaming.WebRTC.MaxViewers,
+			"ice_servers", len(cfg.Streaming.WebRTC.ICEServers),
+		)
 	}
 
 	// Step 7.6: FLV manager

--- a/pkg/app/webrtc_ice_test.go
+++ b/pkg/app/webrtc_ice_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// TestWebRTCICEServersConversion verifies the config-layer → pion-layer
+// conversion in run.go:webrtcICEServers. This is the boundary where
+// streaming.webrtc.ice_servers (user-facing YAML) becomes the runtime ICE
+// config that pion hands to each PeerConnection.
+func TestWebRTCICEServersConversion(t *testing.T) {
+	t.Run("empty input returns nil (LAN-only legacy default)", func(t *testing.T) {
+		// Critical contract: nil return lets WithICEServers fall through to the
+		// legacy LAN-only path — no behavior change for users who don't set
+		// ice_servers.
+		assert.Nil(t, webrtcICEServers(nil))
+		assert.Nil(t, webrtcICEServers([]config.ICEServerConfig{}))
+	})
+
+	t.Run("stun-only server (no creds)", func(t *testing.T) {
+		in := []config.ICEServerConfig{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+		}
+		out := webrtcICEServers(in)
+		require.Len(t, out, 1)
+		assert.Equal(t, []string{"stun:stun.l.google.com:19302"}, out[0].URLs)
+		assert.Empty(t, out[0].Username, "STUN must not set credentials")
+		assert.Equal(t, webrtc.ICECredentialType(0), out[0].CredentialType,
+			"STUN must leave CredentialType zero (unspecified)")
+	})
+
+	t.Run("turn server gets password credential type", func(t *testing.T) {
+		in := []config.ICEServerConfig{{
+			URLs:       []string{"turn:turn.example.com:3478"},
+			Username:   "u",
+			Credential: "p",
+		}}
+		out := webrtcICEServers(in)
+		require.Len(t, out, 1)
+		assert.Equal(t, "u", out[0].Username)
+		assert.Equal(t, "p", out[0].Credential)
+		assert.Equal(t, webrtc.ICECredentialTypePassword, out[0].CredentialType,
+			"TURN with username+password must set CredentialType=Password")
+	})
+
+	t.Run("mixed stun+turn list preserved in order", func(t *testing.T) {
+		in := []config.ICEServerConfig{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+			{URLs: []string{"turn:turn.example.com:3478"}, Username: "u", Credential: "p"},
+			{URLs: []string{"turns:turn.example.com:5349"}, Username: "u2", Credential: "p2"},
+		}
+		out := webrtcICEServers(in)
+		require.Len(t, out, 3)
+		assert.Empty(t, out[0].Username)
+		assert.Equal(t, "u", out[1].Username)
+		assert.Equal(t, "u2", out[2].Username)
+	})
+
+	t.Run("turn with empty username but non-empty credential ignored", func(t *testing.T) {
+		// Guards the `if s.Username != ""` branch — a half-filled TURN entry
+		// (credential without username) is treated as STUN-like (no creds),
+		// because pion would otherwise reject a TURN request with empty user.
+		in := []config.ICEServerConfig{
+			{URLs: []string{"turn:turn.example.com:3478"}, Credential: "p"}, // no Username
+		}
+		out := webrtcICEServers(in)
+		require.Len(t, out, 1)
+		assert.Empty(t, out[0].Username)
+		assert.Equal(t, webrtc.ICECredentialType(0), out[0].CredentialType)
+	})
+}


### PR DESCRIPTION
## Summary

Enables WebRTC WHEP streaming beyond LAN by adding `streaming.webrtc.ice_servers` config (STUN/TURN). Previously `CreateWHEPSession` used an empty `webrtc.Configuration{}`, limiting WebRTC to mDNS host candidates — LAN-only.

This is the **minimal network-reachability layer** to let users' own third-party tunnel/VPN setups carry WebRTC. NVR itself does NOT bundle any P2P SDK, tunnel client, or "one-click remote access" — by design.

## Changes

### Code
- `internal/config/config.go`: `ICEServerConfig` struct + `WebRTCConfig.ICEServers` field + Validate (stun:/turn:/turns: URL scheme check)
- `internal/webrtc/manager.go`: `WithICEServers` option + `CreateWHEPSession` wires `Configuration.ICEServers`; nil slice preserves legacy LAN-only behavior (backward compatible)
- `pkg/app/run.go`: `webrtcICEServers` config→pion conversion helper
- `config.example.yaml`: documented `ice_servers` example (commented out)

### Docs
- `docs/{zh,en}/remote-access.md`: minimal Tailscale + Cloudflare Tunnel guides with WebRTC compatibility notes (TCP-only tunnels like CF Tunnel don't carry WebRTC UDP → use HLS)
- `README.md`: doc index entries

## Tests

**3901 tests pass, 17 new:**
- config Validate: valid STUN/TURN/TURNS + invalid scheme/empty URLs
- config round-trip: `ice_servers` survives YAML save+load (TURN creds persist)
- config omitempty: empty `ice_servers` not serialized
- manager: `WithICEServers` stores config + WHEP still produces valid SDP
- manager: backward compat for legacy no-option path
- conversion: nil→LAN-only, TURN gets `CredentialType=Password`

## End-to-end verification

Verified on local NVR with real WHEP SDP capture:

| | Baseline (no `ice_servers`) | With STUN configured |
|---|---|---|
| host candidates | 6 | 4 |
| **srflx candidates** | **0** | **2** ✅ |
| relay candidates | 0 | 0 |

New srflx candidate in answer SDP (STUN returned the public reflexive IP):
```
a=candidate:1898252731 1 udp 1694498815 116.22.166.8 46604 typ srflx raddr 0.0.0.0 rport 45850
```

This proves `ice_servers` config reaches the PeerConnection and STUN successfully traverses NAT.

## Design notes

- **No new dependencies** — uses pion native API (`webrtc.Configuration.ICEServers`)
- **Backward compatible** — empty `ice_servers` is the default, behavior unchanged
- **No P2P/tunnel logic in NVR** — users bring their own tunnel/VPN; NVR only provides the ICE config hook. WebRTC ICE is a generic RFC 5245/8445 standard, not a commercial differentiator.
- `SetNAT1To1IPs` deliberately NOT used (conflicts with STUN when configured as `srflx`, breaks LAN access when configured as `host`)

## Checklist
- [x] `go build` + `go vet` clean
- [x] `go test ./...` 3901 pass (49 packages)
- [x] gofmt clean
- [x] End-to-end SDP verification (baseline vs STUN-configured)
- [x] Docs bilingual (zh + en)
- [x] `config.example.yaml` updated
- [x] No HARD CONSTRAINT violations (no P2P/commercial content)
