### PR TITLE
fix(storage): async startup scans + bounded reconcile (8m阻塞→8s启动)

### DIFF
--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -511,19 +511,63 @@ func (d *DB) DailyRecordingSummary(ctx context.Context, filter model.RecordingFi
 
 // GetRecordingsByPathSet returns a set of file paths that exist in the recordings table.
 // Used for orphan file reconciliation to determine which files are already registered.
+//
+// Note: this query does NOT scope by camera_id and relies on a full scan of the
+// recordings table (file_path is not indexed). For orphan reconciliation where
+// the caller already knows the camera_id, prefer GetRecordingPathsByCamera which
+// uses the idx_recordings_camera_time index for a bounded range scan.
 func (d *DB) GetRecordingsByPathSet(ctx context.Context, paths []string) (map[string]bool, error) {
 	result := make(map[string]bool)
 	if len(paths) == 0 {
 		return result, nil
 	}
-	placeholders := make([]string, len(paths))
-	args := make([]interface{}, len(paths))
-	for i, p := range paths {
-		placeholders[i] = "?"
-		args[i] = p
+	// SQLite's SQLITE_MAX_VARIABLE_NUMBER defaults to 999 (older) or 32766
+	// (3.32+). modernc.org/sqlite sets 32766, but to stay portable and avoid
+	// pathological planner behavior on huge IN lists, chunk at 500.
+	const chunkSize = 500
+	for start := 0; start < len(paths); start += chunkSize {
+		end := start + chunkSize
+		if end > len(paths) {
+			end = len(paths)
+		}
+		chunk := paths[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]interface{}, len(chunk))
+		for i, p := range chunk {
+			placeholders[i] = "?"
+			args[i] = p
+		}
+		q := "SELECT file_path FROM recordings WHERE file_path IN (" + strings.Join(placeholders, ",") + ")"
+		rows, err := d.readConn().QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var p string
+			if err := rows.Scan(&p); err == nil {
+				result[p] = true
+			}
+		}
+		rows.Close()
 	}
-	q := "SELECT file_path FROM recordings WHERE file_path IN (" + strings.Join(placeholders, ",") + ")"
-	rows, err := d.readConn().QueryContext(ctx, q, args...)
+	return result, nil
+}
+
+// GetRecordingPathsByCamera returns the set of file_path values stored for a
+// single camera. Used by orphan reconciliation as a much cheaper replacement
+// for GetRecordingsByPathSet when the caller knows the camera_id: it uses the
+// idx_recordings_camera_time(camera_id, ...) index for a bounded range scan
+// (only that camera's rows) instead of scanning the entire recordings table.
+//
+// The returned set is the complete path list for the camera; callers intersect
+// it with their disk scan locally (O(n) hashset lookup) rather than via a
+// potentially huge IN (?, ?, ...) list. On a production tree with ~15k
+// recordings, this reduces per-camera reconciliation IO from a full table scan
+// to an index range read of just that camera's rows.
+func (d *DB) GetRecordingPathsByCamera(ctx context.Context, cameraID string) (map[string]bool, error) {
+	result := make(map[string]bool)
+	rows, err := d.readConn().QueryContext(ctx,
+		`SELECT file_path FROM recordings WHERE camera_id = ?`, cameraID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -538,17 +538,22 @@ func (d *DB) GetRecordingsByPathSet(ctx context.Context, paths []string) (map[st
 			args[i] = p
 		}
 		q := "SELECT file_path FROM recordings WHERE file_path IN (" + strings.Join(placeholders, ",") + ")"
-		rows, err := d.readConn().QueryContext(ctx, q, args...)
-		if err != nil {
+		if err := func() error {
+			rows, err := d.readConn().QueryContext(ctx, q, args...)
+			if err != nil {
+				return err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var p string
+				if err := rows.Scan(&p); err == nil {
+					result[p] = true
+				}
+			}
+			return rows.Err()
+		}(); err != nil {
 			return nil, err
 		}
-		for rows.Next() {
-			var p string
-			if err := rows.Scan(&p); err == nil {
-				result[p] = true
-			}
-		}
-		rows.Close()
 	}
 	return result, nil
 }

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1228,6 +1228,54 @@ func TestGetRecordingsByPathSet_Empty(t *testing.T) {
 	require.Len(t, result, 0)
 }
 
+// TestGetRecordingPathsByCamera verifies the per-camera path lookup used by
+// orphan reconciliation. This must scope by camera_id so the query rides the
+// idx_recordings_camera_time index instead of scanning the whole recordings
+// table (which on production with 15k rows dominates reconcile IO).
+func TestGetRecordingPathsByCamera(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_paths_by_cam.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	now := time.Now()
+	// Seed two cameras with overlapping file names to ensure the query
+	// isolates by camera_id.
+	for _, cam := range []string{"camA", "camB"} {
+		for i := 0; i < 3; i++ {
+			rec := &model.Recording{
+				ID:        fmt.Sprintf("%s-%d", cam, i),
+				CameraID:  cam,
+				FilePath:  fmt.Sprintf("/store/%s/seg_%d.mp4", cam, i),
+				Format:    model.FormatH264,
+				StartedAt: now.Add(time.Duration(i) * time.Minute),
+			}
+			require.NoError(t, db.InsertRecording(ctx, rec))
+		}
+	}
+
+	got, err := db.GetRecordingPathsByCamera(ctx, "camA")
+	require.NoError(t, err)
+	require.Len(t, got, 3, "camA should return exactly 3 paths")
+	for i := 0; i < 3; i++ {
+		require.True(t, got[fmt.Sprintf("/store/camA/seg_%d.mp4", i)],
+			"camA path should be in result")
+	}
+	// Ensure no cross-camera leakage.
+	for i := 0; i < 3; i++ {
+		require.False(t, got[fmt.Sprintf("/store/camB/seg_%d.mp4", i)],
+			"camB path must NOT be in camA result")
+	}
+
+	// Unknown camera returns empty set, no error.
+	got, err = db.GetRecordingPathsByCamera(ctx, "camUnknown")
+	require.NoError(t, err)
+	require.Len(t, got, 0)
+}
+
 func TestInsertOrphanRecordings(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test_orphan.db")

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1245,7 +1245,7 @@ func TestGetRecordingPathsByCamera(t *testing.T) {
 	// Seed two cameras with overlapping file names to ensure the query
 	// isolates by camera_id.
 	for _, cam := range []string{"camA", "camB"} {
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			rec := &model.Recording{
 				ID:        fmt.Sprintf("%s-%d", cam, i),
 				CameraID:  cam,
@@ -1260,12 +1260,12 @@ func TestGetRecordingPathsByCamera(t *testing.T) {
 	got, err := db.GetRecordingPathsByCamera(ctx, "camA")
 	require.NoError(t, err)
 	require.Len(t, got, 3, "camA should return exactly 3 paths")
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		require.True(t, got[fmt.Sprintf("/store/camA/seg_%d.mp4", i)],
 			"camA path should be in result")
 	}
 	// Ensure no cross-camera leakage.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		require.False(t, got[fmt.Sprintf("/store/camB/seg_%d.mp4", i)],
 			"camB path must NOT be in camA result")
 	}

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -436,33 +436,66 @@ func (m *Manager) IsAvailable() bool {
 	return err == nil
 }
 
-// CleanupTempFiles removes all orphaned .tmp files and directories from the storage root.
+// CleanupTempFiles removes all orphaned .tmp files and directories left by
+// crashed segment writes. Temp segments are only ever created under
+// <root>/cam-xxx/YYYY/MM/DD/HH/{uuid}.tmp (see CreateSegment), so this scan is
+// scoped to cam-* subtrees only — it skips hls/, recordings/, bin/, certs/,
+// database files, and any other non-camera content at the root. This keeps the
+// scan bounded: on a production tree with 100k+ files it avoids walking the
+// HLS shard directories entirely.
+//
+// This function is safe to call concurrently with recording (each segment uses
+// a unique uuid path; a leftover .tmp from a previous crash never collides with
+// a new write). Callers that don't need the result immediately should run it in
+// a goroutine to avoid blocking startup.
 func (m *Manager) CleanupTempFiles() error {
-	return filepath.WalkDir(m.rootDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip inaccessible entries
+	entries, err := os.ReadDir(m.rootDir)
+	if err != nil {
+		return fmt.Errorf("storage: read root dir %q: %w", m.rootDir, err)
+	}
+	var firstErr error
+	for _, entry := range entries {
+		// Only descend into camera directories (prefix "cam-"). Everything else
+		// at the root (hls/, recordings/, bin/, certs/, *.db, config files,
+		// top-level *.tmp backups, etc.) is out of scope for segment cleanup.
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "cam-") {
+			continue
 		}
-		if d.IsDir() {
-			// Don't remove the root dir itself, and skip .tmp directories
-			if path == m.rootDir {
+		camDir := filepath.Join(m.rootDir, entry.Name())
+		if err := filepath.WalkDir(camDir, func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil // skip inaccessible entries
+			}
+			if !d.IsDir() {
+				// Remove .tmp files
+				if strings.HasSuffix(d.Name(), ".tmp") {
+					if err := os.Remove(path); err != nil {
+						// Don't abort the whole walk on a single failure (file
+						// may be in use); record and continue.
+						logger.Warn("temp cleanup: failed to remove temp file", "path", path, "error", err)
+					}
+				}
+				return nil
+			}
+			// Don't remove the camera dir itself, and skip .tmp directories
+			if path == camDir {
 				return nil
 			}
 			if strings.HasSuffix(d.Name(), ".tmp") {
 				if err := os.RemoveAll(path); err != nil {
-					return fmt.Errorf("storage: failed to remove temp dir %q: %w", path, err)
+					logger.Warn("temp cleanup: failed to remove temp dir", "path", path, "error", err)
 				}
 				return filepath.SkipDir
 			}
 			return nil
-		}
-		// Remove .tmp files
-		if strings.HasSuffix(d.Name(), ".tmp") {
-			if err := os.Remove(path); err != nil {
-				return fmt.Errorf("storage: failed to remove temp file %q: %w", path, err)
+		}); err != nil {
+			logger.Warn("temp cleanup: walk error", "dir", camDir, "error", err)
+			if firstErr == nil {
+				firstErr = err
 			}
 		}
-		return nil
-	})
+	}
+	return firstErr
 }
 
 // ReconcileOrphanedFiles scans camera directories for .mp4 files that are not registered
@@ -507,8 +540,78 @@ func (m *Manager) ReconcileOrphanedFiles(ctx context.Context, db *DB, cameraIDs 
 	return totalReconciled, nil
 }
 
+// recordingNameInfo holds the parsed fields of a recording file/dir name.
+// Populated by parseRecordingName when the name matches the canonical shape.
+type recordingNameInfo struct {
+	cameraID  string
+	startedAt time.Time
+	nanoID    string
+	isMP4File bool // true for .mp4 files (H264), false for extension-less MJPEG dirs
+}
+
+// parseRecordingName parses a cam-dir entry name into its recording fields,
+// without touching the disk. Returns ok=false if the name does not match the
+// canonical recording shape:
+//
+//	<camID>_YYYYMMDD_HHMMSS_<nano>        (MJPEG dir, no extension)
+//	<camID>_YYYYMMDD_HHMMSS_<nano>.mp4     (H264 file)
+//
+// This is the cheap name-shape gate used by reconcileCameraDir to skip
+// non-recording entries — most importantly date-bucket dirs ("202607/", "20/",
+// "07/") created by the segment writer — before paying for any stat or subtree
+// walk. Misclassifying a date dir as an MJPEG recording dir caused a production
+// 8.7GB / 6.5-minute IO storm because each date dir's entire subtree got walked.
+//
+// cameraIDHint, when non-empty, requires parts[0] == cameraIDHint (the parent
+// cam dir name); entries from other cameras are rejected. Pass "" to skip the
+// camera-ID check (only shape is validated).
+func parseRecordingName(name, cameraIDHint string) (recordingNameInfo, bool) {
+	isMP4 := strings.HasSuffix(name, ".mp4")
+	baseName := name
+	if isMP4 {
+		baseName = strings.TrimSuffix(name, ".mp4")
+	} else if filepath.Ext(name) != "" {
+		// Non-mp4 entry with an extension (.avi.tmp, .json, .tmp, ...) — not a
+		// recording name. Extension-less dirs are still candidates (MJPEG).
+		return recordingNameInfo{}, false
+	}
+	parts := strings.SplitN(baseName, "_", 4)
+	if len(parts) != 4 {
+		return recordingNameInfo{}, false
+	}
+	if cameraIDHint != "" && parts[0] != cameraIDHint {
+		return recordingNameInfo{}, false
+	}
+	startedAt, err := time.ParseInLocation("20060102_150405", parts[1]+"_"+parts[2], time.Local)
+	if err != nil {
+		return recordingNameInfo{}, false
+	}
+	return recordingNameInfo{
+		cameraID:  parts[0],
+		startedAt: startedAt,
+		nanoID:    parts[3],
+		isMP4File: isMP4,
+	}, true
+}
+
 // reconcileCameraDir scans a single camera directory and inserts orphaned recordings.
 // Uses incremental batches of orphanBatchSize to minimize write lock duration.
+//
+// To avoid expensive disk IO on large trees, entry filtering is done in two
+// cheap phases BEFORE any stat or subtree walk, both encapsulated in
+// parseRecordingName:
+//  1. Name-shape gate: only entries shaped "<camID>_YYYYMMDD_HHMMSS_<nano>"
+//     (optionally suffixed with .mp4) are considered. This skips date bucket
+//     directories (e.g. "202607/", "20/", "07/") that the segment writer
+//     creates under each cam dir, as well as random unrelated files. Without
+//     this gate, a single date directory like "202607/" would be misclassified
+//     as an MJPEG recording dir and fully walked, causing the entire historical
+//     subtree (potentially 100k+ files) to be re-stat'd per date dir.
+//  2. Camera-ID gate: parts[0] must equal dirName. Entries from other cameras
+//     or stale exports are skipped without IO.
+//
+// Only after both gates does the function call f.Info() (one stat per
+// surviving entry) and, for MJPEG dirs, the per-frame Walk.
 func (m *Manager) reconcileCameraDir(ctx context.Context, db *DB, dirName string) (int, error) {
 	files, err := os.ReadDir(filepath.Join(m.rootDir, dirName))
 	if err != nil {
@@ -519,73 +622,57 @@ func (m *Manager) reconcileCameraDir(ctx context.Context, db *DB, dirName string
 	for _, f := range files {
 		name := f.Name()
 
-		var baseName string
-		var frameCount int
-		var totalSize int64
-		var format model.Format
-		info, infoErr := f.Info()
-		if infoErr != nil {
+		// Phase 1 + 2: cheap name-shape + camera-ID gate, no IO. This is what
+		// prevents date-bucket dirs from being walked.
+		info, ok := parseRecordingName(name, dirName)
+		if !ok {
 			continue
 		}
 
+		// Only now — after the gates pass — pay for one stat per entry.
+		fi, fiErr := f.Info()
+		if fiErr != nil {
+			continue
+		}
+
+		var totalSize int64
+		var frameCount int
+		var format model.Format
 		if f.IsDir() {
-			// Skip dirs with extensions (e.g., .tmp dirs)
-			if ext := filepath.Ext(name); ext != "" {
-				continue
-			}
-			baseName = name
+			// MJPEG recording directory: count JPEG frames and total size.
+			// Only legit recording-named dirs reach here, so this Walk is now
+			// bounded to actual frame dirs (tens of entries), not date trees.
 			format = model.FormatMJPEG
-			// Count JPEG frames and total size
 			dirPath := filepath.Join(m.rootDir, dirName, name)
-			filepath.Walk(dirPath, func(path string, fi os.FileInfo, err error) error {
-				if err != nil || fi.IsDir() {
+			filepath.Walk(dirPath, func(path string, walkFI os.FileInfo, walkErr error) error {
+				if walkErr != nil || walkFI.IsDir() {
 					return nil
 				}
 				frameCount++
-				totalSize += fi.Size()
+				totalSize += walkFI.Size()
 				return nil
 			})
 			if frameCount == 0 {
 				continue
 			}
 		} else {
-			if !strings.HasSuffix(name, ".mp4") {
+			if !info.isMP4File {
+				continue // named like a recording but not .mp4 — shouldn't happen
+			}
+			if fi.Size() == 0 {
 				continue
 			}
-			baseName = strings.TrimSuffix(name, ".mp4")
 			format = model.FormatH264
-			if info.Size() == 0 {
-				continue
-			}
-			totalSize = info.Size()
-		}
-
-		parts := strings.SplitN(baseName, "_", 4)
-		if len(parts) != 4 {
-			continue
-		}
-
-		cameraIDPart := parts[0]
-		dateStr := parts[1]
-		timeStr := parts[2]
-		nanoStr := parts[3]
-
-		if cameraIDPart != dirName {
-			continue
-		}
-
-		startedAt, err := time.ParseInLocation("20060102_150405", dateStr+"_"+timeStr, time.Local)
-		if err != nil {
-			continue
+			totalSize = fi.Size()
 		}
 
 		cameraOrphans = append(cameraOrphans, model.Recording{
-			ID:         nanoStr,
+			ID:         info.nanoID,
 			CameraID:   dirName,
 			FilePath:   filepath.Join(m.rootDir, dirName, name),
 			Format:     format,
-			StartedAt:  startedAt,
-			EndedAt:    startedAt,
+			StartedAt:  info.startedAt,
+			EndedAt:    info.startedAt,
 			Duration:   0,
 			FileSize:   totalSize,
 			FrameCount: frameCount,
@@ -597,12 +684,13 @@ func (m *Manager) reconcileCameraDir(ctx context.Context, db *DB, dirName string
 		return 0, nil
 	}
 
-	// Query which files already exist in DB
-	paths := make([]string, len(cameraOrphans))
-	for i, o := range cameraOrphans {
-		paths[i] = o.FilePath
-	}
-	existing, err := db.GetRecordingsByPathSet(ctx, paths)
+	// Query which files already exist in DB. Use the per-camera path set rather
+	// than GetRecordingsByPathSet(IN ?, ?, ...): the per-camera query rides the
+	// idx_recordings_camera_time index for a bounded range scan of just this
+	// camera's rows, instead of a full table scan on the unindexed file_path
+	// column. On a production tree (~15k recordings, ~6 cameras) this cut
+	// reconcile IO dramatically. We intersect locally against the hashset.
+	existing, err := db.GetRecordingPathsByCamera(ctx, dirName)
 	if err != nil {
 		return 0, fmt.Errorf("query existing recordings for %q: %w", dirName, err)
 	}

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -531,6 +531,83 @@ func TestCleanupTempFiles_NoTempFiles(t *testing.T) {
 	}
 }
 
+// TestCleanupTempFiles_ScopesToCameraDirs verifies the scan is bounded to
+// cam-* subtrees. The original implementation walked the entire tree, which on
+// a 100k+ file production tree blocked startup for 20+ seconds. .tmp segment
+// residue only ever appears under <root>/cam-xxx/YYYY/MM/DD/HH/ (see
+// CreateSegment), so hls/, recordings/, bin/, certs/, and top-level files are
+// out of scope and must be left untouched even if they happen to have a .tmp
+// suffix.
+func TestCleanupTempFiles_ScopesToCameraDirs(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := NewManager(dir)
+
+	// Camera subtree with an orphan .tmp that MUST be removed.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cam-test", "2026", "07", "20", "10"), 0o755))
+	camTmp := filepath.Join(dir, "cam-test", "2026", "07", "20", "10", "orphan.tmp")
+	require.NoError(t, os.WriteFile(camTmp, []byte("x"), 0o644))
+
+	// Out-of-scope locations that must NOT be touched even with .tmp suffix.
+	// These mimic real layout: hls shards, recordings dir, bin, certs, db files,
+	// and a top-level .tmp config backup.
+	outOfScope := []string{
+		filepath.Join(dir, "hls", "cam-test", "segment.tmp"),
+		filepath.Join(dir, "recordings", "stale.tmp"),
+		filepath.Join(dir, "bin", "mibee-nvr.tmp"),
+		filepath.Join(dir, "certs", "selfsigned.crt.tmp"),
+		filepath.Join(dir, "config.yaml.tmp"), // top-level file with .tmp suffix
+	}
+	for _, p := range outOfScope {
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("keep"), 0o644))
+	}
+
+	require.NoError(t, m.CleanupTempFiles())
+
+	// In-scope: removed.
+	_, err := os.Stat(camTmp)
+	require.Error(t, err, "camera .tmp file should be removed")
+
+	// Out-of-scope: all preserved.
+	for _, p := range outOfScope {
+		_, err := os.Stat(p)
+		require.NoError(t, err, "out-of-scope .tmp file should NOT be removed: %s", p)
+	}
+}
+
+// TestCleanupTempFiles_HandlesNonExistentRoot guards the top-level ReadDir
+// against a missing root (e.g. misconfigured storage.root_dir). Must return an
+// error, not panic.
+func TestCleanupTempFiles_HandlesNonExistentRoot(t *testing.T) {
+	m, _ := NewManager(t.TempDir())
+	m.rootDir = filepath.Join(t.TempDir(), "does-not-exist")
+
+	err := m.CleanupTempFiles()
+	require.Error(t, err, "missing root dir should return error")
+}
+
+// TestCleanupTempFiles_PreservesNormalFilesUnderCamera is a regression guard:
+// the walk removes ONLY .tmp entries — normal .mp4 segments and MJPEG frame
+// directories under cam-* must survive.
+func TestCleanupTempFiles_PreservesNormalFilesUnderCamera(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := NewManager(dir)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cam-1", "2026", "07", "20", "10"), 0o755))
+
+	hourDir := filepath.Join(dir, "cam-1", "2026", "07", "20", "10")
+	mp4Path := filepath.Join(hourDir, "cam-1_20260720_100000_123.mp4")
+	mjpegDir := filepath.Join(hourDir, "cam-1_20260720_100001_124")
+	require.NoError(t, os.WriteFile(mp4Path, []byte("mp4"), 0o644))
+	require.NoError(t, os.MkdirAll(mjpegDir, 0o755))
+
+	require.NoError(t, m.CleanupTempFiles())
+
+	_, err := os.Stat(mp4Path)
+	require.NoError(t, err, "normal .mp4 segment must survive cleanup")
+	_, err = os.Stat(mjpegDir)
+	require.NoError(t, err, "normal MJPEG frame dir must survive cleanup")
+}
+
 // --- IsAvailable ---
 
 func TestIsAvailable_DirExists(t *testing.T) {
@@ -997,6 +1074,139 @@ func TestReconcileOrphanedFiles_MJPEGSkipsRandomDirs(t *testing.T) {
 	count, err := m.ReconcileOrphanedFiles(ctx, db, cameraIDs)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
+}
+
+// TestParseRecordingName is the authoritative regression test for the
+// date-bucket-dir misclassification bug. The bug: reconcileCameraDir treated
+// ANY extension-less directory under cam-* as an MJPEG recording dir and
+// fully walked it. The segment writer's date bucket dirs ("202607/", "20/",
+// "07/") are also extension-less, so each was walked recursively — every
+// historical mp4 (540k+ files on production) got stat'd once per enclosing
+// date dir, causing an 8.7GB / 6.5-minute startup IO storm.
+//
+// Fix: parseRecordingName is the cheap name-shape gate. Only names matching
+// "<camID>_YYYYMMDD_HHMMSS_<nano>" (optionally + ".mp4") return ok=true.
+// Date buckets and any other non-conforming names return ok=false WITHOUT
+// touching the disk, so reconcileCameraDir never walks them.
+//
+// This test exercises the pure function directly — no IO, no timing, no
+// flakiness. It is the reliable regression guard; the production deploy
+// measurement (reconcile duration + read_bytes) is the authoritative
+// end-to-end verification.
+func TestParseRecordingName(t *testing.T) {
+	const camID = "cam-4aeeef41-e379-4d93-b289-c3aedbe5d729"
+
+	valid := []struct {
+		name    string
+		wantMP4 bool
+	}{
+		{camID + "_20260629_063758_1782686278819104131.mp4", true},
+		{camID + "_20260629_063758_1782686278819104131", false}, // MJPEG dir
+		{camID + "_20260720_100000_1111111111111111111.mp4", true},
+	}
+	for _, tc := range valid {
+		got, ok := parseRecordingName(tc.name, camID)
+		require.True(t, ok, "valid name rejected: %s", tc.name)
+		require.Equal(t, camID, got.cameraID)
+		require.Equal(t, tc.wantMP4, got.isMP4File)
+		require.False(t, got.startedAt.IsZero(), "startedAt should parse")
+		require.NotEmpty(t, got.nanoID)
+	}
+
+	invalid := []string{
+		// Date bucket dirs from the segment writer layout — the primary bug.
+		"202607",
+		"20",
+		"07",
+		"202606",
+		// MJPEG dirs missing the nano segment (only 3 parts).
+		camID + "_20260629_063758",
+		// Wrong camera ID.
+		"cam-other_20260629_063758_1782686278819104131.mp4",
+		// Bad date format.
+		camID + "_notadate_063758_1782686278819104131.mp4",
+		camID + "_20261329_063758_1782686278819104131.mp4", // month 13
+		// Non-mp4 file with extension.
+		camID + "_20260629_063758_1782686278819104131.avi",
+		"config.yaml",
+		"orphan.tmp",
+		// Random junk.
+		"",
+		"foo",
+		"a_b_c",
+	}
+	for _, name := range invalid {
+		_, ok := parseRecordingName(name, camID)
+		require.False(t, ok, "invalid name accepted (would cause spurious stat/walk): %q", name)
+	}
+
+	// cameraIDHint="" should skip the camera-ID gate but still validate shape.
+	_, ok := parseRecordingName("cam-other_20260629_063758_1782686278819104131.mp4", "")
+	require.True(t, ok, "empty cameraIDHint should accept any camera prefix")
+	_, ok = parseRecordingName("202607", "")
+	require.False(t, ok, "date dir must be rejected even with empty cameraIDHint")
+}
+
+// TestReconcileOrphanedFiles_SkipsDateBucketDirs is the integration-level
+// counterpart to TestParseRecordingName: it seeds a realistic nested layout
+// (date bucket dirs with mp4 files inside, plus legit flat orphans) and
+// asserts only the legit orphans are reconciled. It does NOT assert timing —
+// that's the pure-function test's job — but verifies the end-to-end behavior.
+func TestReconcileOrphanedFiles_SkipsDateBucketDirs(t *testing.T) {
+	dir := t.TempDir()
+	storeDir := filepath.Join(dir, "store")
+	m, err := NewManager(storeDir)
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(dir, "reconcile_dates.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	require.NoError(t, db.UpsertCamera(ctx, "cam-dates", "Date Cam", "rtsp", "h264", "rtsp://x", "", "", "", "", ""))
+	cameraIDs := map[string]bool{"cam-dates": true}
+
+	camDir := filepath.Join(storeDir, "cam-dates")
+	require.NoError(t, os.MkdirAll(camDir, 0o755))
+
+	// (A) Nested current-layout mp4 files under a date bucket. Must NOT
+	// reconcile — date dirs are out of scope (registered via CloseSegment).
+	nestedHour := filepath.Join(camDir, "202607", "20", "10")
+	require.NoError(t, os.MkdirAll(nestedHour, 0o755))
+	nestedNames := []string{
+		"cam-dates_20260720_100000_1111111111111111111.mp4",
+		"cam-dates_20260720_100100_2222222222222222222.mp4",
+		"cam-dates_20260720_100200_3333333333333333333.mp4",
+	}
+	for _, n := range nestedNames {
+		require.NoError(t, os.WriteFile(filepath.Join(nestedHour, n), []byte("x"), 0o644))
+	}
+
+	// (B) A legit legacy-layout flat mp4 at cam dir top level. SHOULD reconcile.
+	flatName := "cam-dates_20260629_100000_4444444444444444444.mp4"
+	require.NoError(t, os.WriteFile(filepath.Join(camDir, flatName), []byte("flat-mp4"), 0o644))
+
+	// (C) A legit MJPEG recording dir at cam dir top level. SHOULD reconcile.
+	mjpegDir := "cam-dates_20260629_100100_5555555555555555555"
+	require.NoError(t, os.MkdirAll(filepath.Join(camDir, mjpegDir), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(camDir, mjpegDir, "frame_0000.jpg"), []byte("jpg"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(camDir, mjpegDir, "frame_0001.jpg"), []byte("jpg"), 0o644))
+
+	count, err := m.ReconcileOrphanedFiles(ctx, db, cameraIDs)
+	require.NoError(t, err)
+	// Exactly 2: the flat mp4 + the legit MJPEG dir. The 3 nested mp4 inside
+	// date buckets must NOT be counted.
+	require.Equal(t, 2, count, "nested date-bucket mp4 files must not be reconciled")
+
+	// Spot-check: the nested mp4s are NOT in DB.
+	for _, n := range nestedNames {
+		nano := strings.SplitN(strings.TrimSuffix(n, ".mp4"), "_", 4)[3]
+		got, err := db.GetRecording(ctx, nano)
+		require.NoError(t, err)
+		require.Nil(t, got, "nested date-bucket file %q must not be reconciled into DB", n)
+	}
 }
 
 // TestReconcileIncrementalCommit verifies that ReconcileOrphanedFiles processes each camera

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -252,25 +252,41 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 		return nil, fmt.Errorf("storage: %w", err)
 	}
 
-	// Cleanup temp files from previous crash
-	if err := store.CleanupTempFiles(); err != nil {
-		slog.Warn("temp cleanup", "error", err)
-	}
+	// Cleanup temp files from previous crash. Run in background — on large
+	// storage trees (100k+ files) the walk can take 20+ seconds, and leftover
+	// .tmp files are harmless to delay (each new segment uses a unique uuid).
+	// CleanupIncomplete below is a single SQL DELETE (ms-scale) and stays sync.
+	go func() {
+		start := time.Now()
+		if err := store.CleanupTempFiles(); err != nil {
+			slog.Warn("background temp cleanup", "error", err)
+			return
+		}
+		slog.Info("background temp cleanup done", "duration", time.Since(start))
+	}()
 	if err := db.CleanupIncomplete(ctx); err != nil {
 		slog.Warn("incomplete cleanup", "error", err)
 	}
 
-	// Reconcile orphaned recording files (exists on disk but not in DB)
+	// Reconcile orphaned recording files (exists on disk but not in DB). Run in
+	// background — on USB HDD with 100k+ legacy flat-layout files this scan
+	// takes 3+ minutes (measured), blocking service availability the whole time.
+	// New recordings write their DB row on CloseSegment regardless, so delaying
+	// reconciliation of historical orphans has no runtime impact.
 	cameraIDs := make(map[string]bool)
 	for _, cam := range cfg.Cameras {
 		cameraIDs[cam.ID] = true
 	}
-	reconciled, err := store.ReconcileOrphanedFiles(ctx, db, cameraIDs)
-	if err != nil {
-		slog.Error("failed to reconcile orphaned files", "error", err)
-	} else if reconciled > 0 {
-		slog.Info("reconciled orphaned recording files", "count", reconciled)
-	}
+	go func() {
+		start := time.Now()
+		reconciled, err := store.ReconcileOrphanedFiles(ctx, db, cameraIDs)
+		if err != nil {
+			slog.Error("background orphan reconciliation failed", "error", err)
+			return
+		}
+		slog.Info("background orphan reconciliation done",
+			"reconciled", reconciled, "duration", time.Since(start))
+	}()
 
 	// Step 4: Auth middleware
 	authmw.SetAuthMetrics(metrics)

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -238,7 +238,7 @@ func TestRunFree_DoesNotBlockOnStorageScan(t *testing.T) {
 		t.Fatalf("mkdir hour: %v", err)
 	}
 	const mp4Count = 2000
-	for i := 0; i < mp4Count; i++ {
+	for i := range mp4Count {
 		// Current layout: nested under date dirs.
 		name := fmt.Sprintf("cam-seed_20260720_1000_%04d.mp4", i)
 		if err := os.WriteFile(filepath.Join(hourDir, name), []byte("x"), 0o644); err != nil {
@@ -254,7 +254,7 @@ func TestRunFree_DoesNotBlockOnStorageScan(t *testing.T) {
 		}
 	}
 	// A few .tmp orphans for CleanupTempFiles.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		name := fmt.Sprintf("cam-seed_20260720_1000_orphan_%04d.tmp", i)
 		if err := os.WriteFile(filepath.Join(hourDir, name), []byte("x"), 0o644); err != nil {
 			t.Fatalf("seed tmp %d: %v", i, err)
@@ -262,12 +262,12 @@ func TestRunFree_DoesNotBlockOnStorageScan(t *testing.T) {
 	}
 	// MJPEG frame directories — reconcile's slow path (full Walk per dir to
 	// count frames). Each has multiple JPEG files inside.
-	for d := 0; d < 20; d++ {
+	for d := range 20 {
 		mjpegDir := filepath.Join(hourDir, fmt.Sprintf("cam-seed_20260720_1000_mjpeg_%04d", d))
 		if err := os.MkdirAll(mjpegDir, 0o755); err != nil {
 			t.Fatalf("mkdir mjpeg %d: %v", d, err)
 		}
-		for f := 0; f < 10; f++ {
+		for f := range 10 {
 			jpg := filepath.Join(mjpegDir, fmt.Sprintf("frame_%04d.jpg", f))
 			if err := os.WriteFile(jpg, []byte("x"), 0o644); err != nil {
 				t.Fatalf("seed jpg %d/%d: %v", d, f, err)

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -201,4 +203,95 @@ func TestRunFree_SmokeStartStop(t *testing.T) {
 	if err := a.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
+}
+
+// TestRunFree_DoesNotBlockOnStorageScan is a regression test for the startup
+// delay caused by synchronous storage scans. Production measurement on a USB
+// HDD with 100k+ files showed:
+//   - CleanupTempFiles (filepath.WalkDir over the whole tree): ~23s
+//   - ReconcileOrphanedFiles (per-camera ReadDir + per-MJPEG-dir Walk): ~3min
+//
+// Both must run in the background so the HTTP server can start serving within
+// seconds. This test seeds a large cam-* subtree with a mix of MP4 files,
+// .tmp orphans, and MJPEG frame directories (the slow path for reconcile),
+// then asserts RunFree returns well within the time a synchronous scan would
+// take.
+//
+// The authoritative fix verification is the production deploy measurement
+// (journalctl: db ready → "listening" interval < 5s, plus "background temp
+// cleanup done" / "background orphan reconciliation done" logs).
+func TestRunFree_DoesNotBlockOnStorageScan(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping startup-blocking regression test in short mode")
+	}
+
+	cfg, dir := minimalConfig(t)
+
+	// Seed a camera subtree with many files in the production layout:
+	//   cam-seed/YYYY/MM/DD/HH/{uuid}.mp4   (current layout)
+	//   cam-seed/{legacy_flat}.mp4          (old layout, still on production)
+	//   cam-seed/YYYY/MM/DD/HH/{uuid}.tmp/  (MJPEG frame dir, reconcile walks it)
+	camDir := filepath.Join(dir, "cam-seed")
+	hourDir := filepath.Join(camDir, "2026", "07", "20", "10")
+	if err := os.MkdirAll(hourDir, 0o755); err != nil {
+		t.Fatalf("mkdir hour: %v", err)
+	}
+	const mp4Count = 2000
+	for i := 0; i < mp4Count; i++ {
+		// Current layout: nested under date dirs.
+		name := fmt.Sprintf("cam-seed_20260720_1000_%04d.mp4", i)
+		if err := os.WriteFile(filepath.Join(hourDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed mp4 %d: %v", i, err)
+		}
+		// Legacy flat layout at cam dir top level (reconcile reads this via
+		// os.ReadDir(camDir) and stats every entry).
+		if i < 500 {
+			flatName := fmt.Sprintf("cam-seed_20260629_1000_%04d.mp4", i)
+			if err := os.WriteFile(filepath.Join(camDir, flatName), []byte("x"), 0o644); err != nil {
+				t.Fatalf("seed flat mp4 %d: %v", i, err)
+			}
+		}
+	}
+	// A few .tmp orphans for CleanupTempFiles.
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("cam-seed_20260720_1000_orphan_%04d.tmp", i)
+		if err := os.WriteFile(filepath.Join(hourDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed tmp %d: %v", i, err)
+		}
+	}
+	// MJPEG frame directories — reconcile's slow path (full Walk per dir to
+	// count frames). Each has multiple JPEG files inside.
+	for d := 0; d < 20; d++ {
+		mjpegDir := filepath.Join(hourDir, fmt.Sprintf("cam-seed_20260720_1000_mjpeg_%04d", d))
+		if err := os.MkdirAll(mjpegDir, 0o755); err != nil {
+			t.Fatalf("mkdir mjpeg %d: %v", d, err)
+		}
+		for f := 0; f < 10; f++ {
+			jpg := filepath.Join(mjpegDir, fmt.Sprintf("frame_%04d.jpg", f))
+			if err := os.WriteFile(jpg, []byte("x"), 0o644); err != nil {
+				t.Fatalf("seed jpg %d/%d: %v", d, f, err)
+			}
+		}
+	}
+
+	configPath := filepath.Join(dir, "mibee-nvr.yaml")
+	if err := config.Save(configPath, cfg); err != nil {
+		t.Fatalf("config.Save: %v", err)
+	}
+
+	start := time.Now()
+	a, err := RunFree(cfg, configPath)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+	defer a.Stop()
+
+	// RunFree returned, so startup was not blocked by either storage scan.
+	// Generous 5s budget covers DB init + manager construction on slow CI.
+	if elapsed > 5*time.Second {
+		t.Errorf("RunFree took %v; cleanup or reconcile may be blocking startup again", elapsed)
+	}
+	t.Logf("RunFree returned in %v with seeded storage tree", elapsed)
 }


### PR DESCRIPTION
## 问题

用户报告 NVR 启动需要 3-4 分钟。生产实测(Banana Pi M5, 54 万文件, USB HDD):**migration 完成 → HTTP listening 需 3-8 分钟**,期间服务完全不可用,systemd 可能触发超时循环重启。

## 根因(三层)

| 层 | 问题 | 实测影响 |
|---|------|---------|
| **启动阻塞** | `CleanupTempFiles` + `ReconcileOrphanedFiles` 在 `RunFree` 主路径同步执行 | 阻塞 HTTP server 启动 |
| **CleanupTempFiles 全树扫** | `filepath.WalkDir(rootDir)` 遍历整个存储树(54 万文件) | ~23 秒 |
| **reconcileCameraDir 误判日期目录** | 把所有无扩展名目录当 MJPEG 录制目录全量 `Walk`,但日期目录 `202607/` `20/` `07/` 也无扩展名 → 整棵历史子树被反复 stat | **8.7GB 元数据读取,6m26s** |
| **GetRecordingsByPathSet 全表扫描** | `WHERE file_path IN (...)` 在无索引列上全表扫 14711 行 × N 相机 | 附加 IO 开销 |

## 修复

1. **异步化**:`CleanupTempFiles` + `ReconcileOrphanedFiles` 改后台 goroutine,各加 done 日志。残留 `.tmp` 和孤儿入库是历史修复性操作,延迟完成无副作用(新录制 segment 用唯一 uuid + CloseSegment 正常入库)。

2. **CleanupTempFiles 限定扫描范围**:`os.ReadDir` 顶层 + 只对 `cam-*` 子树 `WalkDir`,跳过 hls/recordings/bin/certs/数据库文件。

3. **reconcileCameraDir 日期目录 gate**:提取 \`parseRecordingName\` 纯函数做 name-shape gate,不符合 \`<camID>_YYYYMMDD_HHMMSS_<nano>\` 格式的目录零 IO 跳过。\`f.Info()\` 延迟到 name-shape + camera-ID 双 gate 通过后。

4. **GetRecordingPathsByCamera**:新增按 \`camera_id\` 查询的方法,利用 \`idx_recordings_camera_time\` 索引范围扫,替代 \`GetRecordingsByPathSet\` 的全表扫描。原方法保留(migrate.go 仍用),并加 chunk 500 保护 \`SQLITE_MAX_VARIABLE_NUMBER\`。

## 生产实测验证(Banana Pi M5)

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| migration → HTTP listening | **3-8 分钟** | **8 秒** |
| reconcile 后台 duration | 6m26s | **41s** |
| reconcile read_bytes | 8.7GB | **<100MB** |
| reconciled(数据正确性) | 0 | 0(无数据丢失) |

## 测试

- \`TestParseRecordingName\`:纯函数回归守护,已验证能捕获模拟的 bug 回归(故意让日期目录通过 gate → 测试失败)
- \`TestReconcileOrphanedFiles_SkipsDateBucketDirs\`:集成测试(日期目录下 mp4 不被 reconcile)
- \`TestGetRecordingPathsByCamera\`:索引查询正确性 + 相机隔离
- \`TestRunFree_DoesNotBlockOnStorageScan\`:异步化回归(2000 mp4 + MJPEG dir 种子,95ms 返回)
- \`TestCleanupTempFiles_ScopesToCameraDirs\`:扫描范围限定(hls/bin/certs 下 .tmp 不被误删)
- 全部 243 测试通过,gofmt/vet/build 干净

## 变更

\`\`\`
 internal/storage/db_recording.go |  58 +++++++++--
 internal/storage/db_test.go      |  48 +++++++++
 internal/storage/manager.go      | 216 +++++++++++++++++++++++++++------------
 internal/storage/manager_test.go | 210 +++++++++++++++++++++++++++++++++++++
 pkg/app/run.go                   |  38 +++++--
 pkg/app/run_test.go              |  93 +++++++++++++++++
 6 files changed, 581 insertions(+), 82 deletions(-)
\`\`\`

## HARD CONSTRAINT 合规

纯启动性能优化 + bug 修复,无功能变更,无 P2P/商业代码。Diff 已扫描确认无敏感词。