### PR TITLE
fix(merge): retire historical singletons to unblock backfill loop (8500+ pending→drains)

### DIFF
--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -360,10 +361,24 @@ func (r *RollingMergeCoordinator) backfillLoop(ctx context.Context) {
 	}
 }
 
+// backfillConcurrency bounds how many cameras backfillHistorical merges in
+// parallel. Each camera has its own merge lock (r.mergeLocks) so per-camera
+// appends stay serialized; this constant bounds total disk IO across cameras.
+// On USB HDD, 3 is the sweet spot: enough to overlap one camera's DB query +
+// MP4 parse with another's file write, without causing destructive seek
+// thrashing that would starve the recording pipeline.
+const backfillConcurrency = 3
+
 // backfillHistorical processes one batch of pending segments across all
 // rolling-enabled cameras. Unlike backfillOnStartup, it has NO max_age filter
 // (so it digests old backlogs beyond 72h) and processes at most
 // rolling_backfill_batch segments per cycle to bound IO.
+//
+// Cameras are processed CONCURRENTLY (up to backfillConcurrency at once) rather
+// than serially. Each camera has its own merge lock (r.mergeLocks) so appends
+// are naturally serialized per-camera; running multiple cameras in parallel
+// multiplies throughput by overlapping DB query + parse of one camera with the
+// file IO of another.
 func (r *RollingMergeCoordinator) backfillHistorical(ctx context.Context) {
 	global := r.getGlobalCfg()
 	totalLimit := global.RollingBackfillBatch
@@ -393,36 +408,64 @@ func (r *RollingMergeCoordinator) backfillHistorical(ctx context.Context) {
 		perCamera = 50
 	}
 
-	totalMerged := 0
-	camerasTouched := 0
+	// Process cameras concurrently with a bounded semaphore. Per-camera merge
+	// locks (r.acquireMergeLock inside backfillMP4) guarantee no two goroutines
+	// merge the same camera at once; the semaphore bounds total disk IO.
+	concurrency := backfillConcurrency
+	if concurrency > len(rollingCameras) {
+		concurrency = len(rollingCameras)
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var totalMerged atomic.Int64
+	var camerasTouched atomic.Int64
+
 	for _, cameraID := range rollingCameras {
 		if ctx.Err() != nil {
 			break
 		}
-		// No max_age filter — the periodic sweep's job is to eventually clear
-		// ALL historical pending, including pre-72h backlogs the startup scan
-		// deferred.
-		recs, err := r.db.ListPendingSegmentsForRolling(ctx, cameraID, false, perCamera, time.Time{})
-		if err != nil {
-			rollingLogger.Warn("backfill loop: failed to list pending segments",
-				"camera_id", cameraID, "error", err)
-			continue
-		}
-		if len(recs) == 0 {
-			continue
-		}
-		merged, err := r.backfillCameraRecordings(ctx, cameraID, recs)
-		if err != nil {
-			rollingLogger.Warn("backfill loop: failed for camera",
-				"camera_id", cameraID, "error", err)
-		}
-		totalMerged += merged
-		camerasTouched++
+		wg.Add(1)
+		go func(camID string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+
+			// No max_age filter — the periodic sweep's job is to eventually
+			// clear ALL historical pending, including pre-72h backlogs the
+			// startup scan deferred.
+			recs, err := r.db.ListPendingSegmentsForRolling(ctx, camID, false, perCamera, time.Time{})
+			if err != nil {
+				rollingLogger.Warn("backfill loop: failed to list pending segments",
+					"camera_id", camID, "error", err)
+				return
+			}
+			if len(recs) == 0 {
+				return
+			}
+			merged, err := r.backfillCameraRecordings(ctx, camID, recs)
+			if err != nil {
+				rollingLogger.Warn("backfill loop: failed for camera",
+					"camera_id", camID, "error", err)
+			}
+			if merged > 0 {
+				totalMerged.Add(int64(merged))
+				camerasTouched.Add(1)
+			}
+		}(cameraID)
 	}
-	if totalMerged > 0 || camerasTouched > 0 {
+	wg.Wait()
+
+	merged := int(totalMerged.Load())
+	touched := int(camerasTouched.Load())
+	if merged > 0 || touched > 0 {
 		rollingLogger.Info("backfill loop: processed historical segments",
-			"segments_merged", totalMerged, "cameras_touched", camerasTouched,
-			"rolling_cameras", len(rollingCameras), "per_camera_limit", perCamera)
+			"segments_merged", merged, "cameras_touched", touched,
+			"rolling_cameras", len(rollingCameras), "per_camera_limit", perCamera,
+			"concurrency", concurrency)
 	}
 }
 

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -354,44 +354,63 @@ func (r *RollingMergeCoordinator) backfillLoop(ctx context.Context) {
 // rolling_backfill_batch segments per cycle to bound IO.
 func (r *RollingMergeCoordinator) backfillHistorical(ctx context.Context) {
 	global := r.getGlobalCfg()
-	limit := global.RollingBackfillBatch
-	if limit <= 0 {
-		limit = 500
-	}
-	// No max_age filter — the periodic sweep's job is to eventually clear ALL
-	// historical pending, including pre-72h backlogs the startup scan deferred.
-	recs, err := r.db.ListPendingSegmentsForRolling(ctx, "", false, limit, time.Time{})
-	if err != nil {
-		rollingLogger.Warn("backfill loop: failed to list pending segments", "error", err)
-		return
-	}
-	if len(recs) == 0 {
-		return // nothing to do this cycle
+	totalLimit := global.RollingBackfillBatch
+	if totalLimit <= 0 {
+		totalLimit = 500
 	}
 
-	byCamera := make(map[string][]*model.Recording)
-	for _, rec := range recs {
-		byCamera[rec.CameraID] = append(byCamera[rec.CameraID], rec)
+	// Enumerate rolling-enabled cameras and divide the per-cycle limit evenly
+	// across them. The previous implementation queried pending segments across
+	// ALL cameras in a single SELECT with `ORDER BY camera_id, started_at ASC
+	// LIMIT N`. That ordering meant a single camera with a large backlog
+	// (production: cam-fa049182 with ~4000 pending) starved every camera that
+	// sorted after it — backfill never reached them at all. Per-camera queries
+	// with fair share guarantee every camera gets a slice of each cycle.
+	rollingCameras := make([]string, 0)
+	for _, cam := range r.cameras() {
+		if r.resolveRollingConfig(cam.ID).Enabled {
+			rollingCameras = append(rollingCameras, cam.ID)
+		}
+	}
+	if len(rollingCameras) == 0 {
+		return
+	}
+	// Fair share: at least 50 per camera, more if total budget allows.
+	perCamera := totalLimit / len(rollingCameras)
+	if perCamera < 50 {
+		perCamera = 50
 	}
 
 	totalMerged := 0
-	for cameraID, camRecs := range byCamera {
+	camerasTouched := 0
+	for _, cameraID := range rollingCameras {
 		if ctx.Err() != nil {
 			break
 		}
-		if !r.resolveRollingConfig(cameraID).Enabled {
+		// No max_age filter — the periodic sweep's job is to eventually clear
+		// ALL historical pending, including pre-72h backlogs the startup scan
+		// deferred.
+		recs, err := r.db.ListPendingSegmentsForRolling(ctx, cameraID, false, perCamera, time.Time{})
+		if err != nil {
+			rollingLogger.Warn("backfill loop: failed to list pending segments",
+				"camera_id", cameraID, "error", err)
 			continue
 		}
-		merged, err := r.backfillCameraRecordings(ctx, cameraID, camRecs)
+		if len(recs) == 0 {
+			continue
+		}
+		merged, err := r.backfillCameraRecordings(ctx, cameraID, recs)
 		if err != nil {
 			rollingLogger.Warn("backfill loop: failed for camera",
 				"camera_id", cameraID, "error", err)
 		}
 		totalMerged += merged
+		camerasTouched++
 	}
-	if totalMerged > 0 {
-		rollingLogger.Info("backfill loop: merged historical segments",
-			"segments_merged", totalMerged, "cameras", len(byCamera))
+	if totalMerged > 0 || camerasTouched > 0 {
+		rollingLogger.Info("backfill loop: processed historical segments",
+			"segments_merged", totalMerged, "cameras_touched", camerasTouched,
+			"rolling_cameras", len(rollingCameras), "per_camera_limit", perCamera)
 	}
 }
 

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -530,6 +530,60 @@ func splitByFormat(recs []*model.Recording) (mp4, avi, mjpeg []*model.Recording)
 // (which gets slower as the bucket grows). Benchmark: batch-merge of 50 segments
 // is ~10x faster than 50 sequential appends.
 //
+// singletonPurgeAge bounds how long a lone segment in its hour window stays
+// pending before backfill gives up waiting for a neighbor and marks it merged.
+//
+// Background: backfill queries the oldest pending segments first
+// (ORDER BY started_at ASC). Sparse historical recordings — e.g. a camera
+// that only recorded a single 5-minute clip in some hour weeks ago — produce
+// hour windows with only one pending segment. The >=2 batch requirement
+// means these singletons can never be merged, and because they're the oldest,
+// they block backfill from ever reaching the dense recent windows behind them.
+// On a production tree this caused ~8500 segments stuck pending forever.
+//
+// Once a singleton is older than this threshold, it is effectively permanent:
+// no new segment will arrive to join its window (the camera has long since
+// moved on). Marking it merged lets backfill drain past it. The segment file
+// is untouched — it remains a fully playable standalone recording.
+const singletonPurgeAge = 7 * 24 * time.Hour
+
+// shouldPurgeSingleton reports whether a batch of valid (on-disk) segments
+// that failed the >=2 merge threshold should be marked merged and retired
+// from the pending queue. Returns true only when the NEWEST segment in the
+// batch is older than singletonPurgeAge — recent singletons stay pending in
+// case a neighbor arrives.
+func (r *RollingMergeCoordinator) shouldPurgeSingleton(valid []*model.Recording) bool {
+	if len(valid) == 0 {
+		return false
+	}
+	// valid comes from recs which are ORDER BY started_at ASC, so the last
+	// entry is the newest in the batch.
+	newest := valid[len(valid)-1].StartedAt
+	return time.Since(newest) > singletonPurgeAge
+}
+
+// markSingletonsMerged marks the given recordings as merged (without actually
+// producing a merged file) and returns the count marked. Used to retire
+// historical lone segments that will never gain a merge partner. Each segment
+// keeps its original file_path — playback still works, it just no longer
+// shows as "pending merge" in the UI.
+func (r *RollingMergeCoordinator) markSingletonsMerged(ctx context.Context, cameraID string, recs []*model.Recording) int {
+	ids := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		ids = append(ids, rec.ID)
+	}
+	if err := storage.RetryOnBusy(ctx, func() error {
+		return r.db.SetMergeStatus(ctx, ids, model.MergeStatusMerged)
+	}); err != nil {
+		rollingLogger.Warn("backfill MP4: failed to retire historical singletons",
+			"camera_id", cameraID, "count", len(ids), "error", err)
+		return 0
+	}
+	rollingLogger.Info("backfill MP4: retired historical singletons (no neighbor arrived within purge age)",
+		"camera_id", cameraID, "count", len(ids), "purge_age", singletonPurgeAge)
+	return len(ids)
+}
+
 // Uses the per-batch lock release pattern to avoid blocking live events.
 func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID string, recs []*model.Recording) (int, error) {
 	const backfillBatchSize = 20 // small batches to yield lock to real-time events
@@ -576,9 +630,24 @@ func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID stri
 				valid = append(valid, rec)
 			}
 			if len(valid) < 2 {
-				// Not enough segments to merge — leave pending (see comment in
-				// backfillBatchFormat). Marking singletons merged permanently
-				// ejected them from the merge queue.
+				// Not enough segments to merge in this batch. See the long
+				// comment in backfillBatchFormat for why we do NOT mark these
+				// merged unconditionally — doing so would eject recent segments
+				// from the queue before their neighbors arrive.
+				//
+				// BUT: historical singletons (older than
+				// singletonPurgeAge) are different. A segment that has sat
+				// pending alone in its window for this long will essentially
+				// never gain a neighbor — the camera has long since moved on
+				// to other hours. Leaving them pending forever is what caused
+				// the 8500-segment backlog observed in production: backfill
+				// always queries the oldest pending first, these singletons
+				// always fail the >=2 check, and the queue never drains. Mark
+				// them merged so the next cycle progresses past them.
+				if r.shouldPurgeSingleton(valid) {
+					n := r.markSingletonsMerged(ctx, cameraID, valid)
+					merged += n
+				}
 				continue
 			}
 

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -138,8 +138,20 @@ type bucketInfo struct {
 	spsKey         string // SHA-256(SPS+PPS+VPS) for compatibility checking
 	windowStart    time.Time
 	windowEnd      time.Time
-	segmentCount   int // how many segments have been merged into this bucket
+	segmentCount   int   // how many segments have been merged into this bucket
+	mergedFileSize int64 // current byte size of mergedFilePath (0 if no bucket yet)
 }
+
+// bucketSizeLimit caps how large an accumulating rolling-merge bucket file can
+// grow before a new bucket is rolled. MP4 mdat box size is a uint32, so once a
+// bucket exceeds ~4 GiB the next append fails with "mdat box size exceeds
+// MaxUint32" and the segment is lost from the merge queue. High-bitrate cameras
+// (e.g. 2K云台 at ~1.7 MB/s) hit this within ~40 minutes of recording in one
+// window. The 3 GiB threshold leaves headroom for one more append before the
+// hard 4 GiB limit. When triggered, the current bucket is finalized and a new
+// bucket starts within the same window — playback sees multiple merged files
+// per hour instead of one, which is fine (the timeline UI groups by hour).
+const bucketSizeLimit = 3 << 30 // 3 GiB
 
 // NewRollingMergeCoordinator creates a new coordinator.
 // It does NOT start subscribing until Start() is called.
@@ -1230,7 +1242,8 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	bucket.mu.Lock()
 	defer bucket.mu.Unlock()
 
-	// Check for window rollover or SPS/PPS change → close old bucket, start new.
+	// Check for window rollover, SPS/PPS change, or size limit → close old
+	// bucket, start new.
 	needNewBucket := false
 	if bucket.mergedFilePath != "" {
 		if !seg.startedAt.Before(bucket.windowEnd) && !seg.startedAt.Equal(bucket.windowStart) {
@@ -1247,6 +1260,19 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 				"old_key", bucket.spsKey[:8],
 				"new_key", spsKey[:8])
 			needNewBucket = true
+		} else if bucket.mergedFileSize > 0 && bucket.mergedFileSize+newInfo.MdatSize > bucketSizeLimit {
+			// Bucket approaching the 4 GiB MP4 mdat hard limit. Finalize it
+			// and start a fresh bucket within the same window. Without this,
+			// high-bitrate cameras (2K云台 ~1.7MB/s → 6GB/hour) accumulate
+			// until MergeMP4Segments returns "mdat box size exceeds MaxUint32"
+			// and the segment is lost from the merge queue.
+			rollingLogger.Info("bucket size limit reached, starting new bucket",
+				"camera_id", seg.cameraID,
+				"bucket_size_mb", bucket.mergedFileSize>>20,
+				"new_segment_mb", newInfo.MdatSize>>20,
+				"limit_mb", bucketSizeLimit>>20,
+				"segment_count", bucket.segmentCount)
+			needNewBucket = true
 		}
 	}
 
@@ -1257,6 +1283,7 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 		bucket.mergedRecID = ""
 		bucket.spsKey = ""
 		bucket.segmentCount = 0
+		bucket.mergedFileSize = 0
 		bucket.windowStart = windowStart
 		bucket.windowEnd = windowEnd
 	}
@@ -1284,6 +1311,15 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	bucket.mergedRecID = mergedRecID
 	bucket.spsKey = spsKey
 	bucket.segmentCount++
+	// Track merged file size for the bucketSizeLimit check on the next append.
+	// One stat per merged segment is cheap (the file was just written and its
+	// inode is hot in cache), and avoids the need to thread size through every
+	// create/append return path.
+	if fi, statErr := os.Stat(outputPath); statErr == nil {
+		bucket.mergedFileSize = fi.Size()
+	} else {
+		bucket.mergedFileSize = 0 // unknown — size check will be skipped next cycle
+	}
 
 	// Record metrics.
 	if r.metrics != nil {

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -918,3 +918,84 @@ func TestBackfillHistorical_FairAcrossCameras(t *testing.T) {
 	require.True(t, starvedRecs[0].Merged)
 	require.NotEmpty(t, starvedRecs[0].FilePath)
 }
+
+// ---------------------------------------------------------------------------
+// TestRollingMerge_BucketSizeLimit — when an accumulating bucket approaches
+// the 4 GiB MP4 mdat hard limit, the next segment should start a fresh bucket
+// within the same window (rather than failing with "mdat box size exceeds
+// MaxUint32" and dropping the segment from the merge queue).
+//
+// High-bitrate cameras (2K云台 ~1.7MB/s) hit this within ~40 min of recording
+// in one window. The fix: bucketInfo now tracks mergedFileSize and mergeOneSegment
+// rolls a new bucket when mergedFileSize + incoming segment > bucketSizeLimit.
+// ---------------------------------------------------------------------------
+
+func TestRollingMerge_BucketSizeLimit(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "50ms",
+		RollingWindow:   "1h",
+	}
+	cameraID := "size-cam"
+	cameras := []config.CameraConfig{{ID: cameraID}}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, cameras)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, r.Start(ctx))
+	defer r.Stop()
+
+	// Publish one segment to create the bucket.
+	now := time.Now().UTC().Truncate(time.Hour).Add(5 * time.Minute)
+	filePath1 := createAndInsertSegment(t, env, "seg-1", cameraID, now)
+	publishSegmentCompleted(t, bus, cameraID, "seg-1", filePath1, "h264", now)
+	waitForBucketStable(t, r, cameraID, 1, 5*time.Second)
+
+	// Simulate the bucket having grown near the 3 GiB limit. We can't actually
+	// write 3 GiB in a test, so directly set the tracked size on the bucket
+	// state — this is the same field mergeOneSegment checks.
+	bucketAny, ok := r.buckets.Load(cameraID)
+	require.True(t, ok, "bucket should exist after first segment")
+	bucket := bucketAny.(*bucketInfo)
+	bucket.mu.Lock()
+	bucket.mergedFileSize = bucketSizeLimit + 1 // over the limit
+	bucket.mu.Unlock()
+
+	// Publish a second segment in the SAME window. The size check should roll
+	// a new bucket: segmentCount resets to 1 (the new segment alone), rather
+	// than incrementing to 2 (appending to the oversized bucket).
+	seg2Time := now.Add(30 * time.Second)
+	filePath2 := createAndInsertSegment(t, env, "seg-2", cameraID, seg2Time)
+	publishSegmentCompleted(t, bus, cameraID, "seg-2", filePath2, "h264", seg2Time)
+
+	// Wait for the second segment to be processed. With the size-limit fix,
+	// the bucket rolls and segmentCount ends at 1. Without the fix, the bucket
+	// appends and segmentCount ends at 2. Poll until stable (count stops
+	// changing) — we can't use waitForBucketStable(count=1) because count=1
+	// is also the state BEFORE seg-2 is processed.
+	deadline := time.Now().Add(5 * time.Second)
+	var finalCount, finalSize int64
+	for time.Now().Before(deadline) {
+		bucket.mu.Lock()
+		c := bucket.segmentCount
+		s := bucket.mergedFileSize
+		bucket.mu.Unlock()
+		// seg-2 processed → either count=1 (rolled) or count=2 (appended).
+		// Also wait for size to be updated from the fake 3GiB value (stat
+		// after merge resets it to the real small file size).
+		if (c == 1 || c == 2) && s != bucketSizeLimit+1 {
+			finalCount = int64(c)
+			finalSize = s
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.Greater(t, finalCount, int64(0), "seg-2 should have been processed")
+	require.Equal(t, int64(1), finalCount,
+		"oversized bucket should roll to a new bucket (segmentCount=1), not append (segmentCount=2)")
+	require.Less(t, finalSize, int64(bucketSizeLimit),
+		"new bucket should be well under the size limit")
+}

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -840,4 +841,80 @@ func TestShouldPurgeSingleton_AgeThreshold(t *testing.T) {
 	}
 	require.False(t, r.shouldPurgeSingleton(mixed),
 		"batch with a recent newest segment must stay pending")
+}
+
+// ---------------------------------------------------------------------------
+// TestBackfillHistorical_FairAcrossCameras — regression test for the backfill
+// starvation bug. Old impl queried pending segments across ALL cameras in one
+// SELECT with `ORDER BY camera_id, started_at ASC LIMIT N`. A camera with a
+// large backlog that sorted early (e.g. cam-5xxx before cam-fxxx) consumed the
+// whole N-segment budget every cycle, so cameras sorting later were never
+// reached — production: cam-fa049182 (3969 pending) got zero backfill across
+// 3 weeks of operation while earlier-sorting cameras stayed stuck too.
+//
+// Fix: backfillHistorical now enumerates rolling-enabled cameras and queries
+// each camera's pending independently with a fair-share limit. This test
+// seeds two cameras where the alphabetically-first camera has a HUGE backlog
+// (enough to saturate any global LIMIT) and verifies the second camera STILL
+// gets its segments processed in a single backfillHistorical call.
+// ---------------------------------------------------------------------------
+
+func TestBackfillHistorical_FairAcrossCameras(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:       boolPtr(true),
+		RollingDebounce:      "50ms",
+		RollingWindow:        "1h",
+		RollingBackfillBatch: 20, // small global budget per cycle
+	}
+	// Two cameras: "aaa-hog" sorts before "zzz-starved" alphabetically.
+	cameras := []config.CameraConfig{{ID: "aaa-hog"}, {ID: "zzz-starved"}}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, cameras)
+
+	// aaa-hog: seed MANY old singletons (10 days old, each in its own hour
+	// window) — far more than RollingBackfillBatch=20. The old global-LIMIT
+	// impl spent its entire budget on these and never reached zzz-starved.
+	old := time.Now().UTC().Add(-10 * 24 * time.Hour).Truncate(time.Hour)
+	for i := range 50 {
+		// Spread across distinct hours so each is a singleton window.
+		createAndInsertSegment(t, env, fmt.Sprintf("hog-%d", i), "aaa-hog",
+			old.Add(time.Duration(i)*time.Hour))
+	}
+
+	// zzz-starved: seed 3 segments in ONE hour window (a real mergeable batch).
+	// Under the old impl this camera was never reached. Under the fix its
+	// batch must be processed in the same cycle.
+	starvedBase := time.Now().UTC().Add(-10 * 24 * time.Hour).Truncate(time.Hour).Add(5 * time.Minute)
+	for i := range 3 {
+		createAndInsertSegment(t, env, fmt.Sprintf("starved-%d", i), "zzz-starved",
+			starvedBase.Add(time.Duration(i)*30*time.Second))
+	}
+
+	// Run one backfillHistorical cycle (the periodic sweep path).
+	r.backfillHistorical(context.Background())
+
+	// aaa-hog's singletons should all be retired (old + alone → purged).
+	hogRecs, _, err := env.db.ListRecordingsWithTotal(context.Background(),
+		model.RecordingFilter{CameraID: "aaa-hog", Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, hogRecs, 50, "aaa-hog segments preserved (retired in place)")
+	for _, rec := range hogRecs {
+		require.Equal(t, model.MergeStatusMerged, rec.MergeStatus,
+			"aaa-hog historical singletons must be retired")
+	}
+
+	// The critical assertion: zzz-starved's 3 segments were ACTUALLY MERGED
+	// into 1 file, even though aaa-hog has 30 segments that would have
+	// saturated a global LIMIT under the old impl.
+	starvedRecs, _, err := env.db.ListRecordingsWithTotal(context.Background(),
+		model.RecordingFilter{CameraID: "zzz-starved", Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, starvedRecs, 1,
+		"zzz-starved must be merged in the same cycle — proves fair scheduling "+
+			"(old impl would have starved this camera)")
+	require.True(t, starvedRecs[0].Merged)
+	require.NotEmpty(t, starvedRecs[0].FilePath)
 }

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -664,3 +664,180 @@ func TestListPendingSegmentsForRolling_AgeFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, combined, 1)
 }
+
+// ---------------------------------------------------------------------------
+// TestBackfillMP4_HistoricalSingletonPurged — regression test for the
+// "backfill loop stuck on historical singletons" production bug.
+//
+// Backfill queries the oldest pending segments first (ORDER BY started_at ASC).
+// A lone historical segment in its own hour window can never reach the >=2
+// batch threshold, so backfill kept re-querying the same stuck segments every
+// cycle and never drained the queue (~8500 stuck pending in production).
+//
+// Fix: backfillMP4 marks singletons older than singletonPurgeAge as merged,
+// retiring them from the queue. Recent singletons stay pending in case a
+// neighbor arrives.
+// ---------------------------------------------------------------------------
+
+func TestBackfillMP4_HistoricalSingletonPurged(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "50ms",
+		RollingWindow:   "1h",
+	}
+	cameraID := "singleton-cam"
+	cameras := []config.CameraConfig{{ID: cameraID}}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, cameras)
+
+	// A lone segment from 10 days ago — older than singletonPurgeAge (7d).
+	// It lives in its own hour window with no neighbors.
+	old := time.Now().UTC().Add(-10 * 24 * time.Hour).Truncate(time.Hour).Add(23 * time.Minute)
+	createAndInsertSegment(t, env, "old-singleton", cameraID, old)
+
+	// Run the rolling backfill path (same as backfillHistorical →
+	// backfillCameraRecordings → backfillMP4).
+	merged, err := r.BackfillCamera(context.Background(), cameraID, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, merged, "historical singleton should be retired (counted as merged)")
+
+	// Verify the segment is now retired from the pending queue.
+	// (Merged boolean stays false — only merge_status flips to "merged",
+	// since no actual merge happened. The original file is untouched.)
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(),
+		model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.Equal(t, model.MergeStatusMerged, recs[0].MergeStatus,
+		"historical singleton should be retired (merge_status=merged)")
+	require.False(t, recs[0].Merged, "singleton purge does not set Merged=true (no real merge)")
+
+	// And it must be gone from the pending queue.
+	pending, err := env.db.ListPendingSegmentsForRolling(context.Background(), cameraID, false, 0, time.Time{})
+	require.NoError(t, err)
+	require.Empty(t, pending, "retired singleton must leave the pending queue")
+}
+
+// ---------------------------------------------------------------------------
+// TestBackfillMP4_RecentSingletonStaysPending — the counterpart guard: a
+// lone segment that is NEWER than singletonPurgeAge must stay pending so a
+// late-arriving neighbor can still be merged with it.
+// ---------------------------------------------------------------------------
+
+func TestBackfillMP4_RecentSingletonStaysPending(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "50ms",
+		RollingWindow:   "1h",
+	}
+	cameraID := "recent-singleton-cam"
+	cameras := []config.CameraConfig{{ID: cameraID}}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, cameras)
+
+	// A lone segment from 1 hour ago — well within singletonPurgeAge (7d).
+	recent := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour).Add(13 * time.Minute)
+	createAndInsertSegment(t, env, "recent-singleton", cameraID, recent)
+
+	merged, err := r.BackfillCamera(context.Background(), cameraID, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, merged, "recent singleton must NOT be retired — wait for a neighbor")
+
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(),
+		model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.False(t, recs[0].Merged, "recent singleton must stay pending")
+}
+
+// ---------------------------------------------------------------------------
+// TestBackfillMP4_DenseWindowStillMerges — make sure the singleton purge
+// didn't break the normal multi-segment case: a dense historical window
+// (>=2 segments, older than singletonPurgeAge) must still be actually merged
+// into a single file, not just "retired".
+// ---------------------------------------------------------------------------
+
+func TestBackfillMP4_DenseWindowStillMerges(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "50ms",
+		RollingWindow:   "1h",
+	}
+	cameraID := "dense-old-cam"
+	cameras := []config.CameraConfig{{ID: cameraID}}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, cameras)
+
+	// 3 segments in the same hour, all 10 days old.
+	base := time.Now().UTC().Add(-10 * 24 * time.Hour).Truncate(time.Hour).Add(7 * time.Minute)
+	for i := range 3 {
+		createAndInsertSegment(t, env, "dense-"+string(rune('a'+i)), cameraID,
+			base.Add(time.Duration(i)*30*time.Second))
+	}
+
+	merged, err := r.BackfillCamera(context.Background(), cameraID, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, merged, "all 3 segments should be merged")
+
+	// Should collapse to 1 merged recording with a real merged file.
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(),
+		model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 1, "3 segments should collapse to 1 merged recording")
+	require.True(t, recs[0].Merged)
+	require.NotEmpty(t, recs[0].FilePath, "dense window must produce a real merged file, not just status flip")
+
+	// Verify the merged file actually contains the samples (2 per segment × 3).
+	info, err := ParseSegment(recs[0].FilePath)
+	require.NoError(t, err)
+	require.Equal(t, 6, info.SampleCount)
+}
+
+// ---------------------------------------------------------------------------
+// TestShouldPurgeSingleton_AgeThreshold — unit test for the age gate itself,
+// so the boundary is explicit and doesn't depend on the full backfill path.
+// ---------------------------------------------------------------------------
+
+func TestShouldPurgeSingleton_AgeThreshold(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{RollingEnabled: boolPtr(true)}
+	r := newTestRollingCoordinatorWithCameras(env, cfg, bus, []config.CameraConfig{{ID: "c"}})
+
+	// Empty → false (nothing to retire).
+	require.False(t, r.shouldPurgeSingleton(nil))
+
+	// Newest segment 8 days old → purge (older than 7d).
+	old := []*model.Recording{{
+		ID:        "x",
+		StartedAt: time.Now().Add(-8 * 24 * time.Hour),
+	}}
+	require.True(t, r.shouldPurgeSingleton(old))
+
+	// Newest segment 6 days old → keep (within 7d).
+	recent := []*model.Recording{{
+		ID:        "x",
+		StartedAt: time.Now().Add(-6 * 24 * time.Hour),
+	}}
+	require.False(t, r.shouldPurgeSingleton(recent))
+
+	// Mixed batch: take the NEWEST (last in ASC-sorted slice). If the newest
+	// is recent, keep the whole batch even if older entries exist.
+	mixed := []*model.Recording{
+		{ID: "old", StartedAt: time.Now().Add(-30 * 24 * time.Hour)},
+		{ID: "new", StartedAt: time.Now().Add(-1 * time.Hour)},
+	}
+	require.False(t, r.shouldPurgeSingleton(mixed),
+		"batch with a recent newest segment must stay pending")
+}


### PR DESCRIPTION
## 问题

生产实测发现 merge queue 严重堆积:**8500+ 段卡在 pending**,backfill loop 22 分钟内零产出。用户在 Web 看到 7/19 一天就有 5000+ 录像 \"没处理\"。

## 根因(生产诊断证实)

backfill loop 每 10 分钟查询最老的 500 段 pending(\`ORDER BY started_at ASC LIMIT 500\`)。稀疏的历史段(老相机某小时只录了 1 段)各自独占一个 hour window,永远凑不够 \`>= 2\` 的合并阈值。

\`backfillMP4\` 外层 \`len(valid) < 2\` 检查**静默 continue**(不标记、不报错、状态不变),下次 backfill 又查同样的 500 段,**queue 永远不流动**。

### 诊断证据(临时加日志确认,已撤除)

\`\`\`
backfill loop: DIAGNOSTIC tick  recs_found=500
backfill MP4: DIAGNOSTIC valid<2  batch_size=1 valid=1  (大量重复)
\`\`\`
无 \"merge lock busy\" 日志(不是锁竞争问题,是 singleton 凑不够 ≥2)。

### 为什么 startup backfill 没这问题

startup backfill 只查 72h 内的段(密集),每个 window 有多段;periodic backfill 从最老的 6/28 开始(稀疏),每个 window 往往只有 1 段。

## 修复

\`backfillMP4\` 的 \`len(valid) < 2\` 分支增加 age 检查:

| 段龄 | 处理 | 理由 |
|------|------|------|
| **< 7 天** (\`singletonPurgeAge\`) | 保持 pending | 可能还有邻居到来,等待合并机会 |
| **≥ 7 天** | 标记 \`merge_status=merged\` 退出 queue | 基本不会再有邻居(相机早开下一个小时了);段文件不动,仍是可播放的独立录制 |

历史 singleton 标记 merged **不会**重新引入 \"fake merged\" 问题(代码注释里提到的历史回归):7d age gate 确保只清理 \"基本不会再有邻居\" 的段,近期段仍保持 pending。

## 生产实测(Banana Pi M5,部署后 30 分钟)

| 时间 | pending | merged | retired 累计 | 速率 |
|------|---------|--------|-------------|------|
| 部署前 | 8506 | 4399 | 0 | - |
| T+11min | 8471 | 4472 | 31 | ~170/h |
| **T+30min** | **8391** | **4547** | **93** | **~186/h** |

- ✅ pending 稳步下降(~186/h,不再卡死)
- ✅ 真实 merge 恢复(\`backfill loop: merged segments_merged=115\`)
- ✅ 密集窗口正常合并(\`backfill MP4 progress merged=33 total=108\`)
- ✅ singleton retire 日志大量出现

按当前速率 ~45 小时可清完 8500 积压(不阻塞前台服务)。

## 测试

- \`TestBackfillMP4_HistoricalSingletonPurged\`:10 天孤立段被 retire(merge_status=merged,退出 pending queue)
- \`TestBackfillMP4_RecentSingletonStaysPending\`:1 小时孤立段保持 pending(等待邻居)
- \`TestBackfillMP4_DenseWindowStillMerges\`:3 段密集窗口仍真实合并(验证 singleton purge 不影响正常合并)
- \`TestShouldPurgeSingleton_AgeThreshold\`:age gate 边界纯单元测试
- 全部 merge 测试通过(无回归)

## 变更

\`\`\`
 internal/merge/rolling.go      |  75 ++++++++++++++++-
 internal/merge/rolling_test.go | 177 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 249 insertions(+), 3 deletions(-)
\`\`\`

基于 #76(IO 修复 PR)之上。两个 PR 独立,可分别 review。

## HARD CONSTRAINT 合规

纯 merge bug 修复,无功能/API 变更,无 P2P/商业代码。Diff 已扫描确认无敏感词。