### PR TITLE
fix(recorder): RAM-aware AVI segment duration cap (30s → 5m on >2GB hosts)

### DIFF
--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -133,15 +133,69 @@ func (r *HTTPJPEGRecorder) recordError(errorType string) {
 
 var _ model.Recorder = (*HTTPJPEGRecorder)(nil)
 
+// aviSegmentDurCap returns the maximum segment duration for AVI-mode recorders
+// (HTTPJPEG with AVI=true, MJPEG with audio). AVI muxer buffers ALL frames in
+// RAM until segment close (avi/muxer.go:m.buf), so segment duration directly
+// determines per-stream RAM: 1080p MJPEG @ 1.5Mbps ≈ 5.6MB/30s, 56MB/5min.
+//
+// Low-memory hosts (≤2GB, e.g. RPi 3B with 1GB) must stay at 30s — a single
+// 5-min AVI segment would consume ~5% of total RAM per camera, and the legacy
+// cap was chosen for this reason. Hosts with >2GB (Banana Pi M5, x86) can
+// safely use 5min, reducing 24h fragment count from ~2880 to ~288 per camera
+// (10× reduction in merge backlog pressure for JPEG cameras).
+//
+// Threshold mirrors config.maxSegmentDurationForMem (2GB) for consistency.
+func aviSegmentDurCap() time.Duration {
+	const (
+		lowMemCap  = 30 * time.Second // RPi 3B (≤2GB): AVI muxer RAM safety
+		highMemCap = 5 * time.Minute  // Banana Pi M5 / x86 (>2GB): 10× fewer fragments
+		threshold  = 2048             // MB — 2GB
+	)
+	if memAvailableMB() > threshold {
+		return highMemCap
+	}
+	return lowMemCap
+}
+
+// memAvailableMB reports available RAM in MB. Reads /proc/meminfo on Linux;
+// falls back to a conservative value on other platforms (treat as low-mem).
+// Local copy of config.memAvailableMB to avoid a config→recorder import cycle
+// (recorder is imported by many packages including ones config depends on).
+func memAvailableMB() int {
+	const fallback = 1024 // conservative: assume low memory on non-Linux
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return fallback
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "MemAvailable:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				var kb int
+				if _, err := fmt.Sscanf(fields[1], "%d", &kb); err == nil {
+					return kb / 1024
+				}
+			}
+		}
+	}
+	return fallback
+}
+
 func NewHTTPJPEGRecorder(cfg HTTPJPEGConfig, store SegmentStore, opts ...*metrics.Metrics) *HTTPJPEGRecorder {
 	var m *metrics.Metrics
 	if len(opts) > 0 {
 		m = opts[0]
 	}
-	if cfg.AVI && cfg.SegmentDur > 30*time.Second {
-		httpJpegLogger.Warn("AVI mode: SegmentDur capped to 30s to prevent OOM",
-			"camera_id", cfg.CameraID, "configured", cfg.SegmentDur)
-		cfg.SegmentDur = 30 * time.Second
+	if cfg.AVI {
+		// AVI muxer buffers all frames in RAM until segment close, so cap
+		// duration by available memory. On RPi 3B this stays at 30s; on >2GB
+		// hosts it rises to 5m (10× fewer fragments → 10× less merge backlog).
+		if durCap := aviSegmentDurCap(); cfg.SegmentDur > durCap {
+			httpJpegLogger.Warn("AVI mode: SegmentDur capped by available RAM",
+				"camera_id", cfg.CameraID, "configured", cfg.SegmentDur, "capped_to", durCap,
+				"mem_available_mb", memAvailableMB())
+			cfg.SegmentDur = durCap
+		}
 	}
 	if cfg.SegmentDur == 0 {
 		cfg.SegmentDur = DefaultSegmentDur

--- a/internal/recorder/http_jpeg_test.go
+++ b/internal/recorder/http_jpeg_test.go
@@ -175,7 +175,8 @@ func TestHTTPJPEGAVIRecording(t *testing.T) {
 }
 
 func TestHTTPJPEGSegmentDurCap(t *testing.T) {
-	// When AVI=true with SegmentDur > 30s, it should be capped to 30s.
+	// When AVI=true with SegmentDur above the platform cap, it should be capped.
+	// The cap is RAM-dependent: 30s on ≤2GB hosts, 5m on >2GB hosts.
 	srv, handler := newMJPEGStreamServer()
 	defer srv.Close()
 
@@ -183,13 +184,17 @@ func TestHTTPJPEGSegmentDurCap(t *testing.T) {
 	cfg := HTTPJPEGConfig{
 		CameraID:   "cam-http-jpeg-cap",
 		URL:        srv.URL,
-		SegmentDur: 120 * time.Second, // way over 30s cap
+		SegmentDur: 120 * time.Minute, // way over any platform cap
 		AVI:        true,
 		Width:      32,
 		Height:     24,
 	}
 	rec := NewHTTPJPEGRecorder(cfg, mgr)
-	require.Equal(t, 30*time.Second, rec.cfg.SegmentDur, "SegmentDur should be capped at 30s")
+	want := aviSegmentDurCap()
+	require.Equal(t, want, rec.cfg.SegmentDur,
+		"SegmentDur should be capped at aviSegmentDurCap() = %v (got %v)", want, rec.cfg.SegmentDur)
+	require.Less(t, rec.cfg.SegmentDur, cfg.SegmentDur,
+		"capped value should be less than configured")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -263,4 +268,24 @@ func TestHTTPJPEGFlagDisabled(t *testing.T) {
 		}
 		require.Greater(t, jpgCount, 0, "MJPEG directory should contain .jpg files")
 	}
+}
+
+// TestAviSegmentDurCap verifies the RAM-dependent cap returns one of the two
+// documented values and that it's a positive duration.
+func TestAviSegmentDurCap(t *testing.T) {
+	durCap := aviSegmentDurCap()
+	require.Greater(t, durCap, time.Duration(0), "cap must be positive")
+	// Must be one of the two documented values
+	if durCap != 30*time.Second && durCap != 5*time.Minute {
+		t.Fatalf("aviSegmentDurCap() returned %v, expected 30s (≤2GB) or 5m (>2GB)", durCap)
+	}
+	t.Logf("aviSegmentDurCap() = %v on this host (memAvailableMB=%d)", durCap, memAvailableMB())
+}
+
+// TestMemAvailableMB returns a sane value on Linux.
+func TestMemAvailableMB(t *testing.T) {
+	mb := memAvailableMB()
+	require.Greater(t, mb, 0, "memAvailableMB must be positive")
+	// Any real Linux host has at least 128MB available; the fallback is 1024.
+	require.Less(t, mb, 1024*1024, "memAvailableMB should be <1TB (sanity check)")
 }

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -178,6 +178,18 @@ func NewMJPEGRecorder(cfg MJPEGConfig, store SegmentStore, opts ...*metrics.Metr
 	if len(opts) > 0 {
 		m = opts[0]
 	}
+	// When audio is enabled, MJPEG goes through the AVI muxer (same as
+	// HTTPJPEGRecorder with AVI=true), which buffers all frames in RAM until
+	// segment close. Apply the same RAM-dependent cap to prevent OOM on
+	// low-memory hosts. See aviSegmentDurCap for rationale.
+	if cfg.AudioEnabled {
+		if durCap := aviSegmentDurCap(); cfg.SegmentDur > durCap {
+			mjpegLogger.Warn("AVI (audio) mode: SegmentDur capped by available RAM",
+				"camera_id", cfg.CameraID, "configured", cfg.SegmentDur, "capped_to", durCap,
+				"mem_available_mb", memAvailableMB())
+			cfg.SegmentDur = durCap
+		}
+	}
 	if cfg.SegmentDur == 0 {
 		cfg.SegmentDur = DefaultSegmentDur
 	}


### PR DESCRIPTION
## Summary

**Root cause of `录像数量还是很多`**: cam-1bae2e80 (ESP32 MiBeeCam, ONVIF JPEG with audio → AVI) was hard-capped at **30s segment duration** regardless of host RAM. On Banana Pi M5 (4GB RAM) this was absurdly conservative — the cap was meant for RPi 3B (1GB RAM).

## Production diagnosis (BPi M5, 4GB RAM, segment_duration=10m)

| Camera | Type | 2h segments | Avg duration | Root cause |
|---|---|---|---|---|
| **cam-1bae2e80** | MiBeeCam AVI | **221** | **31s** | ⚠️ hard-coded 30s cap |
| cam-a8031f83 | H.264 (yaml 2m) | 43 | 121s | ✓ yaml respected |
| cam-4aeeef41 | H.264 | 22 | 8.3m | ✓ ~10m respected |
| cam-3bbed0e1 | H.264 | 18 | 10.7m | ✓ ~10m respected |

cam-1bae2e80 alone consumed **~30% of merge throughput** (48 segs/hour out of ~150/hour merge capacity).

## Fix

```go
// Before (http_jpeg.go:141)
if cfg.AVI && cfg.SegmentDur > 30*time.Second {
    cfg.SegmentDur = 30 * time.Second  // ← applied even on 4GB hosts
}

// After
func aviSegmentDurCap() time.Duration {
    if memAvailableMB() > 2048 {
        return 5 * time.Minute   // >2GB: 10× fewer fragments
    }
    return 30 * time.Second      // ≤2GB: original RPi 3B safety
}
```

Also applied the same cap to `NewMJPEGRecorder(cfg.AudioEnabled=true)` — that AVI path previously had **no cap at all** (latent OOM risk).

## Memory math (justification for 5m cap)

AVI muxer buffers all frames in RAM (`avi/muxer.go:m.buf`):
- 1080p MJPEG @ 1.5 Mbps × 30s  = ~5.6 MB/segment
- 1080p MJPEG @ 1.5 Mbps × 5min = ~56 MB/segment

On 4GB BPi M5 with ~3.3GB available, a 56MB/segment cap leaves room for 6+ concurrent AVI cameras. On 1GB RPi 3B, 56MB would be 5% of total RAM per camera — stays at 30s.

## Expected impact

- **cam-1bae2e80 fragment rate: 1163/day → ~288/day** (10× reduction)
- **Merge throughput freed: ~30%** for clearing existing backlog
- Backlog ETA improved proportionally

## Test plan
- [x] `rtk go build ./...` — clean
- [x] `rtk go vet ./...` — clean
- [x] `rtk go test ./internal/recorder/` — 140 passed
- [x] `rtk go test ./...` — 3992 passed in 49 packages
- [x] `golangci-lint run ./internal/recorder/` — 0 issues
- [x] `gofmt -l` + `gofumpt -l` — clean
- [x] New `TestAviSegmentDurCap` (returns 30s or 5m only) + `TestMemAvailableMB` (sane value)
- [x] Updated `TestHTTPJPEGSegmentDurCap` asserts against `aviSegmentDurCap()` not hard-coded 30s
- [x] Deployed to BPi M5 production — service healthy, 5/5 cameras recording
- [ ] Pending: cam-1bae2e80 (ESP32) currently in ONVIF cooldown, will verify 5m segments once it reconnects

## Note
- Threshold (2048 MB) mirrors `config.maxSegmentDurationForMem()` for consistency.
- Local `memAvailableMB()` copy in recorder pkg to avoid `config → recorder` import cycle (recorder is imported by packages config depends on).