### PR TITLE
fix(storage): overwrite stale migrate-backup before VACUUM INTO

### DIFF
--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -146,7 +146,13 @@ func MigrateMJPEGToAVI(ctx context.Context, db *DB, store *Manager, opts Migrate
 	}
 
 	// Step 2: DB backup before any writes.
+	// Remove any stale backup from a prior run first — VACUUM INTO fails if
+	// the destination file already exists, which would block repeat invocations
+	// (common when a previous migration was interrupted and re-run).
 	backupPath := db.path + ".migrate-backup"
+	if err := os.Remove(backupPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale backup: %w", err)
+	}
 	if err := db.Backup(ctx, backupPath); err != nil {
 		return fmt.Errorf("db backup: %w", err)
 	}

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -404,3 +404,44 @@ func TestMigrateOneRecording_NoJPGs(t *testing.T) {
 	err := migrateOneRecording(ctx, db, store, rec, logger)
 	require.ErrorIs(t, err, errSkipped)
 }
+
+// TestMigrateMJPEGToAVI_OverwritesStaleBackup verifies that a pre-existing
+// .migrate-backup file (left over from a prior interrupted run) does not block
+// the migration. Before the fix, VACUUM INTO failed with "output file already
+// exists" on every re-run, requiring manual cleanup.
+func TestMigrateMJPEGToAVI_OverwritesStaleBackup(t *testing.T) {
+	db, store, ctx, dir := setupMigrateTest(t)
+	defer db.Close()
+
+	// Simulate a stale backup from a previous run by pre-creating the file
+	// the migration will try to write to.
+	backupPath := db.path + ".migrate-backup"
+	require.NoError(t, os.WriteFile(backupPath, []byte("stale backup from prior run"), 0o644))
+	info, err := os.Stat(backupPath)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0), "precondition: stale backup exists")
+
+	// Seed one eligible recording so the migration does real work.
+	mjpegDir := createTestMJPEGDir(t, dir, "cam1/rec_stale", 3)
+	insertMJPEGRecording(t, db, ctx, "r-stale", "cam1", mjpegDir, time.Now())
+
+	opts := MigrateOptions{
+		Cutoff:      72 * time.Hour,
+		Concurrency: 1,
+		DryRun:      false,
+	}
+	err = MigrateMJPEGToAVI(ctx, db, store, opts)
+	require.NoError(t, err, "migration must succeed despite stale backup file")
+
+	// The backup should now be a valid VACUUM INTO output (larger than the
+	// placeholder we wrote, since it contains the full DB).
+	newInfo, err := os.Stat(backupPath)
+	require.NoError(t, err)
+	require.Greater(t, newInfo.Size(), info.Size(),
+		"backup should be overwritten with a real VACUUM INTO output")
+
+	// And the recording should have been migrated.
+	updated, err := db.GetRecording(ctx, "r-stale")
+	require.NoError(t, err)
+	require.Equal(t, model.FormatAVI, updated.Format)
+}


### PR DESCRIPTION
## Summary

Fixes a blocker hit during production JPEG→AVI migration:

```
Migration failed: db backup: SQL logic error: output file already exists (1)
```

`MigrateMJPEGToAVI` backs up the DB via `VACUUM INTO` before writes. SQLite's `VACUUM INTO` refuses to overwrite an existing destination file, so any stale `.migrate-backup` from a prior interrupted run blocks every retry until the user manually `rm`s it.

## Fix
`os.Remove(backupPath)` before `VACUUM INTO` (ignore not-exist error). 6 lines.

## Test
New `TestMigrateMJPEGToAVI_OverwritesStaleBackup`:
- Pre-creates a stale backup file
- Runs migration
- Asserts migration succeeds + backup overwritten + recording migrated

Verified the test catches the bug: with fix stashed, test fails with the exact production error; with fix applied, 7/7 migrate tests pass.

## Test plan
- [x] `rtk go test ./internal/storage/ -run TestMigrateMJPEGToAVI` — 7 passed
- [x] `rtk go build ./...` — clean
- [x] `golangci-lint run ./internal/storage/` — 0 issues
- [x] Test catches the bug without fix (stash verification)