### PR TITLE
fix(storage): bound MJPEG migration frame count to prevent OOM

### DIFF
--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -28,6 +28,19 @@ type MigrateOptions struct {
 	Resume      bool          // clean orphan .avi files before starting
 }
 
+// maxFramesPerRecording bounds the number of JPEG frames migrateOneRecording
+// will load into the AVI muxer's in-RAM buffer. The muxer (avi.NewVideoOnlyMuxer)
+// accumulates every frame in memory until segment close, so an unbounded frame
+// count risks OOM on memory-constrained hosts.
+//
+// Production hit this: a mis-segmented recording with 24751 frames (~1.2 GB
+// of JPEG data) drove the migration process to 1.4 GB RSS on a 4 GB host and
+// got OOM-killed mid-run, briefly threatening the NVR service sharing the host.
+// Normal recordings are ~500 frames (30s @ 15fps); even 5-minute AVI segments
+// cap around 4500 frames. 10000 frames comfortably covers any legitimate
+// recording while catching pathological cases.
+const maxFramesPerRecording = 10000
+
 // MigrateMJPEGToAVI migrates legacy MJPEG (jpg-directory) recordings to AVI format.
 //
 // Algorithm:
@@ -264,6 +277,19 @@ func migrateOneRecording(ctx context.Context, db *DB, store *Manager, rec model.
 
 	if len(jpgFiles) == 0 {
 		log.Warn("recording has no .jpg files, skipping", "id", rec.ID, "path", rec.FilePath)
+		return errSkipped
+	}
+
+	// Bound the frame count to protect the AVI muxer's in-RAM buffer from
+	// pathological recordings (e.g. a mis-segmented clip with tens of thousands
+	// of frames). The muxer holds every frame in memory until close, so without
+	// this cap a single huge recording can OOM the migration process — and on
+	// a shared host, take the NVR service down with it. See maxFramesPerRecording
+	// for the threshold rationale.
+	if len(jpgFiles) > maxFramesPerRecording {
+		log.Warn("recording has too many frames, skipping (would OOM AVI muxer)",
+			"id", rec.ID, "path", rec.FilePath,
+			"frame_count", len(jpgFiles), "limit", maxFramesPerRecording)
 		return errSkipped
 	}
 

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -445,3 +445,45 @@ func TestMigrateMJPEGToAVI_OverwritesStaleBackup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, model.FormatAVI, updated.Format)
 }
+
+// TestMigrateOneRecording_TooManyFramesSkipped verifies the OOM protection:
+// a recording with more than maxFramesPerRecording frames is skipped rather
+// than loaded into the AVI muxer's in-RAM buffer (which would OOM on
+// memory-constrained hosts). Regression test for a production incident where
+// a 24751-frame recording drove the migration process to 1.4 GB RSS and got
+// OOM-killed on a 4 GB host.
+func TestMigrateOneRecording_TooManyFramesSkipped(t *testing.T) {
+	db, store, ctx, dir := setupMigrateTest(t)
+	defer db.Close()
+
+	// Create a recording with maxFramesPerRecording + 1 frames — one over the
+	// limit. Each frame is a tiny valid JPEG (content doesn't matter; the count
+	// is what triggers the guard).
+	overLimit := maxFramesPerRecording + 1
+	mjpegDir := createTestMJPEGDir(t, dir, "cam1/rec_huge", overLimit)
+
+	rec := model.Recording{
+		ID:        "r-huge",
+		CameraID:  "cam1",
+		FilePath:  mjpegDir,
+		Format:    model.FormatMJPEG,
+		StartedAt: time.Now(),
+	}
+	require.NoError(t, db.InsertRecording(ctx, &rec))
+
+	err := migrateOneRecording(ctx, db, store, rec, logger)
+	require.ErrorIs(t, err, errSkipped,
+		"recording with %d frames (> limit %d) must be skipped, not migrated",
+		overLimit, maxFramesPerRecording)
+
+	// Recording must remain format=mjpeg (unchanged).
+	unchanged, err := db.GetRecording(ctx, "r-huge")
+	require.NoError(t, err)
+	require.NotNil(t, unchanged)
+	require.Equal(t, model.FormatMJPEG, unchanged.Format,
+		"skipped recording must retain its original format")
+
+	// And the source directory must still exist (not deleted).
+	_, err = os.Stat(mjpegDir)
+	require.NoError(t, err, "source directory must be preserved when skipped")
+}


### PR DESCRIPTION
## Summary

Fixes an OOM risk in the MJPEG→AVI migration discovered during production migration.

`migrateOneRecording` loaded every JPEG frame into the AVI muxer's in-RAM buffer (`avi.NewVideoOnlyMuxer` accumulates until Close). A pathological recording with tens of thousands of frames would exhaust host memory.

## Production incident

During the JPEG→AVI migration on Banana Pi M5 (4 GB RAM), a mis-segmented recording with **24751 frames** (~1.2 GB JPEG data) drove the migrate process to:
- RSS 1.4 GB, VSZ 5.4 GB
- System free memory: 45 MB (of 3768 MB)
- Migration stalled mid-run, required manual kill to protect the NVR service sharing the host

These huge frame counts come from a prior bug where MJPEG segment-close logic failed on certain cameras, producing uncut multi-hour recordings.

## Fix

Skip recordings with `> maxFramesPerRecording` (10000) frames. Rationale for the threshold:
- Normal 30s segment @ 15fps = ~500 frames
- 5-minute AVI segment @ 15fps = ~4500 frames (the new cap from #81)
- 10000 covers any legitimate recording with margin, catches pathological cases

Skipped recordings retain their original format and source directory (never deleted — the guard returns `errSkipped`, same as the empty-dir / missing-dir cases).

## Test plan
- [x] `rtk go test ./internal/storage/ -run TestMigrate` — 12 passed (incl. new test)
- [x] `rtk go build ./...` — clean
- [x] `golangci-lint run ./internal/storage/` — 0 issues
- [x] `gofmt -l` — clean
- [x] New `TestMigrateOneRecording_TooManyFramesSkipped` creates a 10001-frame recording and asserts it is skipped + format unchanged + source preserved

## Related
- #85 fixed the `VACUUM INTO` stale-backup blocker on the same migration run
- Together, #85 + #86 make the migration reliably re-runnable on production data