### PR TITLE
fix(timelapse): correct numNalus in H.265 hvcC box so merges are playable

### DIFF
--- a/internal/timelapse/h265_go_merge.go
+++ b/internal/timelapse/h265_go_merge.go
@@ -709,15 +709,27 @@ func buildHvcC(vps, sps, pps []byte) []byte {
 	return buf.Bytes()
 }
 
-// writeHvcCArray writes one NAL array to the hvcC buffer.
+// writeHvcCArray writes one NAL array to the hvcC buffer per ISO 14496-15
+// section 8.3.3.1.2 (HEVC NAL Unit Array).
+//
+// Layout per array:
+//
+//	array_completeness(1) | reserved(0) | NAL_unit_type(6)   — 1 byte
+//	numNalus                                              — 2 bytes  (count of NALUs)
+//	for each NALU:
+//	  nalUnitLength                                       — 2 bytes
+//	  nalUnit                                             — nalUnitLength bytes
+//
+// We always write exactly one NALU per array (numNalus = 1), since each call
+// receives a single parameter set (VPS / SPS / PPS).
 func writeHvcCArray(buf *bytes.Buffer, nalType byte, nalu []byte) {
 	// array_completeness(1) | reserved(0) | NAL_unit_type(6)
 	buf.WriteByte(0x80 | (nalType & 0x3F))
-	// numNalus (16 bits)
-	naluLen := uint16(len(nalu))
-	buf.WriteByte(byte(naluLen >> 8))
-	buf.WriteByte(byte(naluLen))
+	// numNalus (16 bits) — one NALU in this array.
+	buf.WriteByte(0x00)
+	buf.WriteByte(0x01)
 	// nalUnitLength (16 bits) + nalUnit data
+	naluLen := uint16(len(nalu))
 	buf.WriteByte(byte(naluLen >> 8))
 	buf.WriteByte(byte(naluLen))
 	buf.Write(nalu)

--- a/internal/timelapse/h265_go_merge_test.go
+++ b/internal/timelapse/h265_go_merge_test.go
@@ -797,7 +797,7 @@ func TestBuildHvcC_ArrayNumNalusIsOne(t *testing.T) {
 	}
 	wantTypes := []byte{32, 33, 34} // VPS, SPS, PPS
 	wantNALUs := [][]byte{vps, sps, pps}
-	for i := 0; i < 3; i++ {
+	for i := range wantTypes {
 		if off+5 > len(hvcC) {
 			t.Fatalf("array %d: ran off end of hvcC at offset %d", i, off)
 		}

--- a/internal/timelapse/h265_go_merge_test.go
+++ b/internal/timelapse/h265_go_merge_test.go
@@ -766,6 +766,61 @@ func TestBuildHvcC(t *testing.T) {
 		len(hvcC), len(vps), len(sps), len(pps))
 }
 
+// TestBuildHvcC_ArrayNumNalusIsOne is a regression test for a bug where
+// writeHvcCArray wrote the NALU byte length into the numNalus field instead of
+// the value 1. Per ISO 14496-15 §8.3.3.1.2, each HEVC NAL array entry is:
+//
+//	[array_completeness|type (1)] [numNalus (2)] [nalUnitLength (2)] [nalUnit]
+//
+// With one NALU per array, numNalus must be exactly 1. The buggy code wrote
+// numNalus = len(nalu), so a 24-byte VPS produced numNalus=24 — parsers read
+// 24 NALUs, ran off the end of the array, and emitted "Invalid NAL unit size
+// in extradata", making every H.265 timelapse merge unplayable (merge_status
+// reported "merged" because the MP4 box bytes were syntactically valid).
+func TestBuildHvcC_ArrayNumNalusIsOne(t *testing.T) {
+	vps := buildTestH265VPS()
+	sps := buildTestH265SPS(640, 480)
+	pps := buildTestH265PPS()
+	// Use parameter sets whose byte length is NOT 1, so a bug that confuses
+	// numNalus with the byte length is caught (len > 1 makes numNalus != 1).
+	if len(vps) <= 1 || len(sps) <= 1 || len(pps) <= 1 {
+		t.Fatalf("test param sets must be >1 byte: vps=%d sps=%d pps=%d", len(vps), len(sps), len(pps))
+	}
+
+	hvcC := buildHvcC(vps, sps, pps)
+
+	// Walk all 3 arrays and assert each numNalus == 1.
+	// Header is 23 bytes (configurationVersion(1) + profile/level(12) + misc(9) + numOfArrays(1)).
+	off := 23
+	if int(hvcC[22]) != 3 {
+		t.Fatalf("numOfArrays = %d, want 3", hvcC[22])
+	}
+	wantTypes := []byte{32, 33, 34} // VPS, SPS, PPS
+	wantNALUs := [][]byte{vps, sps, pps}
+	for i := 0; i < 3; i++ {
+		if off+5 > len(hvcC) {
+			t.Fatalf("array %d: ran off end of hvcC at offset %d", i, off)
+		}
+		arrType := hvcC[off] & 0x3F
+		if arrType != wantTypes[i] {
+			t.Errorf("array %d: NAL_unit_type = %d, want %d", i, arrType, wantTypes[i])
+		}
+		// THE BUG: numNalus must be 1 (one NALU per array), NOT the NALU byte length.
+		numNalus := uint16(hvcC[off+1])<<8 | uint16(hvcC[off+2])
+		if numNalus != 1 {
+			t.Errorf("array %d (type %d): numNalus = %d, want 1 — "+
+				"this is the bug that made H.265 timelapse merges unplayable "+
+				"(ffprobe: 'Invalid NAL unit size in extradata')",
+				i, arrType, numNalus)
+		}
+		nalUnitLength := uint16(hvcC[off+3])<<8 | uint16(hvcC[off+4])
+		if int(nalUnitLength) != len(wantNALUs[i]) {
+			t.Errorf("array %d: nalUnitLength = %d, want %d", i, nalUnitLength, len(wantNALUs[i]))
+		}
+		off += 5 + len(wantNALUs[i])
+	}
+}
+
 func TestListH265FrameFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes a deterministic bug where **every H.265-source timelapse merge produced an unplayable MP4**, despite reporting `merge_status=merged`.

### Root cause

`writeHvcCArray` (`internal/timelapse/h265_go_merge.go`) wrote the **NALU byte-length** into the `numNalus` field instead of the constant `1`. Per ISO 14496-15 §8.3.3.1.2, each HEVC NAL array entry in an `HEVCDecoderConfigurationRecord` is:

```
[array_completeness|type (1 byte)] [numNalus (2 bytes)] [nalUnitLength (2 bytes)] [nalUnit]
```

With one NALU per array (one VPS, one SPS, one PPS), `numNalus` must be exactly `1`. The buggy code wrote `numNalus = len(nalu)`, so e.g. a 24-byte VPS produced `numNalus=24`. Parsers then tried to read 24 NALUs, ran off the end of the array into the next array's bytes, mis-parsed lengths, and emitted:

```
[hevc @ ...] Invalid NAL unit size in extradata.
```

The decoder refused the stream → unplayable MP4.

### Why "merged" was reported anyway

`RollingMergeManager.runMerge` only validates the output via `os.Stat` + non-zero size (`internal/timelapse/rolling.go:201`). The buggy MP4 has syntactically valid box bytes, so the post-merge check passed and the row was marked `merge_status=merged` — masking the corruption.

### Symptom in production

ONVIF H.265 camera (`H80-9楼楼顶`) switched to timelapse-only mode produced timelapse segments that "merged" but couldn't be played in the browser. `ffprobe` on the merged `.mp4` confirmed `Invalid NAL unit size in extradata`.

### Scope

- **H.265 timelapse merges:** fixed.
- **H.264 timelapse merges:** unaffected (`buildAvcC`/`writeAvcCArray` was already correct).
- **Regular (non-timelapse) H.265 merges:** unaffected (use `internal/merge/mp4merge.go:buildMergeHvcC` via the go-mp4 `mp4.HvcC` struct, which has `NumNalus` and `Length` as separate fields).

### Fix

In `writeHvcCArray`, write `numNalus = 1` (two bytes: `0x00 0x01`) instead of `len(nalu)`. The `nalUnitLength` field still carries `len(nalu)` as before.

## Test plan

- [x] New regression test `TestBuildHvcC_ArrayNumNalusIsOne` walks all 3 arrays (VPS/SPS/PPS) and asserts `numNalus == 1` and `nalUnitLength == len(paramset)`.
- [x] **Verified the test catches the bug**: temporarily reverted the fix → test failed with `numNalus = 10/21/6` (the test VPS/SPS/PPS byte lengths). Restored the fix → test passes.
- [x] `rtk go test ./internal/timelapse/...` — 379 tests pass.
- [x] `rtk go vet` + `gofumpt` clean.

## Production verification (planned after merge)

On Banana Pi M5: redeploy, then reset the H.265 camera's pending/failed timelapse merges via `mibee-nvr repair merge-status` (or wait for the next periodic merge cycle). The re-merged output will be playable.

## Related (NOT fixed here)

A separate pre-existing bug affects H.264 Xiaomi cameras' timelapse merges (`frames missing SPS` — the keyframe extractor captures non-IDR frames with no SPS/PPS). That is unrelated to this fix and tracked separately.