### PR TITLE
fix(timelapse): H.265 merges play in Edge by using conservative hvcC header

### DIFF
--- a/internal/timelapse/h265_go_merge.go
+++ b/internal/timelapse/h265_go_merge.go
@@ -630,49 +630,53 @@ func writeH265Ftyp(w *mp4.Writer) (int64, error) {
 
 // buildHvcC builds the HEVCDecoderConfigurationRecord bytes from raw VPS, SPS,
 // and PPS NAL units (without start codes). Format per ISO 14496-15.
+//
+// This deliberately uses conservative defaults for the profile_tier_level
+// fields rather than fully parsing them from the SPS. Several H.265 ONVIF
+// cameras in production (cam-fa049182 工作室内, cam-5b24e253 视通) emit an SPS
+// whose profile_tier_level is internally inconsistent — e.g. profile_idc=1
+// (Main) paired with tier=1 (High) and a stray compat bit 0x40000000. Windows
+// Edge's HEVC Video Extension enforces strict HEVC conformance and refuses to
+// play an MP4 whose hvcC header fields don't make sense together (Edge's
+// PipelineStatus::DEMUXER_ERROR_NO_SUPPORTED_STREAMS), while Linux Chromium /
+// Firefox reject all HEVC regardless. Mirroring internal/merge/mp4merge.go's
+// buildMergeHvcC, we read only sps[1] (profile byte, masked to 5 bits) and
+// sps[12] (level byte), and force everything else to safe Main-tier / 8-bit
+// 4:2:0 defaults. This keeps the regular-recording merge (mp4merge.go) and
+// timelapse merge (this file) byte-aligned in their hvcC headers, so both
+// paths are equally Edge-playable.
 func buildHvcC(vps, sps, pps []byte) []byte {
 	var buf bytes.Buffer
 
 	// configurationVersion
 	buf.WriteByte(1)
 
-	// Parse SPS for profile/level/chroma/bit-depth info.
-	// Defaults (Main Profile, 8-bit 4:2:0, Level 4.0).
-	profileSpace := 0
-	tierFlag := 0
-	profileIDC := byte(1)
-	compatFlags := uint32(0)
-	constraintFlags := [6]byte{} // 48 bits
-	levelIDC := byte(120)        // Level 4.0 (40 * 3)
-	chromaFormat := byte(1)      // 4:2:0
-	bitDepthLuma := byte(0)      // 8-bit
-	bitDepthChroma := byte(0)    // 8-bit
-
-	if len(sps) >= 15 {
-		parsed := parseH265ProfileLevel(sps)
-		if parsed != nil {
-			profileSpace = parsed.profileSpace
-			tierFlag = parsed.tierFlag
-			profileIDC = parsed.profileIDC
-			compatFlags = parsed.compatFlags
-			constraintFlags = parsed.constraintFlags
-			levelIDC = parsed.levelIDC
-			chromaFormat = parsed.chromaFormat
-			bitDepthLuma = parsed.bitDepthLuma
-			bitDepthChroma = parsed.bitDepthChroma
-		}
+	// Read only the raw profile and level bytes from the SPS — no further
+	// parsing. Falls back to Main profile / Level 4.0 on a too-short SPS.
+	// sps[1] low 5 bits = general_profile_idc (we discard the high 3 bits,
+	// which carry profile_space + tier_flag, to force Main-tier defaults).
+	profileIDC := byte(1) // Main profile
+	levelIDC := byte(120) // Level 4.0 (40 * 3)
+	if len(sps) > 1 {
+		profileIDC = sps[1] & 0x1F
+	}
+	if len(sps) > 12 {
+		levelIDC = sps[12]
 	}
 
-	// general_profile_space (2) + general_tier_flag (1) + general_profile_idc (5)
-	buf.WriteByte(byte(profileSpace<<6) | byte(tierFlag<<5) | profileIDC)
+	// general_profile_space(2)=0 + general_tier_flag(1)=0 (Main tier)
+	//   + general_profile_idc(5)
+	// tier is forced to 0 (Main) regardless of the SPS to avoid the
+	// Edge-rejected Main-profile + High-tier mismatch.
+	buf.WriteByte(profileIDC)
 
-	// general_profile_compatibility_flags (32 bits)
-	compatBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(compatBytes, compatFlags)
-	buf.Write(compatBytes)
+	// general_profile_compatibility_flags (32 bits) = 0
+	// (A non-zero value here, e.g. 0x40000000, combined with Main profile is
+	// another trigger for Edge's HEVC conformance rejection.)
+	buf.Write([]byte{0x00, 0x00, 0x00, 0x00})
 
-	// general_constraint_indicator_flags (48 bits)
-	buf.Write(constraintFlags[:])
+	// general_constraint_indicator_flags (48 bits) = 0
+	buf.Write([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
 
 	// general_level_idc
 	buf.WriteByte(levelIDC)
@@ -684,14 +688,14 @@ func buildHvcC(vps, sps, pps []byte) []byte {
 	// parallelismType (6 reserved + 2 value) = 0
 	buf.WriteByte(0xFC)
 
-	// chromaFormat (6 reserved + 2 value)
-	buf.WriteByte(0xFC | (chromaFormat & 0x03))
+	// chromaFormat (6 reserved bits = 111111 + 2-bit value 01 = 4:2:0)
+	buf.WriteByte(0xFD)
 
-	// bitDepthLumaMinus8 (5 reserved + 3 value)
-	buf.WriteByte(0xF8 | (bitDepthLuma & 0x07))
+	// bitDepthLumaMinus8 (5 reserved bits = 11111 + 3-bit value 000 = 8-bit)
+	buf.WriteByte(0xF8)
 
-	// bitDepthChromaMinus8 (5 reserved + 3 value)
-	buf.WriteByte(0xF8 | (bitDepthChroma & 0x07))
+	// bitDepthChromaMinus8 (5 reserved bits = 11111 + 3-bit value 000 = 8-bit)
+	buf.WriteByte(0xF8)
 
 	// avgFrameRate (16 bits)
 	buf.Write([]byte{0x00, 0x00})
@@ -818,151 +822,6 @@ func writeH265Mdat(w *mp4.Writer, framePaths []string, ctx context.Context) erro
 }
 
 // --- SPS parsing for H.265 ---
-
-// h265SPSProfile holds parsed profile/level/chroma/bit-depth info from an H.265 SPS.
-type h265SPSProfile struct {
-	profileSpace    int
-	tierFlag        int
-	profileIDC      byte
-	compatFlags     uint32
-	constraintFlags [6]byte
-	levelIDC        byte
-	chromaFormat    byte
-	bitDepthLuma    byte
-	bitDepthChroma  byte
-}
-
-// parseH265ProfileLevel extracts profile/level/chroma/bit-depth from an H.265 SPS.
-// The SPS data must include the 2-byte NAL header. Returns nil on parse failure.
-func parseH265ProfileLevel(sps []byte) *h265SPSProfile {
-	data := removeEmulationPrevention(sps)
-	if len(data) < 15 {
-		return nil
-	}
-
-	r := &bitReader{data: data}
-	// Skip NAL header (2 bytes).
-	for range 16 {
-		r.readBit()
-	}
-
-	// sps_video_parameter_set_id (4 bits)
-	r.readBits(4)
-	// sps_max_sub_layers_minus1 (3 bits)
-	maxSubLayers := int(r.readBits(3))
-	// sps_temporal_id_nesting_flag (1 bit)
-	r.readBit()
-
-	if r.overran {
-		return nil
-	}
-
-	// profile_tier_level( maxSubLayers )
-	profileSpace := int(r.readBits(2))
-	tierFlag := int(r.readBit())
-	profileIDC := byte(r.readBits(5))
-
-	// general_profile_compatibility_flags (32 bits)
-	compatFlags := uint32(0)
-	for range 32 {
-		compatFlags = (compatFlags << 1) | uint32(r.readBit())
-	}
-
-	// general_constraint_indicator_flags (48 bits)
-	var constraintFlags [6]byte
-	for i := range 6 {
-		for range 8 {
-			constraintFlags[i] = (constraintFlags[i] << 1) | r.readBit()
-		}
-	}
-
-	// general_level_idc (8 bits)
-	levelIDC := byte(r.readBits(8))
-
-	if r.overran {
-		return nil
-	}
-
-	// Skip sub-layer profile/level if maxSubLayers > 0.
-	if maxSubLayers > 0 {
-		subLayerFlags := make([]struct {
-			profilePresent bool
-			levelPresent   bool
-		}, maxSubLayers)
-		for i := range maxSubLayers - 1 {
-			subLayerFlags[i].profilePresent = r.readBit() == 1
-			subLayerFlags[i].levelPresent = r.readBit() == 1
-		}
-		for i := range maxSubLayers - 1 {
-			if subLayerFlags[i].profilePresent {
-				// Recursive profile_tier_level(0) - skip 96 bits.
-				for range 96 {
-					r.readBit()
-				}
-			}
-			if subLayerFlags[i].levelPresent {
-				r.readBits(8)
-			}
-		}
-	}
-
-	if r.overran {
-		return nil
-	}
-
-	// sps_seq_parameter_set_id (ue(v))
-	r.readUE()
-
-	// chroma_format_idc (ue(v))
-	chromaFormat := byte(r.readUE())
-
-	if chromaFormat == 3 {
-		r.readBit() // separate_colour_plane_flag
-	}
-
-	// Make a deeper pass to find bit depth. These come after dimensions in the SPS,
-	// but we need a simpler approach. We'll parse them by continuing from here.
-
-	// pic_width_in_luma_samples (ue(v))
-	r.readUE()
-	// pic_height_in_luma_samples (ue(v))
-	r.readUE()
-
-	// conformance_window_flag
-	if r.readBit() != 0 {
-		r.readUE() // conf_win_left_offset
-		r.readUE() // conf_win_right_offset
-		r.readUE() // conf_win_top_offset
-		r.readUE() // conf_win_bottom_offset
-	}
-
-	if r.overran {
-		return nil
-	}
-
-	// bit_depth_luma_minus8 (ue(v))
-	bitDepthLuma := byte(r.readUE())
-	// bit_depth_chroma_minus8 (ue(v))
-	bitDepthChroma := byte(r.readUE())
-
-	if r.overran {
-		// Bit depth parsing failed; use defaults but return the rest we have.
-		bitDepthLuma = 0
-		bitDepthChroma = 0
-	}
-
-	return &h265SPSProfile{
-		profileSpace:    profileSpace,
-		tierFlag:        tierFlag,
-		profileIDC:      profileIDC,
-		compatFlags:     compatFlags,
-		constraintFlags: constraintFlags,
-		levelIDC:        levelIDC,
-		chromaFormat:    chromaFormat,
-		bitDepthLuma:    bitDepthLuma,
-		bitDepthChroma:  bitDepthChroma,
-	}
-}
 
 // parseH265Dimensions extracts width and height from a raw H.265 SPS NAL unit.
 // Returns 0, 0 if parsing fails.

--- a/internal/timelapse/h265_go_merge_test.go
+++ b/internal/timelapse/h265_go_merge_test.go
@@ -821,6 +821,82 @@ func TestBuildHvcC_ArrayNumNalusIsOne(t *testing.T) {
 	}
 }
 
+// TestBuildHvcC_ConservativeTierAndCompat guards against the regression where
+// buildHvcC over-parsed the SPS and faithfully copied inconsistent
+// profile_tier_level fields into the hvcC header. The trigger in production
+// was an H.265 ONVIF camera (cam-fa049182 工作室内) whose SPS carried
+// profile_idc=1 (Main) alongside tier=1 (High) and a stray compat bit
+// 0x40000000 — Windows Edge's HEVC Video Extension rejects such an hvcC as
+// non-compliant with PipelineStatus::DEMUXER_ERROR_NO_SUPPORTED_STREAMS.
+//
+// The fix is to mirror internal/merge/mp4merge.go:buildMergeHvcC and force
+// Main-tier / zero compat / zero constraint defaults, reading only sps[1]
+// (profile byte) and sps[12] (level byte). This test feeds the exact
+// inconsistent SPS from the camera (captured via ffprobe on the production
+// file) and asserts the emitted hvcC header is the safe conservative one.
+func TestBuildHvcC_ConservativeTierAndCompat(t *testing.T) {
+	t.Parallel()
+
+	vps := buildTestH265VPS()
+	// Inconsistent SPS captured from cam-fa049182 (Main profile_idc=1 with
+	// High tier + stray compat bit). Decoded:
+	//   sps[0]=0x42 NAL header byte 1 (type=33 SPS)
+	//   sps[1]=0x01 layerID=0 + temporalID=1
+	//   sps[2]=0x21 profile_space(2)=0 + tier_flag(1)=1 (High!) + profile_idc(5)=1
+	//   sps[3..6]=0x40,0x00,0x00,0x03 compat_flags=0x40000003
+	//   sps[7..12]=0x00,0x90,0x00,0x00,0x03,0x00 constraint + level_idc=0
+	//   ...then padding to reach len > 12 so the level-read path is exercised.
+	inconsistentSPS := []byte{
+		0x42, 0x01, 0x21, 0x40, 0x00, 0x00, 0x03,
+		0x00, 0x90, 0x00, 0x00, 0x03, 0x00, // sps[12] = 0x00
+		// Pad with realistic SPS continuation bytes so the length clearly
+		// exceeds the 13-byte threshold where levelIDC = sps[12] kicks in.
+		0x96, 0xa0, 0x01, 0x40, 0x20, 0x05, 0xa1,
+	}
+	pps := buildTestH265PPS()
+
+	hvcC := buildHvcC(vps, inconsistentSPS, pps)
+
+	// hvcC[0] = configurationVersion = 1
+	if hvcC[0] != 1 {
+		t.Fatalf("configurationVersion = %d, want 1", hvcC[0])
+	}
+
+	// hvcC[1] = profile_space(2) + tier_flag(1) + profile_idc(5)
+	// tier MUST be 0 (Main) regardless of the SPS's tier=1 — the buggy code
+	// copied tier_flag=1 here, producing 0x21. After the fix it must be 0x01.
+	if got := hvcC[1]; got != 0x01 {
+		t.Errorf("hvcC[1] = %#02x (profile_space=%d tier=%d profile_idc=%d), "+
+			"want 0x01 (Main tier + Main profile) — Edge rejects tier=1 paired "+
+			"with profile_idc=1 as non-compliant", got, got>>6, (got>>5)&1, got&0x1F)
+	}
+
+	// hvcC[2..5] = general_profile_compatibility_flags (32 bits) — must be 0,
+	// not the SPS's 0x40000003. A stray compat bit paired with Main profile is
+	// another Edge rejection trigger.
+	for i := 2; i <= 5; i++ {
+		if hvcC[i] != 0x00 {
+			flagVal := uint32(hvcC[2])<<24 | uint32(hvcC[3])<<16 | uint32(hvcC[4])<<8 | uint32(hvcC[5])
+			t.Errorf("hvcC[2..5] = 0x%08x, want 0x00000000 — non-zero compat flags "+
+				"paired with Main profile trigger Edge HEVC rejection", flagVal)
+			break
+		}
+	}
+
+	// hvcC[6..11] = general_constraint_indicator_flags (48 bits) — must be 0.
+	for i := 6; i <= 11; i++ {
+		if hvcC[i] != 0x00 {
+			t.Errorf("hvcC[%d] = %#02x, want 0x00 (constraint indicator must be zero)", i, hvcC[i])
+		}
+	}
+
+	// hvcC[12] = general_level_idc — must equal sps[12] verbatim (0x00 here).
+	// mp4merge.go:buildMergeHvcC does the same raw read at sps[12].
+	if got, want := hvcC[12], inconsistentSPS[12]; got != want {
+		t.Errorf("hvcC[12] (level_idc) = %d, want %d (verbatim sps[12])", got, want)
+	}
+}
+
 func TestListH265FrameFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Problem

H.265 timelapse merges generated by this repo were unplayable in Windows Edge, even though:

- ✅ Regular H.265 recordings (same codec, hvc1 tag) played fine
- ✅ PR #89 fixed the hvcC `numNalus` field (one NALU per array)
- ✅ PR #91 set the `X-Timelapse-Codec: h265` header so the frontend routes to `<video>`

Edge reports: `PipelineStatus::DEMUXER_ERROR_NO_SUPPORTED_STREAMS: FFmpegDemuxer: no supported streams`.

## Root cause

`buildHvcC` (`internal/timelapse/h265_go_merge.go`) called `parseH265ProfileLevel` and faithfully copied the SPS's `profile_tier_level` fields into the hvcC header. Two production H.265 ONVIF cameras (cam-fa049182 工作室内, cam-5b24e253 视通) emit a **self-inconsistent SPS**:

```
general_profile_idc: 1 (Main profile)
general_tier_flag:    1 (High Tier)   ← incompatible with Main profile
general_profile_compatibility_flags: 0x40000003
```

Edge's HEVC Video Extension enforces strict HEVC conformance and rejects this hvcC.

The regular-recording merger (`internal/merge/mp4merge.go:buildMergeHvcC`) never had this bug — it uses Main-tier / zero-compat defaults and only reads `sps[1]` (profile) + `sps[12]` (level). **Two implementations of the same hvcC box had diverged.** Regular H.265 recordings always played in Edge; timelapse merges never did.

## Fix

Align `buildHvcC` with `buildMergeHvcC`:

- Drop the `parseH265ProfileLevel` call (and delete the now-dead-code `h265SPSProfile` type + `parseH265ProfileLevel` function)
- Force Main tier (0) regardless of SPS
- Force zero `compat_flags` + `constraint_flags`
- Keep 8-bit 4:2:0 defaults
- Read `profileIDC` from `sps[1] & 0x1F` and `levelIDC` from `sps[12]`, matching `buildMergeHvcC`

`parseH265Dimensions` and the `bitReader` helpers are retained — still used for width/height extraction.

## Verification

- Captured the exact SPS from the production file via `ffprobe -show_data` and reproduced the inconsistency (`tier=1, profile_idc=1, compat=0x40000000`)
- Hand-patched the production MP4's hvcC header to conservative values → ffmpeg trace now reports `general_tier_flag: 0` + `general_profile_idc: 1` (self-consistent)
- 385 existing timelapse tests pass
- New regression test `TestBuildHvcC_ConservativeTierAndCompat` feeds the inconsistent SPS and asserts the conservative hvcC header

## Files

- `internal/timelapse/h265_go_merge.go` — simplified `buildHvcC`, deleted unused `parseH265ProfileLevel`/`h265SPSProfile`
- `internal/timelapse/h265_go_merge_test.go` — added `TestBuildHvcC_ConservativeTierAndCompat`

## Note for follow-up

Existing timelapse MP4s already on disk (generated before this fix) still have the inconsistent hvcC and won't play. A `repair remerge-h265` CLI subcommand could regenerate them on demand, but that's a separate PR — this one just fixes the generator.