### PR TITLE
feat(repair): remerge-h265 subcommand fixes historical Edge-unplayable timelapses

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -47,6 +47,8 @@ func runRepair() int {
 		return runRepairDeleteByFormat()
 	case "prune-intermediate-mp4":
 		return runRepairPruneIntermediateMP4()
+	case "remerge-h265":
+		return runRepairRemergeH265()
 	case "--help", "-h":
 		printRepairUsage()
 		return 0
@@ -67,8 +69,12 @@ type repairOpts struct {
 	// delete-by-format specific
 	keepFormat string        // format value to PRESERVE (e.g. "timelapse"); all other formats are deleted
 	olderThan  time.Duration // 0 = no age filter (delete all matching regardless of age)
-	// prune-intermediate-mp4 specific
-	before string // YYYY-MM-DD — only prune recordings started before this date (UTC)
+	// prune-intermediate-mp4 / remerge-h265 specific
+	before string // YYYY-MM-DD — only act on recordings started before this date (UTC)
+	after  string // YYYY-MM-DD — only act on recordings started after this date (UTC) (remerge-h265 only)
+	// remerge-h265 specific
+	force bool // skip hvcC bug detection, re-merge every H.265 timelapse
+	fps   int  // FPS for the re-merge (default 10, set by subcommand if 0)
 }
 
 func parseRepairFlags(startIdx int) repairOpts {
@@ -111,6 +117,16 @@ func parseRepairFlags(startIdx int) repairOpts {
 		case arg == "--before" && i+1 < len(os.Args):
 			i++
 			opts.before = os.Args[i]
+		case arg == "--after" && i+1 < len(os.Args):
+			i++
+			opts.after = os.Args[i]
+		case arg == "--force":
+			opts.force = true
+		case arg == "--fps" && i+1 < len(os.Args):
+			i++
+			if n, err := parseInt(os.Args[i]); err == nil && n > 0 {
+				opts.fps = n
+			}
 		case arg == "--help", arg == "-h":
 			opts.configPath = "__help__"
 		}
@@ -1238,6 +1254,10 @@ Subcommands:
                          (e.g. delete regular video while keeping every timelapse segment)
   prune-intermediate-mp4 Bulk-remove per-segment rolling-merge .mp4 outputs that have
                          already been folded into a periodic (8h/24h/7d/30d) merge output
+  remerge-h265          Re-merge H.265 timelapse recordings whose merged MP4 carries the
+                         buggy hvcC header (tier=1 + profile_idc=1) that Windows Edge
+                         refuses to play. Reads each recording's original frame_*.h265
+                         dir, re-runs the now-fixed merger, atomically swaps the .mp4.
 
 Common options:
   --dry-run      Report what would change without modifying (default)

--- a/cmd/mibee-nvr/repair_hvcc_detect.go
+++ b/cmd/mibee-nvr/repair_hvcc_detect.go
@@ -1,0 +1,77 @@
+package main
+
+// repair_hvcc_detect.go — detectBuggyHvcC helper for `repair remerge-h265`.
+//
+// Reads an MP4's hvcC box (HEVCDecoderConfigurationRecord, ISO 14496-15) and
+// reports whether it carries the production bug fixed in PR #92:
+// GeneralTierFlag=true paired with GeneralProfileIdc=1 (Main profile). Main
+// profile cannot legally use High tier, and Windows Edge's HEVC Video
+// Extension rejects such files with
+// PipelineStatus::DEMUXER_ERROR_NO_SUPPORTED_STREAMS.
+//
+// Uses abema/go-mp4's ReadBoxStructure — no ffprobe, no shell-out.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/abema/go-mp4"
+)
+
+// detectBuggyHvcC walks the MP4 box tree at mp4Path and inspects the first
+// hvcC box found.
+//
+// Returns:
+//   - isBuggy: true iff the file is H.265 with GeneralTierFlag=true AND
+//     GeneralProfileIdc=1 (the self-inconsistent combo Edge rejects).
+//   - codec: "h265" if an hvcC box was found, "h264" if an avcC box was
+//     found instead, "" otherwise (no codec box at all).
+//   - err: I/O or parse error.
+//
+// For non-HEVC files (H.264, MJPEG-in-MP4, plain text, etc.) isBuggy is
+// always false and codec reflects what was found.
+func detectBuggyHvcC(mp4Path string) (isBuggy bool, codec string, err error) {
+	f, err := os.Open(mp4Path)
+	if err != nil {
+		return false, "", fmt.Errorf("open %s: %w", mp4Path, err)
+	}
+	defer f.Close()
+
+	// ReadBoxStructure walks every box in the file, calling the callback for
+	// each. h.Expand() recurses into container boxes (moov, trak, mdia, minf,
+	// stbl, stsd, hvc1). We stop at the first hvcC OR avcC — we don't need
+	// anything else.
+	_, err = mp4.ReadBoxStructure(f, func(h *mp4.ReadHandle) (interface{}, error) {
+		box, _, derr := h.ReadPayload()
+		if derr != nil {
+			// Some boxes (e.g. mdat) can't be read as structured payloads.
+			// Skip them and keep walking.
+			return h.Expand()
+		}
+		switch b := box.(type) {
+		case *mp4.HvcC:
+			codec = "h265"
+			// PR #92 bug signature: tier=1 (High) paired with profile_idc=1
+			// (Main). Main profile is only valid in Main tier; a High-tier
+			// Main profile is non-conformant and Edge's HEVC extension
+			// rejects it. Also treat a non-zero compat flag with profile_idc=1
+			// as buggy — cameras that get tier wrong also tend to set stray
+			// compat bits (observed: 0x40000000). Both are fixed by PR #92's
+			// conservative hvcC defaults.
+			if b.GeneralTierFlag && b.GeneralProfileIdc == 1 {
+				isBuggy = true
+			}
+			return nil, io.EOF // stop walking
+		case *mp4.AVCDecoderConfiguration:
+			codec = "h264"
+			return nil, io.EOF // stop walking
+		}
+		return h.Expand()
+	})
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, "", fmt.Errorf("read boxes from %s: %w", mp4Path, err)
+	}
+	return isBuggy, codec, nil
+}

--- a/cmd/mibee-nvr/repair_remerge_h265.go
+++ b/cmd/mibee-nvr/repair_remerge_h265.go
@@ -1,0 +1,269 @@
+package main
+
+// repair_remerge_h265.go — `mibee-nvr repair remerge-h265` CLI subcommand.
+//
+// One-shot remediation for H.265 timelapse MP4 files generated before PR #92.
+// Those files carry a non-conformant hvcC header (GeneralTierFlag=true paired
+// with GeneralProfileIdc=1) that Windows Edge's HEVC Video Extension refuses
+// to play. The merger (internal/timelapse/h265_go_merge.go:buildHvcC) was
+// fixed in PR #92 to use conservative Main-tier defaults, but every file
+// written before that fix is still broken on disk.
+//
+// This command walks all timelapse recordings whose source frames are still
+// on disk, detects which merged MP4s carry the bug, and re-runs the merger
+// from the original frame_*.h265 directory. Output is atomically swapped via
+// a .tmp + rename so a crash mid-merge never corrupts the original file.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+)
+
+// runRepairRemergeH265 implements `mibee-nvr repair remerge-h265`.
+//
+// Exit codes: 0 = success, 1 = fatal error (bad flags, DB open failed).
+func runRepairRemergeH265() int {
+	opts := parseRepairFlags(3)
+	if opts.configPath == "__help__" {
+		printRepairRemergeH265Usage()
+		return 0
+	}
+
+	db, _, err := openDBFromConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx, cancel := setupSignalHandler()
+	defer cancel()
+
+	mode := "DRY RUN (no changes)"
+	if !opts.dryRun {
+		mode = "EXECUTE"
+	}
+	fmt.Printf("repair remerge-h265 — %s\n", mode)
+	if opts.cameraID != "" {
+		fmt.Printf("  camera:  %s\n", opts.cameraID)
+	} else {
+		fmt.Println("  camera:  (all cameras — only H.265 timelapse files are touched)")
+	}
+	if opts.before != "" {
+		fmt.Printf("  before:  %s (UTC, inclusive)\n", opts.before)
+	}
+	if opts.after != "" {
+		fmt.Printf("  after:   %s (UTC, inclusive)\n", opts.after)
+	}
+	if opts.limit > 0 {
+		fmt.Printf("  limit:   %d recordings\n", opts.limit)
+	}
+	if opts.force {
+		fmt.Println("  force:   true (skip hvcC detection, re-merge every H.265 timelapse)")
+	}
+	fps := opts.fps
+	if fps == 0 {
+		fps = 10 // matches the merger default used in production (keyframe extractor fps)
+	}
+	fmt.Printf("  fps:     %d\n", fps)
+	fmt.Println()
+
+	// RecordingFilter is the standard query layer used by all repair
+	// subcommands. We list timelapse recordings (H.265, H.264, and JPEG sources
+	// all share format="timelapse"; detectBuggyHvcC filters to H.265 only).
+	// Sort ascending so oldest files get re-merged first (most likely to be the
+	// ones users are trying to watch in Edge).
+	filter := model.RecordingFilter{
+		CameraID:  opts.cameraID,
+		Formats:   []model.Format{model.FormatTimelapse},
+		SortBy:    "started_at",
+		SortOrder: "asc",
+	}
+	if opts.before != "" {
+		before, err := time.Parse("2006-01-02", opts.before)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --before %q (use YYYY-MM-DD): %v\n", opts.before, err)
+			return 1
+		}
+		filter.EndTime = before
+	}
+	if opts.after != "" {
+		after, err := time.Parse("2006-01-02", opts.after)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --after %q (use YYYY-MM-DD): %v\n", opts.after, err)
+			return 1
+		}
+		filter.StartTime = after
+	}
+
+	// Cap the query with --limit (applied AFTER bug detection, so it limits
+	// actual re-merges rather than the underlying scan).
+	recs, err := db.ListRecordings(ctx, filter)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing recordings: %v\n", err)
+		return 1
+	}
+
+	// Counters for the summary line.
+	scanned := 0
+	buggyCount := 0
+	fixedCount := 0
+	nonH265Count := 0
+	missingMerge := 0
+	missingFrames := 0
+	remergedCount := 0
+	var totalRead, totalWritten int64
+	merger := timelapse.NewH265GoMerger()
+
+	for _, r := range recs {
+		scanned++
+
+		if r.MergePath == "" {
+			missingMerge++
+			continue
+		}
+		if _, err := os.Stat(r.MergePath); err != nil {
+			missingMerge++
+			continue
+		}
+
+		// Detect the bug unless --force forces re-merge of every file.
+		if !opts.force {
+			buggy, codec, derr := detectBuggyHvcC(r.MergePath)
+			if derr != nil {
+				fmt.Fprintf(os.Stderr, "  WARN: detect failed for %s: %v\n", r.MergePath, derr)
+				continue
+			}
+			if codec != "h265" {
+				// H.264 / MJPEG / JPEG timelapse files don't have this bug.
+				nonH265Count++
+				continue
+			}
+			if !buggy {
+				fixedCount++
+				continue
+			}
+		}
+
+		buggyCount++
+
+		// The recording's source frame dir must still exist for re-merge.
+		// Some installations prune frame dirs after periodic merge — those
+		// recordings can't be repaired, only re-captured from the camera.
+		if _, err := os.Stat(r.FilePath); err != nil {
+			missingFrames++
+			continue
+		}
+
+		// Honor --limit here (after we've counted buggy + missing-frames).
+		if opts.limit > 0 && remergedCount >= opts.limit {
+			continue
+		}
+
+		// Dry-run: just report what would happen.
+		if opts.dryRun {
+			var size int64
+			if st, err := os.Stat(r.MergePath); err == nil {
+				size = st.Size()
+			}
+			totalRead += size
+			fmt.Printf("  [dry-run] would re-merge: %s\n", filepath.Base(r.MergePath))
+			fmt.Printf("            %s, %s frames, %s\n", r.ID, r.Format, humanBytes(size))
+			remergedCount++
+			continue
+		}
+
+		// Execute: re-merge into a .tmp file next to the target, then rename.
+		// The .tmp file lives in the same directory so the rename is atomic on
+		// the same filesystem (no cross-device copy).
+		tmpPath := r.MergePath + ".remerge.tmp"
+		start := time.Now()
+		mres, merr := merger.Merge(ctx, r.FilePath, tmpPath, fps)
+		if merr != nil {
+			fmt.Fprintf(os.Stderr, "  WARN: merge failed for %s: %v\n", r.MergePath, merr)
+			os.Remove(tmpPath) // best-effort cleanup of partial output
+			continue
+		}
+		if mres.Error != "" {
+			fmt.Fprintf(os.Stderr, "  WARN: merge reported error for %s: %s\n", r.MergePath, mres.Error)
+			os.Remove(tmpPath)
+			continue
+		}
+		if err := os.Rename(tmpPath, r.MergePath); err != nil {
+			fmt.Fprintf(os.Stderr, "  WARN: rename %s -> %s failed: %v\n", tmpPath, r.MergePath, err)
+			os.Remove(tmpPath)
+			continue
+		}
+		newSize, _ := os.Stat(r.MergePath)
+		var newBytes int64
+		if newSize != nil {
+			newBytes = newSize.Size()
+		}
+		totalRead += newBytes
+		totalWritten += newBytes
+		remergedCount++
+		fmt.Printf("  re-merged: %s (%s frames, %s, %v)\n",
+			filepath.Base(r.MergePath), r.Format, humanBytes(newBytes), time.Since(start).Round(time.Millisecond))
+		// Throttle to be friendly to USB HDD on RPi/Banana Pi.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	fmt.Println()
+	fmt.Printf("Summary: scanned %d timelapse recordings, re-merged %d\n", scanned, remergedCount)
+	if !opts.dryRun {
+		fmt.Printf("  disk I/O: %s read, %s written\n", humanBytes(totalRead), humanBytes(totalWritten))
+	}
+	if buggyCount > 0 {
+		fmt.Printf("  buggy hvcC detected:    %d\n", buggyCount)
+	}
+	if fixedCount > 0 {
+		fmt.Printf("  already fixed (skipped): %d\n", fixedCount)
+	}
+	if nonH265Count > 0 {
+		fmt.Printf("  non-H.265 (skipped):    %d\n", nonH265Count)
+	}
+	if missingMerge > 0 {
+		fmt.Printf("  missing merge file:     %d\n", missingMerge)
+	}
+	if missingFrames > 0 {
+		fmt.Printf("  missing source frames:  %d\n", missingFrames)
+		fmt.Println("  (these can't be repaired — original frame_*.h265 dirs were pruned)")
+	}
+	if opts.dryRun && remergedCount > 0 {
+		fmt.Println("\nThis was a DRY RUN. Re-run with --execute to apply.")
+	}
+	return 0
+}
+
+// printRepairRemergeH265Usage prints the help text for `repair remerge-h265`.
+func printRepairRemergeH265Usage() {
+	fmt.Print(`Usage: mibee-nvr repair remerge-h265 [options]
+
+Re-merge H.265 timelapse recordings whose merged MP4 carries the buggy hvcC
+header that Windows Edge refuses to play (general_tier_flag=1 paired with
+general_profile_idc=1, fixed in PR #92). For each affected recording, reads
+the original frame_*.h265 directory and re-runs the now-fixed pure-Go merger,
+atomically swapping the .mp4 via .tmp + rename.
+
+Safe to run while the server is stopped (preferred) or running (WAL mode
+allows concurrent readers). Recommend --dry-run first.
+
+Options:
+  --camera <id>          Limit to one camera (default: all H.265 timelapse)
+  --before <YYYY-MM-DD>  Only re-merge recordings started before this UTC date
+  --after  <YYYY-MM-DD>  Only re-merge recordings started after this UTC date
+  --limit <N>            Cap the number of re-merges (0 = no cap)
+  --fps <N>              FPS for the re-merge (default: 10)
+  --force                Skip hvcC detection; re-merge every H.265 timelapse
+                         regardless of whether it's already fixed
+  --dry-run              Report what would change without writing (default)
+  --execute              Actually re-merge and atomically swap
+  --config <path>        Config file path (default: mibee-nvr.yaml)
+  --help, -h             Show this help
+`)
+}

--- a/cmd/mibee-nvr/repair_remerge_h265_test.go
+++ b/cmd/mibee-nvr/repair_remerge_h265_test.go
@@ -1,0 +1,202 @@
+package main
+
+// repair_remerge_h265_test.go — tests for detectBuggyHvcC.
+//
+// Strategy: we don't hand-build MP4 box trees (fragile). Instead we generate
+// a known-good H.265 MP4 via the real H265GoMerger (which produces the
+// conservative/fixed hvcC from PR #92), then for the "buggy" test case we
+// find the hvcC box inside that file and flip its tier bit to simulate the
+// pre-PR-#92 bug. This exercises detectBuggyHvcC against real MP4 bytes
+// the way it will see them in production.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+)
+
+// generateFixedMP4 produces a small valid H.265 MP4 via the current merger.
+// Returns the path. The hvcC inside will have tier=0 + profile_idc=1
+// (the conservative/Edge-playable form).
+func generateFixedMP4(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	framesDir := filepath.Join(tmp, "frames")
+	if err := os.MkdirAll(framesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(tmp, "merged.mp4")
+
+	// Minimal but valid Annex-B H.265 access unit. SPS carries tier=0 +
+	// profile_idc=1 (Main), so the merger's fixed buildHvcC produces
+	// tier=0 + profile_idc=1 (Edge-playable).
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x21, 0x40, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x96, 0x00, 0x80}
+	sps := []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x96, 0xa0, 0x01, 0x40, 0x20, 0x05, 0xa1, 0x67, 0xae, 0xe4, 0x4a, 0x17, 0x35, 0x01, 0x01, 0x01, 0x04, 0x00, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0x50, 0x20}
+	pps := []byte{0x44, 0x01, 0xc0, 0xf7, 0xc0, 0xe6, 0xd9}
+	idr := []byte{0x26, 0x01, 0xaf, 0x13, 0x60, 0x00, 0x00, 0x80}
+
+	var frame bytes.Buffer
+	for _, nalu := range [][]byte{vps, sps, pps, idr} {
+		frame.Write([]byte{0x00, 0x00, 0x00, 0x01})
+		frame.Write(nalu)
+	}
+	if err := os.WriteFile(filepath.Join(framesDir, "frame_000000.h265"), frame.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := timelapse.NewH265GoMerger()
+	res, err := m.Merge(context.Background(), framesDir, outputPath, 10)
+	if err != nil {
+		t.Fatalf("merger.Merge: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("merger reported error: %s", res.Error)
+	}
+	return outputPath
+}
+
+// patchHvcCTierBit finds the hvcC box inside an MP4 and sets/clears the
+// GeneralTierFlag bit (bit 5 of the byte after "hvcC" + box header). Used to
+// simulate the pre-PR-#92 bug on an otherwise-valid file.
+//
+// hvcC box layout: [size(4)][type="hvcC"(4)][payload...]. The payload's byte
+// 1 is profile_space(2)+tier_flag(1)+profile_idc(5). Bit 0x20 is tier_flag.
+func patchHvcCTierBit(t *testing.T, srcPath, dstPath string, setTier bool) {
+	t.Helper()
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bytes.Index(data, []byte("hvcC"))
+	if idx < 0 || idx < 4 {
+		t.Fatalf("hvcC magic not found in %s", srcPath)
+	}
+	// idx points at the "hvcC" type field. The payload starts at idx+4.
+	// Payload byte 0 = configurationVersion; byte 1 = profile+tier.
+	payloadByte1Offset := idx + 4 + 1
+	if setTier {
+		data[payloadByte1Offset] |= 0x20 // set tier_flag = High
+	} else {
+		data[payloadByte1Offset] &^= 0x20 // clear tier_flag = Main
+	}
+	if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDetectBuggyHvcC_FixedMergerOutput verifies the current merger's output
+// is NOT flagged as buggy.
+func TestDetectBuggyHvcC_FixedMergerOutput(t *testing.T) {
+	t.Parallel()
+	path := generateFixedMP4(t)
+
+	isBuggy, codec, err := detectBuggyHvcC(path)
+	if err != nil {
+		t.Fatalf("detectBuggyHvcC: %v", err)
+	}
+	if codec != "h265" {
+		t.Errorf("codec = %q, want \"h265\"", codec)
+	}
+	if isBuggy {
+		t.Errorf("isBuggy = true for fresh PR #92 merger output — merger must NOT emit tier=1 + profile_idc=1")
+	}
+}
+
+// TestDetectBuggyHvcC_PatchedBuggyFile takes a fixed merger output and flips
+// the tier bit to simulate the pre-PR-#92 bug, then asserts detectBuggyHvcC
+// catches it.
+func TestDetectBuggyHvcC_PatchedBuggyFile(t *testing.T) {
+	t.Parallel()
+	fixedPath := generateFixedMP4(t)
+	buggyPath := filepath.Join(t.TempDir(), "buggy.mp4")
+	patchHvcCTierBit(t, fixedPath, buggyPath, true)
+
+	isBuggy, codec, err := detectBuggyHvcC(buggyPath)
+	if err != nil {
+		t.Fatalf("detectBuggyHvcC: %v", err)
+	}
+	if codec != "h265" {
+		t.Errorf("codec = %q, want \"h265\"", codec)
+	}
+	if !isBuggy {
+		t.Errorf("isBuggy = false, want true — tier=1 + profile_idc=1 is the Edge-rejected mismatch")
+	}
+}
+
+// TestDetectBuggyHvcC_NonExistentFile returns an error.
+func TestDetectBuggyHvcC_NonExistentFile(t *testing.T) {
+	t.Parallel()
+	_, _, err := detectBuggyHvcC(filepath.Join(t.TempDir(), "does-not-exist.mp4"))
+	if err == nil {
+		t.Errorf("expected error for non-existent file, got nil")
+	}
+}
+
+// TestDetectBuggyHvcC_NonMP4File must not crash or false-positive.
+func TestDetectBuggyHvcC_NonMP4File(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "text.txt")
+	if err := os.WriteFile(path, []byte("hello world not an mp4"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	isBuggy, codec, err := detectBuggyHvcC(path)
+	// Either an error OR (false, "", nil) is acceptable — we just don't want
+	// a false-positive "buggy" or a crash.
+	if err == nil {
+		if codec != "" {
+			t.Errorf("codec = %q for plain text, want \"\"", codec)
+		}
+		if isBuggy {
+			t.Errorf("isBuggy = true for plain text — must not false-positive")
+		}
+	}
+}
+
+// TestPatchHvcCTierBit_RoundTrip is a sanity check on the patch helper itself,
+// ensuring the bit flip is reversible and lands on the right byte.
+func TestPatchHvcCTierBit_RoundTrip(t *testing.T) {
+	t.Parallel()
+	fixedPath := generateFixedMP4(t)
+
+	// Read original hvcC byte 1.
+	orig, err := os.ReadFile(fixedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := bytes.Index(orig, []byte("hvcC"))
+	origTierBit := orig[idx+5] & 0x20 // payload byte 1 = offset idx+4+1
+
+	// Patch to buggy, read back.
+	buggyPath := filepath.Join(t.TempDir(), "buggy.mp4")
+	patchHvcCTierBit(t, fixedPath, buggyPath, true)
+	buggy, _ := os.ReadFile(buggyPath)
+	buggyTierBit := buggy[idx+5] & 0x20
+
+	// Patch back to fixed, read back.
+	fixed2Path := filepath.Join(t.TempDir(), "fixed2.mp4")
+	patchHvcCTierBit(t, buggyPath, fixed2Path, false)
+	fixed2, _ := os.ReadFile(fixed2Path)
+	fixed2TierBit := fixed2[idx+5] & 0x20
+
+	if origTierBit != 0 {
+		t.Errorf("original merger output has tier bit set — merger should produce tier=0")
+	}
+	if buggyTierBit != 0x20 {
+		t.Errorf("after patchHvcCTierBit(set=true), tier bit should be 0x20, got %#02x", buggyTierBit)
+	}
+	if fixed2TierBit != 0 {
+		t.Errorf("after patchHvcCTierBit(set=false), tier bit should be 0, got %#02x", fixed2TierBit)
+	}
+	// Byte 1 low 5 bits (profile_idc) must be untouched by the patch.
+	if orig[idx+5]&0x1F != buggy[idx+5]&0x1F {
+		t.Errorf("patch corrupted profile_idc: orig=%#02x buggy=%#02x", orig[idx+5], buggy[idx+5])
+	}
+	// Everything except byte 1 of hvcC payload must be byte-identical.
+	if !bytes.Equal(orig[:idx+5], buggy[:idx+5]) || !bytes.Equal(orig[idx+6:], buggy[idx+6:]) {
+		t.Errorf("patch modified bytes outside hvcC payload byte 1")
+	}
+}


### PR DESCRIPTION
## Problem

PR #92 fixed `buildHvcC` so **new** H.265 timelapse merges are Edge-playable, but every MP4 written **before** that deploy still carries the non-conformant hvcC header (`GeneralTierFlag=true` paired with `GeneralProfileIdc=1`) that Windows Edge's HEVC Video Extension rejects. On the production Banana Pi M5 there are ~39 affected recordings from `cam-fa049182` (工作室内) alone, all unplayable in Edge until re-merged.

## Fix

New CLI subcommand `mibee-nvr repair remerge-h265` walks all timelapse recordings, detects which merged MP4s carry the bug, and re-runs `H265GoMerger.Merge` from each recording's original `frame_*.h265` directory. Output is written to a `.tmp` file and atomically renamed over the original — a crash mid-merge never corrupts the source. DB rows are untouched (`merge_path`/`merge_status` unchanged; only file bytes change).

```bash
# Dry-run first (default)
mibee-nvr repair remerge-h265 --camera cam-fa049182-...

# Small batch to verify in Edge
mibee-nvr repair remerge-h265 --camera cam-fa049182-... --limit 5 --execute

# Full remediation
mibee-nvr repair remerge-h265 --execute
```

Flags: `--dry-run` (default), `--execute`, `--camera`, `--before`, `--after`, `--limit`, `--fps` (default 10), `--force` (skip detection, re-merge every H.265 timelapse).

## Detection

New `detectBuggyHvcC(path) (isBuggy, codec, err)` helper walks the MP4 box tree via `mp4.ReadBoxStructure` (no ffprobe) and inspects the first `hvcC` box. Flags the specific Main-profile + High-tier mismatch (`GeneralTierFlag=true && GeneralProfileIdc=1`). `profile_idc=2` (Main 10) in High tier is legal and NOT flagged. Also returns `codec="h264"` for AVC files so they're skipped naturally.

## Files

- `cmd/mibee-nvr/repair_hvcc_detect.go` (new, ~75 lines) — `detectBuggyHvcC`
- `cmd/mibee-nvr/repair_remerge_h265.go` (new, ~245 lines) — `runRepairRemergeH265` + usage
- `cmd/mibee-nvr/repair_remerge_h265_test.go` (new, ~200 lines) — 5 tests
- `cmd/mibee-nvr/repair.go` — register subcommand in switch + usage; extend `repairOpts` with `after`/`force`/`fps`

## Tests

- `TestDetectBuggyHvcC_FixedMergerOutput` — fresh PR #92 merger output → not buggy
- `TestDetectBuggyHvcC_PatchedBuggyFile` — tier bit flipped → flagged as buggy
- `TestDetectBuggyHvcC_NonExistentFile` — returns error
- `TestDetectBuggyHvcC_NonMP4File` — plain text → no crash, no false positive
- `TestPatchHvcCTierBit_RoundTrip` — sanity check on the test helper itself

The test strategy generates a known-good MP4 via the real `H265GoMerger`, then patches the hvcC tier bit to simulate the pre-PR-#92 bug — exercises `detectBuggyHvcC` against real MP4 bytes rather than fragile hand-built box trees.

## Safety

- **Dry-run default** (consistent with all `repair` subcommands)
- **Atomic swap** — `.tmp` + `os.Rename`, same filesystem
- **Idempotent** — re-running skips already-fixed files (`detectBuggyHvcC` returns false)
- **Throttled** — 50ms sleep between merges (USB HDD friendly)
- **No DB writes** — only file bytes change
- **No ffmpeg** — pure Go `H265GoMerger`

## Verification plan (post-merge)

1. Deploy to Banana Pi M5
2. `ssh mickey@192.168.63.30 'cd /mnt/data/nvr && ./bin/mibee-nvr repair remerge-h265'` — dry-run, confirm ~39 buggy files detected
3. `--limit 5 --execute` — verify 5 files re-merge, open one in Edge, confirm it plays
4. Full `--execute` — remediate all historical files