### PR TITLE
fix(timelapse): handle 'Local' timezone so natural-day merge window aligns to server tz

### DIFF
--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -417,9 +417,18 @@ func (h *Handler) handleTimelapseMergeWithDuration(w http.ResponseWriter, r *htt
 		}
 	}
 
-	// Load display timezone
+	// Load display timezone. "Local" (the config default) means use the
+	// server's local timezone — time.LoadLocation("Local") fails, so handle
+	// it explicitly via time.Local. Without this, the merge window is
+	// computed in UTC and natural-day merges return "no segments found"
+	// because the window misses the camera's local-day segments.
 	loc := time.UTC
-	if h.config.Timezone != "" && h.config.Timezone != "UTC" {
+	switch {
+	case h.config.Timezone == "" || h.config.Timezone == "UTC":
+		// keep UTC
+	case h.config.Timezone == "Local":
+		loc = time.Local
+	default:
 		if l, err := time.LoadLocation(h.config.Timezone); err == nil {
 			loc = l
 		}
@@ -809,9 +818,15 @@ func (h *Handler) handleTimelapseBatchMerge(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Load timezone
+	// Load timezone — handle "Local" explicitly (time.LoadLocation("Local")
+	// fails, which would silently fall back to UTC and misalign the window).
 	loc := time.UTC
-	if h.config.Timezone != "" && h.config.Timezone != "UTC" {
+	switch {
+	case h.config.Timezone == "" || h.config.Timezone == "UTC":
+		// keep UTC
+	case h.config.Timezone == "Local":
+		loc = time.Local
+	default:
 		if l, err := time.LoadLocation(h.config.Timezone); err == nil {
 			loc = l
 		}


### PR DESCRIPTION
## Problem

`handleTimelapseMerge` and `handleTimelapseBatchMerge` loaded the timezone via `time.LoadLocation(h.config.Timezone)`, but the config default is `"Local"` and `time.LoadLocation("Local")` returns an error (it's not an IANA tz name). The error was silently ignored and `loc` fell back to `time.UTC`, so the natural-day merge window was computed in UTC instead of the server's local timezone.

On a Banana Pi M5 set to Asia/Shanghai with `timezone: Local`, a natural-day merge for 2026-07-22 produced a UTC window `[2026-07-22 00:00, 2026-07-23 00:00]` instead of the intended local window `[2026-07-21 16:00, 2026-07-22 16:00 UTC]`. The camera's local-day segments fell outside the window and `PeriodicMergeManager` reported `no segments found for window`.

## Fix

Handle `"Local"` explicitly via `time.Local` in both handlers (switch statement that also keeps ""/"UTC" → UTC and falls through to `LoadLocation` for IANA names). `pkg/app/run.go` already did this correctly for the scheduled path — this fixes the API-triggered path to match.

## Testing

- Build + lint pass
- The scheduled path (`pkg/app/run.go`) already handles "Local" the same way, so this just brings the API path to parity