### PR TITLE
feat: MJPEG cameras stream via WebSocket (wsstream) instead of HTTP polling

### DIFF
--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -51,9 +51,15 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 		}
 
 		codec, sps, pps, vps := getCodecParams(rec)
+		// Normalize JPEG/MJPEG codec names for wsstream: both "jpeg" and "mjpeg"
+		// map to wsstream.CodecMJPEG ("mjpeg") since the wire protocol treats
+		// them identically (complete JPEG frames in VideoFrame.NALUs[0]).
+		if codec == model.EncJPEG {
+			codec = model.FormatMJPEG
+		}
 		slog.Info("WS: on-demand register", "camera_id", id, "codec", codec, "has_sps", sps != nil, "has_pps", pps != nil)
-		// MJPEG/JPEG cameras don't have SPS/PPS — skip the keyframe wait.
-		if codec != model.FormatMJPEG && codec != model.EncJPEG {
+		// MJPEG cameras don't have SPS/PPS — skip the keyframe wait.
+		if codec != model.FormatMJPEG {
 			if sps == nil || pps == nil {
 				// Recorder is active but hasn't received a keyframe yet.
 				// Poll for up to 5 seconds (typical keyframe interval is 1-4s).

--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -52,22 +52,25 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 
 		codec, sps, pps, vps := getCodecParams(rec)
 		slog.Info("WS: on-demand register", "camera_id", id, "codec", codec, "has_sps", sps != nil, "has_pps", pps != nil)
-		if sps == nil || pps == nil {
-			// Recorder is active but hasn't received a keyframe yet.
-			// Poll for up to 5 seconds (typical keyframe interval is 1-4s).
-			const wsCodecWait = 5 * time.Second
-			const wsCodecPoll = 200 * time.Millisecond
-			deadline := time.Now().Add(wsCodecWait)
-			for sps == nil || pps == nil {
-				if time.Now().After(deadline) {
-					slog.Warn("WS: timed out waiting for codec params", "camera_id", id)
-					WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
-					return
+		// MJPEG/JPEG cameras don't have SPS/PPS — skip the keyframe wait.
+		if codec != model.FormatMJPEG && codec != model.EncJPEG {
+			if sps == nil || pps == nil {
+				// Recorder is active but hasn't received a keyframe yet.
+				// Poll for up to 5 seconds (typical keyframe interval is 1-4s).
+				const wsCodecWait = 5 * time.Second
+				const wsCodecPoll = 200 * time.Millisecond
+				deadline := time.Now().Add(wsCodecWait)
+				for sps == nil || pps == nil {
+					if time.Now().After(deadline) {
+						slog.Warn("WS: timed out waiting for codec params", "camera_id", id)
+						WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
+						return
+					}
+					time.Sleep(wsCodecPoll)
+					codec, sps, pps, vps = getCodecParams(rec)
 				}
-				time.Sleep(wsCodecPoll)
-				codec, sps, pps, vps = getCodecParams(rec)
+				slog.Info("WS: codec params available after poll", "camera_id", id, "codec", codec)
 			}
-			slog.Info("WS: codec params available after poll", "camera_id", id, "codec", codec)
 		}
 
 		hub := getStreamHub(rec)

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -412,6 +412,10 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 		// readers treat it as immutable.
 		dp := data
 		r.latestFrame.Store(&dp)
+		// Broadcast to StreamHub for wsstream live preview (HTTP JPEG cameras).
+		if r.Hub != nil {
+			r.Hub.Broadcast(time.Now().UnixNano()/1e6*90, [][]byte{data}, true)
+		}
 
 		// Live-only mode: keep the latest-frame cache (so MJPEG live preview via
 		// /latest-frame polling works) but skip all segment I/O.

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -374,6 +374,13 @@ func (r *MJPEGRecorder) connectAndRecord(ctx context.Context) (error, bool) {
 		// returns a freshly allocated slice, so storing the pointer is safe.
 		dp := jpeg
 		r.latestFrame.Store(&dp)
+		// Broadcast to StreamHub for wsstream live preview (MJPEG cameras).
+		// Each JPEG frame is wrapped as a single-element [][]byte to match
+		// the FrameCallback signature. wsstream treats every MJPEG frame as
+		// a keyframe (independently decodable).
+		if r.Hub != nil {
+			r.Hub.Broadcast(int64(pkt.Timestamp), [][]byte{jpeg}, true)
+		}
 		select {
 		case r.frameCh <- jpeg:
 		default:

--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -259,7 +259,10 @@ func (m *Manager) writeFrame(camID string, pts int64, au [][]byte) {
 	}
 
 	isKeyframe := false
-	if len(au) > 0 && len(au[0]) > 0 {
+	if entry.codec == model.FormatMJPEG {
+		// MJPEG: every frame is independently decodable (like an IDR).
+		isKeyframe = true
+	} else if len(au) > 0 && len(au[0]) > 0 {
 		var naluType int
 		if entry.codec == model.FormatH265 {
 			// H.265: forbidden(1) | nal_unit_type(6) | ...

--- a/internal/wsstream/protocol.go
+++ b/internal/wsstream/protocol.go
@@ -14,6 +14,8 @@ func codecByte(codec string) (byte, error) {
 		return 4, nil
 	case CodecH265:
 		return 5, nil
+	case CodecMJPEG:
+		return 6, nil
 	default:
 		return 0, fmt.Errorf("wsstream: unknown codec %q", codec)
 	}
@@ -25,6 +27,8 @@ func codecFromByte(b byte) (string, error) {
 		return CodecH264, nil
 	case 5:
 		return CodecH265, nil
+	case 6:
+		return CodecMJPEG, nil
 	default:
 		return "", fmt.Errorf("wsstream: unknown codec byte 0x%02x", b)
 	}
@@ -39,8 +43,9 @@ func codecFromByte(b byte) (string, error) {
 //	{type:1}{codec:1}{profile:1}{level:1}{sps_len:2}{sps}{pps_len:2}{pps}[vps_len:2][vps]
 //
 // All multi-byte integers are big-endian.
-// codec byte: 4 = H.264, 5 = H.265.
+// codec byte: 4 = H.264, 5 = H.265, 6 = MJPEG.
 // vps fields are only present for H.265.
+// MJPEG sends only type + codec (no SPS/PPS/VPS).
 func EncodeCodecInfo(ci *CodecInfo) ([]byte, error) {
 	if ci == nil {
 		return nil, errors.New("wsstream: nil CodecInfo")
@@ -49,6 +54,11 @@ func EncodeCodecInfo(ci *CodecInfo) ([]byte, error) {
 	cb, err := codecByte(ci.Codec)
 	if err != nil {
 		return nil, err
+	}
+
+	// MJPEG: minimal CodecInfo — just type + codec byte.
+	if ci.Codec == CodecMJPEG {
+		return []byte{MsgTypeCodecInfo, cb}, nil
 	}
 
 	// type + codec + profile + level + sps_len + sps + pps_len + pps
@@ -96,7 +106,7 @@ func EncodeCodecInfo(ci *CodecInfo) ([]byte, error) {
 
 // decodeCodecInfo decodes binary wire format into a CodecInfo.
 func decodeCodecInfo(data []byte) (*CodecInfo, error) {
-	if len(data) < 5 {
+	if len(data) < 2 {
 		return nil, fmt.Errorf("wsstream: codec info too short: %d bytes", len(data))
 	}
 
@@ -107,6 +117,15 @@ func decodeCodecInfo(data []byte) (*CodecInfo, error) {
 	codec, err := codecFromByte(data[1])
 	if err != nil {
 		return nil, err
+	}
+
+	// MJPEG: only type + codec byte, no SPS/PPS/VPS.
+	if codec == CodecMJPEG {
+		return &CodecInfo{Codec: codec}, nil
+	}
+
+	if len(data) < 5 {
+		return nil, fmt.Errorf("wsstream: codec info too short: %d bytes", len(data))
 	}
 
 	ci := &CodecInfo{

--- a/internal/wsstream/types.go
+++ b/internal/wsstream/types.go
@@ -12,19 +12,20 @@ const (
 
 // Codec string constants.
 const (
-	CodecH264 = "h264"
-	CodecH265 = "h265"
+	CodecH264  = "h264"
+	CodecH265  = "h265"
+	CodecMJPEG = "mjpeg" // JPEG frames: VideoFrame.NALUs[0] contains a complete JPEG image
 )
 
 // CodecInfo contains codec configuration data sent once at stream start.
 // This is the binary equivalent of AVCDecoderConfigurationRecord /
 // HEVCDecoderConfigurationRecord, but simplified for WebSocket transport.
 type CodecInfo struct {
-	Codec   string // "h264" or "h265"
-	Profile byte   // profile indication from SPS
-	Level   byte   // level indication from SPS
-	SPS     []byte // sequence parameter set
-	PPS     []byte // picture parameter set
+	Codec   string // "h264", "h265", or "mjpeg"
+	Profile byte   // profile indication from SPS (0 for MJPEG)
+	Level   byte   // level indication from SPS (0 for MJPEG)
+	SPS     []byte // sequence parameter set (nil for MJPEG)
+	PPS     []byte // picture parameter set (nil for MJPEG)
 	VPS     []byte // video parameter set (H.265 only)
 }
 

--- a/web/src/components/MjpegLivePlayer.svelte
+++ b/web/src/components/MjpegLivePlayer.svelte
@@ -48,6 +48,8 @@
   const MAX_CONSECUTIVE_ERRORS = 3;
   // Track the last ETag to send If-None-Match on subsequent polls.
   let lastEtag: string | null = null;
+  let wsConnection: WebSocket | null = null;
+  let useWebSocket = true; // Try WebSocket first, fall back to HTTP polling
 
   function revokeBlobUrl() {
     if (currentBlobUrl) {
@@ -122,6 +124,119 @@
     }
   }
 
+  // ── WebSocket streaming (preferred over HTTP polling) ──────────────────
+  // Connects to the wsstream WebSocket endpoint, which pushes JPEG frames
+  // in real-time. Falls back to HTTP polling if WebSocket fails.
+  function startWebSocket() {
+    stopWebSocket();
+    if (!cameraId) return;
+
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const authHeader = getAuthHeader();
+    // wsstream endpoint accepts ?token= for auth (base64 user:pass)
+    let wsUrl = `${proto}//${window.location.host}${API_BASE}/cameras/${cameraId}/stream/ws`;
+    if (authHeader) {
+      // Extract credentials from Basic auth header
+      const b64 = authHeader.replace('Basic ', '');
+      wsUrl += `?token=${b64}`;
+    }
+
+    try {
+      wsConnection = new WebSocket(wsUrl);
+    } catch {
+      useWebSocket = false;
+      startPolling();
+      return;
+    }
+
+    wsConnection.binaryType = 'arraybuffer';
+
+    wsConnection.onopen = () => {
+      consecutiveErrors = 0;
+    };
+
+    wsConnection.onmessage = async (event) => {
+      if (destroyed || !(event.data instanceof ArrayBuffer)) return;
+      const data = new Uint8Array(event.data);
+      if (data.length < 1) return;
+
+      const msgType = data[0];
+      // Video frame (0x02): nalus[0] contains the complete JPEG
+      if (msgType === 0x02 && data.length >= 12) {
+        const naluCount = (data[10] << 8) | data[11];
+        if (naluCount < 1) return;
+        let off = 12;
+        const naluLen = (data[off] << 24) | (data[off + 1] << 16) | (data[off + 2] << 8) | data[off + 3];
+        off += 4;
+        if (off + naluLen > data.length) return;
+        const jpegData = data.slice(off, off + naluLen);
+
+        try {
+          const blob = new Blob([jpegData], { type: 'image/jpeg' });
+          revokeBlobUrl();
+          currentBlobUrl = URL.createObjectURL(blob);
+          if (imgEl) imgEl.src = currentBlobUrl;
+
+          lastLoadTime = Date.now();
+          if (streamState === 'loading' || streamState === 'frozen') {
+            streamState = 'playing';
+            reconnectAttempts = 0;
+            startFrozenDetection();
+            onLoad?.();
+          }
+        } catch {
+          // Corrupt JPEG — skip
+        }
+      }
+    };
+
+    wsConnection.onerror = () => {
+      // WebSocket failed — fall back to HTTP polling
+      if (useWebSocket) {
+        useWebSocket = false;
+        stopWebSocket();
+        startPolling();
+      }
+    };
+
+    wsConnection.onclose = () => {
+      if (destroyed || !useWebSocket) return;
+      // Reconnect with backoff (same pattern as polling)
+      consecutiveErrors++;
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        consecutiveErrors = 0;
+        useWebSocket = false;
+        stopWebSocket();
+        startPolling();
+      } else {
+        scheduleWsReconnect();
+      }
+    };
+  }
+
+  function stopWebSocket() {
+    if (wsConnection) {
+      wsConnection.onopen = null;
+      wsConnection.onmessage = null;
+      wsConnection.onerror = null;
+      wsConnection.onclose = null;
+      try {
+        wsConnection.close();
+      } catch { /* already closed */ }
+      wsConnection = null;
+    }
+  }
+
+  function scheduleWsReconnect() {
+    const base = reconnectDelays[Math.min(reconnectAttempts - 1, reconnectDelays.length - 1)];
+    const delay = Math.round(base * (0.75 + Math.random() * 0.5));
+    streamState = 'loading';
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      if (useWebSocket) startWebSocket();
+    }, delay);
+  }
+
   function startPolling() {
     stopPolling();
     consecutiveErrors = 0;
@@ -159,32 +274,30 @@
   }
 
   function scheduleReconnect() {
-    // Always retry — see note on reconnectDelays above. The 'error' state is
-    // reachable only via the manual 'Retry' button or by destroying the
-    // component, not by exhausting automatic retries.
     reconnectAttempts++;
     const base = reconnectDelays[Math.min(reconnectAttempts - 1, reconnectDelays.length - 1)];
-    // ±25% jitter desynchronizes cameras that died together after a shared
-    // transient backend hiccup, avoiding a thundering-herd retry stampede.
     const delay = Math.round(base * (0.75 + Math.random() * 0.5));
     streamState = 'loading';
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
-      startPolling();
+      if (useWebSocket) startWebSocket();
+      else startPolling();
     }, delay);
   }
 
   function handleReconnect() {
     stopFrozenDetection();
     stopPolling();
+    stopWebSocket();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
     }
     reconnectAttempts = 0;
     consecutiveErrors = 0;
+    useWebSocket = true;
     streamState = 'loading';
-    startPolling();
+    startWebSocket();
   }
 
   function handleFrozenRetry() {
@@ -199,6 +312,7 @@
     if (!_id) return;
 
     stopPolling();
+    stopWebSocket();
     stopFrozenDetection();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
@@ -206,12 +320,16 @@
     }
     reconnectAttempts = 0;
     consecutiveErrors = 0;
+    useWebSocket = true;
     streamState = 'loading';
 
-    // Stagger the first poll across cameras (100-500ms) so the fixed 500ms poll
+    // Stagger the first poll across cameras (100-500ms) so the fixed poll
     // cycles stay phase-offset: a short backend hiccup won't push every camera
     // past the consecutive-error threshold in the same window.
-    const timer = setTimeout(() => startPolling(), 100 + Math.random() * 400);
+    const timer = setTimeout(() => {
+      if (useWebSocket) startWebSocket();
+      else startPolling();
+    }, 100 + Math.random() * 400);
     return () => {
       clearTimeout(timer);
     };
@@ -220,6 +338,7 @@
   onDestroy(() => {
     destroyed = true;
     stopPolling();
+    stopWebSocket();
     stopFrozenDetection();
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);

--- a/web/src/lib/webcodecs-player/connection.ts
+++ b/web/src/lib/webcodecs-player/connection.ts
@@ -384,7 +384,7 @@ export class ConnectionManager {
 // ─── Inline CodecInfo decoder (avoids circular import, reuses protocol format) ───
 
 function decodeCodecInfoInline(data: ArrayBuffer): CodecInfo {
-  if (data.byteLength < 5) {
+  if (data.byteLength < 2) {
     throw new Error(`CodecInfo too short: ${data.byteLength} bytes`);
   }
 
@@ -394,6 +394,15 @@ function decodeCodecInfoInline(data: ArrayBuffer): CodecInfo {
   }
 
   const codecByte = dv.getUint8(1);
+  // MJPEG: only type + codec byte, no SPS/PPS/VPS.
+  if (codecByte === 6) {
+    return { codec: 'mjpeg', profile: 0, level: 0, sps: new Uint8Array(0), pps: new Uint8Array(0) };
+  }
+
+  if (data.byteLength < 5) {
+    throw new Error(`CodecInfo too short: ${data.byteLength} bytes`);
+  }
+
   const codec = codecByte === 5 ? 'h265' : 'h264';
   const profile = dv.getUint8(2);
   const level = dv.getUint8(3);

--- a/web/src/lib/webcodecs-player/protocol.ts
+++ b/web/src/lib/webcodecs-player/protocol.ts
@@ -31,6 +31,7 @@ export type MsgType = (typeof MsgType)[keyof typeof MsgType];
 export const CodecId = {
   H264: 'h264',
   H265: 'h265',
+  MJPEG: 'mjpeg',
 } as const;
 
 export type CodecId = (typeof CodecId)[keyof typeof CodecId];
@@ -39,7 +40,8 @@ export type CodecId = (typeof CodecId)[keyof typeof CodecId];
  * CodecInfo: codec configuration data sent once at stream start.
  * Binary wire format:
  *   {type:1}{codec:1}{profile:1}{level:1}{sps_len:2}{sps}{pps_len:2}{pps}[vps_len:2][vps]
- *   where codec byte is 4=H.264, 5=H.265.
+ *   where codec byte is 4=H.264, 5=H.265, 6=MJPEG.
+ * MJPEG sends only {type:1}{codec:1} (no SPS/PPS/VPS).
  */
 export interface CodecInfo {
   codec: CodecId;

--- a/web/src/lib/webcodecs-player/worker.ts
+++ b/web/src/lib/webcodecs-player/worker.ts
@@ -27,6 +27,7 @@ import { Decoder } from './decoder';
 
 let decoder: any = null;
 let pendingFrames: { frame: any }[] = [];
+let isMjpegMode = false;
 
 // ─── Message handler ──────────────────────────────────────────────────────
 
@@ -67,6 +68,15 @@ async function handleCodecInfo(data: {
     decoder.close();
     decoder = null;
   }
+
+  // MJPEG mode: no WebCodecs decoder needed. JPEG frames are decoded via
+  // createImageBitmap in handleVideoFrame, bypassing the Decoder entirely.
+  if (data.codec === 'mjpeg') {
+    isMjpegMode = true;
+    self.postMessage({ type: 'codec-ready' });
+    return;
+  }
+  isMjpegMode = false;
 
   // Create new decoder
   decoder = new Decoder();
@@ -133,6 +143,21 @@ async function handleCodecInfo(data: {
 }
 
 function handleVideoFrame(data: { pts: number; isKeyframe: boolean; nalus: Uint8Array[] }): void {
+  // MJPEG mode: decode JPEG via createImageBitmap (no WebCodecs decoder needed).
+  // nalus[0] contains the complete JPEG image bytes.
+  if (isMjpegMode) {
+    if (data.nalus.length === 0 || data.nalus[0].length === 0) return;
+    const jpegData = data.nalus[0];
+    createImageBitmap(new Blob([jpegData], { type: 'image/jpeg' }))
+      .then((bitmap) => {
+        self.postMessage({ type: 'frame', data: { bitmap, pts: data.pts } }, [bitmap] as any);
+      })
+      .catch(() => {
+        // Corrupt JPEG — silently skip (common during camera reconnection)
+      });
+    return;
+  }
+
   if (!decoder) return;
 
   try {
@@ -149,6 +174,7 @@ function handleReset(): void {
 }
 
 function handleClose(): void {
+  isMjpegMode = false;
   if (decoder) {
     decoder.close();
     decoder = null;


### PR DESCRIPTION
## Summary

MJPEG/HTTP-JPEG cameras (ESP32 MiBeeCam, ONVIF JPEG cameras) now push frames in real-time via the same wsstream WebSocket protocol used by H.264/H.265 cameras. This eliminates the 500ms-1s HTTP polling loop for live preview.

## How it works

```
Before:  Frontend ──HTTP GET──► /latest-frame ──► JPEG bytes (every 1s)
                                      │
                               Full JPEG re-downloaded each poll,
                               even if frame unchanged

After:   Frontend ◄──WebSocket──► wsstream ◄──StreamHub──► MJPEGRecorder
                     (binary)         │                  │
                                  JPEG pushed        Hub.Broadcast()
                                  as-captured        (new)
```

## Backend changes

- **wsstream/types.go**: `CodecMJPEG = "mjpeg"` constant
- **wsstream/protocol.go**: `codecByte`/`codecFromByte` handle mjpeg (byte 6); `EncodeCodecInfo` sends minimal `{type+codec}` for MJPEG (no SPS/PPS/VPS); `decodeCodecInfo` handles the short format
- **wsstream/manager.go**: `writeFrame` treats every MJPEG frame as a keyframe (JPEG is independently decodable)
- **api/handlers_ws.go**: MJPEG/JPEG cameras skip the SPS/PPS 5s keyframe wait
- **recorder/mjpeg.go**: `Hub.Broadcast()` JPEG frames for wsstream fan-out (Hub was already initialized by `initStreamHub` but Broadcast was never called for MJPEG)
- **recorder/http_jpeg.go**: same `Hub.Broadcast()` for HTTP JPEG cameras

## Frontend changes

- **MjpegLivePlayer.svelte**: WebSocket-first mode. Connects to `/api/cameras/{id}/stream/ws`, parses binary JPEG frames (`video_frame` msg type `0x02` with `nalus[0]` = complete JPEG), renders via Blob URL. Falls back to HTTP polling if WebSocket fails (graceful degradation for older backends).
- **webcodecs-player/protocol.ts**: add `MJPEG` codec constant
- **webcodecs-player/connection.ts**: `decodeCodecInfoInline` handles MJPEG short format (type+codec only)
- **webcodecs-player/worker.ts**: MJPEG mode bypasses WebCodecs decoder, uses `createImageBitmap` for JPEG → ImageBitmap rendering

## Protocol compatibility

The MJPEG frame uses the same `MsgTypeVideoFrame (0x02)` binary format as H.264/H.265:
```
{type:0x02}{pts:8}{is_keyframe:1}{nalu_count:2}{nalu1_len:4}{nalu1=JPEG bytes}
```
The only difference: `nalus[0]` contains a complete JPEG image instead of a NAL unit. The codec is identified at handshake via `CodecInfo` (codec byte 6 = MJPEG, sent without SPS/PPS).

## Bandwidth impact (9 MJPEG cameras)

| Metric | Before (HTTP polling) | After (WebSocket push) |
|--------|----------------------|----------------------|
| Requests/sec | ~9 req/s (1 per camera per second) | 0 (persistent connection) |
| HTTP overhead | Headers per request (~500B × 9/s) | None |
| Frame delivery | Polled at fixed interval | Pushed as captured (real-time) |
| Unchanged frames | Re-downloaded every poll | Not sent (no polling) |

## Test Plan
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run` — 0 issues
- [x] `cd web && npm test` — 406 tests pass
- [x] `cd web && npm run build` — builds successfully
- [ ] Manual: verify MJPEG live preview over WebSocket (Network tab shows WS connection, not HTTP polling)
- [ ] Manual: verify fallback to HTTP polling when WebSocket endpoint unavailable

🤖 Generated with ZCode