### PR TITLE
fix(playback): restore protocol selection + LL-HLS always-on + CSP wasm-unsafe-eval

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -567,13 +567,18 @@ func (h *Handler) handleCameraProtocols(w http.ResponseWriter, r *http.Request) 
 		encoding = strings.ToLower(cam.StreamEncoding)
 	}
 
-	// Probe the running recorder for the ACTUAL codec — this outranks the stored
-	// encoding/stream_encoding because some ONVIF cameras lie (e.g. report H264
-	// but stream H265). Without this, /protocols would advertise WebRTC for an
-	// H265 camera (WebRTC only supports H264), and the WHEP negotiation would
-	// fail silently. The recorder's detectEncoding already verified the real
-	// codec via RTSP DESCRIBE, so trust it over the stored value.
-	if h.camMgr != nil {
+	// Probe the running recorder for the actual codec ONLY when the stored
+	// encoding is empty (auto-detect) or for ONVIF cameras that may misreport
+	// their codec (some Hisilicon OEM devices report H264 via ONVIF but stream
+	// H265; their recorder's detectEncoding corrects this via RTSP DESCRIBE).
+	//
+	// We deliberately do NOT unconditionally override the stored encoding: for
+	// non-ONVIF cameras (xiaomi, rtsp, ingest) the user-configured encoding is
+	// authoritative and a runtime probe can mislabel it (e.g. a Xiaomi camera
+	// configured as h264 but momentarily probing h265 during codec auto-detect),
+	// which collapses the protocol list and forces HLS — the playback
+	// black-screen regression (see git blame on this block, pre-67fc4ee9).
+	if h.camMgr != nil && (encoding == "" || strings.EqualFold(cam.Protocol, "onvif")) {
 		if rec := h.camMgr.GetRecorder(id); rec != nil {
 			if codec, _, _, _ := getCodecParams(rec); codec != "" {
 				encoding = string(codec)

--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -406,28 +406,20 @@ type ConditionalHandler interface {
 // LLHLSStreamHandler implements StreamHandler for Low-Latency HLS.
 // It wraps HLSStreamHandler but is registered separately in the StreamRegistry
 // so the frontend can discover LL-HLS as a distinct protocol.
-// When low-latency is disabled, it appears as unavailable with a reason.
+//
+// LL-HLS is always advertised as available (H.264/H.265) — the backend muxer
+// supports low-latency fMP4 unconditionally. Whether the browser can actually
+// play it (e.g. H.265 via MSE) is a frontend capability concern, gated by the
+// same browser-probe logic as HLS/FLV.
 type LLHLSStreamHandler struct {
 	HLSStreamHandler
-	LowLatencyEnabled bool
 }
 
 func (h *LLHLSStreamHandler) Name() string { return "ll-hls" }
 
-// CanHandle returns true only when low-latency is actually enabled.
-// When disabled, the ConditionalHandler interface provides the "greyed out" UX.
+// CanHandle returns true for H.264 and H.265 — LL-HLS is always available.
 func (h *LLHLSStreamHandler) CanHandle(codec model.Format) bool {
-	return h.LowLatencyEnabled && (codec == model.FormatH264 || codec == model.FormatH265)
-}
-
-// SupportedCodec returns true for codecs that LL-HLS would support if enabled.
-func (h *LLHLSStreamHandler) SupportedCodec(codec model.Format) bool {
 	return codec == model.FormatH264 || codec == model.FormatH265
-}
-
-// UnavailabilityReason returns why LL-HLS is not available.
-func (h *LLHLSStreamHandler) UnavailabilityReason(_ model.Format) string {
-	return "Enable low-latency HLS in Settings"
 }
 
 // --- WSStreamHandler ---

--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -372,12 +372,13 @@ type FLVStreamHandler struct{}
 func (h *FLVStreamHandler) Name() string { return "flv" }
 
 func (h *FLVStreamHandler) CanHandle(codec model.Format) bool {
-	// The Go backend CAN mux H.265 into an FLV container, but the browser-side
-	// player (mpegts.js) relies on Media Source Extensions, and Chrome/Firefox
-	// MSE does not decode H.265/HEVC. Only Safari (macOS) supports it. Reporting
-	// FLV as available for H.265 would let the user pick it and see a black
-	// screen. Use the WASM player (WebCodecs + WASM H.265 decoder) for H.265.
-	return codec == model.FormatH264
+	// The FLV manager muxes both H.264 and H.265 into FLV containers. Whether
+	// the browser can actually DECODE the chosen codec (mpegts.js relies on MSE,
+	// and Chrome/Firefox MSE lacks H.265) is a client-side concern — the frontend
+	// gates FLV availability via detectMSEH265() in stream-selection.ts. Keeping
+	// the backend honest about manager capability lets the frontend make the
+	// right per-browser call instead of being force-routed to HLS.
+	return codec == model.FormatH264 || codec == model.FormatH265
 }
 
 func (h *FLVStreamHandler) StartStream(camID string, rec model.Recorder, opts StreamStartOptions) error {

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -12,8 +12,12 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
-		// CSP: Svelte 5 uses inline styles for dynamic styling; unsafe-inline is required
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'")
+		// CSP: Svelte 5 uses inline styles for dynamic styling; unsafe-inline is required.
+		// wasm-unsafe-eval: required for libde265 WASM H.265 decoder (enables H.265
+		// live playback on plain HTTP without WebCodecs/HTTPS) and ONNX Runtime Web
+		// (browser-side AI inference). connect-src ws:/wss:: WebSocket live streaming.
+		// worker-src blob:: WasmPlayer's decoder worker.
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -24,7 +24,7 @@ func TestSecurityHeaders(t *testing.T) {
 		{"X-XSS-Protection", "1; mode=block"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
 		{"Permissions-Policy", "camera=(), microphone=(), geolocation=()"},
-		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'"},
+		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:"},
 	}
 	for _, tt := range tests {
 		got := w.Header().Get(tt.header)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -488,11 +488,11 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// Step 7: HLS manager
 	hlsDataDir := filepath.Join(cfg.Storage.RootDir, "hls")
 	hlsMgr := hls.NewManagerWithOpts(context.Background(), hlsDataDir, cfg.HLS.WriteBufferSize, cfg.HLS.SegmentMaxSizeMB*1024*1024, cfg.HLS.SegmentCount, metrics)
-	// Configure Low-Latency HLS if enabled
-	if cfg.HLS.LowLatency {
-		partDur, _ := time.ParseDuration(cfg.HLS.PartMinDuration)
-		hlsMgr.SetLowLatency(true, partDur)
-	}
+	// Low-Latency HLS is always enabled — the muxer supports fMP4 LL mode
+	// unconditionally. Whether a given browser can play a given codec over
+	// LL-HLS is a frontend concern (same browser-probe as HLS/FLV).
+	partDur, _ := time.ParseDuration(cfg.HLS.PartMinDuration)
+	hlsMgr.SetLowLatency(true, partDur)
 
 	// Step 7.5: WebRTC manager (H.264 only)
 	var webrtcMgr *webrtc.Manager
@@ -733,10 +733,9 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// Create and populate StreamRegistry for protocol discovery
 	reg := api.NewStreamRegistry()
 	reg.Register(&api.HLSStreamHandler{Mgr: hlsMgr})
-	// Always register LL-HLS so it appears as greyed-out when disabled
+	// LL-HLS is always available (low-latency fMP4 muxer always enabled).
 	reg.Register(&api.LLHLSStreamHandler{
-		HLSStreamHandler:  api.HLSStreamHandler{Mgr: hlsMgr},
-		LowLatencyEnabled: cfg.HLS.LowLatency,
+		HLSStreamHandler: api.HLSStreamHandler{Mgr: hlsMgr},
 	})
 	if webrtcMgr != nil {
 		reg.Register(&api.WebRTCStreamHandler{})

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -352,6 +352,11 @@ function handleWebGpuLost() {
           if (cm) {
             cm.setPaused(msg.paused);
           }
+        } else if (msg.type === 'codec-ready') {
+          // Decoder configured — resume frame delivery (paused in onCodecInfo).
+          if (cm) {
+            cm.setPaused(false);
+          }
         }
       };
 
@@ -396,6 +401,12 @@ function handleWebGpuLost() {
       },
       onCodecInfo: (ci) => {
         if (!worker) return;
+        // Pause frame delivery until the worker signals codec-ready. The decoder
+        // configure (esp. libde265 WASM init on HTTP) is async; frames arriving
+        // before it finishes are silently dropped by the worker. Holding here
+        // avoids wasting bandwidth and ensures the next IDR after resume is the
+        // first frame decoded (no partial-state black screen).
+        cm?.setPaused(true);
         worker.postMessage({
           type: 'codec-info',
           data: {

--- a/web/src/lib/webcodecs-player/worker.ts
+++ b/web/src/lib/webcodecs-player/worker.ts
@@ -137,6 +137,7 @@ async function handleCodecInfo(data: {
       vps: data.vps,
     });
     isWasmMode = decoder.isWasm;
+    self.postMessage({ type: "codec-ready" });
   } catch (err: any) {
     self.postMessage({ type: 'error', error: err?.message || 'Codec configuration failed' });
   }


### PR DESCRIPTION
## Summary

Three independent fixes addressing the recent playback regression (black screens, protocols unselectable) and a Content-Security-Policy bug that silently broke all WebAssembly.

### 1. Protocol-selection regression (root cause of black screens)

Commit 67fc4ee9 introduced two changes that, combined, broke live preview for many cameras:

- **Encoding probe**: changed from "probe only when config is empty" (`if encoding == ""`) to "unconditionally override config". Xiaomi H.264 cameras got mis-detected as H.265 → protocol list wrong → fell back to HLS → HLS can't play H.265 → black screen.
- **FLV `CanHandle`**: narrowed from h264+h265 to h264-only → H.265 lost FLV/WebRTC from the protocol list.

**Fix** (`internal/api/handler.go`, `internal/api/handlers_stream.go`):
- Restore the guard: trust config `encoding` when set; only probe the recorder when encoding is empty OR protocol is ONVIF (corrects ONVIF auto-detect cameras that store `encoding=""`).
- `FLVStreamHandler.CanHandle` restored to h264+h265 (FLV manager muxes H.265 fine).

### 2. LL-HLS always available (no config toggle)

LL-HLS was gated behind `cfg.HLS.LowLatency` and a `LowLatencyEnabled` field on the handler. Per request, it's now **always enabled** — no toggle. Browser video-capability detection determines whether it's usable at runtime. Removes `LowLatencyEnabled`/`ConditionalHandler`.

### 3. CSP `wasm-unsafe-eval` (blocked ALL WebAssembly)

`script-src 'self' 'unsafe-inline'` lacked `wasm-unsafe-eval`, which silently broke:
- libde265 WASM H.265 decoder (live playback fallback on HTTP)
- ONNX Runtime Web (browser-side AI inference)

Added the narrow modern directive `wasm-unsafe-eval` (NOT the broad `unsafe-eval`), plus `connect-src ws: wss:` (WebSocket streaming) and `worker-src 'self' blob:` (decoder worker).

Also: `codec-ready` handshake between `WasmPlayer` and the decoder worker — pause frame delivery during async decoder init, resume on the `codec-ready` signal, so the first IDR after configure is the first decoded frame (no partial-state black screen).

## Deploy verification
Verified on Banana Pi M5 (192.168.63.30, production): `/protocols` returns correct encoding + FLV/WebRTC available for H.264 cameras; LL-HLS served; H.265 cameras (LL-HLS) load.

## Test plan
- [x] Frontend build clean
- [x] `go vet` / `go build` clean
- [x] `npm test` — 406 tests pass
- [x] Deployed to M5, protocols render correctly

## Full Changelog
https://github.com/Mi-Bee-Studio/MiBeeNvr/compare/main...fix/playback-regression-csp