### PR TITLE
feat(playback): H.265 live playback via libde265 WASM on plain HTTP

### DIFF
--- a/web/src/components/ProtocolSwitcher.svelte
+++ b/web/src/components/ProtocolSwitcher.svelte
@@ -3,7 +3,7 @@
   import { t } from '$lib/i18n';
   import { apiRequest } from '$lib/api';
   import { showToast } from '$lib/toast';
-  import { detectWebCodecs, getWebCodecsUnavailableReason } from '$lib/webcodecs-player/capabilities';
+  import { detectWebCodecs, getWebCodecsUnavailableReason, detectWasmH265 } from '$lib/webcodecs-player/capabilities';
   import { getCameraProtocolOverride, setCameraProtocolOverride } from '$lib/preferences';
 
   export type StreamingProtocol = 'wasm' | 'hls' | 'll-hls' | 'webrtc' | 'flv' | 'mjpeg';
@@ -49,6 +49,7 @@
 
   let isH265 = $derived((cameraEncoding || '').toLowerCase() === 'h265');
   let browserSupportsWasm = $state(false);
+  let browserSupportsWasmH265 = $state(false);
   let wasmUnavailableReason: string | null = $state(null);
 
   let protocolOptions = [
@@ -68,16 +69,19 @@
   let visibleOptions = $derived(protocolOptions);
 
   function isAvailable(protocol: StreamingProtocol): boolean {
-    // Wasm requires browser WebCodecs support
-    if (protocol === 'wasm' && !browserSupportsWasm) return false;
+    // WebCodecs (HTTPS) for any codec, OR libde265 WASM fallback for H.265 (HTTP)
+    if (protocol === 'wasm' && !browserSupportsWasm && !(isH265 && browserSupportsWasmH265)) return false;
     // H.265 cameras cannot use WebRTC
     if (protocol === 'webrtc' && isH265) return false;
     return availableProtocols.includes(protocol);
   }
 
   function getUnavailableReason(protocol: StreamingProtocol): string | null {
-    if (protocol === 'wasm' && !browserSupportsWasm) {
-      return wasmUnavailableReason || 'Browser does not support WebCodecs';
+    if (protocol === 'wasm' && !browserSupportsWasm && !(isH265 && browserSupportsWasmH265)) {
+      // Only show the WebCodecs reason when WASM H.265 fallback also can't help
+      if (!isH265 || !browserSupportsWasmH265) {
+        return wasmUnavailableReason || 'Browser does not support WebCodecs';
+      }
     }
     if (protocol === 'webrtc' && isH265) {
       return t('live.protocol.tooltip.h265Note');
@@ -187,6 +191,7 @@
 
   onMount(() => {
     browserSupportsWasm = detectWebCodecs();
+    browserSupportsWasmH265 = detectWasmH265();
     if (!browserSupportsWasm) {
       wasmUnavailableReason = getWebCodecsUnavailableReason();
     }

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -18,12 +18,16 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
   let {
     cameraId,
     cameraName,
+    codec = 'h264',
     expanded = false,
     tabVisible = true,
     onFallbackNeeded,
   }: {
     cameraId: string;
     cameraName: string;
+    /** Camera codec ('h264' | 'h265' | 'mjpeg'). Determines whether the WASM
+     *  libde265 fallback path is available on plain HTTP (no WebCodecs). */
+    codec?: string;
     expanded?: boolean;
     tabVisible?: boolean;
     onFallbackNeeded?: (fallback: 'hls') => void;
@@ -290,6 +294,26 @@ let webgpuRenderer: WebGPURenderer | null = null;
     }
   }
 
+  /**
+   * Render a raw RGBA frame (WASM libde265 output) via Canvas2D putImageData.
+   * Used on plain HTTP where WebCodecs VideoFrame is unavailable — this is the
+   * HTTP H.265 playback path. Falls back to a 2D context on the same canvas
+   * element used for WebGL2 (mutually exclusive: only one context per canvas).
+   */
+  function renderWasmFrame(frame: { rgba: Uint8Array; width: number; height: number }) {
+    if (!canvasEl) return;
+    const ctx = canvasEl.getContext('2d');
+    if (!ctx) return;
+    if (canvasEl.width !== frame.width || canvasEl.height !== frame.height) {
+      canvasEl.width = frame.width;
+      canvasEl.height = frame.height;
+      canvasWidth = frame.width;
+      canvasHeight = frame.height;
+    }
+    const imageData = new ImageData(new Uint8ClampedArray(frame.rgba.buffer, frame.rgba.byteOffset, frame.rgba.byteLength), frame.width, frame.height);
+    ctx.putImageData(imageData, 0, 0);
+  }
+
 function handleWebGpuLost() {
   if (!webgpuRenderer) return;
   webgpuRenderer.destroy();
@@ -333,6 +357,12 @@ function handleWebGpuLost() {
             renderFrame(frame);
             frame.close(); // Memory safety — always close after rendering
           }
+          if (streamState !== 'playing') {
+            updateState('playing');
+          }
+        } else if (msg.type === 'wasm-frame' && msg.data) {
+          // HTTP H.265 path: raw RGBA from libde265 WASM (no VideoFrame).
+          renderWasmFrame(msg.data);
           if (streamState !== 'playing') {
             updateState('playing');
           }
@@ -540,9 +570,17 @@ function handleWebGpuLost() {
   function checkTier(): string | null {
     const tier = getPlaybackTier();
     if (tier === 'tier3') {
-      // Trigger auto-fallback to HLS instead of showing error
-      onFallbackNeeded?.('hls');
-      return null; // Don't set error state — parent will switch protocol
+      // No WebCodecs (plain HTTP, non-localhost). The WASM libde265 decoder can
+      // still decode H.265 via Canvas2D putImageData — allow it for H.265 so
+      // HTTP environments aren't forced to HLS (which can't play H.265 either).
+      // H.264 on tier3 has no working decode path (needs WebCodecs), so fall back.
+      if (codec !== 'h265') {
+        onFallbackNeeded?.('hls');
+        return null; // Don't set error state — parent will switch protocol
+      }
+      // H.265 + tier3: proceed with WASM-only rendering (Canvas2D). WebGL2/WebGPU
+      // are unavailable here, but Canvas2D putImageData needs no special context.
+      return null;
     }
     if (!detectWebGL2()) {
       return 'WebGL2 is required for rendering';
@@ -563,8 +601,11 @@ function handleWebGpuLost() {
       streamState = 'error';
       return;
     }
-    // If checkTier() triggered fallback, stop initialization
-    if (!detectWebCodecs()) {
+    // If checkTier() triggered fallback, stop initialization.
+    // On tier3 (no WebCodecs) for H.265, we proceed — the WASM libde265 path
+    // renders via Canvas2D (no WebGL2/WebGPU needed). For all other tier3
+    // cases checkTier already triggered the HLS fallback above.
+    if (!detectWebCodecs() && codec !== 'h265') {
       return;
     }
     unsupportedMsg = null;
@@ -597,8 +638,11 @@ function handleWebGpuLost() {
         }
       }
 
-      // WebGL2 fallback (or tier 2 direct)
-      if (!webgpuRenderer) {
+      // WebGL2 fallback (or tier 2 direct). On tier3 + H.265 (plain HTTP) we
+      // skip WebGL2 entirely — the WASM libde265 path renders via Canvas2D
+      // putImageData, which needs no WebGL context.
+      const isTier3Wasm = getPlaybackTier() === 'tier3' && codec === 'h265';
+      if (!webgpuRenderer && !isTier3Wasm) {
         if (!initWebGL2()) {
           console.error('[WasmPlayer] WebGL2 init failed — canvas context types:', canvasEl ? (canvasEl as unknown as Record<string, unknown>).__svelte_context || 'unknown' : 'no canvas');
           unsupportedMsg = 'Failed to initialize WebGL2';

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -49,6 +49,14 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
   let glTexture: WebGLTexture | null = null;
   let glVao: WebGLVertexArrayObject | null = null;
 
+  // Dedicated Canvas2D context for the WASM (libde265) H.265 path on plain HTTP.
+  // A canvas can only hold ONE context type — if WebGL2 was ever acquired on it
+  // (e.g. from a prior protocol session or a probe), getContext('2d') returns
+  // null forever. So on the WASM path we lazily create a FRESH 2D context the
+  // first time we need it, and reuse it for every frame. This decouples WASM
+  // rendering from any WebGL2 state on the main canvas.
+  let wasm2d: CanvasRenderingContext2D | null = null;
+
 // WebGPU renderer (tier 1)
 let webgpuRenderer: WebGPURenderer | null = null;
 
@@ -297,22 +305,61 @@ let webgpuRenderer: WebGPURenderer | null = null;
   /**
    * Render a raw RGBA frame (WASM libde265 output) via Canvas2D putImageData.
    * Used on plain HTTP where WebCodecs VideoFrame is unavailable — this is the
-   * HTTP H.265 playback path. Falls back to a 2D context on the same canvas
-   * element used for WebGL2 (mutually exclusive: only one context per canvas).
+   * HTTP H.265 playback path.
+   *
+   * A canvas element can hold only ONE context type for its lifetime. If the
+   * main canvas ever acquired a WebGL2 context (prior protocol session, a
+   * capability probe, etc.), getContext('2d') permanently returns null. To stay
+   * robust against that, we lazily create a DEDICATED offscreen 2D canvas for
+   * WASM rendering, then blit it onto whatever context the main canvas currently
+   * exposes (2d if available, else WebGL2). This decouples WASM decoding from
+   * main-canvas context ownership entirely.
    */
   function renderWasmFrame(frame: { rgba: Uint8Array; width: number; height: number }) {
     if (!canvasEl) return;
-    const ctx = canvasEl.getContext('2d');
-    if (!ctx) return;
-    if (canvasEl.width !== frame.width || canvasEl.height !== frame.height) {
-      canvasEl.width = frame.width;
-      canvasEl.height = frame.height;
+
+    // Lazily create the offscreen 2D canvas for WASM frames (done once).
+    if (!wasm2dCanvas) wasm2dCanvas = document.createElement('canvas');
+    if (wasm2dCanvas.width !== frame.width || wasm2dCanvas.height !== frame.height) {
+      wasm2dCanvas.width = frame.width;
+      wasm2dCanvas.height = frame.height;
       canvasWidth = frame.width;
       canvasHeight = frame.height;
     }
-    const imageData = new ImageData(new Uint8ClampedArray(frame.rgba.buffer, frame.rgba.byteOffset, frame.rgba.byteLength), frame.width, frame.height);
-    ctx.putImageData(imageData, 0, 0);
+    // Draw RGBA → offscreen 2D canvas
+    const offCtx = wasm2dCanvas.getContext('2d');
+    if (!offCtx) return;
+    const imageData = new ImageData(
+      new Uint8ClampedArray(frame.rgba.buffer, frame.rgba.byteOffset, frame.rgba.byteLength),
+      frame.width,
+      frame.height,
+    );
+    offCtx.putImageData(imageData, 0, 0);
+
+    // Blit onto the main canvas. Prefer its 2D context; if a WebGL2 context
+    // owns the canvas, upload the offscreen canvas as a texture instead.
+    if (canvasEl.width !== frame.width || canvasEl.height !== frame.height) {
+      canvasEl.width = frame.width;
+      canvasEl.height = frame.height;
+      if (gl) gl.viewport(0, 0, canvasEl.width, canvasEl.height);
+    }
+    const main2d = canvasEl.getContext('2d');
+    if (main2d) {
+      main2d.drawImage(wasm2dCanvas, 0, 0);
+    } else if (gl && glProgram && glTexture && glVao) {
+      // WebGL2 path — reuse the existing program/texture to draw the frame.
+      gl.useProgram(glProgram);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, glTexture);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, wasm2dCanvas);
+      gl.bindVertexArray(glVao);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.bindVertexArray(null);
+    }
   }
+
+  // Dedicated offscreen 2D canvas for WASM frame rendering (see renderWasmFrame).
+  let wasm2dCanvas: HTMLCanvasElement | null = null;
 
 function handleWebGpuLost() {
   if (!webgpuRenderer) return;
@@ -638,18 +685,26 @@ function handleWebGpuLost() {
         }
       }
 
-      // WebGL2 fallback (or tier 2 direct). On tier3 + H.265 (plain HTTP) we
-      // skip WebGL2 entirely — the WASM libde265 path renders via Canvas2D
-      // putImageData, which needs no WebGL context.
+      // WebGL2 initialization. We initialize WebGL2 for ALL paths where it's
+      // available, including the tier3 + H.265 (WASM libde265) path: the WASM
+      // decoder produces RGBA, which we blit onto the main canvas via an
+      // offscreen 2D canvas. If the main canvas has WebGL2, we upload the frame
+      // as a texture (GPU blit); if it only has 2D, we drawImage. Either way the
+      // main canvas needs a context, so try WebGL2 first (best quality/scaling)
+      // and let renderWasmFrame adapt to whatever context the canvas exposes.
       const isTier3Wasm = getPlaybackTier() === 'tier3' && codec === 'h265';
-      if (!webgpuRenderer && !isTier3Wasm) {
+      if (!webgpuRenderer) {
         if (!initWebGL2()) {
-          console.error('[WasmPlayer] WebGL2 init failed — canvas context types:', canvasEl ? (canvasEl as unknown as Record<string, unknown>).__svelte_context || 'unknown' : 'no canvas');
-          unsupportedMsg = 'Failed to initialize WebGL2';
-          streamState = 'error';
-          return;
+          // WebGL2 unavailable — on the WASM path this is fine (renderWasmFrame
+          // falls back to a 2D context). For WebCodecs paths WebGL2 is required.
+          if (!isTier3Wasm) {
+            if (import.meta.env.DEV) console.error('[WasmPlayer] WebGL2 init failed');
+            unsupportedMsg = 'Failed to initialize WebGL2';
+            streamState = 'error';
+            return;
+          }
+          if (import.meta.env.DEV) console.warn('[WasmPlayer] WebGL2 init failed on WASM path — using 2D blit');
         }
-        if (import.meta.env.DEV) console.log('[WasmPlayer] WebGL2 init success');
       }
 
       if (!initWorker()) {

--- a/web/src/lib/stream-selection.ts
+++ b/web/src/lib/stream-selection.ts
@@ -48,12 +48,14 @@ export interface ProtocolsResponse {
 export interface BrowserCaps {
   /** MSE can decode H.265 — when false, FLV renders black on H.265 streams. */
   h265MSE: boolean;
-  /** WebCodecs VideoDecoder present — enables the WASM player. */
+  /** WebCodecs VideoDecoder present — enables the WebCodecs player (HTTPS/localhost). */
   webCodecs: boolean;
+  /** libde265 WASM soft-decoder available — enables H.265 on plain HTTP via Canvas2D. */
+  wasmH265: boolean;
 }
 
 /** Empty (most-conservative) browser capability set — used as a safe fallback. */
-export const EMPTY_CAPS: BrowserCaps = { h265MSE: false, webCodecs: false };
+export const EMPTY_CAPS: BrowserCaps = { h265MSE: false, webCodecs: false, wasmH265: false };
 
 /**
  * Ordered preference of real-time streaming protocols for runtime fallback.
@@ -180,9 +182,11 @@ export function pickCameraMode(
   }
 
   if (candidate === 'wasm') {
-    // WASM player needs WebCodecs; without it, fall to HLS.
-    if (!caps.webCodecs) return 'hls';
-    return 'wasm';
+    // WebCodecs player (HTTPS/localhost) for any codec, OR libde265 WASM
+    // fallback for H.265 on plain HTTP. Without either, fall to HLS.
+    if (caps.webCodecs) return 'wasm';
+    if (enc === 'h265' && caps.wasmH265) return 'wasm';
+    return 'hls';
   }
 
   // Unknown candidate — safest universal default.
@@ -207,8 +211,8 @@ export function isProtocolUsable(
   if (p === 'webrtc') return enc !== 'h265';
   // FLV: H.265 needs MSE H.265, else black screen.
   if (p === 'flv') return enc !== 'h265' || caps.h265MSE;
-  // WASM: needs WebCodecs.
-  if (p === 'wasm') return caps.webCodecs;
+  // WebCodecs (HTTPS) for any codec, or libde265 WASM fallback for H.265 (HTTP).
+  if (p === 'wasm') return caps.webCodecs || (enc === 'h265' && caps.wasmH265);
   // MJPEG: only for JPEG/MJPEG streams.
   if (p === 'mjpeg') return enc === 'mjpeg' || enc === 'jpeg';
   // HLS / LL-HLS: universally usable for H.264/H.265 (browsers decode natively).

--- a/web/src/lib/webcodecs-player/capabilities.ts
+++ b/web/src/lib/webcodecs-player/capabilities.ts
@@ -150,7 +150,7 @@ export function detectWasmSimd(): boolean {
  * Determine playback tier based on available capabilities.
  *
  *   tier1 — WebCodecs + WebGPU        (best performance)
- *   tier2 — WebCodecs + (WebGL2 | OffscreenCanvas)  (good performance)
+ *   tier2 — WebCodecs + (WebGL2 | OffscreenCanvas)  (good playback)
  *   tier3 — fallback                   (basic playback)
  */
 export function getPlaybackTier(): PlaybackTier {
@@ -161,4 +161,20 @@ export function getPlaybackTier(): PlaybackTier {
     return 'tier2';
   }
   return 'tier3';
+}
+
+/**
+ * Check whether H.265 can be played via the libde265 WASM soft-decoder.
+ *
+ * Unlike WebCodecs (which needs HTTPS/localhost), libde265 is pure WASM and
+ * works on plain HTTP. It renders via Canvas2D putImageData (no WebGL needed).
+ * This is the fallback path that enables H.265 live playback in HTTP
+ * environments where HLS/FLV/WebRTC all fail (browsers can't decode HEVC via
+ * MSE or native <video> on Linux/no-HEVC-extension).
+ *
+ * Returns true whenever WebAssembly is available (libde265 loads lazily on
+ * first decode; we don't probe the module here to avoid a network fetch).
+ */
+export function detectWasmH265(): boolean {
+  return typeof WebAssembly !== 'undefined' && typeof CanvasRenderingContext2D !== 'undefined';
 }

--- a/web/src/lib/webcodecs-player/decoder.ts
+++ b/web/src/lib/webcodecs-player/decoder.ts
@@ -138,6 +138,8 @@ export class Decoder {
   private _configured = false;
   private _lastCodecInfo: CodecInfo | null = null;
   private _frameCallback: ((frame: VideoFrame) => void) | null = null;
+  private _wasmFrameCallback:
+    ((frame: { rgba: Uint8Array; width: number; height: number; pts: number }) => void) | null = null;
   private _errorCallback: ((error: Error) => void) | null = null;
   private _errorCount = 0;
   private static readonly MAX_RECOVERY_ATTEMPTS = 3;
@@ -297,6 +299,16 @@ export class Decoder {
     this._backpressureCallback = callback;
   }
 
+  /**
+   * Register a callback for decoded WasmFrames (raw RGBA).
+   * Used ONLY when WebCodecs VideoFrame is unavailable (plain HTTP) — the
+   * caller renders these via Canvas2D putImageData instead of the WebGL2
+   * VideoFrame pipeline.
+   */
+  onWasmFrame(callback: (frame: { rgba: Uint8Array; width: number; height: number; pts: number }) => void): void {
+    this._wasmFrameCallback = callback;
+  }
+
   /** Number of decode requests currently in the WebCodecs pipeline. */
   get pendingDecodeCount(): number {
     return this._pendingDecodeCount;
@@ -390,7 +402,7 @@ export class Decoder {
     this._decoder.decode(chunk);
   }
 
-  /** Decode via WASM — synchronous, outputs VideoFrame immediately. */
+  /** Decode via WASM — synchronous, outputs a frame immediately. */
   private _decodeWasm(nalus: Uint8Array[], pts: number, isKeyframe: boolean): void {
     if (!this._wasmDecoder) return;
 
@@ -413,8 +425,28 @@ export class Decoder {
     const frame = this._wasmDecoder.decode(nalus, pts, isKeyframe);
     if (frame) {
       this._pendingDecodeCount++;
-      // Fire frame callback — WASM decoder produces frame synchronously
-      this.handleOutput(frame, this._decoderEpoch);
+      // Backpressure recovery (WASM decodes synchronously, count decremented below)
+      if (this._backpressured && this._pendingDecodeCount < BACKPRESSURE_THRESHOLD) {
+        this._backpressured = false;
+        if (this._backpressureCallback) {
+          try {
+            this._backpressureCallback(false);
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+      // Route WasmFrame (HTTP, no VideoFrame) vs VideoFrame (HTTPS).
+      if (typeof VideoFrame !== 'undefined') {
+        this.handleOutput(frame as VideoFrame, this._decoderEpoch);
+      } else if (this._wasmFrameCallback) {
+        this._pendingDecodeCount--;
+        try {
+          this._wasmFrameCallback(frame as any);
+        } catch {
+          /* callback failed — frame is plain data, no close() needed */
+        }
+      }
     }
   }
 

--- a/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
+++ b/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
@@ -95,10 +95,15 @@ export class WasmH265Decoder {
   decode(nalus: Uint8Array[], pts: number, _isKeyframe: boolean): VideoFrame | WasmFrame | null {
     if (!this._initialized || !this._decoder || !this._module) return null;
 
-    // Push each NAL unit with start codes
+    // Push each NAL unit. pushNal() expects ONE NAL WITHOUT a start code — the
+    // decoder treats the whole buffer as a single NAL payload (whereas pushData()
+    // expects a raw bytestream WITH start codes and splits NALs itself). The WS
+    // protocol already delivers raw NAL payloads (no start codes), so we feed
+    // them directly. Prepending a start code here corrupts the NAL header (the
+    // decoder reads `00 00` as the 2-byte HEVC NAL header → forbidden
+    // nal_unit_type=0 → every frame rejected → "configure OK, no frames").
     for (const nalu of nalus) {
-      const annexB = prependStartCode(nalu);
-      const err = this._decoder.pushNal(annexB, BigInt(pts));
+      const err = this._decoder.pushNal(nalu, BigInt(pts));
       if (!this._module.isOk(err)) {
         // Push failed — likely need more data or parameter sets
         return null;
@@ -108,19 +113,26 @@ export class WasmH265Decoder {
     this._decoder.pushEndOfFrame();
 
     // Decode and extract frame
-    let frame: VideoFrame | WasmFrame | null = null;
     let more = true;
     while (more) {
       const result = this._decoder.decode();
       more = result.more;
 
       if (!this._module.isOk(result.error)) {
-        // ERROR_WAITING_FOR_INPUT_DATA is normal — need more NALs
-        if (result.error === 13) {
-          // ERROR_WAITING_FOR_INPUT_DATA
-          break;
+        // ERROR_WAITING_FOR_INPUT_DATA (13) is normal — need more NALs.
+        if (result.error === 13) break;
+        // Warnings (>= 1000) are non-fatal per libde265 — a malformed slice,
+        // reference picture issue, etc. Keep going in case a picture is still
+        // available. Only hard errors (1..502) abort this decode cycle.
+        if (result.error >= 1000) {
+          // Still try to retrieve any picture produced before the warning.
+          const warnImage = this._decoder.getNextPicture();
+          if (warnImage) {
+            const produced = this._emitFrame(warnImage, pts);
+            if (produced) return produced;
+          }
+          continue;
         }
-        // Other errors — stop
         break;
       }
 
@@ -128,42 +140,9 @@ export class WasmH265Decoder {
       const image: Libde265Image | null = this._decoder.getNextPicture();
       if (!image) continue;
 
-      // Extract frame dimensions
-      this._width = image.getWidth(0);
-      this._height = image.getHeight(0);
-
-      if (this._width > 0 && this._height > 0) {
-        // Get YUV planes
-        const y = image.getImagePlane(0);
-        const u = image.getImagePlane(1);
-        const v = image.getImagePlane(2);
-
-        // Convert YUV420P → RGBA
-        const rgba = yuv420ToRgba(y.bytes, u.bytes, v.bytes, this._width, this._height);
-
-        if (typeof VideoFrame !== 'undefined') {
-          // WebCodecs available (HTTPS/localhost): wrap in a synthetic VideoFrame
-          // for compatibility with the WebGL2/WebGPU rendering pipeline.
-          frame = new VideoFrame(rgba, {
-            codedWidth: this._width,
-            codedHeight: this._height,
-            timestamp: pts,
-            format: 'RGBA',
-          });
-        } else {
-          // WebCodecs unavailable (plain HTTP): return raw RGBA for Canvas2D
-          // rendering. This is the HTTP H.265 playback path — libde265 WASM
-          // decodes fine without a secure context; only the VideoFrame wrapper
-          // was blocking it.
-          frame = { rgba, width: this._width, height: this._height, pts };
-        }
-      }
-
-      // Must delete image to prevent ERROR_IMAGE_BUFFER_FULL
-      image.delete();
-
-      // Return the first frame found (one decode call = one frame in our use case)
-      if (frame) return frame;
+      // Must delete image to prevent ERROR_IMAGE_BUFFER_FULL — done by _emitFrame
+      const produced = this._emitFrame(image, pts);
+      if (produced) return produced;
     }
 
     return null;
@@ -174,6 +153,45 @@ export class WasmH265Decoder {
     if (this._decoder) {
       this._decoder.reset();
     }
+  }
+
+  /**
+   * Convert a libde265 decoded image to an output frame (VideoFrame or WasmFrame).
+   * Handles YUV→RGBA conversion and ALWAYS deletes the image handle to avoid
+   * ERROR_IMAGE_BUFFER_FULL. Returns null if the image has no valid dimensions.
+   *
+   * @returns output frame, or null if the image was empty/malformed. The image
+   *          is deleted either way (caller must not touch it after this call).
+   */
+  private _emitFrame(image: Libde265Image, pts: number): VideoFrame | WasmFrame | null {
+    let produced: VideoFrame | WasmFrame | null = null;
+    try {
+      this._width = image.getWidth(0);
+      this._height = image.getHeight(0);
+      if (this._width > 0 && this._height > 0) {
+        const y = image.getImagePlane(0);
+        const u = image.getImagePlane(1);
+        const v = image.getImagePlane(2);
+        const rgba = yuv420ToRgba(y.bytes, u.bytes, v.bytes, this._width, this._height);
+        if (typeof VideoFrame !== 'undefined') {
+          // WebCodecs available (HTTPS/localhost): wrap in a synthetic VideoFrame
+          // for compatibility with the WebGL2/WebGPU rendering pipeline.
+          produced = new VideoFrame(rgba, {
+            codedWidth: this._width,
+            codedHeight: this._height,
+            timestamp: pts,
+            format: 'RGBA',
+          });
+        } else {
+          // WebCodecs unavailable (plain HTTP): raw RGBA for Canvas2D putImageData.
+          produced = { rgba, width: this._width, height: this._height, pts };
+        }
+      }
+    } finally {
+      // Always delete to prevent ERROR_IMAGE_BUFFER_FULL.
+      image.delete();
+    }
+    return produced;
   }
 
   /** Full cleanup — release WASM decoder and free memory. */

--- a/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
+++ b/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
@@ -21,6 +21,22 @@ import { yuv420ToRgba } from './yuv-rgba';
 
 const START_CODE = new Uint8Array([0x00, 0x00, 0x00, 0x01]);
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * A decoded H.265 frame as raw RGBA pixels — used when WebCodecs VideoFrame is
+ * unavailable (plain HTTP, non-localhost). The caller renders it via Canvas2D
+ * putImageData instead of the WebGL2/WebGPU VideoFrame pipeline.
+ */
+export interface WasmFrame {
+  /** RGBA pixel data (width * height * 4 bytes). */
+  rgba: Uint8Array;
+  width: number;
+  height: number;
+  /** Presentation timestamp (same units as the input PTS). */
+  pts: number;
+}
+
 // ─── WasmH265Decoder ─────────────────────────────────────────────────────────
 
 export class WasmH265Decoder {
@@ -70,10 +86,13 @@ export class WasmH265Decoder {
   /**
    * Decode a frame from raw NAL units.
    *
-   * @returns VideoFrame (synthetic, from RGBA data) or null if no frame available yet.
-   *          Caller owns the VideoFrame and must call .close() when done.
+   * @returns Decoded frame, or null if no frame is available yet.
+   *          When WebCodecs is available, returns a synthetic VideoFrame (RGBA).
+   *          When WebCodecs is unavailable (HTTP non-localhost), returns a
+   *          WasmFrame (raw RGBA + dimensions) so the caller can render via
+   *          Canvas2D putImageData without depending on the VideoFrame API.
    */
-  decode(nalus: Uint8Array[], pts: number, _isKeyframe: boolean): VideoFrame | null {
+  decode(nalus: Uint8Array[], pts: number, _isKeyframe: boolean): VideoFrame | WasmFrame | null {
     if (!this._initialized || !this._decoder || !this._module) return null;
 
     // Push each NAL unit with start codes
@@ -89,7 +108,7 @@ export class WasmH265Decoder {
     this._decoder.pushEndOfFrame();
 
     // Decode and extract frame
-    let frame: VideoFrame | null = null;
+    let frame: VideoFrame | WasmFrame | null = null;
     let more = true;
     while (more) {
       const result = this._decoder.decode();
@@ -122,15 +141,22 @@ export class WasmH265Decoder {
         // Convert YUV420P → RGBA
         const rgba = yuv420ToRgba(y.bytes, u.bytes, v.bytes, this._width, this._height);
 
-        // Create synthetic VideoFrame from RGBA pixel data
-        // This VideoFrame is CPU-backed (not GPU) — compatible with
-        // WebGL2 texImage2D, createImageBitmap, and VideoFrame cloning.
-        frame = new VideoFrame(rgba, {
-          codedWidth: this._width,
-          codedHeight: this._height,
-          timestamp: pts,
-          format: 'RGBA',
-        });
+        if (typeof VideoFrame !== 'undefined') {
+          // WebCodecs available (HTTPS/localhost): wrap in a synthetic VideoFrame
+          // for compatibility with the WebGL2/WebGPU rendering pipeline.
+          frame = new VideoFrame(rgba, {
+            codedWidth: this._width,
+            codedHeight: this._height,
+            timestamp: pts,
+            format: 'RGBA',
+          });
+        } else {
+          // WebCodecs unavailable (plain HTTP): return raw RGBA for Canvas2D
+          // rendering. This is the HTTP H.265 playback path — libde265 WASM
+          // decodes fine without a secure context; only the VideoFrame wrapper
+          // was blocking it.
+          frame = { rgba, width: this._width, height: this._height, pts };
+        }
       }
 
       // Must delete image to prevent ERROR_IMAGE_BUFFER_FULL

--- a/web/src/lib/webcodecs-player/worker.ts
+++ b/web/src/lib/webcodecs-player/worker.ts
@@ -12,6 +12,7 @@
  *
  * Message protocol (worker → main):
  *   { type: 'frame', data: VideoFrame }        — frame for rendering (transferable if GPU-backed)
+ *   { type: 'wasm-frame', data: {rgba,width,height,pts} } — raw RGBA frame (HTTP, no VideoFrame)
  *   { type: 'error', error: string }            — error notification
  *
  * NOTE: WASM-decoded frames are CPU-backed (synthetic VideoFrame from RGBA).
@@ -86,8 +87,13 @@ async function handleCodecInfo(data: {
   }
 
   // Set frame output callback — forward to main thread
-  // Tracks whether frames are from WASM (CPU-backed, not transferable)
+  // Tracks whether frames are from WASM (CPU backed, not transferable)
   let isWasmMode = false;
+
+  // WASM RGBA frame callback (HTTP, no VideoFrame) — forward raw pixels.
+  decoder.onWasmFrame((frame: { rgba: Uint8Array; width: number; height: number; pts: number }) => {
+    self.postMessage({ type: 'wasm-frame', data: frame });
+  });
 
   decoder.onFrame((frame: any) => {
     try {

--- a/web/src/routes/LiveView.svelte
+++ b/web/src/routes/LiveView.svelte
@@ -265,17 +265,10 @@
                 <WasmPlayer
                   cameraId={camera.id}
                   cameraName={camera.name || camera.id}
+                  codec={(camera.encoding || camera.stream_encoding || '').toLowerCase()}
                   expanded={true}
                   onFallbackNeeded={handleWasmFallback}
                 />
-                <div class="relative w-full bg-black" style="aspect-ratio: 16/9;">
-                  <div class="absolute inset-0 flex items-center justify-center">
-                    <div class="flex flex-col items-center gap-2">
-                      <div class="w-4 h-4 border-2 border-white/30 border-t-white/80 rounded-full animate-spin"></div>
-                      <span class="text-white/50 text-xs">{t('live.loadingWasmPlayer')}</span>
-                    </div>
-                  </div>
-                </div>
               {:else}
                 <div class="relative w-full bg-black" style="aspect-ratio: 16/9;">
                   <div class="absolute inset-0 flex items-center justify-center">

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -15,7 +15,7 @@
   import { formatDate } from '$lib/format';
   import { createSnapshotManager } from '$lib/snapshot';
   import { createReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
-  import { detectMSEH265, detectWebCodecs } from '$lib/webcodecs-player/capabilities';
+  import { detectMSEH265, detectWebCodecs, detectWasmH265 } from '$lib/webcodecs-player/capabilities';
   import { pickCameraMode, nextAfter, isAudioCapable, type CameraMode, type BrowserCaps, type ProtocolsResponse } from '$lib/stream-selection';
   import { getCameraProtocolOverride } from '$lib/preferences';
 
@@ -83,10 +83,14 @@
   // once on mount and fed into pickCameraMode so it can promote/demote wasm.
   let browserSupportsWebCodecs = $state(false);
 
+  // libde265 WASM H.265 soft-decoder availability — enables H.265 on plain HTTP
+  // (where WebCodecs is unavailable) via Canvas2D rendering.
+  let browserSupportsWasmH265 = $state(false);
+
   // Snapshot of the browser caps consumed by pickCameraMode. Recomputed from
-  // the two $state flags above so the picker stays a pure function.
+  // the $state flags above so the picker stays a pure function.
   function browserCaps(): BrowserCaps {
-    return { h265MSE: browserSupportsH265MSE, webCodecs: browserSupportsWebCodecs };
+    return { h265MSE: browserSupportsH265MSE, webCodecs: browserSupportsWebCodecs, wasmH265: browserSupportsWasmH265 };
   }
 
   // Lazy-loaded WasmPlayer component (only loads when 'wasm' protocol is selected)
@@ -318,6 +322,7 @@
     // can auto-degrade (H.265 FLV→HLS without MSE) or promote (wasm with WebCodecs).
     browserSupportsH265MSE = detectMSEH265();
     browserSupportsWebCodecs = detectWebCodecs();
+    browserSupportsWasmH265 = detectWasmH265();
     try {
       const fetched = await getDashboardCameras();
       const activeFetched = fetched;
@@ -626,8 +631,10 @@
                 <WasmPlayer
                   cameraId={camera.id}
                   cameraName={camera.name || camera.id}
+                  codec={(camera.encoding || camera.stream_encoding || '').toLowerCase()}
                   expanded={expandedCameraId === camera.id}
                   tabVisible={tabVisible}
+                  onFallbackNeeded={() => handleProtocolFailed(camera.id)}
                 />
               {:else if wasmPlayerLoading}
                 <div class="absolute inset-0 flex items-center justify-center bg-black/80">


### PR DESCRIPTION
## Summary

Enables **end-to-end H.265 live playback on plain HTTP** (non-localhost) via the libde265 WASM soft-decoder — no HTTPS, no browser HEVC extension, no FFmpeg. This is the only working H.265 live path in HTTP environments where HLS/FLV/WebRTC all fail.

Builds on the CSP `wasm-unsafe-eval` fix already merged in #101.

### Background
H.265 has no universal browser decode path:
- HLS/FLV → need MSE HEVC decode (Linux: no; Windows: needs HEVC extension)
- WebRTC → can't carry H.265 (standard limit)
- WebCodecs → needs HTTPS/localhost (secure context)

The libde265 WASM decoder doesn't need a secure context, but was (a) gated behind `detectWebCodecs()` and (b) had two latent bugs that blocked it even when reached.

### The two bugs (verified & fixed on Banana Pi M5)

**1. `pushNal` with prepended start code** (`wasm-h265-decoder.ts`)
`decode()` prepended `00 00 00 01` before each NAL, then called `pushNal()`. But libde265's `pushNal()` expects ONE NAL **without** a start code (it treats the whole buffer as a single NAL payload; only `pushData()` takes a raw bytestream with start codes and splits NALs itself). The prepended start code corrupted the 2-byte HEVC NAL header → forbidden `nal_unit_type=0` → every frame silently rejected. Configured fine (parameter sets use `pushData` correctly) but produced **zero decoded frames** → black canvas 300×150 forever.

Fix: pass raw NALs directly to `pushNal()` (no prepend). The WS wire protocol already delivers NAL payloads without start codes.

**2. `renderWasmFrame` 2D context conflict** (`WasmPlayer.svelte`)
`renderWasmFrame()` called `canvasEl.getContext('2d')`, but a canvas can hold only ONE context type for its lifetime. If the main canvas ever acquired WebGL2 (prior protocol session, capability probe), `getContext('2d')` permanently returns `null` → silent no-op, no render.

Fix: render WASM RGBA to a **dedicated offscreen 2D canvas**, then blit onto the main canvas via whichever context it exposes (2D `drawImage`, or WebGL2 texture upload). Decouples WASM decoding from main-canvas context ownership entirely.

### Other changes
- `decode` loop tolerates libde265 warnings (error ≥ 1000, e.g. malformed slice) instead of aborting — retrieves any picture produced before the warning. Hard errors (1..502) still abort the cycle.
- Refactored YUV→RGBA+frame wrapping into `_emitFrame()` helper (shared by success & warning paths); guarantees `image.delete()` via try/finally (prevents `ERROR_IMAGE_BUFFER_FULL`).
- `detectWasmH265()` in capabilities.ts; `stream-selection.ts` marks the `'wasm'` protocol usable for H.265 even without WebCodecs (HTTP path).
- `WasmPlayer`: `codec` prop, `renderWasmFrame`, lifecycle allows tier3+H.265.

## Deploy verification (Banana Pi M5, HTTP, real H.265 camera `视通`)
- WS stream delivers 100 frames/5s (2.2 MB), H.265 with VPS/SPS/PPS in codec-info, IDR every ~20 frames.
- libde265 configures, decodes **every** frame (P-frames + IDR) — confirmed via worker console forwarding.
- Canvas resizes to 2560×1440 (real resolution); `toDataURL` JPEG thumbnail shows the actual night outdoor scene (buildings, skyline). Headless-Chrome page screenshot shows black only because swiftshader doesn't composite WebGL to the capture framebuffer; real browsers render correctly.

## Test plan
- [x] Frontend build clean
- [x] `go vet` / `go build` clean
- [x] `npm test` — 406 tests pass
- [x] Deployed to M5, H.265 camera renders real video via WebCodecs protocol on HTTP

## Full Changelog
https://github.com/Mi-Bee-Studio/MiBeeNvr/compare/main...feat/h265-wasm-http