### PR TITLE
feat(auth): stateless signed session token (drop base64 password) (#110)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -465,12 +465,7 @@ func testHandlerWithAuth(db *storage.DB, store *storage.Manager, username, passw
 		GetUsername: func() string { return username },
 		GetHash:     func() string { return passwordHash },
 	}, "", middleware.AuthRateLimitConfig{})
-	// handleLogin signs a session token using config.Auth (username + bcrypt
-	// hash), so the test handler must carry a populated config — not nil.
-	cfg := &config.Config{
-		Auth: config.AuthConfig{Username: username, PasswordHash: passwordHash},
-	}
-	return NewHandler(db, store, authMW, cfg, nil, nil, "", nil, nil, nil)
+	return NewHandler(db, store, authMW, nil, nil, nil, "", nil, nil, nil)
 }
 
 // extractDIDFromURL parses the DID from a xiaomi:// URL.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -465,7 +465,12 @@ func testHandlerWithAuth(db *storage.DB, store *storage.Manager, username, passw
 		GetUsername: func() string { return username },
 		GetHash:     func() string { return passwordHash },
 	}, "", middleware.AuthRateLimitConfig{})
-	return NewHandler(db, store, authMW, nil, nil, nil, "", nil, nil, nil)
+	// handleLogin signs a session token using config.Auth (username + bcrypt
+	// hash), so the test handler must carry a populated config — not nil.
+	cfg := &config.Config{
+		Auth: config.AuthConfig{Username: username, PasswordHash: passwordHash},
+	}
+	return NewHandler(db, store, authMW, cfg, nil, nil, "", nil, nil, nil)
 }
 
 // extractDIDFromURL parses the DID from a xiaomi:// URL.

--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
@@ -96,11 +96,13 @@ func (h *Handler) handleSetup(w http.ResponseWriter, r *http.Request) {
 	h.config.Auth.PasswordHash = hash
 	h.config.Storage.RootDir = dataDir
 
-	// Generate basic auth token for auto-login
-	token := base64.StdEncoding.EncodeToString([]byte(req.Username + ":" + req.Password))
+	// Issue a stateless signed session token (same scheme as /api/auth/login) so
+	// the just-initialized browser session never carries a reversible password.
+	token, expiresAt := middleware.SignSessionToken(req.Username, hash, time.Now())
 
 	writeJSON(w, http.StatusOK, map[string]string{
-		"status": "ok",
-		"token":  token,
+		"status":     "ok",
+		"token":      token,
+		"expires_at": expiresAt.UTC().Format(time.RFC3339),
 	})
 }

--- a/internal/api/handlers_setup_test.go
+++ b/internal/api/handlers_setup_test.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
@@ -160,11 +160,18 @@ func TestHandleSetup_TokenIsValid(t *testing.T) {
 	var resp map[string]string
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 
-	// Verify token matches expected BasicAuth encoding
-	decoded, err := base64.StdEncoding.DecodeString(resp["token"])
-	require.NoError(t, err)
-	require.Equal(t, username+":"+password, string(decoded))
+	// Setup now returns a stateless HMAC-signed session token (mbs_...) instead
+	// of the legacy base64(user:pass). Verify it carries the mbs_ prefix and
+	// validates against the bcrypt hash just stored in config.
+	tok := resp["token"]
+	require.NotEmpty(t, tok)
+	require.True(t, middleware.IsSessionToken(tok), "token must carry the mbs_ prefix")
 
 	// Verify the hashed password actually validates via bcrypt
 	require.True(t, middleware.CheckPassword(password, h.config.Auth.PasswordHash))
+
+	// And the signed token must verify under that same hash.
+	claims, err := middleware.VerifySessionToken(tok, h.config.Auth.PasswordHash, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, username, claims.Sub)
 }

--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -301,7 +301,7 @@ func (h *Handler) handleStats(w http.ResponseWriter, r *http.Request) {
 
 	// Camera count from the in-memory config (O(1)) — avoids a redundant
 	// ListCameras DB round-trip on every 30s Dashboard poll.
-	cameraCount := 0
+	var cameraCount int
 	if h.camMgr != nil {
 		cameraCount = h.camMgr.CameraCount()
 	} else {

--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -254,7 +254,22 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	select {
 	case status := <-done:
 		if status == http.StatusOK {
-			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			// Credentials validated by the middleware (BasicAuth path). Mint a
+			// stateless signed session token so the browser can stop carrying the
+			// reversible base64(user:pass). The username comes from the request's
+			// BasicAuth header (just validated); the bcrypt hash from config drives
+			// the HMAC key, so a later password change invalidates this token.
+			username := h.config.Auth.Username
+			if u, _, ok := r.BasicAuth(); ok && u != "" {
+				username = u
+			}
+			hash := h.config.Auth.PasswordHash
+			token, expiresAt := middleware.SignSessionToken(username, hash, time.Now())
+			writeJSON(w, http.StatusOK, map[string]string{
+				"status":     "ok",
+				"token":      token,
+				"expires_at": expiresAt.UTC().Format(time.RFC3339),
+			})
 		}
 	default:
 		// Forward the middleware's captured response (503 SETUP_REQUIRED, 401, etc.)

--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -259,6 +259,11 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 			// reversible base64(user:pass). The username comes from the request's
 			// BasicAuth header (just validated); the bcrypt hash from config drives
 			// the HMAC key, so a later password change invalidates this token.
+			// Tests use a nil-config handler, so guard against that here.
+			if h.config == nil {
+				writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+				return
+			}
 			username := h.config.Auth.Username
 			if u, _, ok := r.BasicAuth(); ok && u != "" {
 				username = u

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -111,10 +111,51 @@ func NewAuthMiddleware(provider AuthProvider, plaintextPassword string, rateLimi
 				return
 			}
 
+			// --- Signed session token (mbs_...) ---
+			// Tried BEFORE BasicAuth so already-logged-in browsers (which send a
+			// Bearer token) skip the bcrypt path entirely. The token is validated
+			// purely by recomputing the HMAC against the current bcrypt hash, so a
+			// password change naturally invalidates old tokens.
+			if tok := bearerSessionToken(r); tok != "" {
+				claims, err := VerifySessionToken(tok, currentHash, time.Now())
+				if err != nil {
+					recordAuthAttempt("failure")
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				// Username must match the configured account. (A token signed under
+				// an old username after the admin renamed the account is rejected.)
+				if claims.Sub != currentUsername {
+					recordAuthAttempt("failure")
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				// Sliding renewal: if little lifetime remains, mint a fresh token
+				// and hand it back in the response header. The frontend swaps it in.
+				expiresAt := time.Unix(claims.EXP, 0)
+				if NeedsRenewal(expiresAt, time.Now()) {
+					newTok, newExp := SignSessionToken(claims.Sub, currentHash, time.Now())
+					_ = newExp
+					// It is safe to set the header before calling next: headers are
+					// flushed only when the first Write/WriteHeader happens downstream.
+					w.Header().Set(RenewedTokenHeader, newTok)
+				}
+				recordAuthAttempt("success")
+				if rateLimit.Enabled {
+					authFailures.Delete(ip)
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			user, pass, ok := r.BasicAuth()
 			if !ok {
-				// Fallback: check ?token= query parameter (for WebSocket which cannot set headers)
-				if tok := r.URL.Query().Get("token"); tok != "" {
+				// Fallback: check ?token= query parameter.
+				// Session tokens (mbs_) are validated above via the Bearer path; the
+				// ?token= variant for WS/sendBeacon is also handled by bearerSessionToken.
+				// Anything left here is the legacy base64(user:pass) form, kept only
+				// for migration compatibility.
+				if tok := r.URL.Query().Get("token"); tok != "" && !IsSessionToken(tok) {
 					decoded, err := base64.StdEncoding.DecodeString(tok)
 					if err == nil {
 						parts := strings.SplitN(string(decoded), ":", 2)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -134,8 +134,9 @@ func NewAuthMiddleware(provider AuthProvider, plaintextPassword string, rateLimi
 				// and hand it back in the response header. The frontend swaps it in.
 				expiresAt := time.Unix(claims.EXP, 0)
 				if NeedsRenewal(expiresAt, time.Now()) {
-					newTok, newExp := SignSessionToken(claims.Sub, currentHash, time.Now())
-					_ = newExp
+					// Mint a fresh token; its expiry is carried inside the token
+					// itself, so we discard the returned expiresAt here.
+					newTok, _ := SignSessionToken(claims.Sub, currentHash, time.Now())
 					// It is safe to set the header before calling next: headers are
 					// flushed only when the first Write/WriteHeader happens downstream.
 					w.Header().Set(RenewedTokenHeader, newTok)

--- a/internal/middleware/token.go
+++ b/internal/middleware/token.go
@@ -1,0 +1,216 @@
+package middleware
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Session token (a.k.a. signed-token) authentication.
+//
+// This replaces the legacy "base64(user:pass) in sessionStorage" scheme, which
+// stored a reversible encoding of the plaintext password in the browser and was
+// scoped to a single tab. The new scheme issues a stateless HMAC-SHA256 signed
+// token that the browser keeps in localStorage (so it survives new tabs and
+// browser restarts) and that NEVER contains the password — only a username plus
+// expiry. The server validates it purely by recomputing the HMAC; there is no
+// session store, no revocation list, no DB table.
+//
+// Token format:  mbs_<base64url(payload)>.<base64url(signature)>
+//   - "mbs_" (MiBee Session) prefix separates it from "mbv_" API keys.
+//   - payload = { sub (username), iat, exp, jti (random nonce) } — JSON, NOT
+//     encrypted (confidentiality comes from the password never being in it).
+//   - signing key = HMAC-SHA256(pepper, passwordBcryptHash). The pepper is a
+//     random 32-byte value generated once per process start (see init below) and
+//     kept only in memory, so:
+//       • process restart  → pepper changes → all tokens invalidated (clean slate)
+//       • password changed → bcrypt hash changes → that user's tokens invalidated
+//       • config file leak alone CANNOT forge tokens (still needs the in-memory pepper)
+//
+// Sliding renewal: when a presented token has less than RenewThreshold lifetime
+// left, the auth middleware signs a fresh token and returns it via the
+// X-Renewed-Token response header; the frontend swaps it in silently. There is
+// deliberately NO revocation/refresh endpoint — revocation is impossible without
+// server-side state, which the project's stateless philosophy forbids. The risk
+// window for a leaked token is therefore bounded only by TokenTTL.
+
+// SessionTokenPrefix identifies browser session tokens (as opposed to "mbv_"
+// API keys used by MiBeeVision).
+const SessionTokenPrefix = "mbs_"
+
+// TokenTTL is how long a signed session token remains valid.
+const TokenTTL = 2 * time.Hour
+
+// RenewThreshold is the remaining-lifetime below which the middleware issues a
+// fresh token in the X-Renewed-Token response header (sliding renewal).
+const RenewThreshold = 15 * time.Minute
+
+// RenewedTokenHeader is the response header carrying a freshly-signed token on
+// sliding renewal.
+const RenewedTokenHeader = "X-Renewed-Token"
+
+// pepper is a per-process random key mixed into the HMAC signing key. It is
+// generated once at startup and never persisted, so restarting the binary
+// invalidates every outstanding token. This is intentional: the only "state"
+// the token scheme requires lives in memory and is wiped on restart.
+var pepper []byte
+
+func init() {
+	pepper = make([]byte, 32)
+	if _, err := rand.Read(pepper); err != nil {
+		// rand.Read on Linux/Windows/macOS only errors when the system CSPRNG is
+		// unavailable, which means the host is already broken for any crypto use.
+		// Failing fast at startup is the safe choice — never continue with a zero
+		// key, which would let anyone forge tokens.
+		panic(fmt.Sprintf("middleware: failed to generate token pepper: %v", err))
+	}
+}
+
+// tokenClaims is the JSON payload embedded in the token (base64url-encoded, not
+// encrypted). Only non-secret fields are stored.
+type tokenClaims struct {
+	Sub string `json:"sub"` // username (subject)
+	IAT int64  `json:"iat"` // issued-at, unix seconds
+	EXP int64  `json:"exp"` // expiry, unix seconds
+	JTI string `json:"jti"` // random nonce — guarantees every signed token differs
+}
+
+// ErrInvalidToken is returned by Verify for any malformed, tampered, or
+// expired token. Callers should treat all variants identically (reject).
+var ErrInvalidToken = errors.New("invalid session token")
+
+// SignSessionToken mints a new session token for the given username.
+// passwordBcryptHash is the user's current bcrypt hash (the very same value the
+// auth middleware already reads on every request via AuthProvider.GetHash); it
+// is folded into the signing key so changing the password invalidates old tokens
+// without any revocation list.
+//
+// The token expires at TokenTTL from now. The returned expiry is the absolute
+// time for the caller to hand back to clients (e.g. login response body).
+func SignSessionToken(username, passwordBcryptHash string, now time.Time) (token string, expiresAt time.Time) {
+	expiresAt = now.Add(TokenTTL)
+	jti := randNonce(16)
+	claims := tokenClaims{
+		Sub: username,
+		IAT: now.Unix(),
+		EXP: expiresAt.Unix(),
+		JTI: jti,
+	}
+	payloadJSON, _ := json.Marshal(claims) // json.Marshal on this struct cannot fail
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	sig := signingMAC(passwordBcryptHash, []byte(payloadB64))
+	sigB64 := base64.RawURLEncoding.EncodeToString(sig)
+
+	return SessionTokenPrefix + payloadB64 + "." + sigB64, expiresAt
+}
+
+// VerifySessionToken validates a token's signature and expiry and returns the
+// parsed claims. Any failure (bad format, tampered payload, wrong key, expired)
+// returns ErrInvalidToken. now lets tests inject time.
+func VerifySessionToken(token, passwordBcryptHash string, now time.Time) (*tokenClaims, error) {
+	if !strings.HasPrefix(token, SessionTokenPrefix) {
+		return nil, ErrInvalidToken
+	}
+	body := token[len(SessionTokenPrefix):]
+	dot := strings.IndexByte(body, '.')
+	if dot < 0 {
+		return nil, ErrInvalidToken
+	}
+	payloadB64 := body[:dot]
+	sigB64 := body[dot+1:]
+
+	wantSig := signingMAC(passwordBcryptHash, []byte(payloadB64))
+	gotSig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	// Constant-time compare of the full MAC; length mismatch still returns 0 and
+	// is rejected. This guards against timing oracles on the signature.
+	if !hmac.Equal(wantSig, gotSig) {
+		return nil, ErrInvalidToken
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	var claims tokenClaims
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, ErrInvalidToken
+	}
+	if now.Unix() >= claims.EXP {
+		return nil, ErrInvalidToken
+	}
+	return &claims, nil
+}
+
+// NeedsRenewal reports whether a token with the given expiry should be renewed
+// at the current time (i.e. its remaining life is under RenewThreshold).
+func NeedsRenewal(expiresAt, now time.Time) bool {
+	return expiresAt.Sub(now) <= RenewThreshold
+}
+
+// signingMAC derives the per-user signing key (HMAC(pepper, bcryptHash)) and
+// returns HMAC-SHA256(key, msg). The double-HMAC means an attacker who learns
+// one token's signature learns nothing reusable about the pepper or the bcrypt
+// hash, and cannot forge a signature for a different payload.
+func signingMAC(passwordBcryptHash string, msg []byte) []byte {
+	key := hmacSHA256(pepper, []byte(passwordBcryptHash))
+	return hmacSHA256(key, msg)
+}
+
+func hmacSHA256(key, msg []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(msg)
+	return mac.Sum(nil)
+}
+
+// randNonce returns n random bytes hex-encoded (URL-safe, compact). It is used
+// only to guarantee that two tokens signed at the same second for the same user
+// still differ byte-for-byte; it is not a secret.
+func randNonce(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// Should not happen on a healthy host; return a deterministic fallback so
+		// the token is still valid (just not unique). Uniqueness is a nice-to-have,
+		// signature validity is the hard requirement.
+		return "00000000000000000000000000000000"
+	}
+	return hex.EncodeToString(b)
+}
+
+// IsSessionToken reports whether s looks like a session token (mbs_ prefix).
+// Used by the auth middleware to route ?token= query params to the right path
+// without trying to base64-decode them.
+func IsSessionToken(s string) bool {
+	return strings.HasPrefix(s, SessionTokenPrefix)
+}
+
+// bearerSessionToken extracts a session token (mbs_...) from a request, in
+// either of the two forms the frontend uses:
+//   - Authorization: Bearer mbs_...   (normal API calls)
+//   - ?token=mbs_...                  (WebSocket upgrades + sendBeacon, which
+//     cannot set headers)
+//
+// Returns "" when no session token is present (the request then falls through
+// to API-Key / BasicAuth / legacy base64 ?token= handling).
+func bearerSessionToken(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer "+SessionTokenPrefix) {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	if tok := r.URL.Query().Get("token"); IsSessionToken(tok) {
+		return tok
+	}
+	return ""
+}
+
+

--- a/internal/middleware/token.go
+++ b/internal/middleware/token.go
@@ -212,5 +212,3 @@ func bearerSessionToken(r *http.Request) string {
 	}
 	return ""
 }
-
-

--- a/internal/middleware/token_test.go
+++ b/internal/middleware/token_test.go
@@ -1,0 +1,256 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSessionTokenRoundTrip signs a token and verifies it decodes back to the
+// same subject. This is the baseline happy path for the whole scheme.
+func TestSessionTokenRoundTrip(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	token, expiresAt := SignSessionToken("admin", hash, now)
+	require.True(t, strings.HasPrefix(token, "mbs_"), "token must carry the mbs_ prefix")
+	require.Equal(t, now.Add(TokenTTL).Unix(), expiresAt.Unix())
+
+	claims, err := VerifySessionToken(token, hash, now)
+	require.NoError(t, err)
+	require.Equal(t, "admin", claims.Sub)
+	require.Equal(t, now.Unix(), claims.IAT)
+	require.Equal(t, expiresAt.Unix(), claims.EXP)
+	require.NotEmpty(t, claims.JTI, "jti nonce must be present")
+}
+
+// TestSessionTokenExpired is the reason the scheme is safe to keep in localStorage
+// across browser restarts: an expired token is rejected regardless of signature.
+func TestSessionTokenExpired(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	token, _ := SignSessionToken("admin", hash, now)
+
+	later := now.Add(TokenTTL + time.Second)
+	_, err := VerifySessionToken(token, hash, later)
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+// TestSessionTokenPasswordChangeInvalidates ensures that when the user changes
+// their password (→ new bcrypt hash), every token signed under the old hash
+// stops validating. This is the property that replaces a server-side revocation
+// list: there is no need to track "logged-out" tokens because changing the
+// password key rolls them all.
+func TestSessionTokenPasswordChangeInvalidates(t *testing.T) {
+	oldHash := "$2a$10$oldhashplaceholderfortestvalue12345678901234567890123456"
+	newHash := "$2a$10$newhashplaceholderfortestvalue12345678901234567890123456"
+	now := time.Now()
+
+	token, _ := SignSessionToken("admin", oldHash, now)
+	_, err := VerifySessionToken(token, newHash, now)
+	require.ErrorIs(t, err, ErrInvalidToken, "token signed with old hash must not validate under new hash")
+
+	// Sanity: it still validates under the original hash.
+	_, err = VerifySessionToken(token, oldHash, now)
+	require.NoError(t, err)
+}
+
+// TestSessionTokenTamperRejected covers the core forgery defense: mutating the
+// payload (or signature) breaks the HMAC check.
+func TestSessionTokenTamperRejected(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	now := time.Now()
+	token, _ := SignSessionToken("admin", hash, now)
+
+	// Flip a character in the payload region. We must avoid touching the prefix.
+	tampered := token[:len(SessionTokenPrefix)+5] + "X" + token[len(SessionTokenPrefix)+6:]
+	_, err := VerifySessionToken(tampered, hash, now)
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+// TestSessionTokenUniqueJTI guards the "every renewal differs" property: two
+// tokens signed in the same second for the same user must still differ, because
+// the frontend relies on X-Renewed-Token carrying a genuinely new token.
+func TestSessionTokenUniqueJTI(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	now := time.Now()
+	t1, _ := SignSessionToken("admin", hash, now)
+	t2, _ := SignSessionToken("admin", hash, now)
+	require.NotEqual(t, t1, t2, "two tokens in the same second must still differ (random jti)")
+}
+
+// TestSessionTokenBadPrefix rejects anything that doesn't carry the mbs_ prefix
+// (notably mbv_ API keys and legacy base64(user:pass) strings).
+func TestSessionTokenBadPrefix(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	_, err := VerifySessionToken("mbv_xyz", hash, time.Now())
+	require.ErrorIs(t, err, ErrInvalidToken)
+
+	// No dot separator.
+	_, err = VerifySessionToken("mbs_onlypayloadnosig", hash, time.Now())
+	require.ErrorIs(t, err, ErrInvalidToken)
+}
+
+// TestBearerSessionTokenExtraction confirms the two surfaces a browser uses
+// (Authorization header for normal calls, ?token= for WS/sendBeacon) are both
+// recognized, and that non-session tokens (legacy base64) are left alone.
+func TestBearerSessionTokenExtraction(t *testing.T) {
+	hash := "$2a$10$placeholderhashfortestvalue123456789012345678901234567890"
+	tok, _ := SignSessionToken("admin", hash, time.Now())
+
+	// 1. Bearer header.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+tok)
+	require.Equal(t, tok, bearerSessionToken(r))
+
+	// 2. ?token= query (WebSocket / sendBeacon path).
+	r2 := httptest.NewRequest(http.MethodGet, "/?token="+tok, nil)
+	require.Equal(t, tok, bearerSessionToken(r2))
+
+	// 3. Legacy base64(user:pass) ?token= must NOT be picked up as a session token.
+	r3 := httptest.NewRequest(http.MethodGet, "/?token=YWRtaW46cGFzcw==", nil)
+	require.Equal(t, "", bearerSessionToken(r3))
+
+	// 4. mbv_ API key in Authorization must not be picked up.
+	r4 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r4.Header.Set("Authorization", "Bearer mbv_abcdef")
+	require.Equal(t, "", bearerSessionToken(r4))
+}
+
+// TestNeedsRenewal covers the sliding-renewal threshold: tokens within the last
+// RenewThreshold of their life get refreshed, others don't.
+func TestNeedsRenewal(t *testing.T) {
+	now := time.Now()
+	require.True(t, NeedsRenewal(now.Add(RenewThreshold-time.Second), now), "under threshold → renew")
+	require.False(t, NeedsRenewal(now.Add(RenewThreshold+time.Minute), now), "over threshold → keep")
+}
+
+// TestAuthMiddlewareBearerSession is the integration test for the end-to-end
+// path the browser actually uses after login: send Bearer mbs_..., get 200,
+// and crucially get NO bcrypt computation (the token path must short-circuit).
+func TestAuthMiddlewareBearerSession(t *testing.T) {
+	hash, _ := HashPassword("secret")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", hash), "", AuthRateLimitConfig{})
+
+	called := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, _ := SignSessionToken("admin", hash, time.Now())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.True(t, called, "handler must be invoked for a valid session token")
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAuthMiddlewareBearerSessionWrongPasswordChange guarantees that after a
+// password change, old browser tokens stop authenticating — the user is forced
+// to log in again. This is the closest thing to "logout-everywhere" the
+// stateless scheme provides.
+func TestAuthMiddlewareBearerSessionPasswordChanged(t *testing.T) {
+	oldHash, _ := HashPassword("oldpw")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", oldHash), "", AuthRateLimitConfig{})
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Token signed under the OLD hash, but the middleware now serves a NEW hash.
+	oldToken, _ := SignSessionToken("admin", oldHash, time.Now())
+	newHash, _ := HashPassword("newpw")
+	// Swap the provider's hash to simulate a password change in config.
+	mwChanged, _ := NewAuthMiddleware(staticProvider("admin", newHash), "", AuthRateLimitConfig{})
+	handler = mwChanged(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "stale token must be rejected after password change")
+}
+
+// TestAuthMiddlewareBearerSessionQueryToken covers the WebSocket / sendBeacon
+// surface, which cannot set headers and instead passes ?token=mbs_...
+func TestAuthMiddlewareBearerSessionQueryToken(t *testing.T) {
+	hash, _ := HashPassword("secret")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", hash), "", AuthRateLimitConfig{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token, _ := SignSessionToken("admin", hash, time.Now())
+	req := httptest.NewRequest(http.MethodGet, "/?token="+token, nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "?token=mbs_ must authenticate (WS path)")
+}
+
+// TestAuthMiddlewareLegacyBasicAuthStillWorks guards backward compatibility:
+// external scripts and the login call itself still use BasicAuth, which must
+// keep working alongside the new Bearer path.
+func TestAuthMiddlewareLegacyBasicAuthStillWorks(t *testing.T) {
+	hash, _ := HashPassword("secret")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", hash), "", AuthRateLimitConfig{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Basic "+basic("admin", "secret"))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestAuthMiddlewareLegacyQueryBase64TokenStillWorks guards the migration window:
+// old browsers still holding base64(user:pass) in their ?token= continue to work
+// until the next login, which swaps them for a signed token.
+func TestAuthMiddlewareLegacyQueryBase64TokenStillWorks(t *testing.T) {
+	hash, _ := HashPassword("secret")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", hash), "", AuthRateLimitConfig{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/?token="+basic("admin", "secret"), nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "legacy base64 ?token= must still work during migration")
+}
+
+// TestAuthMiddlewareRenewsExpiringToken checks that a token within the renewal
+// window causes the middleware to attach a fresh token in X-Renewed-Token, and
+// that the renewed token itself validates.
+func TestAuthMiddlewareRenewsExpiringToken(t *testing.T) {
+	hash, _ := HashPassword("secret")
+	mw, _ := NewAuthMiddleware(staticProvider("admin", hash), "", AuthRateLimitConfig{})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Sign a token that is about to expire (5s of life left, well under RenewThreshold).
+	issuedAt := time.Now().Add(-(TokenTTL - 5 * time.Second))
+	token, _ := SignSessionToken("admin", hash, issuedAt)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	renewed := w.Header().Get(RenewedTokenHeader)
+	require.NotEmpty(t, renewed, "expiring token must trigger a renewal header")
+
+	// The renewed token must validate under the same hash.
+	_, err := VerifySessionToken(renewed, hash, time.Now())
+	require.NoError(t, err, "renewed token must be valid")
+}

--- a/internal/middleware/token_test.go
+++ b/internal/middleware/token_test.go
@@ -238,7 +238,7 @@ func TestAuthMiddlewareRenewsExpiringToken(t *testing.T) {
 	}))
 
 	// Sign a token that is about to expire (5s of life left, well under RenewThreshold).
-	issuedAt := time.Now().Add(-(TokenTTL - 5 * time.Second))
+	issuedAt := time.Now().Add(-(TokenTTL - 5*time.Second))
 	token, _ := SignSessionToken("admin", hash, issuedAt)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/web/src/components/AviPlayback.svelte
+++ b/web/src/components/AviPlayback.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { AudioPlayer, AudioCodec } from '$lib/audio-player';
-  import { getAuthHeader } from '$lib/api';
+  import { getTokenForUrl } from '$lib/api';
   import { t } from '$lib/i18n';
 
   let {
@@ -72,9 +72,9 @@
   function buildWsUrl(): string {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     let url = `${proto}//${location.host}/api/recordings/${recordingId}/playback`;
-    const authHeader = getAuthHeader();
-    if (authHeader) {
-      const token = authHeader.startsWith('Basic ') ? authHeader.slice(6) : authHeader;
+    // ?token= carries the bare session token (mbs_...), NOT a "Bearer ..." header.
+    const token = getTokenForUrl();
+    if (token) {
       url += `?token=${encodeURIComponent(token)}`;
     }
     return url;

--- a/web/src/components/CameraAudioButton.svelte
+++ b/web/src/components/CameraAudioButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { Volume2, VolumeX } from 'lucide-svelte';
-  import { getAuthHeader } from '$lib/api';
+  import { getTokenForUrl } from '$lib/api';
   import { t } from '$lib/i18n';
   import { AudioPlayer } from '$lib/audio-player';
   import {
@@ -26,9 +26,9 @@
   function buildUrl(): string {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     let url = `${proto}//${location.host}/api/cameras/${cameraId}/stream/ws?audio_only=1`;
-    const authHeader = getAuthHeader();
-    if (authHeader) {
-      const token = authHeader.startsWith('Basic ') ? authHeader.slice(6) : authHeader;
+    // ?token= carries the bare session token (mbs_...), NOT a "Bearer ..." header.
+    const token = getTokenForUrl();
+    if (token) {
       url += `&token=${encodeURIComponent(token)}`;
     }
     return url;

--- a/web/src/components/FlvPlayer.svelte
+++ b/web/src/components/FlvPlayer.svelte
@@ -3,7 +3,7 @@
   import { t } from '$lib/i18n';
   import { AlertCircle, RefreshCw, ImageIcon } from 'lucide-svelte';
   import CameraAudioButton from './CameraAudioButton.svelte';
-  import { getAuthHeader } from '$lib/api';
+  import { getAuthHeader, getTokenForUrl } from '$lib/api';
   import { getSnapshotUrl } from '$lib/api/cameras';
   import { captureFrame } from '$lib/freeze-frame';
   import { sendTelemetry } from '$lib/telemetry';
@@ -164,10 +164,10 @@ let videoEventAc: AbortController | null = null;
   }
 
   function refreshSnapshot() {
-    const authHeader = getAuthHeader();
     let url = getSnapshotUrl(cameraId);
-    if (authHeader) {
-      const token = authHeader.replace('Basic ', '');
+    // ?token= carries the bare session token (mbs_...), NOT a "Bearer ..." header.
+    const token = getTokenForUrl();
+    if (token) {
       url += `?token=${encodeURIComponent(token)}`;
     }
     snapshotSrc = `${url}&_t=${Date.now()}`;

--- a/web/src/components/MjpegLivePlayer.svelte
+++ b/web/src/components/MjpegLivePlayer.svelte
@@ -2,7 +2,7 @@
   import { onDestroy } from 'svelte';
   import { t } from '$lib/i18n';
   import { AlertCircle, RefreshCw, ImageIcon } from 'lucide-svelte';
-  import { getAuthHeader, API_BASE } from '$lib/api';
+  import { getAuthHeader, getTokenForUrl, API_BASE } from '$lib/api';
 
   interface Props {
     cameraId: string;
@@ -132,13 +132,12 @@
     if (!cameraId) return;
 
     const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const authHeader = getAuthHeader();
-    // wsstream endpoint accepts ?token= for auth (base64 user:pass)
+    // wsstream endpoint accepts ?token= for auth. The token is the bare session
+    // token (mbs_...), NOT a "Bearer ..." header value.
     let wsUrl = `${proto}//${window.location.host}${API_BASE}/cameras/${cameraId}/stream/ws`;
-    if (authHeader) {
-      // Extract credentials from Basic auth header
-      const b64 = authHeader.replace('Basic ', '');
-      wsUrl += `?token=${b64}`;
+    const token = getTokenForUrl();
+    if (token) {
+      wsUrl += `?token=${encodeURIComponent(token)}`;
     }
 
     try {

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -2,7 +2,7 @@
   import { onDestroy, getContext } from 'svelte';
   import { t } from '$lib/i18n';
   import { Maximize, Minimize, AlertCircle, RefreshCw, Volume2, VolumeX } from 'lucide-svelte';
-  import { getAuthHeader } from '$lib/api';
+  import { getTokenForUrl } from '$lib/api';
   import type { StreamState } from '$lib/hls-errors';
   import { getPlaybackTier, detectWebCodecs, detectWebGL2 } from '$lib/webcodecs-player/capabilities';
   import { decodeVideoFrame } from '$lib/webcodecs-player/protocol';
@@ -477,9 +477,11 @@ function handleWebGpuLost() {
   function buildWsUrl(): string {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     let url = `${proto}//${location.host}/api/cameras/${cameraId}/stream/ws`;
-    const authHeader = getAuthHeader();
-    if (authHeader) {
-      const token = authHeader.startsWith('Basic ') ? authHeader.slice(6) : authHeader;
+    // ?token= carries the bare session token (mbs_...), NOT a "Bearer ..." header —
+    // the backend auth middleware reads ?token= directly. getTokenForUrl returns
+    // the token without the "Bearer " prefix.
+    const token = getTokenForUrl();
+    if (token) {
       url += `?token=${encodeURIComponent(token)}`;
     }
     return url;

--- a/web/src/components/WebRTCPlayer.svelte
+++ b/web/src/components/WebRTCPlayer.svelte
@@ -3,7 +3,7 @@
   import { t } from '$lib/i18n';
   import { AlertCircle, RefreshCw, ImageIcon } from 'lucide-svelte';
   import CameraAudioButton from './CameraAudioButton.svelte';
-  import { getAuthHeader } from '$lib/api';
+  import { getAuthHeader, getTokenForUrl } from '$lib/api';
   import { getSnapshotUrl } from '$lib/api/cameras';
   import { captureFrame } from '$lib/freeze-frame';
   import { sendTelemetry } from '$lib/telemetry';
@@ -211,10 +211,10 @@ let destroyed = false;
   }
 
   function refreshSnapshot() {
-    const authHeader = getAuthHeader();
     let url = getSnapshotUrl(cameraId);
-    if (authHeader) {
-      const token = authHeader.replace('Basic ', '');
+    // ?token= carries the bare session token (mbs_...), NOT a "Bearer ..." header.
+    const token = getTokenForUrl();
+    if (token) {
       url += `?token=${encodeURIComponent(token)}`;
     }
     snapshotSrc = `${url}&_t=${Date.now()}`;

--- a/web/src/components/__tests__/AviPlayback.test.js
+++ b/web/src/components/__tests__/AviPlayback.test.js
@@ -25,6 +25,7 @@ vi.mock('$lib/audio-player', () => {
 vi.mock('$lib/api', () => {
   return {
     getAuthHeader: vi.fn(() => 'Bearer mbs_testtoken.sig'),
+    getTokenForUrl: vi.fn(() => 'mbs_testtoken.sig'),
     apiRequest: vi.fn(),
     API_BASE: '/api',
   };

--- a/web/src/components/__tests__/AviPlayback.test.js
+++ b/web/src/components/__tests__/AviPlayback.test.js
@@ -24,7 +24,7 @@ vi.mock('$lib/audio-player', () => {
 
 vi.mock('$lib/api', () => {
   return {
-    getAuthHeader: vi.fn(() => 'Basic dGVzdDp0ZXN0'),
+    getAuthHeader: vi.fn(() => 'Bearer mbs_testtoken.sig'),
     apiRequest: vi.fn(),
     API_BASE: '/api',
   };

--- a/web/src/lib/__tests__/telemetry.test.ts
+++ b/web/src/lib/__tests__/telemetry.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { sendTelemetry, optInTelemetry, isTelemetryOptedIn, __resetOptIn } from '$lib/telemetry';
 
-const AUTH_KEY = 'mibee_nvr_auth';
-const TEST_CRED = btoa('admin:admin123');
+// Session token storage key (must match web/src/lib/api/client.ts). The value
+// is a JSON {token, expiresAt} blob, exactly what getToken()/getTokenForUrl()
+// reads from localStorage.
+const TOKEN_KEY = 'mibee_nvr_token';
+const TEST_TOKEN = 'mbs_testtokenvalue.signaturesuffix';
 
 function mockSendBeacon(): ReturnType<typeof vi.fn> {
   const spy = vi.fn().mockReturnValue(true);
@@ -22,13 +25,21 @@ function removeSendBeacon(): void {
   });
 }
 
+function seedSessionToken(token: string = TEST_TOKEN): void {
+  localStorage.setItem(
+    TOKEN_KEY,
+    JSON.stringify({ token, expiresAt: Date.now() + 2 * 60 * 60 * 1000 }),
+  );
+}
+
 beforeEach(() => {
-  sessionStorage.setItem(AUTH_KEY, TEST_CRED);
+  seedSessionToken();
   __resetOptIn();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  localStorage.clear();
   sessionStorage.clear();
 });
 
@@ -59,7 +70,7 @@ describe('sendTelemetry in dev mode', () => {
     const [url] = sendBeacon.mock.calls[0];
     expect(url).toContain('/api/telemetry');
     expect(url).toContain('token=');
-    expect(url).toContain(encodeURIComponent(TEST_CRED));
+    expect(url).toContain(encodeURIComponent(TEST_TOKEN));
   });
 
   it('should call navigator.sendBeacon with a Blob payload', () => {
@@ -109,7 +120,7 @@ describe('sendTelemetry in dev mode', () => {
   });
 
   it('should silently skip if auth credentials are missing', () => {
-    sessionStorage.clear();
+    localStorage.removeItem(TOKEN_KEY);
     const sendBeacon = mockSendBeacon();
 
     sendTelemetry('playback_start', 'cam-1');

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -1,7 +1,7 @@
 /**
  * Camera API — CRUD, ONVIF discovery, PTZ, protocols, per-camera merge config
  */
-import { apiRequest, getAuthHeader, clearCredentials, API_BASE } from './client';
+import { apiRequest, getAuthHeader, clearToken, API_BASE } from './client';
 
 // --- Types ---
 
@@ -317,7 +317,7 @@ export async function listCameras(signal?: AbortSignal): Promise<Camera[]> {
   }
   if (!resp.ok) {
     if (resp.status === 401) {
-      clearCredentials();
+      clearToken();
       window.location.hash = '#/login';
     }
     throw new Error(`HTTP ${resp.status}`);

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -2,8 +2,22 @@
  * Base HTTP client — auth, generic fetch wrappers
  */
 
-// Auth credentials storage (sessionStorage — cleared on browser close)
-const AUTH_KEY = 'mibee_nvr_auth';
+// Session token storage.
+//
+// The browser holds a stateless HMAC-signed session token (issued by
+// /api/auth/login or /api/setup). It is kept in localStorage (NOT sessionStorage)
+// so that opening a new tab or restarting the browser does NOT force a re-login.
+// localStorage is shared across same-origin tabs, which is exactly the behavior
+// users expect from an NVR dashboard.
+//
+// The token NEVER contains the password — only a username + expiry, signed by
+// the server with a per-process pepper. See internal/middleware/token.go for the
+// signing/verification scheme. Sliding renewal happens transparently: when the
+// server sees a token nearing expiry it returns a fresh one in the
+// X-Renewed-Token response header, and apiRequest swaps it in here.
+const TOKEN_KEY = 'mibee_nvr_token';
+// Renewed-token response header (must match internal/middleware/token.go).
+const RENEWED_TOKEN_HEADER = 'X-Renewed-Token';
 
 export interface AuthCredentials {
   username: string;
@@ -12,6 +26,8 @@ export interface AuthCredentials {
 
 export interface LoginResponse {
   status: string;
+  token?: string;
+  expires_at?: string;
 }
 
 export interface ApiError {
@@ -60,44 +76,92 @@ export interface SystemStats {
   timestamp: number;
 }
 
-// Store credentials in sessionStorage (cleared on browser close)
-export function storeCredentials(username: string, password: string): void {
-  const encoded = btoa(`${username}:${password}`);
-  sessionStorage.setItem(AUTH_KEY, encoded);
+// --- Session token storage (localStorage) ---------------------------------
+
+interface StoredSession {
+  token: string;
+  expiresAt: number; // epoch ms
 }
 
-// Get credentials from sessionStorage
-export function getCredentials(): AuthCredentials | null {
-  const encoded = sessionStorage.getItem(AUTH_KEY);
-  if (!encoded) return null;
-
+function readSession(): StoredSession | null {
   try {
-    const decoded = atob(encoded);
-    const [username, password] = decoded.split(':');
-    return { username, password };
+    const raw = localStorage.getItem(TOKEN_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredSession;
+    if (!parsed || typeof parsed.token !== 'string' || typeof parsed.expiresAt !== 'number') {
+      return null;
+    }
+    return parsed;
   } catch (e) {
-    console.warn('Failed to decode credentials:', e);
+    console.warn('Failed to parse stored session:', e);
     return null;
   }
 }
 
-// Clear credentials
-export function clearCredentials(): void {
-  sessionStorage.removeItem(AUTH_KEY);
+// Store the session token returned by /api/auth/login (or /api/setup). The
+// token is kept in localStorage so the session survives new tabs and browser
+// restarts. expiresAt is the absolute epoch-ms expiry (from the server's
+// expires_at RFC3339 field, or Date.now()+fallback if absent).
+export function storeToken(token: string, expiresAtIso?: string): void {
+  let expiresAt: number;
+  if (expiresAtIso) {
+    const t = Date.parse(expiresAtIso);
+    expiresAt = Number.isNaN(t) ? Date.now() + 2 * 60 * 60 * 1000 : t;
+  } else {
+    expiresAt = Date.now() + 2 * 60 * 60 * 1000;
+  }
+  const session: StoredSession = { token, expiresAt };
+  localStorage.setItem(TOKEN_KEY, JSON.stringify(session));
 }
 
-// Check if user is authenticated
+// Get the raw session token, or null if absent/expired. Expired tokens are
+// purged on read so a stale localStorage entry doesn't fool isAuthenticated().
+export function getToken(): string | null {
+  const s = readSession();
+  if (!s) return null;
+  if (Date.now() >= s.expiresAt) {
+    // Locally expired — clear it so the next navigation goes to login cleanly.
+    localStorage.removeItem(TOKEN_KEY);
+    return null;
+  }
+  return s.token;
+}
+
+// Clear the stored session token (logout).
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+// Silently swap in a renewed token delivered via the X-Renewed-Token response
+// header, preserving the original expiry scheme. No-op when the header is absent
+// or the value looks invalid.
+function maybeApplyRenewedToken(response: Response): void {
+  const renewed = response.headers.get(RENEWED_TOKEN_HEADER);
+  if (!renewed) return;
+  const s = readSession();
+  // Preserve existing expiry (the server renewed near the same lifetime); if we
+  // somehow have no session, fall back to +TTL from now.
+  const expiresAt = s?.expiresAt ?? Date.now() + 2 * 60 * 60 * 1000;
+  localStorage.setItem(TOKEN_KEY, JSON.stringify({ token: renewed, expiresAt } as StoredSession));
+}
+
+// Check if user is authenticated (has a non-expired session token).
 export function isAuthenticated(): boolean {
-  return getCredentials() !== null;
+  return getToken() !== null;
 }
 
-// Get Basic Auth header value
+// Get the Authorization header value for API calls: "Bearer <session-token>".
 export function getAuthHeader(): string | null {
-  const creds = getCredentials();
-  if (!creds) return null;
+  const token = getToken();
+  if (!token) return null;
+  return `Bearer ${token}`;
+}
 
-  const encoded = btoa(`${creds.username}:${creds.password}`);
-  return `Basic ${encoded}`;
+// Get just the session token, for use as a ?token= query parameter where
+// headers cannot be set (WebSocket upgrades, sendBeacon telemetry). The backend
+// auth middleware accepts ?token=mbs_... on the same path as the Bearer header.
+export function getTokenForUrl(): string | null {
+  return getToken();
 }
 
 // API base URL (relative path for embedded static files)
@@ -139,10 +203,14 @@ export async function apiRequest<T>(endpoint: string, options: RequestInit = {})
     window.dispatchEvent(new CustomEvent('nvr-api-offline'));
   }
 
+  // Sliding renewal: a token nearing expiry causes the middleware to mint a
+  // fresh one and return it here. Swap it into localStorage transparently.
+  maybeApplyRenewedToken(response);
+
   if (!response.ok) {
     // 401 → session expired or invalid credentials → force re-login
     if (response.status === 401) {
-      clearCredentials();
+      clearToken();
       window.location.hash = '#/login';
       throw new ApiRequestError('Session expired', 'AUTH_EXPIRED');
     }
@@ -173,9 +241,11 @@ export async function apiRequestBlob(endpoint: string, options: RequestInit = {}
     }
     throw e;
   }
+  // Sliding renewal applies to blob responses too (e.g. snapshot downloads).
+  maybeApplyRenewedToken(response);
   if (!response.ok) {
     if (response.status === 401) {
-      clearCredentials();
+      clearToken();
       window.location.hash = '#/login';
       throw new Error('Session expired');
     }
@@ -216,7 +286,13 @@ export async function apiHeadHeader(
   }
 }
 
-// Login endpoint
+// Login endpoint.
+//
+// The request itself still uses BasicAuth (the server validates user:pass via
+// bcrypt), but on success the server returns a stateless signed session token
+// which we persist — the browser then NEVER holds the password again. This is
+// the core security improvement over the old base64(user:pass)-in-sessionStorage
+// scheme.
 export async function login(username: string, password: string, signal?: AbortSignal): Promise<LoginResponse> {
   const authHeader = `Basic ${btoa(`${username}:${password}`)}`;
 
@@ -237,17 +313,20 @@ export async function login(username: string, password: string, signal?: AbortSi
     throw new Error((errorData as ApiError).error || 'Invalid credentials');
   }
 
-  const data = await response.json();
+  const data = (await response.json()) as LoginResponse;
 
-  // Store credentials on success
-  storeCredentials(username, password);
+  // Store the signed session token (NOT the password). expires_at drives local
+  // expiry so isAuthenticated() can short-circuit without a round-trip.
+  if (data.token) {
+    storeToken(data.token, data.expires_at);
+  }
 
-  return data as LoginResponse;
+  return data;
 }
 
 // Logout
 export function logout(): void {
-  clearCredentials();
+  clearToken();
   window.location.hash = '#/login';
 }
 
@@ -266,6 +345,7 @@ export async function getSystemStats(signal?: AbortSignal): Promise<SystemStats>
 export interface SetupResponse {
   status: string;
   token: string;
+  expires_at?: string;
 }
 
 // First-time setup endpoint (no auth required)

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -4,9 +4,10 @@
 
 // Client — auth, base fetch wrappers
 export {
-  storeCredentials,
-  getCredentials,
-  clearCredentials,
+  storeToken,
+  getToken,
+  clearToken,
+  getTokenForUrl,
   isAuthenticated,
   login,
   logout,

--- a/web/src/lib/hls-config.ts
+++ b/web/src/lib/hls-config.ts
@@ -9,7 +9,7 @@
  * backward-compat with existing callers but no longer changes the output.
  */
 
-import { getCredentials } from '$lib/api';
+import { getAuthHeader } from '$lib/api';
 import type Hls from 'hls.js';
 
 /** RPi-optimized hls.js configuration. Always low-latency. */
@@ -57,21 +57,21 @@ export function createHlsConfig(_protocol: string = 'hls'): Partial<Hls.Config> 
       },
     },
     xhrSetup: (xhr: XMLHttpRequest, url: string) => {
-      const creds = getCredentials();
-      if (creds) {
+      const authHeader = getAuthHeader();
+      if (authHeader) {
         if (!xhr.readyState) {
           xhr.open('GET', url, true);
         }
-        xhr.setRequestHeader('Authorization', 'Basic ' + btoa(`${creds.username}:${creds.password}`));
+        xhr.setRequestHeader('Authorization', authHeader);
       }
     },
     // HLS.js 1.6+ uses fetch by default; xhrSetup alone doesn't add auth to fetch requests.
     fetchSetup: (context, initParams) => {
-      const creds = getCredentials();
-      if (creds) {
+      const authHeader = getAuthHeader();
+      if (authHeader) {
         initParams.headers = {
           ...initParams.headers,
-          Authorization: 'Basic ' + btoa(`${creds.username}:${creds.password}`),
+          Authorization: authHeader,
         };
       }
       return new Request(context.url, initParams);

--- a/web/src/lib/snapshot.js
+++ b/web/src/lib/snapshot.js
@@ -9,7 +9,7 @@
  *
  * @param {object} opts
  * @param {string} opts.cameraId
- * @param {() => { username: string; password: string } | null} opts.getCredentials
+ * @param {() => string | null} opts.getAuthHeader - Returns "Bearer <token>" or null
  * @param {(id: string, url: string) => void} opts.onUrlUpdate - Called with new blob URL
  * @param {(id: string) => void} opts.onUrlRevoke - Called before URL update to revoke old URL
  * @param {(id: string, loading: boolean) => void} opts.onLoadingChange
@@ -18,17 +18,17 @@
  */
 export async function fetchSnapshot({
   cameraId,
-  getCredentials,
+  getAuthHeader,
   onUrlUpdate,
   onUrlRevoke,
   onLoadingChange,
   onErrorChange,
   onUnsupported,
 }) {
-  const creds = getCredentials();
+  const authHeader = getAuthHeader();
   const headers = {};
-  if (creds) {
-    headers['Authorization'] = 'Basic ' + btoa(`${creds.username}:${creds.password}`);
+  if (authHeader) {
+    headers['Authorization'] = authHeader;
   }
 
   try {
@@ -59,7 +59,7 @@ export async function fetchSnapshot({
  *
  * @param {object} opts
  * @param {number} [opts.intervalMs=3000] - Refresh interval in milliseconds
- * @param {() => { username: string; password: string } | null} opts.getCredentials
+ * @param {() => string | null} opts.getAuthHeader - Returns "Bearer <token>" or null
  * @param {(id: string, url: string) => void} opts.onUrlUpdate
  * @param {(id: string) => void} opts.onUrlRevoke
  * @param {(id: string, loading: boolean) => void} opts.onLoadingChange
@@ -67,7 +67,7 @@ export async function fetchSnapshot({
  * @param {(id: string) => void} opts.onUnsupported
  */
 export function createSnapshotManager(opts) {
-  const { intervalMs = 3000, getCredentials, onUrlUpdate, onUrlRevoke, onLoadingChange, onErrorChange } = opts;
+  const { intervalMs = 3000, getAuthHeader, onUrlUpdate, onUrlRevoke, onLoadingChange, onErrorChange } = opts;
 
   const intervals = {};
   const noSnapshotSet = new Set();
@@ -77,7 +77,7 @@ export function createSnapshotManager(opts) {
 
     const fetchOpts = {
       cameraId,
-      getCredentials,
+      getAuthHeader,
       onUrlUpdate,
       onUrlRevoke,
       onLoadingChange,

--- a/web/src/lib/telemetry.ts
+++ b/web/src/lib/telemetry.ts
@@ -6,7 +6,8 @@
  * delivery that survives page unload.
  */
 
-const AUTH_KEY = 'mibee_nvr_auth';
+import { getTokenForUrl } from '$lib/api/client';
+
 const TELEMETRY_ENDPOINT = '/api/telemetry';
 
 /** Whether user has explicitly opted into telemetry in production mode. */
@@ -37,28 +38,11 @@ interface TelemetryEvent {
   details?: object;
 }
 
-/** Get stored BasicAuth credentials from sessionStorage. */
-function getAuthCredentials(): { username: string; password: string } | null {
-  try {
-    const encoded = sessionStorage.getItem(AUTH_KEY);
-    if (!encoded) return null;
-    const decoded = atob(encoded);
-    const colonIdx = decoded.indexOf(':');
-    if (colonIdx === -1) return null;
-    return {
-      username: decoded.substring(0, colonIdx),
-      password: decoded.substring(colonIdx + 1),
-    };
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Send a telemetry event to the backend using navigator.sendBeacon.
  *
- * Gracefully degrades: if sendBeacon is unavailable or auth credentials
- * are missing, silently skips. Never throws.
+ * Gracefully degrades: if sendBeacon is unavailable or no session token
+ * is present, silently skips. Never throws.
  *
  * @param event      Event type (e.g., "playback_start", "playback_error")
  * @param cameraId   Camera identifier
@@ -71,8 +55,8 @@ export function sendTelemetry(event: string, cameraId: string, durationMs?: numb
 
   if (typeof navigator?.sendBeacon !== 'function') return;
 
-  const creds = getAuthCredentials();
-  if (!creds) return;
+  const token = getTokenForUrl();
+  if (!token) return;
 
   const payload: TelemetryEvent = {
     event,
@@ -81,15 +65,9 @@ export function sendTelemetry(event: string, cameraId: string, durationMs?: numb
     ...(details && { details }),
   };
 
-  // sendBeacon cannot set headers directly. Use Blob + FormData to pass
-  // BasicAuth. The server's BasicAuth middleware also accepts ?token= for
-  // WebSocket, but for POST we use Blob with the right Content-Type and
-  // embed auth in a custom header via the fetch-with-keepalive fallback
-  // when sendBeacon can't carry the auth header.
-
-  // Build BasicAuth token as query param — the auth middleware supports
-  // this fallback (originally for WebSocket).
-  const token = btoa(`${creds.username}:${creds.password}`);
+  // sendBeacon cannot set headers, so pass the session token as a ?token= query
+  // param — the auth middleware accepts ?token=mbs_... on the same path as the
+  // Bearer header. The token is already the signed "mbs_..." string.
   const url = `${TELEMETRY_ENDPOINT}?token=${encodeURIComponent(token)}`;
 
   const blob = new Blob([JSON.stringify(payload)], {

--- a/web/src/routes/Cameras.svelte
+++ b/web/src/routes/Cameras.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { listCameras, deleteCamera, startCamera, stopCamera, updateCamera, xiaomiDevices, listProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, listArchives, setArchiveRetention, deleteArchiveGroup, listArchiveRecordings, deleteArchiveRecording, getHealthStatus, getTranscodingStatus, getTranscodingSettings, getTranscodingCheck, getCameraRecordingStats, rediscoverCamera, activateCamera } from '$lib/api';
+  import { listCameras, deleteCamera, startCamera, stopCamera, updateCamera, xiaomiDevices, listProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, listArchives, setArchiveRetention, deleteArchiveGroup, listArchiveRecordings, deleteArchiveRecording, getHealthStatus, getTranscodingStatus, getTranscodingSettings, getTranscodingCheck, getCameraRecordingStats, rediscoverCamera, activateCamera, getAuthHeader } from '$lib/api';
   import type { Camera, XiaomiDevice, ProtocolInfo, ArchiveGroup, Recording, CameraHealth, HealthStatusResponse } from '$lib/api';
   import { t } from '$lib/i18n';
   import { showToast } from '$lib/toast';
@@ -164,10 +164,10 @@
 
   function downloadRecording(rec: Recording) {
     const url = `/api/archives/${expandedArchiveId}/recordings/${rec.id}/download`;
-    const encoded = localStorage.getItem('mibee_nvr_auth');
-    if (encoded) {
+    const authHeader = getAuthHeader();
+    if (authHeader) {
       fetch(url, {
-        headers: { 'Authorization': `Basic ${encoded}` }
+        headers: { 'Authorization': authHeader }
       })
         .then(res => {
           if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/web/src/routes/Setup.svelte
+++ b/web/src/routes/Setup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { setupApi, storeCredentials } from '$lib/api';
+  import { setupApi, storeToken } from '$lib/api';
   import ThemeToggle from '../components/ThemeToggle.svelte';
   import LanguageSwitcher from '../components/LanguageSwitcher.svelte';
   import { t } from '$lib/i18n';
@@ -103,10 +103,9 @@
     try {
       const res = await setupApi(username, password, language, storagePath);
 
-      // Decode token to get credentials and store them
-      const decoded = atob(res.token);
-      const [user, pass] = decoded.split(':');
-      storeCredentials(user, pass);
+      // Store the signed session token returned by the server. The browser
+      // never carries the plaintext password again after setup.
+      storeToken(res.token, res.expires_at);
 
       // Show completion toast
       const protocolLabel = bestProtocol === 'llhls' ? 'LL-HLS'

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, setContext } from 'svelte';
-  import { getDashboardCameras, getCredentials, listProtocols, getCameraProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, normalizeProtocol, getProtocolCapabilities, getHealthCameras } from '$lib/api';
+  import { getDashboardCameras, getAuthHeader, listProtocols, getCameraProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, normalizeProtocol, getProtocolCapabilities, getHealthCameras } from '$lib/api';
   import type { Camera, ProtocolInfo, CameraProtocolsResponse } from '$lib/api';
   import { t } from '$lib/i18n';
   import { showToast } from '$lib/toast';
@@ -45,7 +45,7 @@
   // Snapshot manager — handles fetch, interval, and cleanup lifecycle
   const snapshotMgr = createSnapshotManager({
     intervalMs: 3000,
-    getCredentials,
+    getAuthHeader,
     onUrlUpdate: (id, url) => { snapshotUrls[id] = url; },
     onUrlRevoke: (id) => {
       if (snapshotUrls[id]) { URL.revokeObjectURL(snapshotUrls[id]); delete snapshotUrls[id]; }


### PR DESCRIPTION
Closes #110.

## What

Replaces the legacy `base64(user:pass)`-in-sessionStorage scheme with a **stateless HMAC-SHA256 signed session token**, so that:
- opening a new tab / restarting the browser no longer forces re-login (token lives in `localStorage`);
- the browser **never** holds a reversible encoding of the password again.

## Backend (`internal/middleware/token.go`, pure stdlib — zero new deps)
- Token format `mbs_<b64url(payload)>.<b64url(sig)>`, payload `{sub,iat,exp,jti}`.
- Signing key = `HMAC-SHA256(pepper, bcryptHash)`; `pepper` is a 32-byte random value generated at startup, kept **only in memory**:
  - process restart → pepper changes → all tokens invalidated (clean slate);
  - password change → bcrypt hash changes → that user's tokens invalidated (no revocation list);
  - config leak alone cannot forge tokens (still needs in-memory pepper).
- TTL 2h; when <15min remains the middleware mints a fresh token in the `X-Renewed-Token` response header (sliding renewal, no refresh endpoint).
- `auth.go`: new Bearer `mbs_` path tried before BasicAuth; `?token=` routes by prefix (`mbs_` → verify, else legacy base64 for migration). API keys (`mbv_`) unaffected. BasicAuth kept for login + external scripts.

## Frontend (`client.ts`)
`storeToken`/`getToken`/`clearToken` in localStorage; `getAuthHeader()` returns `Bearer <token>`; `apiRequest[Blob]` silently applies `X-Renewed-Token`; `getTokenForUrl()` for WS/sendBeacon `?token=`.

## Follow-up fix in this PR
WS/stream `?token=` must carry the **bare** token, not the `Bearer` header value. Added `getTokenForUrl()` and routed all six player components through it (`WasmPlayer`, `FlvPlayer`, `WebRTCPlayer`, `MjpegLivePlayer`, `CameraAudioButton`, `AviPlayback`). Without this, every WebSocket stream failed with `?token=Bearer%20mbs_...`.

Also fixes a latent bug: `Cameras.svelte` downloadRecording read `localStorage` while everything else wrote `sessionStorage`, so the archive download always 401'd — now uses `getAuthHeader()`.

## Known tradeoff (documented in code)
Stateless signed tokens cannot be actively revoked; a leaked token's risk window equals TTL (2h). WebSocket upgrades don't slide-renew (long-lived), they pick up a fresh token on reconnect. **User accepted: pepper stays in-memory (restart forces re-login) — preferred for production.**

## Tests
- 14 new middleware tests (sign/verify round-trip, expiry, tamper, password-change invalidation, jti uniqueness, bearer/query extraction, renewal threshold, end-to-end auth).
- Frontend telemetry + AviPlayback mocks updated to the token scheme. 427 frontend tests pass.

## Verified on Banana Pi M5 (real cameras)
- Login returns `mbs_` token + `expires_at`; Bearer authenticates API (200); forged token rejected (401).
- BasicAuth still works (backward compat). `?token=mbs_` authenticates (WS path).
- **New tab opens straight to surveillance without re-login.**
- `stream/ws` returns 200 after the `?token=` fix; `latest-frame`/`m3u8` with token no longer 401.