### PR TITLE
feat(surveillance): drag-and-drop to reorder grid cells (#111)

### DIFF
--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1182,6 +1182,7 @@
   "surveillance.upgraded": "Upgraded to {protocol} for lower latency",
   "surveillance.upgradeReverted": "Reverted to {protocol} (upgrade was unstable)",
   "surveillance.title": "Surveillance",
+  "surveillance.dragToReorder": "Drag to reorder",
   "timelapse.batchMerge": "Batch Merge",
   "timelapse.dailyMerge": "Daily Merge",
   "timelapse.deleteOriginal": "Delete original frames after conversion",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1182,6 +1182,7 @@
   "surveillance.upgraded": "已升级到 {protocol}（更低延迟）",
   "surveillance.upgradeReverted": "已回退到 {protocol}（升级后不稳定）",
   "surveillance.title": "监控大屏",
+  "surveillance.dragToReorder": "拖动以调整顺序",
   "timelapse.batchMerge": "批量合并",
   "timelapse.dailyMerge": "每日合并",
   "timelapse.deleteOriginal": "转换后删除原始帧",

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -4,7 +4,7 @@
   import type { Camera, ProtocolInfo, CameraProtocolsResponse } from '$lib/api';
   import { t } from '$lib/i18n';
   import { showToast } from '$lib/toast';
-  import { Loader2, AlertCircle, Video, VideoOff, X, Settings, ImageOff, CircleCheck, CirclePause } from 'lucide-svelte';
+  import { Loader2, AlertCircle, Video, VideoOff, X, Settings, ImageOff, CircleCheck, CirclePause, GripVertical } from 'lucide-svelte';
   import PtzControl from '../components/PtzControl.svelte';
   import CameraPlayer from '../components/CameraPlayer.svelte';
   import { formatDate } from '$lib/format';
@@ -18,6 +18,17 @@
   let loading = $state(true);
   let error = $state('');
   let expandedCameraId = $state<string | null>(null);
+
+  // Drag-and-drop reorder state. We use a handle-initiated drag so it
+  // doesn't collide with click/dblclick-to-expand. draggedIndex marks the
+  // cell being dragged; dragOverIndex marks the cell under the cursor (for
+  // the drop-target highlight). Both null when no drag is in progress.
+  let draggedIndex = $state<number | null>(null);
+  let dragOverIndex = $state<number | null>(null);
+  // handleDragIndex is the cell whose drag-handle is currently held down.
+  // Only that cell becomes draggable=true, so the rest of the cell body keeps
+  // click/dblclick-to-expand working (dragging doesn't swallow clicks).
+  let handleDragIndex = $state<number | null>(null);
 
   // Page Visibility — pause/resume all players when tab hidden/visible
   let tabVisible = $state(true);
@@ -233,6 +244,71 @@
   function shrinkToGrid() {
     expandedCameraId = null;
   }
+
+  // --- Drag-and-drop reorder ---
+
+  // Swapping two cells = swapping their position in the `cameras` array
+  // (render order) AND the `selectedCameraIds` array (persisted order).
+  // Camera identity is camera.id, so no player/orchestrator state is touched.
+  function reorderCameras(from: number, to: number) {
+    if (from === to || from < 0 || to < 0 || from >= cameras.length || to >= cameras.length) return;
+    const next = [...cameras];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    cameras = next;
+    // Keep selectedCameraIds in the same new order so persistence reflects it.
+    selectedCameraIds = next.map((c) => c.id);
+    saveCameraIds(selectedCameraIds);
+  }
+
+  function handleDragStart(index: number, e: DragEvent) {
+    draggedIndex = index;
+    // Required by some browsers for the drag to actually start / carry data.
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move';
+      // Firefox/Chrome need data set, or the drag is cancelled.
+      e.dataTransfer.setData('text/plain', String(index));
+    }
+  }
+
+  function handleDragOver(index: number, e: DragEvent) {
+    if (draggedIndex === null) return;
+    e.preventDefault(); // allow drop
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    if (dragOverIndex !== index) dragOverIndex = index;
+  }
+
+  function handleDrop(index: number, e: DragEvent) {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === index) {
+      draggedIndex = null;
+      dragOverIndex = null;
+      return;
+    }
+    reorderCameras(draggedIndex, index);
+    draggedIndex = null;
+    dragOverIndex = null;
+  }
+
+  function handleDragEnd() {
+    draggedIndex = null;
+    dragOverIndex = null;
+    handleDragIndex = null;
+  }
+
+  // Grip handle: pressing it makes its cell draggable; releasing clears it.
+  // stopPropagation so the press never reaches the cell's click→expand handler.
+  function handleGripDown(index: number, e: MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    handleDragIndex = index;
+  }
+
+  function handleGripUp(e: MouseEvent) {
+    e.stopPropagation();
+    handleDragIndex = null;
+  }
+
 
   function handleFullscreenChange() {
     if (!document.fullscreenElement) {
@@ -476,14 +552,14 @@
         onexpand={(e: CustomEvent) => expandToHls(e.detail.cameraId)}
         onshrink={(e: CustomEvent) => shrinkToGrid()}
       >
-        {#each cameras as camera, index}
+        {#each cameras as camera, index (camera.id)}
 {@const status = getStatusBadge(camera)}
           {@const mode = getCameraMode(camera)}
           {@const StatusIcon = status.icon}
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            class="relative bg-black rounded-lg overflow-hidden group camera-grid-cell {getCellClass(camera, index, cameras.length)}"
+            class="relative bg-black rounded-lg overflow-hidden group camera-grid-cell {getCellClass(camera, index, cameras.length)} {dragOverIndex === index && draggedIndex !== null && draggedIndex !== index ? 'cell-drop-target' : ''}"
             class:cell-expanded={expandedCameraId === camera.id}
             style="min-height: {cameras.length === 1 ? 'calc(100vh - 140px)' : 'calc((100vh - 160px) / 2)'};"
             role="button"
@@ -492,6 +568,11 @@
             onclick={() => handleCellClick(camera, index)}
             onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCellClick(camera, index); } }}
             ondblclick={() => handleCellDblClick(camera)}
+            draggable={handleDragIndex === index}
+            ondragstart={(e: DragEvent) => handleDragStart(index, e)}
+            ondragover={(e: DragEvent) => handleDragOver(index, e)}
+            ondrop={(e: DragEvent) => handleDrop(index, e)}
+            ondragend={handleDragEnd}
           >
             {#if mode === 'snapshot'}
               <!-- Snapshot thumbnail mode (HTTP_JPEG cameras) -->
@@ -579,6 +660,25 @@
               </span>
             {/if}
 
+            <!-- Drag handle — only in multi-cell, non-expanded mode. Pressing
+                 the handle makes this cell draggable (see handleDragIndex), so
+                 dragging never steals clicks from the cell body's expand. -->
+            {#if cameras.length > 1 && !expandedCameraId}
+              <button
+                type="button"
+                class="drag-handle absolute bottom-2 right-2 z-10 p-1 rounded-md bg-black/60 text-white/70 hover:text-white hover:bg-black/90 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing"
+                title={t('surveillance.dragToReorder')}
+                aria-label={t('surveillance.dragToReorder')}
+                onmousedown={(e: MouseEvent) => handleGripDown(index, e)}
+                onmouseup={handleGripUp}
+                onmouseleave={handleGripUp}
+                draggable="true"
+                ondragstart={(e: DragEvent) => { e.preventDefault(); }}
+              >
+                <GripVertical size={14} />
+              </button>
+            {/if}
+
             <!-- Health indicator dot + score -->
             {#if healthScores[camera.id] !== undefined}
               {@const hs = healthScores[camera.id]}
@@ -627,6 +727,18 @@
   /* Subtle hover lift on grid cells */
   .camera-grid-cell:not(.hidden):hover {
     opacity: 0.92;
+  }
+
+  /* Drop target highlight during drag — outline, not fill, so it stays visible
+     over any video content. */
+  .camera-grid-cell.cell-drop-target {
+    outline: 2px dashed var(--color-primary, #8b5cf6);
+    outline-offset: -4px;
+  }
+
+  /* The cell being dragged fades so the user sees it "lift". */
+  .camera-grid-cell[draggable='true']:active {
+    opacity: 0.5;
   }
 
   /* Fade-in + scale-up when a cell expands */

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -4,7 +4,7 @@
   import type { Camera, ProtocolInfo, CameraProtocolsResponse } from '$lib/api';
   import { t } from '$lib/i18n';
   import { showToast } from '$lib/toast';
-  import { Loader2, AlertCircle, Video, VideoOff, X, Settings, ImageOff, CircleCheck, CirclePause, GripVertical } from 'lucide-svelte';
+  import { Loader2, AlertCircle, Video, VideoOff, X, Settings, ImageOff, CircleCheck, CirclePause } from 'lucide-svelte';
   import PtzControl from '../components/PtzControl.svelte';
   import CameraPlayer from '../components/CameraPlayer.svelte';
   import { formatDate } from '$lib/format';
@@ -25,10 +25,6 @@
   // the drop-target highlight). Both null when no drag is in progress.
   let draggedIndex = $state<number | null>(null);
   let dragOverIndex = $state<number | null>(null);
-  // handleDragIndex is the cell whose drag-handle is currently held down.
-  // Only that cell becomes draggable=true, so the rest of the cell body keeps
-  // click/dblclick-to-expand working (dragging doesn't swallow clicks).
-  let handleDragIndex = $state<number | null>(null);
 
   // Page Visibility — pause/resume all players when tab hidden/visible
   let tabVisible = $state(true);
@@ -293,20 +289,6 @@
   function handleDragEnd() {
     draggedIndex = null;
     dragOverIndex = null;
-    handleDragIndex = null;
-  }
-
-  // Grip handle: pressing it makes its cell draggable; releasing clears it.
-  // stopPropagation so the press never reaches the cell's click→expand handler.
-  function handleGripDown(index: number, e: MouseEvent) {
-    e.stopPropagation();
-    e.preventDefault();
-    handleDragIndex = index;
-  }
-
-  function handleGripUp(e: MouseEvent) {
-    e.stopPropagation();
-    handleDragIndex = null;
   }
 
 
@@ -559,7 +541,7 @@
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <!-- svelte-ignore a11y_no_static_element_interactions -->
           <div
-            class="relative bg-black rounded-lg overflow-hidden group camera-grid-cell {getCellClass(camera, index, cameras.length)} {dragOverIndex === index && draggedIndex !== null && draggedIndex !== index ? 'cell-drop-target' : ''}"
+            class="relative bg-black rounded-lg overflow-hidden group camera-grid-cell {getCellClass(camera, index, cameras.length)} {dragOverIndex === index && draggedIndex !== null && draggedIndex !== index ? 'cell-drop-target' : ''} {draggedIndex === index ? 'cell-dragging' : ''}"
             class:cell-expanded={expandedCameraId === camera.id}
             style="min-height: {cameras.length === 1 ? 'calc(100vh - 140px)' : 'calc((100vh - 160px) / 2)'};"
             role="button"
@@ -568,7 +550,7 @@
             onclick={() => handleCellClick(camera, index)}
             onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCellClick(camera, index); } }}
             ondblclick={() => handleCellDblClick(camera)}
-            draggable={handleDragIndex === index}
+            draggable={cameras.length > 1 && !expandedCameraId ? 'true' : undefined}
             ondragstart={(e: DragEvent) => handleDragStart(index, e)}
             ondragover={(e: DragEvent) => handleDragOver(index, e)}
             ondrop={(e: DragEvent) => handleDrop(index, e)}
@@ -660,25 +642,6 @@
               </span>
             {/if}
 
-            <!-- Drag handle — only in multi-cell, non-expanded mode. Pressing
-                 the handle makes this cell draggable (see handleDragIndex), so
-                 dragging never steals clicks from the cell body's expand. -->
-            {#if cameras.length > 1 && !expandedCameraId}
-              <button
-                type="button"
-                class="drag-handle absolute bottom-2 right-2 z-10 p-1 rounded-md bg-black/60 text-white/70 hover:text-white hover:bg-black/90 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing"
-                title={t('surveillance.dragToReorder')}
-                aria-label={t('surveillance.dragToReorder')}
-                onmousedown={(e: MouseEvent) => handleGripDown(index, e)}
-                onmouseup={handleGripUp}
-                onmouseleave={handleGripUp}
-                draggable="true"
-                ondragstart={(e: DragEvent) => { e.preventDefault(); }}
-              >
-                <GripVertical size={14} />
-              </button>
-            {/if}
-
             <!-- Health indicator dot + score -->
             {#if healthScores[camera.id] !== undefined}
               {@const hs = healthScores[camera.id]}
@@ -736,8 +699,10 @@
     outline-offset: -4px;
   }
 
-  /* The cell being dragged fades so the user sees it "lift". */
-  .camera-grid-cell[draggable='true']:active {
+  /* The cell being dragged-from fades so the user sees it "lift". Driven by
+     draggedIndex state, not a CSS attribute selector, so it tracks the active
+     drag reliably even though the drag source is the handle, not the cell. */
+  .camera-grid-cell.cell-dragging {
     opacity: 0.5;
   }
 


### PR DESCRIPTION
Closes #111.

## What
Drag-and-drop to rearrange camera cells in the surveillance grid, persisted across reloads.

## Approach — whole-cell HTML5 DnD
The **entire cell is the drag source AND the drop target** (`draggable=true` on the cell div). This is the standard, robust pattern; a bare mousedown without movement still raises `click` → expand-to-fullscreen, so existing click/dblclick behavior is preserved — only a real drag (pointer move past threshold) starts a reorder.

- `{#each}` carries a `(camera.id)` key so heavy player instances (wasm WS, WebRTC RTCPeerConnection) are not positionally reused after reorder.
- Drop reorders the `cameras` array and persists via the existing `saveCameraIds` (localStorage `dashboard-selected-cameras`) — no new storage key.
- Disabled in single-cell and fullscreen-expanded modes.
- Drop target outline highlight; source cell fades while dragged.

## Why not a drag handle?
An earlier iteration used a grip-icon handle as the drag source. It did not work reliably: camera player components render `absolute inset-0` overlay layers (canvas/video/reconnect overlay) that sat above the handle and swallowed the mousedown, so `dragstart` never fired for WASM/WebRTC cells (MJPEG partially dragged but the drop never landed). Making the whole cell draggable sidesteps all stacking/pointer-event issues.

## Zero new dependencies
Native HTML5 Drag and Drop. No `svelte-dnd-action` / sortablejs.

## Verified on Banana Pi M5 (real cameras)
- Continuous multi-drag works (no 'first-drag-works-then-stops' regression).
- Click-to-expand still works (drag does not steal clicks).
- Drag is smooth; order persists across reload.
- Works for all player modes (WASM / WebRTC / FLV / HLS / MJPEG).