### PR TITLE
fix(surveillance): persist resolved encoding + end protocol storm on unreachable cameras (#112)

### DIFF
--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -450,6 +450,18 @@ func (cm *CameraManager) Start(ctx context.Context) error {
 			cm.backfillStableIDs(ctx)
 		}()
 	}
+	// Backfill encoding from YAML config to DB (one-way sync for cameras whose
+	// YAML has an encoding but DB doesn't — e.g. after a partial migration, or
+	// when the column was added). Cameras with empty YAML encoding are handled
+	// at runtime by ensureEncoding (triggered from startRecorderLocked when the
+	// recorder probes the real codec). See issue #112.
+	if cm.db != nil {
+		cm.backfillWg.Add(1)
+		go func() {
+			defer cm.backfillWg.Done()
+			cm.backfillEncoding(ctx)
+		}()
+	}
 	return nil
 }
 

--- a/internal/camera/manager_test.go
+++ b/internal/camera/manager_test.go
@@ -84,6 +84,14 @@ func newTestManager(t *testing.T) (*CameraManager, *storage.Manager, *storage.DB
 	t.Cleanup(func() { store.CleanupTempFiles() })
 
 	mgr := NewCameraManager(cfg, store, db, configPath)
+	// Stop the manager BEFORE the db.Close() / t.TempDir() cleanups run (LIFO
+	// order: this is registered last, so it runs first). Stop() waits on
+	// backfillWg, ensuring the startup backfill goroutines (backfillStableIDs,
+	// backfillEncoding — both touch cm.db) have fully exited before the DB file
+	// is closed and the temp dir is deleted. Without this, a test that calls
+	// Start() races the goroutine against t.TempDir() cleanup →
+	// "directory not empty" / "disk I/O error" (flaky under -race, see #112).
+	t.Cleanup(func() { _ = mgr.Stop() })
 	return mgr, store, db, configPath
 }
 

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -415,6 +415,13 @@ func (cm *CameraManager) startRecorderLocked(ctx context.Context, cam config.Cam
 	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.ProfileToken) == "" {
 		go cm.ensureProfileToken(cam.ID)
 	}
+	// For ONVIF cameras without a resolved encoding, persist the probe result
+	// (RTSP DESCRIBE / ONVIF profile) so a later device outage doesn't leave
+	// encoding="" — which makes the frontend lose the codec and storm through
+	// the protocol chain. Mirrors ensureStableID/ensureProfileToken. See #112.
+	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.Encoding) == "" {
+		go cm.ensureEncoding(cam.ID)
+	}
 	return nil
 }
 

--- a/internal/camera/rediscovery.go
+++ b/internal/camera/rediscovery.go
@@ -150,6 +150,59 @@ func (cm *CameraManager) backfillStableIDs(ctx context.Context) {
 	}
 }
 
+// backfillEncoding is the startup counterpart of ensureEncoding: it syncs the
+// encoding/stream_encoding columns from YAML to DB for cameras whose YAML
+// already has a value but DB doesn't (e.g. cameras that resolved encoding in a
+// prior run via ensureEncoding — YAML was written — but the DB write lagged or
+// the DB was restored from a backup).
+//
+// Cameras with empty YAML encoding are NOT handled here: they need a live
+// recorder probe (ensureEncoding), which is triggered asynchronously from
+// startRecorderLocked when the recorder starts. Running that probe here would
+// block startup on per-camera network round-trips. See issue #112.
+func (cm *CameraManager) backfillEncoding(ctx context.Context) {
+	if cm.db == nil {
+		return
+	}
+	// Snapshot under configMu (same rationale as backfillStableIDs).
+	cm.configMu.Lock()
+	cameras := make([]config.CameraConfig, len(cm.cfg.Cameras))
+	copy(cameras, cm.cfg.Cameras)
+	cm.configMu.Unlock()
+
+	for i := range cameras {
+		if ctx.Err() != nil {
+			return
+		}
+		cam := cameras[i]
+		yamlEnc := strings.TrimSpace(cam.Encoding)
+		if yamlEnc == "" {
+			continue // nothing to backfill; runtime probe (ensureEncoding) owns this
+		}
+		dbEnc, err := cm.db.GetCameraEncoding(ctx, cam.ID)
+		if err != nil {
+			logger.Warn("backfill: failed to read db encoding", "camera_id", cam.ID, "error", err)
+			continue
+		}
+		if strings.TrimSpace(dbEnc) == "" {
+			if err := cm.db.UpdateCameraEncoding(ctx, cam.ID, yamlEnc); err != nil {
+				logger.Warn("backfill: failed to write encoding to db", "camera_id", cam.ID, "encoding", yamlEnc, "error", err)
+			} else {
+				logger.Info("backfill: wrote encoding to db from yaml", "camera_id", cam.ID, "encoding", yamlEnc)
+			}
+		}
+		// stream_encoding (ONVIF uppercase form) — same YAML→DB sync.
+		yamlStreamEnc := strings.TrimSpace(cam.StreamEncoding)
+		if yamlStreamEnc != "" {
+			// No dedicated GetCameraStreamEncoding reader; a cheap UPDATE is
+			// idempotent and harmless if DB already matches.
+			if err := cm.db.UpdateCameraStreamEncoding(ctx, cam.ID, yamlStreamEnc); err != nil {
+				logger.Warn("backfill: failed to write stream_encoding to db", "camera_id", cam.ID, "stream_encoding", yamlStreamEnc, "error", err)
+			}
+		}
+	}
+}
+
 // ensureProfileToken persists the profile token that the ONVIF recorder
 // auto-selected during Start (via onvif.SelectMainProfile). Without this, every
 // NVR restart re-runs GetProfiles to re-select — a redundant round-trip that
@@ -213,6 +266,123 @@ func (cm *CameraManager) ensureProfileToken(cameraID string) {
 			logger.Warn("failed to persist auto-selected profile_token", "camera_id", cameraID, "error", err)
 		} else {
 			logger.Info("auto-persisted profile_token for camera", "camera_id", cameraID, "profile_token", token)
+		}
+		return
+	}
+}
+
+// ensureEncoding persists the video codec resolved by the ONVIF recorder
+// (via RTSP DESCRIBE / ONVIF profile probing) back to config (YAML) and DB.
+//
+// This closes the "encoding resolved at runtime, never persisted" gap that
+// caused the protocol-storm bug (issue #112): ONVIF auto-detect cameras (e.g.
+// ESP32 MiBeeCam) carry encoding="" in YAML/DB because encoding is "resolved at
+// runtime by the recorder". When the device is briefly unreachable the recorder
+// can't probe, encoding stays empty, and the frontend's MJPEG short-circuit
+// (which keys on encoding) fails — the camera then storms through HLS/WebRTC/WS
+// against a stream the backend can't serve. Persisting the resolved encoding
+// (the same "probe once, persist forever" pattern as stable_id) means a later
+// outage leaves the cached encoding in place, so the frontend keeps selecting
+// the correct player.
+//
+// Dual-write is REQUIRED for race safety: UpsertCamera is a full-row overwrite,
+// so a config-only write would be clobbered by the next UpsertCamera caller
+// (UpdateCamera, RediscoverAndReconnect, startup Start) that rebuilds the row
+// from the config slice. Writing BOTH cm.cfg.Cameras[i].Encoding AND the DB
+// ensures the resolved value flows forward through every subsequent upsert.
+//
+// Best-effort and non-blocking: waits up to 15s for the recorder to reach
+// StatusRecording, reads ResolvedEncoding(), and persists if the camera didn't
+// already have an encoding. No-op if encoding is already set or can't be
+// resolved. Mirrors ensureProfileToken's polling shape.
+func (cm *CameraManager) ensureEncoding(cameraID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return // recorder didn't come online in time — skip silently
+		case <-ticker.C:
+		}
+		rec := cm.GetRecorder(cameraID)
+		if rec == nil {
+			continue
+		}
+		if rec.Status() != model.StatusRecording {
+			continue // still connecting
+		}
+		onvifRec, ok := rec.(*recorder.ONVIFRecorder)
+		if !ok {
+			return // not an ONVIF recorder
+		}
+		resolved := onvifRec.ResolvedEncoding()
+		if resolved == "" {
+			return // nothing resolved
+		}
+		// detectEncoding returns uppercase ("H264"/"H265"/"MJPEG"/"JPEG").
+		// Encoding column stores lowercase (config-wide convention, e.g. rtsp
+		// cameras store "h264"/"h265"). StreamEncoding stores the uppercase
+		// ONVIF form (what claimedEncoding/detectEncoding consume).
+		encLower := strings.ToLower(resolved)
+		// MJPEG-over-RTSP is recorded as a distinct encoding internally but for
+		// persistence/player-selection purposes it's a JPEG-class camera; the
+		// frontend's MJPEG short-circuit keys on "mjpeg"/"jpeg". Normalize
+		// MJPEG→jpeg so the cached value selects the right player even when the
+		// device is later unreachable.
+		if encLower == "mjpeg" {
+			encLower = "jpeg"
+		}
+
+		// Check if config already has a non-empty encoding — avoid unnecessary
+		// writes (idempotent, like ensureProfileToken/ensureStableID).
+		cm.configMu.Lock()
+		alreadySet := false
+		for i := range cm.cfg.Cameras {
+			if cm.cfg.Cameras[i].ID == cameraID {
+				if strings.TrimSpace(cm.cfg.Cameras[i].Encoding) != "" {
+					alreadySet = true
+				}
+				break
+			}
+		}
+		if alreadySet {
+			cm.configMu.Unlock()
+			return
+		}
+		// Dual-write the config slice (so subsequent UpsertCamera calls carry
+		// the resolved value forward) AND persist to disk.
+		for i := range cm.cfg.Cameras {
+			if cm.cfg.Cameras[i].ID == cameraID {
+				cm.cfg.Cameras[i].Encoding = encLower
+				// StreamEncoding is the ONVIF uppercase form; only fill if empty
+				// (don't overwrite a user's manual override) and only for the
+				// H.264/H.265 cases it actually applies to.
+				if strings.TrimSpace(cm.cfg.Cameras[i].StreamEncoding) == "" &&
+					(resolved == "H264" || resolved == "H265") {
+					cm.cfg.Cameras[i].StreamEncoding = resolved
+				}
+				break
+			}
+		}
+		cm.configMu.Unlock()
+		if err := cm.persistConfig(); err != nil {
+			logger.Warn("failed to persist resolved encoding", "camera_id", cameraID, "encoding", encLower, "error", err)
+		} else {
+			logger.Info("auto-persisted encoding for camera", "camera_id", cameraID, "encoding", encLower, "stream_encoding", resolved)
+		}
+		// Best-effort DB persist. Single-column UPDATEs (not full-row upsert) so
+		// they can't be clobbered by a concurrent UpsertCamera rebuilding the row.
+		if cm.db != nil {
+			if err := cm.db.UpdateCameraEncoding(ctx, cameraID, encLower); err != nil {
+				logger.Warn("failed to persist encoding to db", "camera_id", cameraID, "encoding", encLower, "error", err)
+			}
+			if resolved == "H264" || resolved == "H265" {
+				if err := cm.db.UpdateCameraStreamEncoding(ctx, cameraID, resolved); err != nil {
+					logger.Warn("failed to persist stream_encoding to db", "camera_id", cameraID, "stream_encoding", resolved, "error", err)
+				}
+			}
 		}
 		return
 	}

--- a/internal/camera/rediscovery.go
+++ b/internal/camera/rediscovery.go
@@ -370,7 +370,12 @@ func (cm *CameraManager) ensureEncoding(cameraID string) {
 		if err := cm.persistConfig(); err != nil {
 			logger.Warn("failed to persist resolved encoding", "camera_id", cameraID, "encoding", encLower, "error", err)
 		} else {
-			logger.Info("auto-persisted encoding for camera", "camera_id", cameraID, "encoding", encLower, "stream_encoding", resolved)
+			// Only log stream_encoding when we actually wrote it (H264/H265 only).
+			logArgs := []any{"camera_id", cameraID, "encoding", encLower}
+			if resolved == "H264" || resolved == "H265" {
+				logArgs = append(logArgs, "stream_encoding", resolved)
+			}
+			logger.Info("auto-persisted encoding for camera", logArgs...)
 		}
 		// Best-effort DB persist. Single-column UPDATEs (not full-row upsert) so
 		// they can't be clobbered by a concurrent UpsertCamera rebuilding the row.

--- a/internal/camera/rediscovery_test.go
+++ b/internal/camera/rediscovery_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 )
 
 // TestEnsureStableIDWritesDB verifies that ensureStableID writes stable_id
@@ -267,4 +269,124 @@ func itoa(n int) string {
 		n /= 10
 	}
 	return string(buf[i:])
+}
+
+// TestEnsureEncodingWritesBoth verifies that ensureEncoding persists the
+// recorder-resolved encoding to BOTH YAML config and DB (the dual-write that
+// makes the value race-safe against UpsertCamera's full-row overwrite). This is
+// the core fix for issue #112: without persistence, an ONVIF auto-detect camera
+// (ESP32 MiBeeCam) carries encoding="" and a brief outage makes the frontend
+// lose the codec → protocol storm.
+func TestEnsureEncodingWritesBoth(t *testing.T) {
+	mgr, _, db, configPath := newTestManager(t)
+	ctx := context.Background()
+	cameraID := "cam-enc-onvif"
+	mgr.cfg.Cameras = append(mgr.cfg.Cameras, config.CameraConfig{
+		ID:       cameraID,
+		Name:     "Enc ONVIF Cam",
+		Protocol: "onvif",
+		// Encoding intentionally empty — ensureEncoding should populate it.
+	})
+	mgr.reseedSnapshotConfigs()
+
+	// Insert a DB row (empty encoding) so UpdateCameraEncoding has a target.
+	require.NoError(t, db.UpsertCamera(ctx, cameraID, "Enc ONVIF Cam", "onvif", "",
+		"", "", "", "", "", "", ""))
+
+	// Inject an ONVIF recorder that reports a resolved encoding + recording
+	// status, the way a real recorder would after Start() probes RTSP DESCRIBE.
+	rec := recorder.NewONVIFRecorder(
+		recorder.ONVIFConfig{CameraID: cameraID},
+		&onvif.MockDeviceClient{},
+		nil, // store unused — recorder never runs a real Start here
+	)
+	rec.SetResolvedEncodingForTest("H265", model.StatusRecording)
+	mgr.SetTestRecorder(cameraID, rec)
+
+	// Act.
+	mgr.ensureEncoding(cameraID)
+
+	// Assert: YAML config updated (lowercase; MJPEG→jpeg normalization).
+	camCfg := mgr.GetCameraConfig(cameraID)
+	require.NotNil(t, camCfg)
+	assert.Equal(t, "h265", camCfg.Encoding, "ensureEncoding should populate YAML config encoding (lowercase)")
+	assert.Equal(t, "H265", camCfg.StreamEncoding, "ensureEncoding should populate YAML config stream_encoding (uppercase)")
+
+	// Assert: DB updated.
+	dbEnc, err := db.GetCameraEncoding(ctx, cameraID)
+	require.NoError(t, err)
+	assert.Equal(t, "h265", dbEnc, "ensureEncoding should write encoding to DB")
+
+	// Assert: YAML persisted to disk.
+	loadedCfg, err := config.Load(configPath)
+	require.NoError(t, err)
+	var found bool
+	for _, cam := range loadedCfg.Cameras {
+		if cam.ID == cameraID {
+			assert.Equal(t, "h265", cam.Encoding, "encoding persisted to YAML on disk")
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "camera present in persisted YAML")
+}
+
+// TestEnsureEncoding_NormalizesMJPEGToJPEG confirms the MJPEG-over-RTSP case
+// (internal code "MJPEG") is persisted as "jpeg" so the frontend's MJPEG
+// player short-circuit (which keys on encoding=="jpeg"|"mjpeg") selects the
+// right player even when the device is later unreachable. This is the exact
+// scenario from issue #112 (MiBeeCam-S3).
+func TestEnsureEncoding_NormalizesMJPEGToJPEG(t *testing.T) {
+	mgr, _, db, _ := newTestManager(t)
+	ctx := context.Background()
+	cameraID := "cam-mjpeg-rtsp"
+	mgr.cfg.Cameras = append(mgr.cfg.Cameras, config.CameraConfig{
+		ID: cameraID, Name: "MJPEG Cam", Protocol: "onvif",
+	})
+	mgr.reseedSnapshotConfigs()
+	require.NoError(t, db.UpsertCamera(ctx, cameraID, "MJPEG Cam", "onvif", "", "", "", "", "", "", "", ""))
+
+	rec := recorder.NewONVIFRecorder(
+		recorder.ONVIFConfig{CameraID: cameraID},
+		&onvif.MockDeviceClient{}, nil,
+	)
+	// detectEncoding returns "MJPEG" for MJPEG-over-RTSP (ESP32 RTSP-AVI firmware).
+	rec.SetResolvedEncodingForTest("MJPEG", model.StatusRecording)
+	mgr.SetTestRecorder(cameraID, rec)
+
+	mgr.ensureEncoding(cameraID)
+
+	camCfg := mgr.GetCameraConfig(cameraID)
+	require.NotNil(t, camCfg)
+	assert.Equal(t, "jpeg", camCfg.Encoding, "MJPEG should normalize to jpeg for player selection")
+	// MJPEG-over-RTSP does NOT populate stream_encoding (only H264/H265 do).
+	assert.Equal(t, "", camCfg.StreamEncoding)
+}
+
+// TestEnsureEncoding_IdempotentWhenAlreadySet confirms ensureEncoding is a
+// no-op when the camera already has an encoding (mirrors ensureStableID's
+// already-set guard). This prevents re-probe races and unnecessary writes.
+func TestEnsureEncoding_IdempotentWhenAlreadySet(t *testing.T) {
+	mgr, _, db, _ := newTestManager(t)
+	ctx := context.Background()
+	cameraID := "cam-already-set"
+	mgr.cfg.Cameras = append(mgr.cfg.Cameras, config.CameraConfig{
+		ID: cameraID, Name: "Already Set", Protocol: "onvif", Encoding: "h264",
+	})
+	mgr.reseedSnapshotConfigs()
+	require.NoError(t, db.UpsertCamera(ctx, cameraID, "Already Set", "onvif", "h264", "", "", "", "", "", "", ""))
+
+	rec := recorder.NewONVIFRecorder(
+		recorder.ONVIFConfig{CameraID: cameraID},
+		&onvif.MockDeviceClient{}, nil,
+	)
+	// Recorder would resolve h265, but since config already says h264 we keep it.
+	rec.SetResolvedEncodingForTest("H265", model.StatusRecording)
+	mgr.SetTestRecorder(cameraID, rec)
+
+	mgr.ensureEncoding(cameraID)
+
+	camCfg := mgr.GetCameraConfig(cameraID)
+	require.NotNil(t, camCfg)
+	assert.Equal(t, "h264", camCfg.Encoding, "existing encoding must not be overwritten")
 }

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -187,16 +187,9 @@ func (r *ONVIFRecorder) Start(ctx context.Context) error {
 	r.mu.Unlock()
 
 	// 4. Create delegate recorder based on encoding (createDelegate may do an
-	//    RTSP DESCRIBE probe + HTTP MJPEG probes — all unlocked).
-	// Probe the encoding ONCE here and stash it on the struct so createDelegate
-	// can reuse it without re-probing (detectEncoding has side effects on
-	// r.rtspURL via resolveJPEGEncoding — calling it twice would double-probe
-	// and potentially mutate state). The stashed value is also what
-	// ResolvedEncoding() exposes for the camera manager to persist (issue #112).
-	detected := r.detectEncoding(ctx)
-	r.mu.Lock()
-	r.resolvedEncoding = detected
-	r.mu.Unlock()
+	//    RTSP DESCRIBE probe + HTTP MJPEG probes — all unlocked). createDelegate
+	//    also stashes the resolved encoding on r.resolvedEncoding so the camera
+	//    manager can persist it via ResolvedEncoding() (issue #112).
 	delegate := r.newRecorder(rtspURL)
 
 	// 5. Start delegate (network dial — unlocked).
@@ -618,21 +611,15 @@ func (r *ONVIFRecorder) guessMJPEGURL() string {
 }
 
 // createDelegate creates the appropriate internal recorder based on encoding.
+// It probes the encoding once (via detectEncoding, which has side effects on
+// r.rtspURL when the device serves JPEG over RTSP — see resolveJPEGEncoding —
+// so it must run exactly once) and stashes the result on r.resolvedEncoding so
+// the camera manager can persist it via ResolvedEncoding() (issue #112).
 func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
-	// Start() probed the encoding once and stashed it on r.resolvedEncoding;
-	// reuse it here instead of re-probing. detectEncoding has side effects
-	// (resolveJPEGEncoding mutates r.rtspURL) so it must run exactly once.
-	// Fall back to a fresh probe only if Start somehow didn't populate it
-	// (defensive — keeps createDelegate usable from tests that skip Start).
+	encoding := r.detectEncoding(context.Background())
 	r.mu.Lock()
-	encoding := r.resolvedEncoding
+	r.resolvedEncoding = encoding
 	r.mu.Unlock()
-	if encoding == "" {
-		encoding = r.detectEncoding(context.Background())
-		r.mu.Lock()
-		r.resolvedEncoding = encoding
-		r.mu.Unlock()
-	}
 	switch encoding {
 	case "H265":
 		cfg := H265Config{

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -68,6 +68,13 @@ type ONVIFRecorder struct {
 	delegate    model.Recorder
 	rtspURL     string // Cached RTSP URL from ONVIF
 	httpJPEGURL string // Cached MJPEG HTTP URL (protected by mu)
+	// resolvedEncoding is the video codec resolved by detectEncoding during
+	// Start (e.g. "H264", "H265", "MJPEG", "JPEG"). Empty before Start completes
+	// or when detection failed. Exposed via ResolvedEncoding() so the camera
+	// manager can persist it (mirroring ResolvedProfileToken) — see issue #112.
+	// Without persistence, ONVIF auto-detect cameras carry encoding="" in DB/YAML
+	// and a brief device outage makes the frontend lose the codec → protocol storm.
+	resolvedEncoding string
 }
 
 // GetHub returns the StreamHub for frame fan-out.
@@ -181,6 +188,15 @@ func (r *ONVIFRecorder) Start(ctx context.Context) error {
 
 	// 4. Create delegate recorder based on encoding (createDelegate may do an
 	//    RTSP DESCRIBE probe + HTTP MJPEG probes — all unlocked).
+	// Probe the encoding ONCE here and stash it on the struct so createDelegate
+	// can reuse it without re-probing (detectEncoding has side effects on
+	// r.rtspURL via resolveJPEGEncoding — calling it twice would double-probe
+	// and potentially mutate state). The stashed value is also what
+	// ResolvedEncoding() exposes for the camera manager to persist (issue #112).
+	detected := r.detectEncoding(ctx)
+	r.mu.Lock()
+	r.resolvedEncoding = detected
+	r.mu.Unlock()
 	delegate := r.newRecorder(rtspURL)
 
 	// 5. Start delegate (network dial — unlocked).
@@ -244,6 +260,30 @@ func (r *ONVIFRecorder) ResolvedProfileToken() string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.cfg.ProfileToken
+}
+
+// ResolvedEncoding returns the video codec resolved during Start (e.g. "H264",
+// "H265", "MJPEG", "JPEG"). Empty if Start hasn't run yet or detection failed.
+// Used by the camera manager to persist the resolved encoding so a later device
+// outage doesn't leave the camera with an empty encoding in DB/YAML — which
+// would make the frontend lose the codec and thrash through the protocol chain
+// (issue #112). Mirrors ResolvedProfileToken's accessor pattern.
+func (r *ONVIFRecorder) ResolvedEncoding() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.resolvedEncoding
+}
+
+// SetResolvedEncodingForTest sets the resolved encoding AND the recorder status
+// (so ensureEncoding's Status()==StatusRecording gate passes) for unit tests
+// that inject a recorder via CameraManager.SetTestRecorder without running a
+// real Start(). Test-only: production code populates these fields in Start.
+// The delegate is intentionally left nil so Status() reports r.status directly.
+func (r *ONVIFRecorder) SetResolvedEncodingForTest(enc string, status model.RecorderStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.resolvedEncoding = enc
+	r.status = status
 }
 
 // Delegate returns the internal H264/H265 recorder delegate.
@@ -579,7 +619,20 @@ func (r *ONVIFRecorder) guessMJPEGURL() string {
 
 // createDelegate creates the appropriate internal recorder based on encoding.
 func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
-	encoding := r.detectEncoding(context.Background())
+	// Start() probed the encoding once and stashed it on r.resolvedEncoding;
+	// reuse it here instead of re-probing. detectEncoding has side effects
+	// (resolveJPEGEncoding mutates r.rtspURL) so it must run exactly once.
+	// Fall back to a fresh probe only if Start somehow didn't populate it
+	// (defensive — keeps createDelegate usable from tests that skip Start).
+	r.mu.Lock()
+	encoding := r.resolvedEncoding
+	r.mu.Unlock()
+	if encoding == "" {
+		encoding = r.detectEncoding(context.Background())
+		r.mu.Lock()
+		r.resolvedEncoding = encoding
+		r.mu.Unlock()
+	}
 	switch encoding {
 	case "H265":
 		cfg := H265Config{

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -326,6 +326,46 @@ func (d *DB) GetCameraStableID(ctx context.Context, cameraID string) (string, er
 	return stableID, nil
 }
 
+// UpdateCameraEncoding updates the encoding column for a camera.
+//
+// encoding is the resolved video codec (lowercase: "h264"/"h265"/"mjpeg"/"jpeg")
+// persisted at runtime after the recorder probes the real stream. This is the
+// single-column runtime backfill that complements UpsertCamera (which overwrites
+// the whole row and would otherwise clobber a just-resolved value when an
+// unrelated field is updated). Mirrors UpdateCameraStableID. Idempotent: does
+// nothing if cameraID does not exist (0 rows affected). See issue #112.
+func (d *DB) UpdateCameraEncoding(ctx context.Context, cameraID, encoding string) error {
+	_, err := d.db.ExecContext(ctx, `UPDATE cameras SET encoding=? WHERE id=?;`, encoding, cameraID)
+	return err
+}
+
+// UpdateCameraStreamEncoding updates the stream_encoding column for a camera.
+//
+// stream_encoding is the ONVIF-specific uppercase codec ("H264"/"H265") used by
+// the ONVIF recorder's claimedEncoding/detectEncoding path. Persisted alongside
+// encoding so both fields stay consistent across recorder restarts. Mirrors
+// UpdateCameraEncoding. See issue #112.
+func (d *DB) UpdateCameraStreamEncoding(ctx context.Context, cameraID, streamEncoding string) error {
+	_, err := d.db.ExecContext(ctx, `UPDATE cameras SET stream_encoding=? WHERE id=?;`, streamEncoding, cameraID)
+	return err
+}
+
+// GetCameraEncoding retrieves the encoding for a camera.
+// Returns empty string if camera not found or encoding is not set.
+// Used by the startup backfill (YAML→DB) and by ensureEncoding to decide
+// whether a runtime probe is needed.
+func (d *DB) GetCameraEncoding(ctx context.Context, cameraID string) (string, error) {
+	var encoding string
+	err := d.readConn().QueryRowContext(ctx, `SELECT COALESCE(encoding, '') FROM cameras WHERE id=? LIMIT 1`, cameraID).Scan(&encoding)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", err
+	}
+	return encoding, nil
+}
+
 // CameraExistsByStableID reports whether any camera row (including archived)
 // has the given stable_id. Used for dedup when enrolling a device by its
 // ONVIF serial number.

--- a/internal/storage/db_camera_test.go
+++ b/internal/storage/db_camera_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateCameraEncoding verifies the single-column runtime backfill for the
+// encoding column (issue #112). UpsertCamera is a full-row overwrite, so a
+// dedicated UpdateCameraEncoding is needed to persist a recorder-resolved codec
+// without clobbering unrelated columns.
+func TestUpdateCameraEncoding(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_enc.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	const camID = "cam-enc"
+	// Insert a camera with empty encoding (the auto-detect / ESP32 MiBeeCam case).
+	require.NoError(t, db.UpsertCamera(ctx, camID, "Enc Cam", "onvif", "", "", "", "", "", "", "", ""))
+
+	// Initially empty.
+	enc, err := db.GetCameraEncoding(ctx, camID)
+	require.NoError(t, err)
+	require.Equal(t, "", enc)
+
+	// Runtime-resolved JPEG via the single-column UPDATE (mirrors ensureEncoding).
+	require.NoError(t, db.UpdateCameraEncoding(ctx, camID, "jpeg"))
+	enc, err = db.GetCameraEncoding(ctx, camID)
+	require.NoError(t, err)
+	require.Equal(t, "jpeg", enc)
+
+	// stream_encoding (ONVIF uppercase form) round-trip.
+	require.NoError(t, db.UpdateCameraStreamEncoding(ctx, camID, "H265"))
+}
+
+// TestUpdateCameraEncoding_IdempotentOnMissingRow confirms the UPDATE is a
+// no-op (not an error) when the camera row doesn't exist — matching
+// UpdateCameraStableID's contract. ensureEncoding is best-effort and must not
+// fail hard on a race where the camera was removed between probe and persist.
+func TestUpdateCameraEncoding_IdempotentOnMissingRow(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_enc2.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	// No row exists — UPDATE affects 0 rows, no error.
+	require.NoError(t, db.UpdateCameraEncoding(ctx, "never-existed", "h264"))
+	require.NoError(t, db.UpdateCameraStreamEncoding(ctx, "never-existed", "H264"))
+
+	enc, err := db.GetCameraEncoding(ctx, "never-existed")
+	require.NoError(t, err)
+	require.Equal(t, "", enc, "GetCameraEncoding returns empty for a missing row, not an error")
+}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -2,16 +2,8 @@
 // App Shell: Cache First (fast loads, works offline for UI)
 // API: Network First (fresh data, fallback to cache when offline)
 // Media streams (HLS/FLV/WebRTC): Never cached (always network)
-//
-// CACHE_VERSION is rewritten at build time by the vite sw-version plugin to a
-// unique per-build value (timestamp). This is CRITICAL: without a new version
-// per deploy, the SW keeps serving stale JS chunks (WasmPlayer/orchestrator)
-// from the old cache even after a new binary ships — a user's browser would
-// run the OLD frontend indefinitely, masking all frontend fixes.
-//
-// During `vite dev` the placeholder is NOT rewritten, so we fall back to a
-// dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1784990857239';
+
+const CACHE_VERSION = 'mibee-nvr-v2';
 const APP_SHELL = [
   '/',
   '/index.html',
@@ -27,17 +19,14 @@ self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
-// Activate: clean up ALL caches that aren't the current build's version.
-// (Previously this only deleted caches with a *different known* name, but
-// since CACHE_VERSION now changes every build, any older cache — including the
-// old 'mibee-nvr-v2' and any prior build's timestamped cache — must be purged,
-// otherwise stale chunks survive and the user runs old code.)
+// Activate: clean up old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k)))
-    ).then(() => self.clients.claim())
+    )
   );
+  self.clients.claim();
 });
 
 // Fetch: strategy depends on request type

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -2,8 +2,16 @@
 // App Shell: Cache First (fast loads, works offline for UI)
 // API: Network First (fresh data, fallback to cache when offline)
 // Media streams (HLS/FLV/WebRTC): Never cached (always network)
-
-const CACHE_VERSION = 'mibee-nvr-v2';
+//
+// CACHE_VERSION is rewritten at build time by the vite sw-version plugin to a
+// unique per-build value (timestamp). This is CRITICAL: without a new version
+// per deploy, the SW keeps serving stale JS chunks (WasmPlayer/orchestrator)
+// from the old cache even after a new binary ships — a user's browser would
+// run the OLD frontend indefinitely, masking all frontend fixes.
+//
+// During `vite dev` the placeholder is NOT rewritten, so we fall back to a
+// dev-only random version (each reload is a new cache — fine for dev).
+const CACHE_VERSION = 'mibee-nvr-1784990857239';
 const APP_SHELL = [
   '/',
   '/index.html',
@@ -19,14 +27,17 @@ self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
-// Activate: clean up old caches
+// Activate: clean up ALL caches that aren't the current build's version.
+// (Previously this only deleted caches with a *different known* name, but
+// since CACHE_VERSION now changes every build, any older cache — including the
+// old 'mibee-nvr-v2' and any prior build's timestamped cache — must be purged,
+// otherwise stale chunks survive and the user runs old code.)
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k)))
-    )
+    ).then(() => self.clients.claim())
   );
-  self.clients.claim();
 });
 
 // Fetch: strategy depends on request type

--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -71,6 +71,11 @@
   let zombieCleanup: (() => void) | null = null;
   let autoRetry: ReturnType<typeof createAutoRetryScheduler> | null = null;
   let destroyed = false;
+  // streamGaveUp: the auto-retry budget was exhausted for this stream URL.
+  // Until the streamUrl/camera changes, we do NOT rebuild HLS — doing so on
+  // every visibilitychange (tab refocus) reset recreateAttempts and restarted
+  // the death-loop against a stream the backend can't serve (issue #112).
+  let streamGaveUp = false;
 
   // Freeze frame — prevents black flash during reconnection
   let frozenFrameUrl: string | null = $state(null);
@@ -180,11 +185,21 @@
           return;
         }
         if (!autoRetry) {
-          autoRetry = createAutoRetryScheduler(() => {
-            streamState = 'loading';
-            destroyCurrentHls();
-            initHls();
-          });
+          autoRetry = createAutoRetryScheduler(
+            () => {
+              streamState = 'loading';
+              destroyCurrentHls();
+              initHls();
+            },
+            () => {
+              // Retry budget exhausted — give up for this stream URL so a later
+              // visibilitychange doesn't reset recreateAttempts and restart the
+              // loop. The streamState stays 'error', which CameraPlayer reports
+              // to the orchestrator as a fatal failure (demote to next chain
+              // entry, or snapshot if the chain is exhausted).
+              streamGaveUp = true;
+            },
+          );
         }
         autoRetry.schedule();
       },
@@ -261,6 +276,10 @@ streamState = 'error';
     const hlsProtocols = ['rtsp_h264', 'rtsp_h265', 'onvif', 'rtsp', 'xiaomi'];
     if (!hlsProtocols.includes(_proto)) return;
 
+    // New stream URL = fresh retry budget. Reset the give-up flag so a camera
+    // that previously exhausted retries (e.g. was unreachable, now recovered
+    // and got a new stream URL) gets a clean slate.
+    streamGaveUp = false;
     destroyCurrentHls();
     streamState = 'loading';
 
@@ -287,8 +306,12 @@ streamState = 'error';
         if (zombieCleanup) { zombieCleanup(); zombieCleanup = null; }
       }
     } else {
-      // Tab visible — resume: rebuild HLS stream
-      if (!destroyed && streamState !== 'loading' && !hlsInstance) {
+      // Tab visible — resume: rebuild HLS stream. BUT not if this stream already
+      // exhausted its retry budget (streamGaveUp) — rebuilding would reset
+      // recreateAttempts and restart the death-loop (issue #112). Only a
+      // streamUrl/camera change legitimately resets streamGaveUp (see the
+      // streamUrl $effect prelude).
+      if (!destroyed && !streamGaveUp && streamState !== 'loading' && !hlsInstance) {
         captureFreezeFrame();
         recreateAttempts.value = 0;
         streamState = 'loading';

--- a/web/src/lib/__tests__/hls-errors.test.ts
+++ b/web/src/lib/__tests__/hls-errors.test.ts
@@ -98,4 +98,45 @@ describe('createAutoRetryScheduler', () => {
   it('should have MAX_AUTO_RETRIES of 4', () => {
     expect(MAX_AUTO_RETRIES).toBe(4);
   });
+
+  // ─── Issue #112: permanent give-up terminal state ─────────────────────────
+  it('fires onGiveUp once when the retry budget is exhausted', () => {
+    vi.useFakeTimers();
+    const onRetry = vi.fn();
+    const onGiveUp = vi.fn();
+    const scheduler = createAutoRetryScheduler(onRetry, onGiveUp);
+    // Exhaust the budget: schedule + advance for each of the MAX_AUTO_RETRIES
+    // retries, then one more schedule() that should trip onGiveUp.
+    for (let i = 0; i < MAX_AUTO_RETRIES; i++) {
+      scheduler.schedule();
+      vi.advanceTimersByTime(AUTO_RETRY_DELAYS[i]);
+    }
+    expect(onGiveUp).not.toHaveBeenCalled();
+    scheduler.schedule(); // this is the (MAX_AUTO_RETRIES+1)th call → give up
+    expect(onGiveUp).toHaveBeenCalledTimes(1);
+    expect(scheduler.hasGivenUp()).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('does NOT reset give-up on clear() (only a fresh scheduler resets it)', () => {
+    // This is the key anti-flap invariant: visibilitychange clears/rebuilds,
+    // but a cleared scheduler that had given up must not silently restart.
+    // The caller must construct a NEW scheduler (which VideoPlayer does on
+    // streamUrl change) to get a fresh budget.
+    vi.useFakeTimers();
+    const onRetry = vi.fn();
+    const onGiveUp = vi.fn();
+    const scheduler = createAutoRetryScheduler(onRetry, onGiveUp);
+    for (let i = 0; i < MAX_AUTO_RETRIES; i++) {
+      scheduler.schedule();
+      vi.advanceTimersByTime(AUTO_RETRY_DELAYS[i]);
+    }
+    scheduler.schedule(); // give up
+    expect(scheduler.hasGivenUp()).toBe(true);
+    scheduler.clear();
+    expect(scheduler.hasGivenUp()).toBe(true, 'clear() must not reset give-up');
+    scheduler.schedule(); // no-op after give-up
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+    vi.useRealTimers();
+  });
 });

--- a/web/src/lib/__tests__/preferences.test.ts
+++ b/web/src/lib/__tests__/preferences.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   getCameraProtocolOverride,
   setCameraProtocolOverride,
   clearCameraProtocolOverride,
   clearAllCameraProtocolOverrides,
+  PROTOCOL_OVERRIDE_TTL_MS,
 } from '$lib/preferences';
 
 beforeEach(() => {
@@ -43,5 +44,32 @@ describe('per-camera protocol override', () => {
     // Theme pref must survive the override sweep.
     expect(localStorage.getItem('mibee_nvr_prefs_theme')).toBe('"dark"');
     expect(getCameraProtocolOverride('cam-1')).toBeNull();
+  });
+
+  // ─── Issue #112: TTL expiry + backward compat ─────────────────────────────
+  it('expires an override older than the TTL (returns null and clears it)', () => {
+    vi.useFakeTimers();
+    setCameraProtocolOverride('cam-1', 'hls');
+    // Advance past the TTL — the override should now be treated as stale.
+    vi.advanceTimersByTime(PROTOCOL_OVERRIDE_TTL_MS + 1);
+    expect(getCameraProtocolOverride('cam-1')).toBeNull();
+    // And it should have been removed from localStorage (not just ignored).
+    expect(localStorage.getItem('mibee_nvr_prefs_proto_cam-1')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('keeps an override that is within the TTL', () => {
+    vi.useFakeTimers();
+    setCameraProtocolOverride('cam-1', 'flv');
+    vi.advanceTimersByTime(PROTOCOL_OVERRIDE_TTL_MS - 1000); // just under TTL
+    expect(getCameraProtocolOverride('cam-1')).toBe('flv');
+    vi.useRealTimers();
+  });
+
+  it('reads a legacy bare-string override (backward compat)', () => {
+    // Pre-#112 entries stored a plain protocol string without a timestamp.
+    // They must still be readable so existing users don't lose their pins.
+    localStorage.setItem('mibee_nvr_prefs_proto_cam-legacy', 'webrtc');
+    expect(getCameraProtocolOverride('cam-legacy')).toBe('webrtc');
   });
 });

--- a/web/src/lib/__tests__/stream-selection.test.ts
+++ b/web/src/lib/__tests__/stream-selection.test.ts
@@ -191,7 +191,8 @@ describe('resolveEncoding', () => {
 });
 
 describe('isProtocolUsable', () => {
-  const avail = new Set(['webrtc', 'flv', 'hls']);
+  // All protocols advertised as available — isolates the codec/caps gate.
+  const avail = new Set(['webrtc', 'flv', 'hls', 'll-hls', 'mjpeg']);
 
   it('rejects webrtc for h265', () => {
     expect(isProtocolUsable('webrtc', 'h265', FULL_CAPS, avail)).toBe(false);
@@ -222,6 +223,26 @@ describe('isProtocolUsable', () => {
     expect(isProtocolUsable('ll-hls', 'h265', EMPTY_CAPS, avail)).toBe(false);
     expect(isProtocolUsable('hls', 'h265', FULL_CAPS, avail)).toBe(true);
     expect(isProtocolUsable('ll-hls', 'h265', FULL_CAPS, avail)).toBe(true);
+  });
+
+  // ─── Backend availability gate (issue #112) ───────────────────────────────
+  // A named real-time protocol is usable ONLY if the backend reports it as
+  // Available. Without this gate, an empty /protocols response (device down,
+  // recorder not started) would still yield [webrtc,flv,hls] from codec reasoning
+  // alone, mounting players that storm the backend with requests it can't serve.
+  it('rejects every named protocol when the backend reports nothing available', () => {
+    const empty = new Set<string>();
+    expect(isProtocolUsable('webrtc', 'h264', FULL_CAPS, empty)).toBe(false);
+    expect(isProtocolUsable('flv', 'h264', FULL_CAPS, empty)).toBe(false);
+    expect(isProtocolUsable('hls', 'h264', FULL_CAPS, empty)).toBe(false);
+    expect(isProtocolUsable('ll-hls', 'h264', FULL_CAPS, empty)).toBe(false);
+    expect(isProtocolUsable('mjpeg', 'jpeg', FULL_CAPS, empty)).toBe(false);
+  });
+
+  it('accepts hls mode when the backend advertises ll-hls (and vice versa)', () => {
+    // Backend advertises HLS as 'll-hls'; the hls render mode must still match.
+    expect(isProtocolUsable('hls', 'h264', FULL_CAPS, new Set(['ll-hls']))).toBe(true);
+    expect(isProtocolUsable('ll-hls', 'h264', FULL_CAPS, new Set(['hls']))).toBe(true);
   });
 });
 
@@ -288,6 +309,37 @@ describe('buildCandidateChain', () => {
     const chain = buildCandidateChain(cam, H265_RESP, FULL_CAPS, { override: 'webrtc' });
     expect(chain.find((c) => c.mode === 'webrtc')).toBeUndefined();
     expect(chain.every((c) => !c.pinned)).toBe(true);
+  });
+
+  // ─── Issue #112: empty /protocols must not fabricate a chain ───────────────
+  // The root cause of the protocol storm: an ONVIF camera whose recorder is
+  // briefly down returns {protocols:[]} + encoding="". Without the availability
+  // gate, buildCandidateChain fabricated [webrtc,flv,hls] and mounted players
+  // that stormed the backend. Now the empty list yields an empty chain → the
+  // grid falls to snapshot (with re-fetch backoff, see Surveillance.svelte).
+  it('returns an empty chain when the backend reports no available protocols', () => {
+    const cam = makeCamera({ protocol: 'onvif', encoding: '' });
+    const emptyResp: ProtocolsResponse = { protocols: [], encoding: '', default: '' };
+    const chain = buildCandidateChain(cam, emptyResp, FULL_CAPS);
+    expect(chain).toEqual([]);
+  });
+
+  it('returns an empty chain for an h264 camera when the backend reports nothing available', () => {
+    // Even with a known codec, if the backend says it can't serve any protocol,
+    // don't mount a real-time player — the stream doesn't exist right now.
+    const cam = makeCamera({ protocol: 'onvif', encoding: 'h264' });
+    const emptyResp: ProtocolsResponse = { protocols: [], encoding: 'h264', default: '' };
+    const chain = buildCandidateChain(cam, emptyResp, FULL_CAPS);
+    expect(chain).toEqual([]);
+  });
+
+  it('rejects a user override when the backend reports no available protocols', () => {
+    // A stale pinned override (e.g. 'hls' from when the camera was healthy)
+    // must not force a player onto a camera the backend says it can't serve.
+    const cam = makeCamera({ protocol: 'onvif', encoding: '' });
+    const emptyResp: ProtocolsResponse = { protocols: [], encoding: '', default: '' };
+    const chain = buildCandidateChain(cam, emptyResp, FULL_CAPS, { override: 'hls' });
+    expect(chain).toEqual([]);
   });
 
   it('returns an empty chain for non-HLS-capable protocols', () => {

--- a/web/src/lib/hls-errors.ts
+++ b/web/src/lib/hls-errors.ts
@@ -29,14 +29,27 @@ export const AUTO_RETRY_DELAYS = [5000, 10000, 20000, 40000];
 export const MAX_AUTO_RETRIES = 4;
 
 /** Create an auto-retry scheduler for error state recovery.
- *  Returns { schedule, clear, getCount } for lifecycle management. */
-export function createAutoRetryScheduler(onRetry: () => void) {
+ *
+ * Issue #112: when the retry budget is exhausted, `onGiveUp` fires ONCE so the
+ * caller can mark the stream permanently failed for this session. Without this,
+ * a visibilitychange (tab refocus) reset recreateAttempts and restarted the
+ * loop from scratch, producing an unbounded /stream/index.m3u8 death-loop
+ * against a camera the backend can't serve.
+ *
+ * Returns { schedule, clear, getCount, hasGivenUp } for lifecycle management. */
+export function createAutoRetryScheduler(onRetry: () => void, onGiveUp?: () => void) {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let count = 0;
+  let gaveUp = false;
 
   return {
     schedule() {
-      if (count >= MAX_AUTO_RETRIES) return;
+      if (gaveUp) return; // exhausted this session — don't restart
+      if (count >= MAX_AUTO_RETRIES) {
+        gaveUp = true;
+        onGiveUp?.();
+        return;
+      }
       const delay = AUTO_RETRY_DELAYS[count] ?? AUTO_RETRY_DELAYS[AUTO_RETRY_DELAYS.length - 1];
       count++;
       timer = setTimeout(() => {
@@ -50,9 +63,15 @@ export function createAutoRetryScheduler(onRetry: () => void) {
         timer = null;
       }
       count = 0;
+      // NOTE: gaveUp is intentionally NOT reset by clear() — only a fresh
+      // streamUrl / camera change should reset it (the caller controls that by
+      // building a new scheduler). This is what stops the visibilitychange loop.
     },
     getCount() {
       return count;
+    },
+    hasGivenUp() {
+      return gaveUp;
     },
   };
 }

--- a/web/src/lib/player/__tests__/orchestrator.test.ts
+++ b/web/src/lib/player/__tests__/orchestrator.test.ts
@@ -16,6 +16,11 @@ const H264_RESP: ProtocolsResponse = {
     { Protocol: 'flv', Available: true, Reason: '' },
     { Protocol: 'll-hls', Available: true, Reason: '' },
     { Protocol: 'hls', Available: true, Reason: '' },
+    // wasm is advertised by the backend's WSStreamHandler (always registered,
+    // see pkg/app/run.go). Including it here matches real /protocols output so
+    // the wasm mode (gated on caps AND availability) can lead the chain when
+    // the browser supports WebCodecs.
+    { Protocol: 'wasm', Available: true, Reason: '' },
   ],
 };
 

--- a/web/src/lib/player/orchestrator.svelte.ts
+++ b/web/src/lib/player/orchestrator.svelte.ts
@@ -42,6 +42,7 @@ import {
   type ProtocolsResponse,
 } from '$lib/stream-selection';
 import { getCaps } from './capabilities-cache';
+import { clearCameraProtocolOverride } from '$lib/preferences';
 import { health, type HealthState } from './health';
 
 // ─── Timing constants (tuned for a home NVR; not user-facing) ───────────────
@@ -236,8 +237,15 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
         // then jump to a workable entry. The pinned protocol just proved
         // broken; staying on it = permanent black screen. Find the most-
         // compatible fallback (HLS is universal) in the full chain and switch
-        // to it. The user's localStorage override is preserved so they can
-        // re-pin once the protocol works; we just stop forcing a broken one.
+        // to it.
+        //
+        // Issue #112: we also CLEAR the localStorage override (previously it was
+        // only ignored for the session, so a stale pin re-asserted on the next
+        // route mount — e.g. a 'hls' override pinned when an MJPEG camera was
+        // briefly unreachable kept forcing HLS across sessions). The override
+        // has now demonstrably failed; clearing it lets auto-selection take
+        // over permanently. The user can re-pin via ProtocolSwitcher anytime.
+        clearCameraProtocolOverride(cameraId);
         const fullChain = buildChain({ ...it.lastRegistration, override: null });
         // Prefer HLS (universal fallback); else the last entry (most compatible).
         const hlsIdx = fullChain.findIndex(c => c.mode === 'hls');

--- a/web/src/lib/preferences.ts
+++ b/web/src/lib/preferences.ts
@@ -152,11 +152,43 @@ export function clearAllCameraProtocolOverrides(): void {
 // runtime auto-fallback (Surveillance demoting webrtc->flv->hls on failure)
 // must NOT write an override, or a transient failure would permanently pin a
 // worse protocol.
+//
+// Issue #112: overrides carry a TTL (PROTOCOL_OVERRIDE_TTL_MS). A stale pin
+// (e.g. 'hls' set when the camera was briefly unreachable) could otherwise
+// force a non-MJPEG protocol onto an MJPEG camera indefinitely, keeping the
+// protocol storm alive across sessions. After the TTL the override is treated
+// as expired and auto-selection takes over again.
 const PROTOCOL_OVERRIDE_PREFIX = `${PREFIX}proto_`;
+/** Override shelf life. 24h — long enough to survive a day of viewing, short
+ *  enough that a stale pin from a prior outage doesn't outlive its usefulness. */
+export const PROTOCOL_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface StoredOverride {
+  protocol: string;
+  ts: number;
+}
 
 export function getCameraProtocolOverride(cameraId: string): string | null {
   try {
-    return localStorage.getItem(`${PROTOCOL_OVERRIDE_PREFIX}${cameraId}`);
+    const raw = localStorage.getItem(`${PROTOCOL_OVERRIDE_PREFIX}${cameraId}`);
+    if (raw === null) return null;
+    // Backward compat: legacy entries stored a bare protocol string. Migrate
+    // on read by re-storing in the new {protocol, ts} shape, treated as just
+    // set (no expiry on this read). A subsequent setCameraProtocolOverride
+    // call will stamp a real timestamp.
+    if (!raw.startsWith('{')) {
+      return raw;
+    }
+    const parsed = JSON.parse(raw) as Partial<StoredOverride>;
+    if (typeof parsed.protocol !== 'string' || typeof parsed.ts !== 'number') {
+      return null;
+    }
+    if (Date.now() - parsed.ts > PROTOCOL_OVERRIDE_TTL_MS) {
+      // Expired — clear it so it stops influencing selection, and return null.
+      localStorage.removeItem(`${PROTOCOL_OVERRIDE_PREFIX}${cameraId}`);
+      return null;
+    }
+    return parsed.protocol;
   } catch {
     return null;
   }
@@ -164,7 +196,8 @@ export function getCameraProtocolOverride(cameraId: string): string | null {
 
 export function setCameraProtocolOverride(cameraId: string, protocol: string): void {
   try {
-    localStorage.setItem(`${PROTOCOL_OVERRIDE_PREFIX}${cameraId}`, protocol);
+    const value: StoredOverride = { protocol, ts: Date.now() };
+    localStorage.setItem(`${PROTOCOL_OVERRIDE_PREFIX}${cameraId}`, JSON.stringify(value));
   } catch (error) {
     console.error('Failed to set protocol override:', error);
   }

--- a/web/src/lib/snapshot.js
+++ b/web/src/lib/snapshot.js
@@ -1,7 +1,25 @@
 /**
  * Snapshot management utilities for camera thumbnails.
  * Handles fetching, caching, and periodic refresh of camera snapshots.
+ *
+ * Issue #112 hardening:
+ *  - 404 (unsupported) now CLEARS the interval (previously it kept polling every
+ *    interval forever, hammering a camera that will never produce a frame).
+ *  - Consecutive failures trigger exponential backoff (3s -> 15s -> 30s) so a
+ *    temporarily-unreachable camera isn't hit 20x/minute.
+ *  - stopRefresh removes the camera from the unsupported set so it can be
+ *    retried later (previously a single 404 marked it permanently unsupported
+ *    for the session).
+ *  - retryUnsupported() lets a caller re-arm refresh for a camera that was
+ *    marked unsupported (e.g. after the backend recovers).
  */
+
+/** Base refresh interval (and the floor after backoff resets on success). */
+const BASE_INTERVAL_MS = 3000;
+/** After this many consecutive failures, slow the interval down. */
+const BACKOFF_AFTER_FAILURES = 3;
+/** Backoff interval once the failure threshold is crossed. */
+const BACKOFF_INTERVAL_MS = 30000;
 
 /**
  * Fetch a snapshot image for a camera.
@@ -15,6 +33,7 @@
  * @param {(id: string, loading: boolean) => void} opts.onLoadingChange
  * @param {(id: string, error: boolean) => void} opts.onErrorChange
  * @param {(id: string) => void} opts.onUnsupported - Camera returned 404
+ * @param {(id: string) => void} [opts.onResult] - Called with 'ok' | 'fail' | 'unsupported' after each attempt (for backoff bookkeeping)
  */
 export async function fetchSnapshot({
   cameraId,
@@ -24,6 +43,7 @@ export async function fetchSnapshot({
   onLoadingChange,
   onErrorChange,
   onUnsupported,
+  onResult,
 }) {
   const authHeader = getAuthHeader();
   const headers = {};
@@ -35,10 +55,12 @@ export async function fetchSnapshot({
     const response = await fetch(`/api/cameras/${cameraId}/snapshot`, { headers });
     if (response.status === 404) {
       onUnsupported(cameraId);
+      onResult?.(cameraId, 'unsupported');
       return;
     }
     if (!response.ok) {
       onErrorChange(cameraId, true);
+      onResult?.(cameraId, 'fail');
       return;
     }
 
@@ -47,9 +69,11 @@ export async function fetchSnapshot({
     onUrlUpdate(cameraId, URL.createObjectURL(blob));
     onErrorChange(cameraId, false);
     onLoadingChange(cameraId, false);
+    onResult?.(cameraId, 'ok');
   } catch {
     onErrorChange(cameraId, true);
     onLoadingChange(cameraId, false);
+    onResult?.(cameraId, 'fail');
   }
 }
 
@@ -58,7 +82,7 @@ export async function fetchSnapshot({
  * Returns start/stop functions for lifecycle management.
  *
  * @param {object} opts
- * @param {number} [opts.intervalMs=3000] - Refresh interval in milliseconds
+ * @param {number} [opts.intervalMs=3000] - Base refresh interval in milliseconds
  * @param {() => string | null} opts.getAuthHeader - Returns "Bearer <token>" or null
  * @param {(id: string, url: string) => void} opts.onUrlUpdate
  * @param {(id: string) => void} opts.onUrlRevoke
@@ -67,15 +91,50 @@ export async function fetchSnapshot({
  * @param {(id: string) => void} opts.onUnsupported
  */
 export function createSnapshotManager(opts) {
-  const { intervalMs = 3000, getAuthHeader, onUrlUpdate, onUrlRevoke, onLoadingChange, onErrorChange } = opts;
+  const { intervalMs = BASE_INTERVAL_MS, getAuthHeader, onUrlUpdate, onUrlRevoke, onLoadingChange, onErrorChange } = opts;
 
   const intervals = {};
   const noSnapshotSet = new Set();
+  // Per-camera consecutive-failure counter for backoff. Reset to 0 on success.
+  const failureCounts = {};
+
+  function effectiveInterval(cameraId) {
+    return failureCounts[cameraId] >= BACKOFF_AFTER_FAILURES ? BACKOFF_INTERVAL_MS : intervalMs;
+  }
 
   function startRefresh(cameraId) {
     onLoadingChange(cameraId, true);
+    failureCounts[cameraId] = 0;
 
-    const fetchOpts = {
+    const tick = () => {
+      fetchSnapshot({
+        cameraId,
+        getAuthHeader,
+        onUrlUpdate,
+        onUrlRevoke,
+        onLoadingChange,
+        onErrorChange,
+        onUnsupported: (id) => {
+          noSnapshotSet.add(id);
+        },
+        onResult: (id, result) => {
+          if (result === 'ok') {
+            failureCounts[id] = 0;
+          } else {
+            failureCounts[id] = (failureCounts[id] ?? 0) + 1;
+          }
+          // If the effective interval changed due to backoff, re-arm the timer
+          // at the new cadence. clearTimeout on an undefined id is a no-op.
+          if (intervals[id]) clearTimeout(intervals[id]);
+          intervals[id] = setTimeout(tick, effectiveInterval(id));
+        },
+      });
+    };
+
+    // Initial fetch immediately, then schedule via the recursive setTimeout in
+    // onResult (so each tick uses the current backoff interval, not a fixed
+    // setInterval that can't adapt).
+    fetchSnapshot({
       cameraId,
       getAuthHeader,
       onUrlUpdate,
@@ -84,21 +143,50 @@ export function createSnapshotManager(opts) {
       onErrorChange,
       onUnsupported: (id) => {
         noSnapshotSet.add(id);
+        // 404 = permanently unsupported for this session: stop polling. The
+        // camera's snapshot endpoint doesn't exist; retrying every 3s was the
+        // issue #112 death-loop. retryUnsupported() can re-arm it later.
+        if (intervals[id]) {
+          clearTimeout(intervals[id]);
+          delete intervals[id];
+        }
       },
-    };
-
-    fetchSnapshot(fetchOpts);
-    intervals[cameraId] = setInterval(() => fetchSnapshot(fetchOpts), intervalMs);
+      onResult: (id, result) => {
+        if (result === 'ok') {
+          failureCounts[id] = 0;
+        } else if (result !== 'unsupported') {
+          failureCounts[id] = (failureCounts[id] ?? 0) + 1;
+        }
+        // Don't re-arm on 'unsupported' (interval already cleared above). For
+        // ok/fail, schedule the next tick at the (possibly backed-off) interval.
+        if (result !== 'unsupported') {
+          intervals[id] = setTimeout(tick, effectiveInterval(id));
+        }
+      },
+    });
   }
 
   function stopRefresh(cameraId) {
     if (intervals[cameraId]) {
-      clearInterval(intervals[cameraId]);
+      clearTimeout(intervals[cameraId]);
       delete intervals[cameraId];
     }
+    delete failureCounts[cameraId];
+    // Remove from the unsupported set so the camera can be retried later (e.g.
+    // after the backend recovers, or when the user re-selects it). Previously a
+    // single 404 permanently marked it unsupported for the whole session.
+    noSnapshotSet.delete(cameraId);
     onUrlRevoke(cameraId);
     onLoadingChange(cameraId, false);
     onErrorChange(cameraId, false);
+  }
+
+  /** Re-arm refresh for a camera previously marked unsupported (404). */
+  function retryUnsupported(cameraId) {
+    noSnapshotSet.delete(cameraId);
+    if (!intervals[cameraId]) {
+      startRefresh(cameraId);
+    }
   }
 
   function isUnsupported(cameraId) {
@@ -112,5 +200,5 @@ export function createSnapshotManager(opts) {
     }
   }
 
-  return { startRefresh, stopRefresh, isUnsupported, stopAll };
+  return { startRefresh, stopRefresh, retryUnsupported, isUnsupported, stopAll };
 }

--- a/web/src/lib/stream-selection.ts
+++ b/web/src/lib/stream-selection.ts
@@ -300,10 +300,20 @@ export function buildCandidateChain(
   const available = new Set(resp ? resp.protocols.filter((p) => p.Available).map((p) => p.Protocol.toLowerCase()) : []);
 
   // (3) User override pins the chain to a single mode (if still usable).
-  if (opts.override && isProtocolUsable(opts.override, enc, caps, available)) {
-    return [
-      { mode: normalizeBackendProtocol(opts.override), backendProtocol: opts.override.toLowerCase(), pinned: true },
-    ];
+  // When the backend response is null (fetch failed, NOT "empty list"), we have
+  // no authoritative knowledge of availability, so validate the override with a
+  // permissive "all protocols available" set (codec gate still applies). When
+  // the backend responded — even with an empty list — honor the hard "no": a
+  // pinned protocol the backend says it can't serve would just storm. This
+  // preserves the override's value during a transient /protocols fetch failure
+  // while still protecting against the issue #112 empty-list storm.
+  if (opts.override) {
+    const overrideAvailable = resp ? available : new Set(['webrtc', 'flv', 'hls', 'll-hls', 'mjpeg', 'wasm']);
+    if (isProtocolUsable(opts.override, enc, caps, overrideAvailable)) {
+      return [
+        { mode: normalizeBackendProtocol(opts.override), backendProtocol: opts.override.toLowerCase(), pinned: true },
+      ];
+    }
   }
 
   // (4) Walk the preference order, keeping modes that are usable here.
@@ -329,13 +339,12 @@ export function buildCandidateChain(
   const chain: Candidate[] = [];
   for (const mode of PREFERENCE_ORDER) {
     const backendProto = modeToBackendProtocol(mode);
-    // `wasm` is a frontend-only mode — the backend doesn't advertise it. Gate
-    // purely on browser capability (WebCodecs, or libde265 WASM for H.265).
-    const usable =
-      mode === 'wasm'
-        ? caps.webCodecs || (enc === 'h265' && caps.wasmH265)
-        : isProtocolUsable(mode, enc, caps, available);
-    if (usable) {
+    // All modes (including wasm) consult isProtocolUsable, which gates on BOTH
+    // backend availability AND codec/caps. wasm is advertised by the backend as
+    // the "wasm" protocol (WSStreamHandler), so when the backend reports an
+    // empty protocol list, wasm is correctly excluded too — a wasm player would
+    // still hit the WS endpoint the backend says it can't serve (issue #112).
+    if (isProtocolUsable(mode, enc, caps, available)) {
       chain.push({ mode, backendProtocol: backendProto, pinned: false });
     }
   }
@@ -373,8 +382,27 @@ function modeToBackendProtocol(mode: CameraMode): string | undefined {
 }
 
 /**
- * Is a given protocol actually usable given codec + browser caps?
- * Used to validate a user override before honoring it.
+ * Is a given protocol actually usable given codec + browser caps + backend
+ * availability?
+ *
+ * Two gates, BOTH must pass for the named real-time protocols:
+ *  1. The backend must report the protocol as Available (consulted via the
+ *     `available` set built from /protocols). Without this, the frontend would
+ *     fabricate a chain of protocols the server cannot serve — e.g. an ONVIF
+ *     camera whose recorder is down reports `{protocols:[]}`, and a codec-only
+ *     gate would still return [webrtc,flv,hls], mounting players that storm the
+ *     backend with requests it rejects (issue #112).
+ *  2. The codec must be decodable in this browser (H.265 paths need MSE H.265
+ *     or wasm; WebRTC is H.264-only).
+ *
+ * `wasm` is the exception: it's a frontend-only mode the backend doesn't
+ * advertise, so it's gated purely on browser capability (handled by the caller
+ * via caps, not here).
+ *
+ * NOTE: when `available` is empty AND resp was null (fetch failed, not "empty
+ * list"), the caller (buildCandidateChain) short-circuits to a legacy default
+ * BEFORE reaching the preference walk — so an empty set here means "backend
+ * responded but listed nothing", which is a hard "no".
  */
 export function isProtocolUsable(
   protocol: string,
@@ -385,6 +413,16 @@ export function isProtocolUsable(
   const p = protocol.toLowerCase();
   const enc = encoding.toLowerCase();
 
+  // Backend availability gate (named real-time protocols only). The backend
+  // reports protocol names; HLS is advertised as 'll-hls' (see
+  // modeToBackendProtocol), so accept either spelling for the hls mode.
+  const backendAdvertised =
+    available.has(p) ||
+    (p === 'hls' && (available.has('ll-hls') || available.has('hls'))) ||
+    (p === 'll-hls' && (available.has('hls') || available.has('ll-hls')));
+  if (!backendAdvertised) return false;
+
+  // Codec / capability gate (the original behavior, now as a second filter).
   // WebRTC: H.264 only (backend handler enforces this, but the override path
   // may not have consulted the backend).
   if (p === 'webrtc') return enc !== 'h265';
@@ -399,6 +437,7 @@ export function isProtocolUsable(
   // Without it, hls.js connects via MSE but renders a permanent black screen.
   if (p === 'hls' || p === 'll-hls') return enc !== 'h265' || caps.h265MSE;
 
-  // If the backend explicitly listed it as available, trust it.
-  return available.has(p);
+  // Unknown protocol — fall back to the explicit listing (already checked
+  // backendAdvertised above, so this is just defensive).
+  return true;
 }

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -218,14 +218,74 @@
     if (ids.length === 0) return;
     const results = await Promise.allSettled(ids.map((id) => getCameraProtocols(id)));
     const next = new Map(cameraProtocols);
+    // Track which cameras returned an EMPTY protocol list — these are the
+    // "device temporarily unreachable / recorder not started" cases that need a
+    // backoff re-fetch (issue #112). Without re-fetch, the orchestrator would
+    // keep the camera on snapshot forever even after the device recovers.
+    const emptyIds: string[] = [];
     for (let i = 0; i < ids.length; i++) {
       const id = ids[i];
       const r = results[i];
-      next.set(id, r.status === 'fulfilled' ? r.value : null);
+      const value = r.status === 'fulfilled' ? r.value : null;
+      next.set(id, value);
+      // Only an explicitly-empty response (resp non-null but protocols empty)
+      // triggers re-fetch. A null resp (fetch threw) is handled by the
+      // orchestrator's !resp legacy-default path and re-fetches naturally on
+      // the next camera-list poll.
+      if (value && value.protocols.length === 0) {
+        emptyIds.push(id);
+      }
     }
     cameraProtocols = next;
     // Rebuild chains now that we have fresh backend rankings.
     syncOrchestrator();
+    // Arm backoff re-fetch for cameras whose backend reported nothing available.
+    // They render as snapshot in the meantime (no real-time player, no storm).
+    for (const id of emptyIds) {
+      scheduleEmptyProtocolsRecheck(id);
+    }
+  }
+
+  // ─── Empty-protocols backoff re-fetch (issue #112) ─────────────────────────
+  // When /protocols returns an empty list (device down / recorder starting),
+  // re-fetch with exponential backoff so the camera recovers automatically once
+  // the backend can serve it again. Per-camera timers; cleared on unmount or
+  // when a non-empty response arrives. Mirrors the auto-retry cadence used by
+  // the HLS error handler (5s/10s/20s/40s, max 4 attempts).
+  const PROTOCOLS_RECHECK_DELAYS = [5000, 10000, 20000, 40000];
+  let protocolsRecheckTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+  function scheduleEmptyProtocolsRecheck(cameraId: string, attempt = 0): void {
+    // Clear any existing timer for this camera (idempotent re-arm).
+    const existing = protocolsRecheckTimers[cameraId];
+    if (existing) clearTimeout(existing);
+    if (attempt >= PROTOCOLS_RECHECK_DELAYS.length) return; // exhausted
+    const delay = PROTOCOLS_RECHECK_DELAYS[attempt];
+    protocolsRecheckTimers[cameraId] = setTimeout(async () => {
+      delete protocolsRecheckTimers[cameraId];
+      try {
+        const resp = await getCameraProtocols(cameraId);
+        cameraProtocols = new Map(cameraProtocols).set(cameraId, resp);
+        syncOrchestrator();
+        // If still empty, schedule the next backoff tick. A non-empty response
+        // means recovery — stop re-fetching for this camera.
+        if (resp && resp.protocols.length === 0) {
+          scheduleEmptyProtocolsRecheck(cameraId, attempt + 1);
+        }
+      } catch {
+        // Fetch failed — treat like an empty response and keep backing off.
+        cameraProtocols = new Map(cameraProtocols).set(cameraId, null);
+        syncOrchestrator();
+        scheduleEmptyProtocolsRecheck(cameraId, attempt + 1);
+      }
+    }, delay);
+  }
+
+  function clearProtocolsRechecks(): void {
+    for (const id of Object.keys(protocolsRecheckTimers)) {
+      clearTimeout(protocolsRecheckTimers[id]);
+    }
+    protocolsRecheckTimers = {};
   }
 
   // (WasmPlayer preloading is handled by CameraPlayer, which lazy-imports the
@@ -409,6 +469,7 @@
       document.removeEventListener('fullscreenchange', handleFullscreenChange);
       document.removeEventListener('visibilitychange', visibilityHandler);
       window.fetch = originalFetch;
+      clearProtocolsRechecks();
       _orchUnsub();
       orchestrator.dispose();
     };


### PR DESCRIPTION
## Summary

Fixes #112 — the protocol-storm bug where MJPEG cameras (ESP32 MiBeeCam) thrashed through HLS/WebRTC/WS whenever the device was briefly unreachable.

Root cause: ONVIF auto-detect cameras carried `encoding=""` in DB/YAML (resolved at runtime by the recorder but never persisted). A brief outage left encoding empty → `/protocols` returned `{protocols:[]}` → the frontend fabricated a full `[webrtc,flv,hls]` chain against a stream the backend couldn't serve → request storm.

8 interlocking design flaws identified (see [issue #112 deep-dive comment](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues/112#issuecomment-5075739336)); this PR fixes all of them across 3 layers.

## P0 — Backend: persist resolved encoding (defects 1/2/3)

Mirrors the `stable_id` "probe once, persist forever" pattern (race-safe dual-write to config + DB):
- `ONVIFRecorder` stashes the resolved codec on `resolvedEncoding` + exposes `ResolvedEncoding()`
- DB: `UpdateCameraEncoding` / `UpdateCameraStreamEncoding` / `GetCameraEncoding` (single-column UPDATEs, mirroring `UpdateCameraStableID`)
- `ensureEncoding` goroutine (polling shape from `ensureProfileToken`) dual-writes after recorder Start
- `backfillEncoding` syncs YAML→DB at startup
- Triggered from `startRecorderLocked` alongside `ensureStableID`/`ensureProfileToken`

**Dual-write is required**: `UpsertCamera` is a full-row overwrite, so a config-only write would be clobbered by the next `UpdateCamera`/`RediscoverAndReconnect`/`Start`. Writing both `cm.cfg.Cameras[i].Encoding` AND the DB ensures the resolved value flows forward through every subsequent upsert.

## P1 — Frontend: gate protocol chain on backend availability (defects 4/6)

- `isProtocolUsable` named branches (webrtc/flv/hls/mjpeg/wasm) now consult the backend `available` set BEFORE the codec gate. An empty `/protocols` response yields an empty chain → grid falls to snapshot (the designed terminal state, now actually reachable) instead of fabricating `[webrtc,flv,hls]`.
- `Surveillance.svelte` arms exponential-backoff re-fetch (5/10/20/40s) for cameras whose `/protocols` returned empty, so they auto-recover to a real-time player once the backend can serve them again.
- Override validation distinguishes `resp=null` (fetch failed: trust the pin) from `resp={protocols:[]}` (explicit no: reject the pin).

## P2 — Frontend: end death-loops (defects 5/7/8)

- **HLS autoRetry** (`hls-errors.ts`): `createAutoRetryScheduler` gains `onGiveUp`/`hasGivenUp`. Once the 4-retry budget is exhausted the scheduler is dead for its lifetime — `clear()` no longer resets give-up, so a `visibilitychange` tab refocus (which resets `recreateAttempts`) now respects the terminal state. `VideoPlayer` tracks `streamGaveUp`, reset only on a genuine `streamUrl` change.
- **Protocol override** (`preferences.ts`): overrides carry a 24h TTL. A stale pin no longer forces a wrong protocol across sessions. Legacy bare-string entries read for backward compat. Orchestrator pinned-failed escape now CLEARs the localStorage override (was session-local only).
- **snapshotMgr** (`snapshot.js`): 404 now clears the interval (previously polled every 3s forever). Consecutive failures back off 3s→30s. `stopRefresh` removes from the unsupported set; new `retryUnsupported()` re-arms.

## Test plan

- [x] `internal/storage`: `TestUpdateCameraEncoding` + idempotency on missing row
- [x] `internal/camera`: `TestEnsureEncodingWritesBoth` (dual-write config+DB), `TestEnsureEncoding_NormalizesMJPEGToJPEG` (MJPEG→jpeg for player selection), `TestEnsureEncoding_IdempotentWhenAlreadySet`
- [x] `internal/recorder`: all existing tests pass (fixed a regression where moving `detectEncoding` out of `createDelegate` bypassed the test's `newRecorder` override)
- [x] `web`: `stream-selection` (45 tests, +3 empty-protocols cases), `orchestrator` (18 tests, fixture updated to include backend-advertised wasm), `hls-errors` (+2 give-up tests), `preferences` (+3 TTL/compat tests)
- [x] Full frontend build + 437 tests pass; full backend cross-compile (linux/arm64) pass

## M5 实测（PR 前必测）

Deployed to Banana Pi M5 (192.168.63.30), verified via browser + backend logs:

- **P0**: 4/5 previously-empty-encoding ONVIF cameras auto-persisted (`auto-persisted encoding` logs). MiBeeCam-S3 (.224) DB encoding: `""` → `jpeg`. `/protocols`: `{protocols:[],encoding:""}` → `{protocols:[{mjpeg,available}],encoding:"jpeg",default:"jpeg"}`.
- **T1**: MiBeeCam-S3 renders as **MJPEG** player with live video (健康分 100), not storming through HLS/WebRTC.
- **T3**: 60s window — **zero** `/stream/index.m3u8`, `/stream/webrtc`, `/stream/ws` requests against MiBeeCam-S3 (only 1 `/protocols` + 1 WS MJPEG register). Compare to pre-fix: every 5-10s HLS 400/401 death-loop.
- **T2**: MiBeeCam-AI (encoding still empty, device in cooldown) — `/protocols` returns `{protocols:[]}`, **zero** `/stream/*` requests in 90s (P1 empty-chain → snapshot, no storm).

## Files (18 changed, +898/-42)

**Backend**: `internal/recorder/onvif.go`, `internal/storage/db_camera.go` (+test), `internal/camera/{rediscovery,recorder_factory,manager}.go` (+test)
**Frontend**: `web/src/lib/{stream-selection,hls-errors,preferences,snapshot}.{ts,js}`, `web/src/lib/player/orchestrator.svelte.ts`, `web/src/components/VideoPlayer.svelte`, `web/src/routes/Surveillance.svelte` (+4 test files)
