### PR TITLE
fix(recordings): unbounded lightweight timeline endpoint (#115)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -194,6 +194,7 @@ func (h *Handler) Routes() http.Handler {
 		r.Route("/api/recordings", func(r chi.Router) {
 			r.Get("/", h.handleListRecordings)
 			r.Get("/daily-summary", h.handleDailyRecordingSummary)
+			r.Get("/timeline", h.handleTimelineSegments)
 			r.Post("/", h.handleCreateRecording)
 			r.Post("/timeline/seek-event", h.handleTimelineSeekEvent)
 			r.Post("/batch-delete", h.handleBatchDeleteRecordings)

--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -108,6 +108,53 @@ func (h *Handler) handleListRecordings(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleTimelineSegments returns the lightweight timeline projection of a day's
+// recordings for the recordings-page day strip and the player DVR bar. Unlike
+// handleListRecordings (capped at 500 full rows), this selects only 7 small
+// columns per row and caps at maxTimelineSegments (10k), so a full fragmented
+// day ships in one response without silently truncating the afternoon.
+//
+// Query params mirror handleListRecordings: start/end (RFC3339), camera_id,
+// format, merged. Sorting is fixed to started_at ASC (timelines render L→R).
+// Response: {segments: [...], total: N, truncated: bool}. Issue #115.
+//
+// GET /api/recordings/timeline
+func (h *Handler) handleTimelineSegments(w http.ResponseWriter, r *http.Request) {
+	filter := model.RecordingFilter{
+		CameraID: r.URL.Query().Get("camera_id"),
+		Format:   model.Format(r.URL.Query().Get("format")),
+	}
+	if v := r.URL.Query().Get("merged"); v != "" {
+		merged := v == "true" || v == "1"
+		filter.Merged = &merged
+	}
+	if v := r.URL.Query().Get("start"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.StartTime = t
+		}
+	}
+	if v := r.URL.Query().Get("end"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			filter.EndTime = t
+		}
+	}
+
+	segments, total, err := h.db.ListRecordingTimelineSegments(r.Context(), filter)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "failed to list timeline segments")
+		return
+	}
+	if segments == nil {
+		segments = []model.TimelineSegment{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"segments":  segments,
+		"total":     total,
+		"truncated": total > len(segments),
+	})
+}
+
 // handleDailyRecordingSummary returns per-day recording counts and format categories for
 // calendar rendering. Unlike handleListRecordings, this is a lightweight GROUP BY query
 // with no row-level limit — the result is bounded by the number of days in the range.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -87,6 +87,29 @@ type TimelapseMerge struct {
 	CompletedAt      time.Time `json:"completed_at,omitempty"`
 }
 
+// TimelineSegment is the lightweight projection of a Recording used only for
+// timeline rendering (the recordings-page day strip + the player DVR bar).
+// It omits file_path/merge_*/file_size/etc. to minimize bandwidth when a day
+// has thousands of segments — a full-day window for a fragmentation-prone
+// camera (Xiaomi AVI reconnect storms, ~5000+ segments/day) is ~10x smaller
+// than the full Recording projection. Issue #115: the full-row endpoint caps
+// at 500 rows and silently truncated the afternoon; this endpoint caps at
+// maxTimelineSegments (10k) and the rows are cheap enough to ship in bulk.
+//
+// Fields are exactly what DayTimeline.svelte / TimelineBar.svelte read:
+// id (seek navigation), camera_id + started_at + ended_at (band position),
+// duration (fallback when ended_at is null on the in-progress last segment),
+// format (color band), merge_status (pending "(N ⚠)" counter).
+type TimelineSegment struct {
+	ID          string    `json:"id"`
+	CameraID    string    `json:"camera_id"`
+	StartedAt   time.Time `json:"started_at"`
+	EndedAt     time.Time `json:"ended_at"`
+	Duration    float64   `json:"duration"`
+	Format      Format    `json:"format"`
+	MergeStatus string    `json:"merge_status"`
+}
+
 type Segment struct {
 	ID         string
 	CameraID   string

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -436,6 +436,73 @@ func (d *DB) CountRecordingsWithFilter(ctx context.Context, filter model.Recordi
 	return count, err
 }
 
+// maxTimelineSegments is the row ceiling for ListRecordingTimelineSegments. It
+// is deliberately much higher than the 500-row cap on handleListRecordings
+// because each timeline row carries only 7 small columns (~10x smaller than a
+// full Recording), so shipping a whole fragmented day in one response is cheap
+// and avoids the silent afternoon-truncation bug (issue #115). 10k covers the
+// worst observed fragmentation (Xiaomi reconnect storms ~5k/day) with headroom.
+const maxTimelineSegments = 10000
+
+// ListRecordingTimelineSegments returns the lightweight timeline projection of
+// recordings matching the filter. It reuses recordingsFilterWhere (so camera_id
+// / start / end / format / merged / archived all work) but selects only the 7
+// columns a timeline needs, forces ORDER BY started_at ASC (timelines always
+// render left-to-right), and caps at maxTimelineSegments.
+//
+// Returns (segments, total) where total is the unfiltered-by-limit match count
+// (via the cached CountRecordingsWithFilter) so the caller can set a truncated
+// flag. The cache key already omits Limit/Offset/Sort, so the count is correct
+// regardless of the 10k cap.
+func (d *DB) ListRecordingTimelineSegments(ctx context.Context, filter model.RecordingFilter) ([]model.TimelineSegment, int, error) {
+	defer d.observeQuery("ListRecordingTimelineSegments", time.Now())
+	where, args := recordingsFilterWhere(filter)
+
+	// 7-column projection — omit file_path/merge_*/file_size/frame_count/etc.
+	sqlstr := "SELECT id, camera_id, started_at, ended_at, duration, format, merge_status FROM recordings"
+	if len(where) > 0 {
+		sqlstr += " WHERE " + strings.Join(where, " AND ")
+	}
+	// Timeline always renders left→right; ignore caller SortBy/SortOrder.
+	sqlstr += " ORDER BY started_at ASC"
+	sqlstr += fmt.Sprintf(" LIMIT %d", maxTimelineSegments)
+	sqlstr += ";"
+
+	rows, err := d.readConn().QueryContext(ctx, sqlstr, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	res := make([]model.TimelineSegment, 0, 64)
+	for rows.Next() {
+		var s model.TimelineSegment
+		var startedAtStr, endedAtStr, mergeStatusStr sql.NullString
+		if err := rows.Scan(&s.ID, &s.CameraID, &startedAtStr, &endedAtStr, &s.Duration, &s.Format, &mergeStatusStr); err != nil {
+			return nil, 0, err
+		}
+		s.StartedAt = scanTime(startedAtStr)
+		s.EndedAt = scanTime(endedAtStr)
+		if mergeStatusStr.Valid && mergeStatusStr.String != "" {
+			s.MergeStatus = mergeStatusStr.String
+		} else {
+			s.MergeStatus = model.MergeStatusPending
+		}
+		res = append(res, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	// Total (uncapped) so the handler can flag truncation. Best-effort: a failed
+	// count must not fail the timeline render — mirror ListRecordingsWithTotal.
+	total, err := d.countRecordingsCached(ctx, filter)
+	if err != nil {
+		return res, len(res), nil
+	}
+	return res, total, nil
+}
+
 // DailyRecordingSummary returns per-day recording counts and format categories for the
 // given filter, grouped by local date. tzOffsetMinutes is the client's signed UTC offset
 // in minutes (e.g. 480 for UTC+8, -300 for UTC-5); 0 groups by UTC date. The result is

--- a/internal/storage/db_recording_test.go
+++ b/internal/storage/db_recording_test.go
@@ -55,3 +55,132 @@ func TestListRecordingsWithoutTranscode(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 0)
 }
+
+// TestListRecordingTimelineSegments covers the lightweight timeline projection
+// (issue #115): column projection, camera filter, time window, ASC ordering,
+// and the truncation flag. The full-row endpoint caps at 500 and was silently
+// dropping the afternoon; this endpoint's 7-column projection has no such
+// problem for realistic days.
+func TestListRecordingTimelineSegments(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC) // day window start
+
+	// 3 recordings for cam-A across the morning, 1 for cam-B, 1 the next day.
+	insert := func(id, cam string, offsetMin time.Duration, format model.Format, mergeStatus string) {
+		start := base.Add(offsetMin)
+		r := &model.Recording{
+			ID:          id,
+			CameraID:    cam,
+			FilePath:    "/" + cam + "/" + id + ".mp4",
+			Format:      format,
+			StartedAt:   start,
+			EndedAt:     start.Add(60 * time.Second),
+			Duration:    60,
+			FileSize:    4096,
+			FrameCount:  60,
+			MergeStatus: mergeStatus,
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+		// InsertRecording does not set merge_status post-insert for empty strings;
+		// force the merge_status we asked for via UpdateRecording when non-default.
+		if mergeStatus != "" && mergeStatus != model.MergeStatusPending {
+			r.MergeStatus = mergeStatus
+			require.NoError(t, db.UpdateRecording(ctx, r))
+		}
+	}
+	insert("a1", "cam-A", 1*time.Minute, model.FormatH264, model.MergeStatusMerged)
+	insert("a2", "cam-A", 2*time.Hour, model.FormatH264, model.MergeStatusPending)
+	insert("a3", "cam-A", 20*time.Hour, model.FormatH265, model.MergeStatusMerged) // late evening
+	insert("b1", "cam-B", 30*time.Minute, model.FormatMJPEG, model.MergeStatusMerged)
+	insert("a4", "cam-A", 26*time.Hour, model.FormatH264, model.MergeStatusMerged) // next day — outside window
+
+	dayStart := base
+	dayEnd := base.Add(24 * time.Hour)
+
+	// (1) Camera filter: only cam-A segments within the day.
+	segs, total, err := db.ListRecordingTimelineSegments(ctx, model.RecordingFilter{
+		CameraID:  "cam-A",
+		StartTime: dayStart,
+		EndTime:   dayEnd,
+	})
+	require.NoError(t, err)
+	require.Len(t, segs, 3, "cam-A has a1/a2/a3 within the day; a4 is next day, b1 is cam-B")
+	require.Equal(t, 3, total)
+	require.False(t, total > len(segs), "no truncation expected")
+
+	// (2) ASC ordering by started_at.
+	require.Equal(t, "a1", segs[0].ID)
+	require.Equal(t, "a2", segs[1].ID)
+	require.Equal(t, "a3", segs[2].ID, "evening segment (20h) must be present — the bug was afternoon truncation")
+
+	// (3) Only the 7 projected fields are populated; the rest are zero-valued.
+	//     (We can't assert "column not selected" directly, but we assert the
+	//     fields a timeline needs are correct.)
+	require.Equal(t, "cam-A", segs[2].CameraID)
+	require.Equal(t, model.FormatH265, segs[2].Format)
+	require.Equal(t, model.MergeStatusMerged, segs[2].MergeStatus)
+	require.Equal(t, float64(60), segs[2].Duration)
+	require.WithinDuration(t, base.Add(20*time.Hour), segs[2].StartedAt, time.Second)
+
+	// (4) No camera filter: all 4 segments within the day (a1,a2,a3,b1).
+	segsAll, totalAll, err := db.ListRecordingTimelineSegments(ctx, model.RecordingFilter{
+		StartTime: dayStart,
+		EndTime:   dayEnd,
+	})
+	require.NoError(t, err)
+	require.Len(t, segsAll, 4)
+	require.Equal(t, 4, totalAll)
+
+	// (5) merged=true filter keeps only the merged rows.
+	mergedTrue := true
+	segsMerged, _, err := db.ListRecordingTimelineSegments(ctx, model.RecordingFilter{
+		StartTime: dayStart,
+		EndTime:   dayEnd,
+		Merged:    &mergedTrue,
+	})
+	require.NoError(t, err)
+	require.Len(t, segsMerged, 3, "a1(merged), a3(merged), b1(merged); a2 is pending")
+
+	// (6) Empty window → empty result, no error.
+	segsEmpty, totalEmpty, err := db.ListRecordingTimelineSegments(ctx, model.RecordingFilter{
+		CameraID:  "cam-A",
+		StartTime: base.Add(48 * time.Hour),
+		EndTime:   base.Add(49 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Empty(t, segsEmpty)
+	require.Equal(t, 0, totalEmpty)
+}
+
+// TestListRecordingTimelineSegments_Truncation verifies the truncation flag is
+// reported correctly when a window exceeds maxTimelineSegments. We can't insert
+// 10k+ rows cheaply, so this asserts the (total > len) contract directly via a
+// focused unit check of the invariants the handler relies on.
+func TestListRecordingTimelineSegments_Truncation(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 7, 24, 0, 0, 0, 0, time.UTC)
+
+	// Insert a handful; total will be < maxTimelineSegments → truncated is false.
+	for i := range 5 {
+		require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+			ID:        "t" + string(rune('a'+i)),
+			CameraID:  "cam-T",
+			FilePath:  "/t.mp4",
+			Format:    model.FormatH264,
+			StartedAt: base.Add(time.Duration(i) * time.Minute),
+		}))
+	}
+	segs, total, err := db.ListRecordingTimelineSegments(ctx, model.RecordingFilter{
+		CameraID:  "cam-T",
+		StartTime: base,
+		EndTime:   base.Add(24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Len(t, segs, 5)
+	require.Equal(t, 5, total)
+	// The handler computes `truncated = total > len(segments)`. With total == len,
+	// it must be false — proving the flag is accurate when not capped.
+	require.False(t, total > len(segs))
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -177,6 +177,7 @@ export {
   fetchTimelapsePreview,
   recordTimelineSeek,
   getRecordingDailySummary,
+  getRecordingsTimeline,
 } from './recordings';
 
 export type {
@@ -192,6 +193,8 @@ export type {
   ArchiveListResponse,
   TimelapseFrame,
   TimelapsePreviewFrame,
+  RecordingTimelineSegment,
+  RecordingTimelineResponse,
 } from './recordings';
 
 // Timelapse merges — periodic-merge outputs (8h / 12h / 24h / natural-day / 7d / 30d)

--- a/web/src/lib/api/recordings.ts
+++ b/web/src/lib/api/recordings.ts
@@ -159,6 +159,58 @@ export async function getRecording(id: string, signal?: AbortSignal): Promise<Re
   return apiRequest<Recording>(`/recordings/${id}`, { signal });
 }
 
+// RecordingTimelineSegment is the lightweight projection of a Recording used
+// for timeline rendering only. It carries the 7 fields the timeline components
+// (DayTimeline / TimelineBar) actually read — omitting file_path/merge_*/
+// file_size/frame_count etc. — so a full fragmented day (~5000 segments for a
+// Xiaomi reconnect storm) ships in ~10x less bandwidth than a full Recording
+// list and never hits the 500-row cap that truncated the afternoon (issue #115).
+//
+// Named "Recording..." (not "TimelineSegment") to avoid colliding with the
+// local TimelineSegment type inside TimelineBar.svelte.
+export interface RecordingTimelineSegment {
+  id: string;
+  camera_id: string;
+  started_at: string;
+  ended_at: string;
+  duration: number;
+  format: Recording['format'];
+  merge_status: Recording['merge_status'];
+}
+
+export interface RecordingTimelineResponse {
+  segments: RecordingTimelineSegment[];
+  total: number;
+  truncated: boolean; // true when the day exceeded the backend cap (maxTimelineSegments)
+}
+
+// getRecordingsTimeline fetches the lightweight day-window timeline for the
+// recordings-page day strip and the player DVR bar. Sorting is fixed to
+// started_at ASC server-side; the cap (10k) is also server-side, so this client
+// takes no limit/sort_by/order params. Issue #115.
+export async function getRecordingsTimeline(
+  params: {
+    camera_id?: string;
+    format?: string;
+    merged?: boolean;
+    start?: string; // RFC3339 day-start
+    end?: string; // RFC3339 day-end
+    signal?: AbortSignal;
+  } = {},
+): Promise<RecordingTimelineResponse> {
+  const queryParams = new URLSearchParams();
+  if (params.camera_id) queryParams.set('camera_id', params.camera_id);
+  if (params.format) queryParams.set('format', params.format);
+  if (params.merged !== undefined) queryParams.set('merged', String(params.merged));
+  if (params.start) queryParams.set('start', params.start);
+  if (params.end) queryParams.set('end', params.end);
+
+  const query = queryParams.toString();
+  const endpoint = query ? `/recordings/timeline?${query}` : '/recordings/timeline';
+  const { signal } = params;
+  return apiRequest<RecordingTimelineResponse>(endpoint, { signal });
+}
+
 export async function deleteRecording(id: string, signal?: AbortSignal): Promise<{ status: string }> {
   return apiRequest<{ status: string }>(`/recordings/${id}`, {
     method: 'DELETE',

--- a/web/src/lib/components/DayTimeline.svelte
+++ b/web/src/lib/components/DayTimeline.svelte
@@ -14,9 +14,18 @@
   import { t } from '$lib/i18n';
   import { Clock } from 'lucide-svelte';
 
+  // Minimal shape DayTimeline actually reads from each recording. Accepting this
+  // subset (instead of the full Recording) lets the page pass the lightweight
+  // RecordingTimelineSegment[] from /api/recordings/timeline (issue #115) without
+  // a cast — both Recording and RecordingTimelineSegment satisfy it.
+  type TimelineRecording = Pick<
+    Recording,
+    'id' | 'camera_id' | 'started_at' | 'ended_at' | 'duration' | 'format' | 'merge_status'
+  >;
+
   interface Props {
     cameras: Camera[];
-    recordings: Recording[];
+    recordings: TimelineRecording[];
     selectedDate: string; // YYYY-MM-DD
     onseek: (recordingId: string, offsetSeconds: number) => void;
     aiEvents?: unknown[]; // reserved for stage E (AI event markers)
@@ -46,7 +55,7 @@
 
   const rows = $derived.by<CameraRow[]>(() => {
     // Group recordings by camera
-    const byCam = new Map<string, Recording[]>();
+    const byCam = new Map<string, TimelineRecording[]>();
     for (const r of recordings) {
       const list = byCam.get(r.camera_id) ?? [];
       list.push(r);

--- a/web/src/lib/components/TimelineBar.svelte
+++ b/web/src/lib/components/TimelineBar.svelte
@@ -12,7 +12,7 @@
    *   - Hit a segment → onSeek(recordingId, offsetSecondsWithinSegment)
    *   - Hit a gap (no recording) → snap to nearest segment edge + warn
    */
-  import { listRecordings, type Recording } from '$lib/api';
+  import { getRecordingsTimeline, type Recording, type RecordingTimelineSegment } from '$lib/api';
   import { listAIEvents, type AIEvent } from '$lib/api/ai-events';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/format';
@@ -34,7 +34,12 @@
     showEvents?: boolean;
   } = $props();
 
-  let segments = $state<Array<{ rec: Recording; startSec: number; endSec: number }>>([]);
+  // Each segment carries the lightweight RecordingTimelineSegment projection
+  // (7 fields) from /api/recordings/timeline — issue #115. The old path used
+  // /api/recordings with limit=10000, but the backend clamped that to 500 full
+  // rows, silently dropping the afternoon on fragmented cameras. The lightweight
+  // endpoint caps at 10k and the rows are ~10x smaller.
+  let segments = $state<Array<{ rec: RecordingTimelineSegment; startSec: number; endSec: number }>>([]);
   let aiEvents = $state<AIEvent[]>([]);
   let loading = $state(false);
   let error = $state('');
@@ -135,22 +140,19 @@
       // Local-midnight range (see loadAIEvents comment).
       const startISO = new Date(y, m - 1, dd, 0, 0, 0).toISOString();
       const endISO = new Date(y, m - 1, dd, 23, 59, 59).toISOString();
-      const resp = await listRecordings({
+      // Lightweight timeline endpoint (issue #115): the old /api/recordings call
+      // with limit=10000 was silently clamped to 500 full rows by the backend,
+      // dropping the afternoon on fragmented cameras. This endpoint caps at 10k
+      // 7-column rows and ships ~10x less data per day.
+      const resp = await getRecordingsTimeline({
         camera_id: cid,
         start: startISO,
         end: endISO,
-        sort_by: 'started_at',
-        order: 'asc',
-        // Same fragmentation cap as Recordings.svelte loadTimelineData (10000):
-        // a single badly-fragmented camera can produce thousands of short
-        // segments/day. asc + a low cap silently truncates the day so the
-        // afternoon appears empty on this per-camera DVR bar.
-        limit: 10000,
       });
 
       const dayStartMs = new Date(y, m - 1, dd).getTime();
 
-      segments = resp.recordings
+      segments = resp.segments
         .map((rec) => {
           const sMs = Date.parse(rec.started_at);
           const eMs = rec.ended_at ? Date.parse(rec.ended_at) : sMs + rec.duration * 1000;
@@ -162,7 +164,7 @@
             endSec: eMs,
           };
         })
-        .filter((x): x is { rec: Recording; startSec: number; endSec: number } => x !== null);
+        .filter((x): x is { rec: RecordingTimelineSegment; startSec: number; endSec: number } => x !== null);
 
       // --- Auto-compute visible window ---
       if (segments.length > 0) {

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -539,6 +539,7 @@
   "library.viewTimelapse": "Timelapse",
   "library.timelapseOnly": "Timelapse recordings only",
   "library.videoOnly": "Video recordings only",
+  "library.timelineTruncated": "This day has more recordings than the timeline cap — only the first {count} are shown. Use list view for the complete set.",
   "live.backToCameras": "Back to Cameras",
   "live.cameraIdRequired": "Camera ID is required",
   "live.error": "Stream error",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -539,6 +539,7 @@
   "library.viewTimelapse": "延时摄影",
   "library.timelapseOnly": "仅延时摄影录像",
   "library.videoOnly": "仅视频录像",
+  "library.timelineTruncated": "当天录像段数超过时间轴上限，仅显示前 {count} 段，完整数据请使用列表视图。",
   "live.backToCameras": "返回摄像头",
   "live.cameraIdRequired": "摄像头 ID 为必填项",
   "live.error": "流错误",

--- a/web/src/routes/Recordings.svelte
+++ b/web/src/routes/Recordings.svelte
@@ -11,13 +11,14 @@
     subscribeTimelapseMergeProgress,
     listTimelapseMerges,
     getRecordingDailySummary,
+    getRecordingsTimeline,
   } from '$lib/api';
   import type { TimelapseMerge } from '$lib/api';
   import type { ManagerStatus, TranscodeTask } from '$lib/api/transcoding';
   import { getTranscodingStatus, enqueueTranscodeTask, cancelTranscodeTask } from '$lib/api/transcoding';
   import { getItemsPerPage, getAutoRefresh, parseRefreshInterval } from '../lib/preferences';
 
-  import type { Recording, Camera, RecordingDaySummary } from '$lib/api';
+  import type { Recording, Camera, RecordingDaySummary, RecordingTimelineSegment } from '$lib/api';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/format';
   import { showToast } from '$lib/toast';
@@ -87,7 +88,11 @@
   let viewMode = $state<'timeline' | 'list' | 'timelapse'>(initialViewMode);
 
   // ── Timeline data (all recordings for the selected day, grouped by camera in-component) ──
-  let timelineRecordings = $state<Recording[]>([]);
+  // Uses the lightweight RecordingTimelineSegment (7 fields) from
+  // /api/recordings/timeline instead of the full Recording — issue #115: the
+  // full-row endpoint caps at 500 and silently truncated the afternoon on
+  // fragmented days. The lightweight endpoint caps at 10k and ships ~10x less.
+  let timelineRecordings = $state<RecordingTimelineSegment[]>([]);
   let timelineLoading = $state(false);
   let timelineTruncated = $state(false);
   let timelineAbortController: AbortController | null = null;
@@ -364,23 +369,18 @@ let selectedPresetCamera = $state<string>('');
     try {
       const dayStart = new Date(selectedDate + 'T00:00:00');
       const dayEnd = new Date(selectedDate + 'T23:59:59.999');
-      // 0.10.1: reduced from 10000 to 500 — the backend now enforces a default
-      // limit clamp of 50 and max 500. For most days this covers the full day.
-      // For badly-fragmented days (Xiaomi reconnection storms, 5000+/day), the
-      // timeline will show the first 500 segments. Users can switch to list
-      // view for pagination. This trades edge-case completeness for a 20×
-      // bandwidth reduction on every timeline refresh (~5MB → ~250KB per day).
-      const response = await listRecordings({
+      // Lightweight timeline endpoint (issue #115): 7-column projection with a
+      // 10k cap and fixed ASC order. The old path used /api/recordings with
+      // limit=500 + asc, which silently dropped everything after the first 500
+      // segments on fragmented days (Xiaomi storms ~5k/day) — the afternoon
+      // vanished from the timeline even though the recordings existed.
+      const response = await getRecordingsTimeline({
         start: dayStart.toISOString(),
         end: dayEnd.toISOString(),
-        sort_by: 'started_at',
-        order: 'asc',
-        limit: 500,
         signal: timelineAbortController.signal,
       });
-      timelineRecordings = response.recordings;
-      // If there are more recordings than the limit, show a notice.
-      timelineTruncated = response.total > response.recordings.length;
+      timelineRecordings = response.segments;
+      timelineTruncated = response.truncated;
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') return;
       // Non-fatal: timeline stays stale on error
@@ -954,6 +954,13 @@ let selectedPresetCamera = $state<string>('');
         {:else}
           <div class="card p-4 border th-border">
             <p class="text-xs th-text-tertiary mb-2">{t('library.videoOnly')}</p>
+            {#if timelineTruncated}
+              <div class="flex items-start gap-2 mb-3 p-2 rounded border text-xs th-text-secondary"
+                   style="background: rgba(234, 179, 8, 0.08); border-color: rgba(234, 179, 8, 0.35);">
+                <AlertCircle size={14} class="mt-0.5 shrink-0" style="color: #eab308;" />
+                <span>{t('library.timelineTruncated', { count: timelineRecordings.length })}</span>
+              </div>
+            {/if}
             <DayTimeline
               {cameras}
               recordings={timelineRecordingsVideo}
@@ -1011,6 +1018,13 @@ let selectedPresetCamera = $state<string>('');
 
           <div class="card p-4 border th-border">
             <p class="text-xs th-text-tertiary mb-2">{t('library.timelapseOnly')}</p>
+            {#if timelineTruncated}
+              <div class="flex items-start gap-2 mb-3 p-2 rounded border text-xs th-text-secondary"
+                   style="background: rgba(234, 179, 8, 0.08); border-color: rgba(234, 179, 8, 0.35);">
+                <AlertCircle size={14} class="mt-0.5 shrink-0" style="color: #eab308;" />
+                <span>{t('library.timelineTruncated', { count: timelineRecordings.length })}</span>
+              </div>
+            {/if}
             <DayTimeline
               {cameras}
               recordings={timelineRecordingsTimelapse}


### PR DESCRIPTION
## 修复 issue #115：录像页时间轴被 limit clamp 截断

Closes #115

## 问题
录像页日时间轴和播放器 DVR 条都通过 `GET /api/recordings`（`order=asc` + `limit`）获取数据。后端把该端点的 limit 硬 clamp 到 500（防全表扫描），ASC 排序下只能返回当天前 500 段——**段数多的日子（小米 AVI 重连风暴 ~2000-3000 段/天）下午和晚上静默从时间轴消失**，但录像本身存在。`timelineTruncated` 标志被计算却从未渲染，用户完全无感知。

## 修复
新增专用轻量端点 `GET /api/recordings/timeline`：
- 只返回时间轴组件实际读取的 **7 个字段**（`id/camera_id/started_at/ended_at/duration/format/merge_status`），而非全字段的 16 列
- 上限 **10000 段**（覆盖最坏重连风暴 ~5k/天，留余量）——单行 ~10x 更小，全天批量返回仍很便宜
- 排序固定 `started_at ASC`（时间轴恒左→右渲染）

两个时间轴 surface 都切到新端点：
- `Recordings.svelte` → `DayTimeline`（录像页日时间轴）
- `TimelineBar.svelte` → 播放器内 DVR 条

同时把一直死掉的 `timelineTruncated` 标志渲染成可见的警告横幅（issue 的 Bug 3），作为未来任何截断的兜底提示。

`GET /api/recordings` 的 500 clamp **保留**——列表视图分页和 MiBeeVision API 都依赖它防全表扫描。

## 改动
| 文件 | 改动 |
|------|------|
| `internal/model/types.go` | 新增 `TimelineSegment` 类型（7 字段） |
| `internal/storage/db_recording.go` | 新增 `ListRecordingTimelineSegments`（复用 `recordingsFilterWhere`，固定 ASC，cap 10k）+ `maxTimelineSegments` 常量 |
| `internal/api/handlers_recording.go` | 新增 `handleTimelineSegments` handler |
| `internal/api/handler.go` | 注册 `GET /timeline` 路由（`/{id}` 之前） |
| `internal/storage/db_recording_test.go` | 新增 2 个测试（字段投影/过滤/排序 + 截断标志） |
| `web/src/lib/api/recordings.ts` | 新增 `RecordingTimelineSegment` 类型 + `getRecordingsTimeline` |
| `web/src/lib/api/index.ts` | barrel 导出 |
| `web/src/lib/components/DayTimeline.svelte` | props 类型放宽为 `Pick<Recording, 7字段>` |
| `web/src/lib/components/TimelineBar.svelte` | `loadSegments` 切换到新端点 |
| `web/src/routes/Recordings.svelte` | `loadTimelineData` 切换 + 截断警告横幅 |
| `web/src/lib/i18n/{en,zh}.json` | `library.timelineTruncated` 文案 |

## 验证（PR 前硬约束，AGENTS.md）
- ✅ `make build` / `make cross`（ARM64）通过
- ✅ `cd web && npm test`：437 测试全绿
- ✅ `go vet`（model/api/storage）干净
- ✅ 部署 Banana Pi M5（`63.30`），服务 healthy，7 摄像头正常
- ✅ **后端 API 直测**：Jul 24 返回全部 **2014 段**（旧端点 500），`truncated=false`
- ✅ **浏览器实测**（录像页 + 播放器）：
  - Jul 20（2175 段）日时间轴：多摄像头 **99-100% 全天覆盖**（旧 bug 下约 25-30%）
  - 播放器 DVR 条：单摄像头 **346 段**全天显示（23:00:12 – 次日 00:59:59）
  - 无截断警告横幅（未超 10k 上限，符合预期）
- ✅ 后端日志：所有 `/api/recordings/timeline` 请求 `status=200`（27-167ms），无报错
- ✅ storage 测试在 M5（ARM64/Linux）实跑通过

## 不改动
- `GET /api/recordings` 的 500 clamp（列表分页 + MiBeeVision 依赖）
- `GET /api/recordings/daily-summary`（服务日历聚合，独立端点）
- `handleListArchiveRecordings` 的 clamp 不一致（不在本 issue 范围）