### PR TITLE
fix(recordings): delete merged MP4 output on recording delete + reclaim-orphan-merges repair (#117)

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -47,6 +49,8 @@ func runRepair() int {
 		return runRepairDeleteByFormat()
 	case "prune-intermediate-mp4":
 		return runRepairPruneIntermediateMP4()
+	case "reclaim-orphan-merges":
+		return runRepairReclaimOrphanMerges()
 	case "--help", "-h":
 		printRepairUsage()
 		return 0
@@ -999,6 +1003,143 @@ func runRepairPruneIntermediateMP4() int {
 	return 0
 }
 
+// runRepairReclaimOrphanMerges implements `repair reclaim-orphan-merges`: a
+// one-shot reclaim of merged-output MP4 files left on disk after their
+// recording rows were deleted via the web UI before the #117 fix shipped.
+//
+// The merged MP4 (recordings.merge_path) is written by the rolling/segment
+// merge into the nested tree <rootDir>/<cameraID>/YYYYMM/DD/HH/. The recording
+// delete paths historically only removed file_path, so the merge output leaked
+// — and the automatic orphan scanner (cleanOrphansForCamera) never reaches
+// that nested tree, so the leak was permanent. This command closes the gap for
+// already-leaked historical files. Going forward, the delete paths reclaim
+// merge_path themselves.
+//
+// For each .mp4 under the camera tree that is not referenced by any
+// recording's file_path or merge_path (PathIsRecordingFile), it removes the
+// file. Only *.mp4 files are considered — source frame directories and the
+// raw segment files are never touched.
+//
+// Safety:
+//   - Per-camera by default (--camera); omit --camera to scan ALL cameras.
+//   - --limit caps the count for bounded runs.
+//   - --dry-run default; --execute to apply. 20ms throttle between deletes.
+func runRepairReclaimOrphanMerges() int {
+	opts := parseRepairFlags(3)
+	if opts.configPath == "__help__" {
+		printRepairReclaimOrphanMergesUsage()
+		return 0
+	}
+
+	db, cfg, err := openDBFromConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx, cancel := setupSignalHandler()
+	defer cancel()
+
+	mode := "DRY RUN (no changes)"
+	if !opts.dryRun {
+		mode = "EXECUTE"
+	}
+	fmt.Printf("repair reclaim-orphan-merges — %s\n", mode)
+	if opts.cameraID != "" {
+		fmt.Printf("  camera: %s\n", opts.cameraID)
+	} else {
+		fmt.Println("  camera: (all cameras)")
+	}
+	if opts.limit > 0 {
+		fmt.Printf("  limit:  %d orphan files\n", opts.limit)
+	}
+	fmt.Println()
+
+	rootDir := cfg.Storage.RootDir
+	// Determine the camera directories to scan.
+	var cameras []string
+	if opts.cameraID != "" {
+		cameras = []string{opts.cameraID}
+	} else {
+		entries, err := os.ReadDir(rootDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading storage root %q: %v\n", rootDir, err)
+			return 1
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				cameras = append(cameras, e.Name())
+			}
+		}
+	}
+
+	reclaimedCount := 0
+	skippedReferenced := 0
+	totalBytes := int64(0)
+	limitHit := false
+	for _, cam := range cameras {
+		if limitHit {
+			break
+		}
+		camRoot := filepath.Join(rootDir, cam)
+		// Recursively walk the camera tree. Only .mp4 files at the leaf
+		// (YYYYMM/DD/HH/) level are candidates — that is where merge_path lives.
+		walkErr := filepath.WalkDir(camRoot, func(path string, d os.DirEntry, werr error) error {
+			if werr != nil {
+				return nil // tolerate FS errors (e.g. a vanished file), keep scanning
+			}
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".mp4") {
+				return nil
+			}
+			if opts.limit > 0 && reclaimedCount >= opts.limit {
+				limitHit = true
+				return filepath.SkipDir
+			}
+			referenced, err := db.PathIsRecordingFile(ctx, cam, path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "  WARN: PathIsRecordingFile(%s): %v\n", path, err)
+				return nil
+			}
+			if referenced {
+				skippedReferenced++
+				return nil
+			}
+			var size int64
+			if st, err := os.Stat(path); err == nil {
+				size = st.Size()
+			}
+			if opts.dryRun {
+				totalBytes += size
+				fmt.Printf("  [dry-run] would reclaim: %s  (%s)\n", path, humanBytes(size))
+				reclaimedCount++
+				return nil
+			}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "  WARN: failed to remove %s: %v\n", path, err)
+				return nil
+			}
+			reclaimedCount++
+			totalBytes += size
+			time.Sleep(20 * time.Millisecond) // friendly to USB HDD
+			return nil
+		})
+		if walkErr != nil && walkErr != filepath.SkipDir {
+			fmt.Fprintf(os.Stderr, "  WARN: walk %s: %v\n", camRoot, walkErr)
+		}
+	}
+
+	fmt.Println()
+	fmt.Printf("Summary: reclaimed %d orphan merge MP4s (%s freed)\n", reclaimedCount, humanBytes(totalBytes))
+	if skippedReferenced > 0 {
+		fmt.Printf("  skipped (still referenced by a recording): %d\n", skippedReferenced)
+	}
+	if opts.dryRun && reclaimedCount > 0 {
+		fmt.Println("\nThis was a DRY RUN. Re-run with --execute to apply.")
+	}
+	return 0
+}
+
 // humanBytes formats a byte count as a human-readable string (KB/MB/GB).
 func humanBytes(b int64) string {
 	const (
@@ -1098,6 +1239,9 @@ Subcommands:
                          (e.g. delete regular video while keeping every timelapse segment)
   prune-intermediate-mp4 Bulk-remove per-segment rolling-merge .mp4 outputs that have
                          already been folded into a periodic (8h/24h/7d/30d) merge output
+  reclaim-orphan-merges Remove merged-output .mp4 files left on disk after their recording
+                         row was deleted via the web UI (pre-#117 fix leak). Only touches
+                         unreferenced .mp4 files; never source segments or frame dirs.
 
 Common options:
   --dry-run      Report what would change without modifying (default)
@@ -1292,6 +1436,45 @@ Options:
   --execute              Actually prune files + clear DB pointers
   --config <path>        Config file path (default: mibee-nvr.yaml)
   --help, -h             Show this help
+`)
+}
+
+func printRepairReclaimOrphanMergesUsage() {
+	fmt.Print(`Usage: mibee-nvr repair reclaim-orphan-merges [options]
+
+Reclaim merged-output .mp4 files left on disk after their recording row was
+deleted via the web UI before the #117 fix shipped. The rolling/segment merge
+writes each recording's merged MP4 into the nested tree
+  <rootDir>/<cameraID>/YYYYMM/DD/HH/<cameraID>_<ts>_<uuid>.mp4
+and records its path in recordings.merge_path. Before the #117 fix, deleting a
+recording removed the DB row and the source file (file_path) but left the
+merged MP4 behind — and the automatic orphan scanner never reaches that nested
+tree, so the file leaked permanently. This command reclaims those historical
+leaks. (Going forward, the delete paths reclaim merge_path themselves.)
+
+For each .mp4 under the camera tree, it asks the DB whether any recording still
+references it (as file_path OR merge_path); if not, the file is removed. Only
+unreferenced .mp4 files are touched — source frame directories and the raw
+segment files are never deleted.
+
+Examples:
+
+  # Dry-run: see what would be reclaimed across all cameras
+  mibee-nvr repair reclaim-orphan-merges
+
+  # Dry-run for one camera
+  mibee-nvr repair reclaim-orphan-merges --camera=front-door
+
+  # Apply (one camera, bounded)
+  mibee-nvr repair reclaim-orphan-merges --camera=front-door --limit 200 --execute
+
+Options:
+  --camera <id>      Limit to one camera (optional; omit for all cameras)
+  --limit <n>        Cap the number of orphan files removed (0 = no limit)
+  --dry-run          Report only, no changes (default)
+  --execute          Actually remove orphan files
+  --config <path>    Config file path (default: mibee-nvr.yaml)
+  --help, -h         Show this help
 `)
 }
 

--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -1087,7 +1088,10 @@ func runRepairReclaimOrphanMerges() int {
 		// (YYYYMM/DD/HH/) level are candidates — that is where merge_path lives.
 		walkErr := filepath.WalkDir(camRoot, func(path string, d os.DirEntry, werr error) error {
 			if werr != nil {
-				return nil // tolerate FS errors (e.g. a vanished file), keep scanning
+				// Tolerate per-entry FS errors (e.g. a file vanished mid-scan)
+				// by reporting and continuing the walk, rather than aborting.
+				fmt.Fprintf(os.Stderr, "  WARN: walk error at %s: %v\n", path, werr)
+				return nil
 			}
 			if d.IsDir() || !strings.HasSuffix(d.Name(), ".mp4") {
 				return nil
@@ -1124,7 +1128,7 @@ func runRepairReclaimOrphanMerges() int {
 			time.Sleep(20 * time.Millisecond) // friendly to USB HDD
 			return nil
 		})
-		if walkErr != nil && walkErr != filepath.SkipDir {
+		if walkErr != nil && !errors.Is(walkErr, filepath.SkipDir) {
 			fmt.Fprintf(os.Stderr, "  WARN: walk %s: %v\n", camRoot, walkErr)
 		}
 	}

--- a/internal/api/handlers_archive.go
+++ b/internal/api/handlers_archive.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -154,7 +155,14 @@ func (h *Handler) handleDeleteArchiveRecording(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Delete file from disk (non-fatal)
+	// Delete on-disk files (non-fatal). Reclaim the merged MP4 (merge_path) too
+	// — it is the largest artifact and would otherwise leak permanently.
+	// Mirrors handleDeleteRecording / handleTimelapseDelete.
+	if rec.MergePath != "" {
+		if err := os.RemoveAll(rec.MergePath); err != nil {
+			logger.Warn("failed to delete archived merged file", "merge_path", rec.MergePath, "error", err)
+		}
+	}
 	if rec.FilePath != "" {
 		if err := h.store.DeleteFile(rec.FilePath); err != nil {
 			logger.Warn("failed to delete archived recording file", "file_path", rec.FilePath, "error", err)

--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -452,7 +452,16 @@ func (h *Handler) handleDeleteRecording(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Then delete file (non-fatal if fails)
+	// Then delete on-disk files (non-fatal if they fail).
+	// The merged MP4 (merge_path) is the largest artifact and the one playback
+	// actually loads; without this it leaked permanently because the orphan
+	// scanner never reaches the nested YYYYMM/DD/HH/ tree. Mirrors
+	// handleTimelapseDelete. os.RemoveAll tolerates a missing path.
+	if rec.MergePath != "" {
+		if err := os.RemoveAll(rec.MergePath); err != nil {
+			logger.Warn("failed to delete merged file", "merge_path", rec.MergePath, "error", err)
+		}
+	}
 	if rec.FilePath != "" {
 		if err := h.store.DeleteFile(rec.FilePath); err != nil {
 			logger.Warn("failed to delete file", "file_path", rec.FilePath, "error", err)
@@ -480,16 +489,20 @@ func (h *Handler) handleBatchDeleteRecordings(w http.ResponseWriter, r *http.Req
 		WriteError(w, http.StatusBadRequest, "ids must not exceed 100")
 		return
 	}
-	// Fetch file paths before batch delete
-	filePaths := map[string]string{}
+	// Fetch on-disk paths before batch delete (need both source file_path and
+	// the merged MP4 merge_path — see handleDeleteRecording for why merge_path
+	// must be reclaimed here too).
+	type recPaths struct {
+		filePath  string
+		mergePath string
+	}
+	paths := map[string]recPaths{}
 	recordings, err := h.db.GetRecordingsByIDBatch(ctx, body.IDs)
 	if err != nil {
 		logger.Warn("batch delete: failed to fetch recordings", "error", err)
 	} else {
 		for _, rec := range recordings {
-			if rec.FilePath != "" {
-				filePaths[rec.ID] = rec.FilePath
-			}
+			paths[rec.ID] = recPaths{filePath: rec.FilePath, mergePath: rec.MergePath}
 		}
 	}
 
@@ -505,9 +518,18 @@ func (h *Handler) handleBatchDeleteRecordings(w http.ResponseWriter, r *http.Req
 	deletedSet := make(map[string]bool, len(deleted))
 	for _, id := range deleted {
 		deletedSet[id] = true
-		if fp, ok := filePaths[id]; ok {
-			if err := h.store.DeleteFile(fp); err != nil {
-				logger.Warn("batch delete: failed to delete file", "file_path", fp, "error", err)
+		p, ok := paths[id]
+		if !ok {
+			continue
+		}
+		if p.mergePath != "" {
+			if err := os.RemoveAll(p.mergePath); err != nil {
+				logger.Warn("batch delete: failed to delete merged file", "merge_path", p.mergePath, "error", err)
+			}
+		}
+		if p.filePath != "" {
+			if err := h.store.DeleteFile(p.filePath); err != nil {
+				logger.Warn("batch delete: failed to delete file", "file_path", p.filePath, "error", err)
 			}
 		}
 	}

--- a/internal/api/handlers_recording_test.go
+++ b/internal/api/handlers_recording_test.go
@@ -270,3 +270,86 @@ func TestBatchDeleteRecordings_Success(t *testing.T) {
 	got2, _ := db.GetRecording(context.Background(), "batch-2")
 	require.Nil(t, got2)
 }
+
+// --- handleDeleteRecording must also delete the merged MP4 (merge_path) ---
+// Regression test for issue #117: deleting a recording left the merged-output
+// MP4 (recordings.merge_path) on disk permanently, because the handler only
+// removed file_path. The merged MP4 is the largest artifact and the file
+// playback actually loads.
+
+func TestDeleteRecording_DeletesMergePath(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording("rec-merge", "cam-1", "h264", now, false)
+	rec.FilePath = filepath.Join(store.RootDir(), "rec-merge-src.mp4")
+	require.NoError(t, os.WriteFile(rec.FilePath, []byte("src"), 0o644))
+	mergePath := filepath.Join(store.RootDir(), "rec-merge-merged.mp4")
+	require.NoError(t, os.WriteFile(mergePath, []byte("merged"), 0o644))
+	seedRecording(t, db, rec)
+	// Set the merge_path on the row (mirrors how the rolling merge writes it).
+	require.NoError(t, db.SetMergeResult(context.Background(), rec.ID, mergePath, "go"))
+
+	rr := doRequest(t, h.Routes(), "DELETE", "/api/recordings/rec-merge", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Both on-disk files must be gone.
+	_, err := os.Stat(rec.FilePath)
+	require.True(t, os.IsNotExist(err), "source file should be deleted, got err=%v", err)
+	_, err = os.Stat(mergePath)
+	require.True(t, os.IsNotExist(err), "merged file (merge_path) should be deleted, got err=%v", err)
+
+	got, _ := db.GetRecording(context.Background(), "rec-merge")
+	require.Nil(t, got)
+}
+
+func TestDeleteRecording_MissingMergePath_NoError(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	// Recording with an empty merge_path (never merged) — deletion must still
+	// succeed and clean up the source file.
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording("rec-nomerge", "cam-1", "h264", now, false)
+	rec.FilePath = filepath.Join(store.RootDir(), "rec-nomerge.mp4")
+	require.NoError(t, os.WriteFile(rec.FilePath, []byte("data"), 0o644))
+	seedRecording(t, db, rec)
+
+	rr := doRequest(t, h.Routes(), "DELETE", "/api/recordings/rec-nomerge", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	_, err := os.Stat(rec.FilePath)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestBatchDeleteRecordings_DeletesMergePath(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording("batch-merge", "cam-1", "h264", now, false)
+	rec.FilePath = filepath.Join(store.RootDir(), "batch-merge-src.mp4")
+	require.NoError(t, os.WriteFile(rec.FilePath, []byte("src"), 0o644))
+	mergePath := filepath.Join(store.RootDir(), "batch-merge-merged.mp4")
+	require.NoError(t, os.WriteFile(mergePath, []byte("merged"), 0o644))
+	seedRecording(t, db, rec)
+	require.NoError(t, db.SetMergeResult(context.Background(), rec.ID, mergePath, "go"))
+
+	body, _ := json.Marshal(map[string][]string{"ids": {"batch-merge"}})
+	rr := doRequest(t, h.Routes(), "POST", "/api/recordings/batch-delete", bytes.NewReader(body), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Both files reclaimed.
+	_, err := os.Stat(rec.FilePath)
+	require.True(t, os.IsNotExist(err), "source file should be deleted, got err=%v", err)
+	_, err = os.Stat(mergePath)
+	require.True(t, os.IsNotExist(err), "merged file (merge_path) should be deleted, got err=%v", err)
+	got, _ := db.GetRecording(context.Background(), "batch-merge")
+	require.Nil(t, got)
+}

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -517,10 +517,19 @@ func (cm *CleanupManager) BatchDeleteRecordingsWithFiles(ctx context.Context, re
 		deletedSet[id] = true
 	}
 
-	// 5. Delete files for successfully deleted recordings (best-effort)
+	// 5. Delete files for successfully deleted recordings (best-effort).
+	// Reclaim the merged MP4 (merge_path) too — it is the largest artifact and
+	// the one playback loads; without this it leaks permanently because the
+	// orphan scanner never reaches the nested YYYYMM/DD/HH/ tree. Mirrors
+	// handleDeleteRecording / handleTimelapseDelete.
 	for _, rec := range toDelete {
 		if !deletedSet[rec.ID] {
 			continue
+		}
+		if rec.MergePath != "" {
+			if err := os.RemoveAll(rec.MergePath); err != nil {
+				logger.Warn("failed to delete merged file", "merge_path", rec.MergePath, "error", err)
+			}
 		}
 		if err := cm.store.DeleteFile(rec.FilePath); err != nil {
 			logger.Warn("failed to delete file", "file_path", rec.FilePath, "error", err)

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -879,6 +879,30 @@ func (d *DB) ListRecordingPathsByCamera(ctx context.Context, cameraID string) (m
 	return result, nil
 }
 
+// PathIsRecordingFile reports whether the given on-disk path is still
+// referenced by any recording row for the camera — either as the source
+// file_path or the merged-output merge_path. Both the full path and its
+// basename are checked, because merge_path is sometimes stored as a full path
+// and sometimes relative to the storage root. Used by the orphan scanner
+// (repair reclaim-orphan-merges) to avoid reclaiming files that still belong
+// to a live recording.
+func (d *DB) PathIsRecordingFile(ctx context.Context, cameraID, fullpath string) (bool, error) {
+	base := filepath.Base(fullpath)
+	var exists int
+	err := d.readConn().QueryRowContext(ctx, `
+		SELECT 1 FROM recordings
+		WHERE camera_id=?
+		  AND (file_path=? OR merge_path=? OR file_path=? OR merge_path=?)
+		LIMIT 1;`, cameraID, fullpath, fullpath, base, base).Scan(&exists)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // ListPendingMJPEGRecordings returns recordings for a camera where format IN ('mjpeg','jpeg')
 // AND merge_status='pending' AND ended_at IS NOT NULL.
 func (d *DB) ListPendingMJPEGRecordings(ctx context.Context, cameraID string) ([]model.Recording, error) {

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -147,9 +147,9 @@ func (d *DB) GetRecordingsByIDBatch(ctx context.Context, ids []string) ([]model.
 	var res []model.Recording
 	for rows.Next() {
 		var r model.Recording
-		var startedAtStr, endedAtStr, mergePathStr, mergeTierStr, mergeErrorStr sql.NullString
+		var startedAtStr, endedAtStr, mergePathStr, mergeTierStr, mergeErrorStr, mergeQualityStr sql.NullString
 		var mergeProgress sql.NullInt64
-		if err := rows.Scan(&r.ID, &r.CameraID, &r.FilePath, &r.Format, &startedAtStr, &endedAtStr, &r.Duration, &r.FileSize, &r.FrameCount, &r.MergeStatus, &mergePathStr, &mergeTierStr, &mergeProgress, &mergeErrorStr, &r.Archived); err != nil {
+		if err := rows.Scan(&r.ID, &r.CameraID, &r.FilePath, &r.Format, &startedAtStr, &endedAtStr, &r.Duration, &r.FileSize, &r.FrameCount, &r.MergeStatus, &mergePathStr, &mergeTierStr, &mergeProgress, &mergeErrorStr, &mergeQualityStr, &r.Archived); err != nil {
 			return nil, err
 		}
 		r.StartedAt = scanTime(startedAtStr)
@@ -165,6 +165,11 @@ func (d *DB) GetRecordingsByIDBatch(ctx context.Context, ids []string) ([]model.
 		}
 		if mergeErrorStr.Valid {
 			r.MergeError = mergeErrorStr.String
+		}
+		if mergeQualityStr.Valid && mergeQualityStr.String != "" {
+			r.MergeQuality = mergeQualityStr.String
+		} else {
+			r.MergeQuality = model.MergeQualityComplete
 		}
 		if r.MergeStatus == "" {
 			r.MergeStatus = model.MergeStatusPending
@@ -881,19 +886,17 @@ func (d *DB) ListRecordingPathsByCamera(ctx context.Context, cameraID string) (m
 
 // PathIsRecordingFile reports whether the given on-disk path is still
 // referenced by any recording row for the camera — either as the source
-// file_path or the merged-output merge_path. Both the full path and its
-// basename are checked, because merge_path is sometimes stored as a full path
-// and sometimes relative to the storage root. Used by the orphan scanner
-// (repair reclaim-orphan-merges) to avoid reclaiming files that still belong
-// to a live recording.
+// file_path or the merged-output merge_path. The comparison is on the full
+// path, which is how both columns are stored (absolute paths under the storage
+// root). Used by the orphan scanner (repair reclaim-orphan-merges) to avoid
+// reclaiming files that still belong to a live recording.
 func (d *DB) PathIsRecordingFile(ctx context.Context, cameraID, fullpath string) (bool, error) {
-	base := filepath.Base(fullpath)
 	var exists int
 	err := d.readConn().QueryRowContext(ctx, `
 		SELECT 1 FROM recordings
 		WHERE camera_id=?
-		  AND (file_path=? OR merge_path=? OR file_path=? OR merge_path=?)
-		LIMIT 1;`, cameraID, fullpath, fullpath, base, base).Scan(&exists)
+		  AND (file_path=? OR merge_path=?)
+		LIMIT 1;`, cameraID, fullpath, fullpath).Scan(&exists)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil

--- a/internal/storage/db_recording_test.go
+++ b/internal/storage/db_recording_test.go
@@ -184,3 +184,47 @@ func TestListRecordingTimelineSegments_Truncation(t *testing.T) {
 	// it must be false — proving the flag is accurate when not capped.
 	require.False(t, total > len(segs))
 }
+
+func TestPathIsRecordingFile(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	filePath := "/data/cam-1/202607/26/12/cam-1_ts_abc"
+	mergePath := "/data/cam-1/202607/26/12/cam-1_ts_abc.mp4"
+	require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+		ID:        "rec-ref",
+		CameraID:  "cam-1",
+		FilePath:  filePath,
+		Format:    model.FormatH264,
+		StartedAt: now,
+		EndedAt:   now.Add(time.Minute),
+		Duration:  60,
+	}))
+	require.NoError(t, db.SetMergeResult(ctx, "rec-ref", mergePath, "go"))
+
+	// Full path matches file_path.
+	got, err := db.PathIsRecordingFile(ctx, "cam-1", filePath)
+	require.NoError(t, err)
+	require.True(t, got, "full file_path should be referenced")
+
+	// Full path matches merge_path.
+	got, err = db.PathIsRecordingFile(ctx, "cam-1", mergePath)
+	require.NoError(t, err)
+	require.True(t, got, "full merge_path should be referenced")
+
+	// Basename match (merge output stored elsewhere but same basename).
+	got, err = db.PathIsRecordingFile(ctx, "cam-1", "/different/root/cam-1_ts_abc.mp4")
+	require.NoError(t, err)
+	require.True(t, got, "basename of merge_path should be referenced")
+
+	// Unrelated path → not referenced.
+	got, err = db.PathIsRecordingFile(ctx, "cam-1", "/data/cam-1/202607/26/12/orphan_xyz.mp4")
+	require.NoError(t, err)
+	require.False(t, got, "unreferenced path should not be a recording file")
+
+	// Wrong camera → not referenced (camera_id is part of the filter).
+	got, err = db.PathIsRecordingFile(ctx, "cam-other", mergePath)
+	require.NoError(t, err)
+	require.False(t, got, "path under a different camera should not match")
+}

--- a/internal/storage/db_recording_test.go
+++ b/internal/storage/db_recording_test.go
@@ -213,11 +213,6 @@ func TestPathIsRecordingFile(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, got, "full merge_path should be referenced")
 
-	// Basename match (merge output stored elsewhere but same basename).
-	got, err = db.PathIsRecordingFile(ctx, "cam-1", "/different/root/cam-1_ts_abc.mp4")
-	require.NoError(t, err)
-	require.True(t, got, "basename of merge_path should be referenced")
-
 	// Unrelated path → not referenced.
 	got, err = db.PathIsRecordingFile(ctx, "cam-1", "/data/cam-1/202607/26/12/orphan_xyz.mp4")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes #117 — "网页端删除了录像文件，但是本地依然存在".

Investigation narrowed the leak: the **source file (`file_path`) WAS being deleted**, but the **merged-output MP4 (`merge_path`) — the largest artifact and the file playback actually loads — was never unlinked** by any of the four recording-delete paths. Because the merged MP4 lives in the nested \`<camID>/YYYYMM/DD/HH/\` tree that the automatic orphan scanner (\`cleanOrphansForCamera\`, non-recursive) never reaches, and \`ListRecordingPathsByCamera\` only collects \`file_path\` (never \`merge_path\`), the leak was permanent.

On the production M5 server this had accumulated **1297 orphan merge MP4s ≈ 130.56 GB** of leaked files.

## Changes

### Fix the 4 delete paths (mirror existing \`handleTimelapseDelete\` pattern)
Each now unlinks \`rec.MergePath\` via \`os.RemoveAll\` (best-effort, tolerates a missing path) in addition to \`rec.FilePath\`:
- \`handleDeleteRecording\`
- \`handleBatchDeleteRecordings\`
- \`handleDeleteArchiveRecording\`
- \`cleanup.BatchDeleteRecordingsWithFiles\`

### New repair subcommand: \`reclaim-orphan-merges\`
Reclaims the merged MP4 files already leaked by the pre-fix delete paths. Walks the camera tree, asks the DB (new \`PathIsRecordingFile\` helper) whether each \`.mp4\` is still referenced as \`file_path\` OR \`merge_path\`, and removes the orphans. \`--dry-run\` default, \`--execute\` to apply, \`--camera\`/\`--limit\` for scoping. Does **not** touch source frame directories or the raw segment files.

### Tests
- Handler tests: \`TestDeleteRecording_DeletesMergePath\`, \`TestDeleteRecording_MissingMergePath_NoError\`, \`TestBatchDeleteRecordings_DeletesMergePath\` — assert both \`file_path\` and \`merge_path\` disk files are removed on single + batch delete.
- DB test: \`TestPathIsRecordingFile\` covers full-path / basename / merge_path / unreferenced / wrong-camera cases.

## Verification (Banana Pi M5, production data)

Deployed to M5 (\`63.30\`) and verified with both the API and the browser UI:

1. **API delete (timelapse w/ merge_path)**: deleted \`cam-fa049182...\` recording via \`DELETE /api/recordings/{id}/\` → both the source frame dir (`file_path`) and the **11.7 MB merged MP4** (`merge_path`) removed from disk; DB row gone.
2. **UI delete (H80-9楼楼顶 timelapse, 4.94 MB)**: clicked 删除 → 删除 in the Recordings list → both disk artifacts gone, DB row gone, row removed from list.
3. **\`reclaim-orphan-merges --execute --limit 1\`**: reclaimed 1 orphan (344 KB); re-dry-run confirmed it no longer appears. Full dry-run on M5 reports **1297 orphans ≈ 130.56 GB** reclaimable (left for the owner to run deliberately).
4. Health check green: 9 cameras recording, DB/goroutines/storage OK.

The Go unit tests run on Linux CI (the \`storage\` package uses a Unix syscall not available on Windows, so tests can't run locally here). \`go vet\` + \`go test -c\` pass under \`CGO_ENABLED=0 GOOS=linux\`.

## Risk

- **Behavior change**: deleting a recording now also removes its merged MP4. This is the user-expected fix; no backward-compat concern.
- **No file sharing**: \`merge_path\` is written per-segment (UUID-named via \`CreateSegment\`), so deletion is safe — no risk of unlinking a file another recording depends on.

Closes #117.