### PR TITLE
fix(surveillance): debounce player state dispatch + H.265 LiveView/chain fixes (#107) (#108)

### DIFF
--- a/docs/known-issues-h265-multicam.md
+++ b/docs/known-issues-h265-multicam.md
@@ -20,10 +20,13 @@ In a 4-camera surveillance grid where all cameras are H.265 (HTTPS, WebCodecs av
 ## Root Cause (as originally diagnosed)
 
 1. **WebCodecs demote under load**: With 4 simultaneous WS connections, the Xiaomi CS2
-   camera with the slowest P2P connection has delayed frame delivery during the first
-   ~20s. The wall-clock no-media guard (`NO_MEDIA_TOTAL_MS`) misjudges this as
-   "no media" and demotes to HLS. Single-camera testing confirms this camera is stable
-   on WebCodecs — the issue is multi-camera load causing frame-delivery timing contention.
+   camera with the slowest P2P connection has delayed frame delivery during startup.
+   The no-media watchdog (`NO_MEDIA_TIMEOUT_MS = 30000` in WasmPlayer) could misjudge
+   a slow-to-start camera as "no media" and report failure. Single-camera testing
+   confirmed such cameras are stable on WebCodecs — the issue was multi-camera load
+   causing frame-delivery timing contention. (Note: the final fix does NOT change this
+   timeout; the demote itself was correct behavior. The freeze came from the un-debounced
+   state dispatch amplifying the resulting transitions, fixed separately.)
 
 2. **HLS H.265 state-oscillation**: After demotion to HLS, hls.js feeds H.265 to MSE,
    which reports `isTypeSupported('hvc1') = true` but the actual decode stalls at
@@ -38,41 +41,101 @@ In a 4-camera surveillance grid where all cameras are H.265 (HTTPS, WebCodecs av
    which bypassed the codec gate entirely. Either way, the un-debounced state
    dispatch turned the resulting HLS H.265 stall into a console freeze.
 
-## Fixes Applied (this branch)
+## Fixes Applied (this branch — PR #120, 4 commits)
 
-1. **Debounced + deduped state dispatch** (`web/src/lib/player/dispatch.ts`):
-   every player adapter (Video/Flv/Wasm/WebRTC) now routes its `statechange`
+### Issue #107 — state-oscillation storm (root cause + cascade)
+
+1. **Debounced + deduped + ASYNC state dispatch** (`web/src/lib/player/dispatch.ts`):
+   every player adapter (Video/Flv/Wasm/WebRTC) routes its `statechange`
    CustomEvent through a shared dispatcher that (a) drops identical-to-last
    states and (b) coalesces non-`playing` states into a single trailing
-   dispatch within a 500ms window. `playing` (recovery) flushes immediately and
-   cancels any pending trailing dispatch. A burst of hls.js buffering↔playing
-   oscillation now collapses to ~1 event per window instead of thousands/sec.
-   Assignment-side dedupe was also added to `updateState` in each player so the
-   `$effect` itself doesn't re-run on redundant assignments.
+   dispatch within a 500ms window. **Every emit is deferred out of the
+   synchronous stack** — `'playing'` (recovery) flushes on a `queueMicrotask`
+   (near-immediate but NOT synchronous), other states on `setTimeout`. This is
+   critical: a synchronous emit inside the player's `$effect` reached
+   `orchestrator.reportHealth → setSlot` (a reactive `$state` write) during
+   Svelte's effect flush, and combined with a player remount produced
+   `effect_update_depth_exceeded`. Async deferral guarantees the DOM dispatch →
+   reportHealth → setSlot chain runs in a fresh task, never inside an effect
+   flush. A burst of hls.js buffering↔playing oscillation now collapses to ~1
+   event per window instead of thousands/sec.
 
-2. **LiveView no longer clobbers its own registration** (issue #108): the
-   `listProtocols()` `.then()` used to re-call `registerCamera(makeRegistration(
-   camera, null, …))`, racing the real registration done in `loadCamera()`. The
-   null `resp` collapsed the chain to forced HLS against the codec gate. Removed;
-   `listProtocols()` now only populates the global `protocolsMap` (PTZ/HLS
-   capability gating) and re-registers with the SAME probed resp when it lands.
+2. **`reportHealth` short-circuits when health is unchanged** (`orchestrator.svelte.ts`):
+   the deepest root cause of the H80-triggered `effect_update_depth_exceeded`.
+   `reportHealth` previously called `setSlot` (which does `slots = { ...slots }`
+   — a new object) on EVERY report, even when `(status, reason)` were identical
+   to the current health. Because `healthFromStreamState('error')` returns a new
+   object each call (`since: Date.now()` differs), a reference check could not
+   short-circuit. An H.265 camera whose WS never reaches steady-state
+   `'playing'` (e.g. H80) reports `'failed'` repeatedly → each report churned
+   `slots` → every `$derived(mode)` re-ran → player `$effect`s re-entered →
+   effect recursion overflow. Fix: skip the reactive `setSlot` write when
+   `slot.health.{status,reason}` equals the incoming `h.{status,reason}`. The
+   timers/demote logic uses non-reactive internal bookkeeping and is unaffected.
+   Also removed a redundant trailing `setSlot` on the `'ok'` path that would
+   re-arm the loop for cameras oscillating around the ok/degraded boundary.
 
-3. **LiveView ProtocolSwitcher reads the probed encoding** (issue #108): the
-   `cameraEncoding` prop now prefers `cameraProtocolsResp.encoding` (recorder-
-   probed, authoritative) over the possibly-stale DB `camera.encoding`, so an
-   H.265 camera stored as h264 still shows its H.265 badge and hides WebRTC.
+### Issue #108 — H.265 LiveView black screen (codec-data-flow integrity)
 
-4. **`buildCandidateChain` `!resp` branch no longer traps H.265 on HLS**:
-   when `/protocols` fetch fails (resp=null) and the camera is H.265 with a
-   working decode path (WebCodecs or libde265 WASM), the chain is now
-   `[{wasm}]` instead of the forced `[{hls}]`. HLS H.265 via MSE is a black
-   screen + oscillation in most browsers; wasm always works. H.264 behavior
-   is unchanged (still HLS).
+3. **CameraPlayer feeds the player the RECORDER-PROBED codec, not the DB value**:
+   the direct cause of H80's black screen. `CameraPlayer` derived the player's
+   `codec` prop from `camera.encoding` (the DB value). H80 is stored as `h264`
+   in the DB but streams `h265`; the orchestrator correctly built a wasm/WebCodecs
+   chain from the probed `h265`, but CameraPlayer fed WasmPlayer `codec='h264'`,
+   so it configured an H.264 decoder that silently failed to decode the H.265
+   NALUs (data was flowing — WS 101 + binary frames — but the decoder mismatch
+   produced a permanent black screen). Fix: orchestrator exposes
+   `resolvedEncoding(cameraId)` (the same `resolveEncoding(camera, resp)` the
+   candidate chain was built from), and CameraPlayer uses it with a DB fallback.
+   This is a generic data-flow fix — any camera whose DB encoding drifts from
+   the real stream benefits, not just H80.
 
-5. **Orchestrator storm regression guards** (`orchestrator.test.ts`): tests
-   confirm a high-frequency buffering↔playing oscillation that returns to ok
-   does NOT demote, and repeated degraded reports arm exactly one degrade
-   timer (debounce is idempotent).
+4. **`buildCandidateChain` `!resp` branch no longer traps H.265 on HLS**: when
+   the `/protocols` fetch fails (resp=null) and the camera is H.265 with a
+   working decode path (WebCodecs or libde265 WASM), the chain is now `[{wasm}]`
+   instead of the forced `[{hls}]`. HLS H.265 via MSE is a black screen +
+   oscillation in most browsers; wasm always works. H.264 behavior is unchanged.
+
+5. **LiveView no longer clobbers its own registration**: the `listProtocols()`
+   `.then()` used to re-call `registerCamera(makeRegistration(camera, null, …))`,
+   racing the real registration done in `loadCamera()`. The null `resp`
+   collapsed the chain to forced HLS against the codec gate. Removed;
+   `listProtocols()` now only populates the global `protocolsMap` and
+   re-registers with the SAME probed resp (guarded by a `cameraRegistered`
+   flag) when it lands.
+
+6. **LiveView ProtocolSwitcher reads the probed encoding**: the `cameraEncoding`
+   prop now prefers `cameraProtocolsResp.encoding` (recorder-probed,
+   authoritative) over the possibly-stale DB `camera.encoding`, so an H.265
+   camera stored as h264 still shows its H.265 badge and hides WebRTC.
+
+### Regression coverage
+
+- `dispatch.test.ts` (12): dedupe, debounce coalescing, **`'playing'` must NOT
+  emit synchronously** (the effect_update_depth guard), `'playing'` cancels
+  pending trailing, dispose cancels both queues.
+- `orchestrator.test.ts` (+3): a high-frequency buffering↔playing oscillation
+  that returns to ok does NOT demote; repeated degraded reports arm exactly one
+  degrade timer; **repeated `'failed'` on an exhausted chain does NOT rewrite
+  `slots`** (the H80 regression — slot reference stays stable across 50
+  identical reports).
+- `stream-selection.test.ts` (+4): `!resp` + H.265 + WebCodecs/wasm → `[{wasm}]`;
+  H.264 + `!resp` still HLS (regression guard).
+
+## Verification (Banana Pi M5, real cameras)
+
+- **#107 grid storm**: 4-camera H.265 grid stable after 30s+ soak; no console
+  freeze; click responsiveness 100–200ms (the pre-fix storm froze the console
+  within 55s). All H.265 cameras stayed on WebCodecs (never demoted to HLS).
+- **effect_update_depth_exceeded regression**: H80 (cam-608e6966) added to the
+  grid + 60s soak (past the 30s `noMediaTimer` + multiple WS reconnect cycles):
+  no freeze, `allAlive: true`, expand/shrink/drag all responsive.
+- **#108 H80 black screen**: LiveView now shows **"实时" (live)** on WebCodecs
+  with the correct H.265 decoder (was "快照模式"/black). ProtocolSwitcher
+  shows "H.265 WebCodecs" (was "H.264"). WS handshake confirmed working
+  (101 + binary H.265 frames) — the black screen was purely a decoder-config
+  mismatch, not a connection issue.
+- Backend logs clean; 9 cameras recording; no regressions on healthy cameras.
 
 ## What IS Fixed (in the player-orchestrator-adaptive branch, PR #106)
 

--- a/docs/known-issues-h265-multicam.md
+++ b/docs/known-issues-h265-multicam.md
@@ -1,8 +1,11 @@
 # Known Issue: H.265 Multi-Camera Grid — WebCodecs Demote + HLS Oscillation
 
-> **Status**: Identified, not yet fixed. Tracking issue for follow-up.
+> **Status**: ✅ **Fixed** (issues #107, #108). This document is retained as a
+> postmortem / regression reference.
 > **Affected**: H.265 cameras (Xiaomi CS2, ONVIF H.265) in a 4-camera grid on HTTPS.
-> **Impact**: 1 of 4 cameras may demote to HLS and trigger a console-freezing state-oscillation loop.
+> **Impact (pre-fix)**: 1 of 4 cameras could demote to HLS and trigger a
+> console-freezing state-oscillation loop; LiveView failed to play for H.265
+> cameras whose DB `encoding` was stale.
 
 ## Problem
 
@@ -14,11 +17,11 @@ In a 4-camera surveillance grid where all cameras are H.265 (HTTPS, WebCodecs av
   (7428 statechange events in 55s observed). Each state change fires Svelte's `$effect`
   dispatcher, overloading the reactive scheduler and freezing the browser console.
 
-## Root Cause
+## Root Cause (as originally diagnosed)
 
 1. **WebCodecs demote under load**: With 4 simultaneous WS connections, the Xiaomi CS2
    camera with the slowest P2P connection has delayed frame delivery during the first
-   ~20s. The wall-clock no-media guard (`NO_MEDIA_TOTAL_MS = 20000`) misjudges this as
+   ~20s. The wall-clock no-media guard (`NO_MEDIA_TOTAL_MS`) misjudges this as
    "no media" and demotes to HLS. Single-camera testing confirms this camera is stable
    on WebCodecs — the issue is multi-camera load causing frame-delivery timing contention.
 
@@ -28,19 +31,50 @@ In a 4-camera surveillance grid where all cameras are H.265 (HTTPS, WebCodecs av
    and `VideoPlayer.$effect(dispatchStateChange)` fires on every transition →
    Svelte scheduler overload → console freeze.
 
-## Suggested Fixes
+3. **Investigation correction (issue #107 deep-dive)**: the chain-walk demote could
+   not actually reach HLS for an H.265/no-MSE camera (the codec gate excludes it),
+   so the real trigger was a transient `/protocols` fetch failure collapsing
+   `buildCandidateChain` to a forced single-`hls` chain via its `!resp` branch —
+   which bypassed the codec gate entirely. Either way, the un-debounced state
+   dispatch turned the resulting HLS H.265 stall into a console freeze.
 
-1. **Don't demote H.265 WebCodecs to HLS**: If WebCodecs is available and the camera
-   is H.265, raise the demote threshold significantly or skip HLS as a demote target
-   (HLS H.265 is unreliable in most browsers anyway).
+## Fixes Applied (this branch)
 
-2. **Debounce VideoPlayer state dispatch**: Coalesce `loading ↔ buffering` transitions
-   within a 500ms window so the reactive scheduler isn't flooded.
+1. **Debounced + deduped state dispatch** (`web/src/lib/player/dispatch.ts`):
+   every player adapter (Video/Flv/Wasm/WebRTC) now routes its `statechange`
+   CustomEvent through a shared dispatcher that (a) drops identical-to-last
+   states and (b) coalesces non-`playing` states into a single trailing
+   dispatch within a 500ms window. `playing` (recovery) flushes immediately and
+   cancels any pending trailing dispatch. A burst of hls.js buffering↔playing
+   oscillation now collapses to ~1 event per window instead of thousands/sec.
+   Assignment-side dedupe was also added to `updateState` in each player so the
+   `$effect` itself doesn't re-run on redundant assignments.
 
-3. **Staggered multi-camera init**: Delay each camera's WS connect by ~500ms to avoid
-   simultaneous P2P connection contention.
+2. **LiveView no longer clobbers its own registration** (issue #108): the
+   `listProtocols()` `.then()` used to re-call `registerCamera(makeRegistration(
+   camera, null, …))`, racing the real registration done in `loadCamera()`. The
+   null `resp` collapsed the chain to forced HLS against the codec gate. Removed;
+   `listProtocols()` now only populates the global `protocolsMap` (PTZ/HLS
+   capability gating) and re-registers with the SAME probed resp when it lands.
 
-## What IS Fixed (in the player-orchestrator-adaptive branch)
+3. **LiveView ProtocolSwitcher reads the probed encoding** (issue #108): the
+   `cameraEncoding` prop now prefers `cameraProtocolsResp.encoding` (recorder-
+   probed, authoritative) over the possibly-stale DB `camera.encoding`, so an
+   H.265 camera stored as h264 still shows its H.265 badge and hides WebRTC.
+
+4. **`buildCandidateChain` `!resp` branch no longer traps H.265 on HLS**:
+   when `/protocols` fetch fails (resp=null) and the camera is H.265 with a
+   working decode path (WebCodecs or libde265 WASM), the chain is now
+   `[{wasm}]` instead of the forced `[{hls}]`. HLS H.265 via MSE is a black
+   screen + oscillation in most browsers; wasm always works. H.264 behavior
+   is unchanged (still HLS).
+
+5. **Orchestrator storm regression guards** (`orchestrator.test.ts`): tests
+   confirm a high-frequency buffering↔playing oscillation that returns to ok
+   does NOT demote, and repeated degraded reports arm exactly one degrade
+   timer (debounce is idempotent).
+
+## What IS Fixed (in the player-orchestrator-adaptive branch, PR #106)
 
 - ✅ Backend encoding probe: Xiaomi cameras now correctly report h265 (was h264)
 - ✅ Triple visibility conflict eliminated (ConnectionManager/WasmPlayer/orchestrator)

--- a/web/src/components/CameraPlayer.svelte
+++ b/web/src/components/CameraPlayer.svelte
@@ -60,7 +60,18 @@
   // `camera.id` directly in module scope would capture only the initial value.
   let cameraId = $derived(camera.id);
   let cameraName = $derived(camera.name || camera.id);
-  let codec = $derived((camera.encoding || camera.stream_encoding || '').toLowerCase());
+  // CRITICAL (issue #108): use the RECORDER-PROBED codec from the orchestrator,
+  // NOT the possibly-stale DB `camera.encoding`. The candidate chain (and thus
+  // the selected player mode) is built from the probed encoding; if we feed the
+  // player a different codec here, its decoder is misconfigured for the ACTUAL
+  // stream → black screen. Example: H80 is stored as h264 in the DB but its
+  // recorder streams h265; the orchestrator selects wasm (WebCodecs H.265), but
+  // passing codec='h264' here would make WasmPlayer configure an H.264 decoder
+  // that silently fails to decode the H.265 NALUs. Fall back to the DB fields
+  // only before the orchestrator has registered the camera (resp not yet loaded).
+  let codec = $derived(
+    (orchestrator?.resolvedEncoding(cameraId) || camera.encoding || camera.stream_encoding || '').toLowerCase(),
+  );
   let audioCapable = $derived(isAudioCapable(camera));
 
   function report(h: HealthState): void {

--- a/web/src/components/FlvPlayer.svelte
+++ b/web/src/components/FlvPlayer.svelte
@@ -9,6 +9,7 @@
   import { sendTelemetry } from '$lib/telemetry';
   import type { StreamState } from '$lib/hls-errors';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
+  import { createStateDispatcher } from '$lib/player/dispatch';
 
   let {
     cameraId,
@@ -101,12 +102,20 @@ let videoEventAc: AbortController | null = null;
   }
 
   function dispatchStateChange(state: StreamState | 'loading') {
+    // Routes through the debounced+deduped dispatcher so a burst of mpegts
+    // state transitions collapses to one event per window (issue #107).
+    stateDispatcher.report(state);
+  }
+
+  // Per-instance dispatcher. Emits the real CustomEvent on the component root;
+  // trailing-edge debounce is cleared on destroy.
+  const stateDispatcher = createStateDispatcher((state) => {
     const event = new CustomEvent('statechange', {
       bubbles: true,
       detail: { cameraId, state },
     });
     videoEl?.parentElement?.dispatchEvent(event);
-  }
+  });
 
   $effect(() => {
     dispatchStateChange(streamState);
@@ -408,6 +417,7 @@ let videoEventAc: AbortController | null = null;
     if (coordinator) coordinator.cancelRequest(cameraId);
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
     frozenFrameUrl = null;
+    stateDispatcher.dispose();
     destroyPlayer();
   });
 

--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -130,12 +130,6 @@
 
   function updateState(cameraId_: string, state: StreamState) {
     if (cameraId_ === cameraId) {
-      // Assignment-side dedupe (issue #107): hls.js can report the same state
-      // back-to-back (e.g. 'buffering' from multiple fatal-recovery cycles).
-      // Without this guard each redundant assignment re-triggers the $effect
-      // above. The dispatcher dedupes too, but stopping it here avoids the
-      // Svelte microtask entirely.
-      if (state === streamState) return;
       // Capture frame before leaving 'playing' state
       if (streamState === 'playing' && state !== 'playing') {
         captureFreezeFrame();
@@ -152,6 +146,13 @@
         coordinator.completeReconnect(cameraId);
         hasActiveCoordinatedReconnect = false;
       }
+      // NOTE: no manual dedupe guard here — Svelte 5 treats reassigning an
+      // identical primitive to a $state as a no-op (no effect re-run), so
+      // redundant hls.js callbacks don't churn the dispatcher. An earlier
+      // revision added `if (state === streamState) return;` here, but that
+      // changed timing in a way that contributed to effect_update_depth_exceeded
+      // when combined with the dispatcher; main has no guard and works, so we
+      // keep main's behavior and let Svelte's primitive equality do the dedupe.
       streamState = state;
     }
   }

--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -14,6 +14,7 @@
   import type { StreamState } from '$lib/hls-errors';
   import { captureFrame } from '$lib/freeze-frame';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
+  import { createStateDispatcher } from '$lib/player/dispatch';
 
   let {
     cameraId,
@@ -101,23 +102,40 @@
   }
 
   function dispatchStateChange(state: StreamState | 'loading') {
-    // Svelte 5 custom events via bubbling — parent reads detail from DOM event
-    const event = new CustomEvent('statechange', {
-      bubbles: true,
-      detail: { cameraId, state },
-    });
-    // Dispatch on the component's root element if available
-    videoEl?.parentElement?.dispatchEvent(event);
+    // Svelte 5 custom events via bubbling — parent reads detail from DOM event.
+    // Routes through the debounced+deduped dispatcher so hls.js's sub-second
+    // buffering↔playing oscillation (issue #107) collapses to ~1 event/window
+    // instead of thousands/sec that froze the console.
+    stateDispatcher.report(state);
   }
 
-  // Watch streamState changes and dispatch
+  // Watch streamState changes and dispatch. The dispatcher itself dedupes
+  // identical states and debounces non-recovery states, so even though this
+  // effect re-runs on every assignment, the actual DOM dispatch is bounded.
+  // (Assignment-side dedupe in updateState below prevents most re-runs.)
   $effect(() => {
     const _state = streamState;
     dispatchStateChange(_state);
   });
 
+  // Per-instance dispatcher. Emits the real CustomEvent on the component root.
+  // Trailing-edge debounce is cleared on destroy so no stale event fires post-unmount.
+  const stateDispatcher = createStateDispatcher((state) => {
+    const event = new CustomEvent('statechange', {
+      bubbles: true,
+      detail: { cameraId, state },
+    });
+    videoEl?.parentElement?.dispatchEvent(event);
+  });
+
   function updateState(cameraId_: string, state: StreamState) {
     if (cameraId_ === cameraId) {
+      // Assignment-side dedupe (issue #107): hls.js can report the same state
+      // back-to-back (e.g. 'buffering' from multiple fatal-recovery cycles).
+      // Without this guard each redundant assignment re-triggers the $effect
+      // above. The dispatcher dedupes too, but stopping it here avoids the
+      // Svelte microtask entirely.
+      if (state === streamState) return;
       // Capture frame before leaving 'playing' state
       if (streamState === 'playing' && state !== 'playing') {
         captureFreezeFrame();
@@ -326,6 +344,7 @@ streamState = 'error';
     if (coordinator) coordinator.cancelRequest(cameraId);
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
     frozenFrameUrl = null;
+    stateDispatcher.dispose();
     destroyCurrentHls();
     destroyCurrentHls();
   });

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -179,11 +179,6 @@ let webgpuRenderer: WebGPURenderer | null = null;
   });
 
   function updateState(newState: PlayerState) {
-    // Assignment-side dedupe (issue #107): the WS connection layer can report
-    // the same state back-to-back; without this guard each redundant
-    // assignment re-triggers the $effect. The dispatcher dedupes too, but
-    // stopping it here avoids the Svelte microtask entirely.
-    if (newState === streamState) return;
     // Capture frame before leaving 'playing'
     if (streamState === 'playing' && newState !== 'playing') {
       captureFreezeFrame();
@@ -192,6 +187,11 @@ let webgpuRenderer: WebGPURenderer | null = null;
     if (newState === 'playing' && frozenFrameUrl) {
       clearFreezeFrame();
     }
+    // NOTE: no manual dedupe guard — Svelte 5 treats reassigning an identical
+    // primitive to a $state as a no-op (no effect re-run). An earlier revision
+    // added `if (newState === streamState) return;` but that altered timing in
+    // a way that contributed to effect_update_depth_exceeded when combined with
+    // the dispatcher. Keep main's behavior; let Svelte dedupe primitives.
     streamState = newState;
   }
 

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -9,6 +9,7 @@
   import { ConnectionManager, type ConnectionState } from '$lib/webcodecs-player/connection';
   import { AudioPlayer } from '$lib/audio-player';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
+  import { createStateDispatcher } from '$lib/player/dispatch';
 import { WebGPURenderer } from '$lib/webgpu-renderer';
   import AiOverlay from './AiOverlay.svelte';
   import { AiRuntime } from '$lib/ai-detection/runtime';
@@ -157,18 +158,32 @@ let webgpuRenderer: WebGPURenderer | null = null;
   // ─── State dispatch ────────────────────────────────────────────────────
 
   function dispatchStateChange(state: PlayerState) {
+    // Routes through the debounced+deduped dispatcher so a burst of
+    // connection-state transitions collapses to one event per window
+    // (issue #107). 'playing' (recovery) still flushes immediately.
+    stateDispatcher.report(state);
+  }
+
+  // Per-instance dispatcher. Emits the real CustomEvent on the canvas root;
+  // trailing-edge debounce is cleared on destroy.
+  const stateDispatcher = createStateDispatcher((state) => {
     const event = new CustomEvent('statechange', {
       bubbles: true,
       detail: { cameraId, state },
     });
     canvasEl?.parentElement?.dispatchEvent(event);
-  }
+  });
 
   $effect(() => {
     dispatchStateChange(streamState);
   });
 
   function updateState(newState: PlayerState) {
+    // Assignment-side dedupe (issue #107): the WS connection layer can report
+    // the same state back-to-back; without this guard each redundant
+    // assignment re-triggers the $effect. The dispatcher dedupes too, but
+    // stopping it here avoids the Svelte microtask entirely.
+    if (newState === streamState) return;
     // Capture frame before leaving 'playing'
     if (streamState === 'playing' && newState !== 'playing') {
       captureFreezeFrame();
@@ -798,6 +813,7 @@ onDestroy(() => {
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
     if (decodeErrorTimer) { clearTimeout(decodeErrorTimer); decodeErrorTimer = null; }
     if (noMediaTimer) { clearTimeout(noMediaTimer); noMediaTimer = null; }
+    stateDispatcher.dispose();
     if (frozenFrameUrl) { URL.revokeObjectURL(frozenFrameUrl); frozenFrameUrl = null; }
     if (webgpuRenderer) { webgpuRenderer.destroy(); webgpuRenderer = null; }
     if (cm) { cm.destroy(); cm = null; }

--- a/web/src/components/WebRTCPlayer.svelte
+++ b/web/src/components/WebRTCPlayer.svelte
@@ -9,6 +9,7 @@
   import { sendTelemetry } from '$lib/telemetry';
   import type { StreamState } from '$lib/hls-errors';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
+  import { createStateDispatcher } from '$lib/player/dispatch';
 
   let {
     cameraId,
@@ -119,12 +120,20 @@ let destroyed = false;
   }
 
   function dispatchStateChange(state: StreamState | 'loading') {
+    // Routes through the debounced+deduped dispatcher so a burst of ICE state
+    // transitions collapses to one event per window (issue #107).
+    stateDispatcher.report(state);
+  }
+
+  // Per-instance dispatcher. Emits the real CustomEvent on the component root;
+  // trailing-edge debounce is cleared on destroy.
+  const stateDispatcher = createStateDispatcher((state) => {
     const event = new CustomEvent('statechange', {
       bubbles: true,
       detail: { cameraId, state },
     });
     videoEl?.parentElement?.dispatchEvent(event);
-  }
+  });
 
   $effect(() => {
     dispatchStateChange(streamState);
@@ -132,23 +141,27 @@ let destroyed = false;
 
   function updateStreamState() {
     const prevState = streamState;
+    let next: StreamState | 'loading';
     if (webrtcState === 'connected') {
-      streamState = 'playing';
+      next = 'playing';
+    } else if (webrtcState === 'connecting' || webrtcState === 'disconnected') {
+      next = 'buffering';
+    } else {
+      next = 'error';
+    }
+    // Assignment-side dedupe (issue #107): the WebRTC ICE layer can emit the
+    // same state back-to-back; skip the side effects (freeze-frame capture,
+    // coordinator completion, and the dispatch $effect) when nothing changed.
+    if (next === prevState) return;
+    if (prevState === 'playing' && next !== 'playing') captureFreezeFrame();
+    if (next === 'playing') {
       if (prevState !== 'playing' && frozenFrameUrl) clearFreezeFrame();
       if (coordinator && hasActiveCoordinatedReconnect) {
         coordinator.completeReconnect(cameraId);
         hasActiveCoordinatedReconnect = false;
       }
-    } else if (webrtcState === 'connecting') {
-      if (prevState === 'playing') captureFreezeFrame();
-      streamState = 'buffering';
-    } else if (webrtcState === 'disconnected') {
-      if (prevState === 'playing') captureFreezeFrame();
-      streamState = 'buffering';
-    } else {
-      if (prevState === 'playing') captureFreezeFrame();
-      streamState = 'error';
     }
+    streamState = next;
   }
 
   $effect(() => {
@@ -535,6 +548,7 @@ let destroyed = false;
     if (coordinator) coordinator.cancelRequest(cameraId);
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
     frozenFrameUrl = null;
+    stateDispatcher.dispose();
     destroyPeerConnection();
   });
 

--- a/web/src/components/WebRTCPlayer.svelte
+++ b/web/src/components/WebRTCPlayer.svelte
@@ -149,10 +149,11 @@ let destroyed = false;
     } else {
       next = 'error';
     }
-    // Assignment-side dedupe (issue #107): the WebRTC ICE layer can emit the
-    // same state back-to-back; skip the side effects (freeze-frame capture,
-    // coordinator completion, and the dispatch $effect) when nothing changed.
-    if (next === prevState) return;
+    // NOTE: no manual dedupe guard (`if (next === prevState) return;`). Svelte 5
+    // treats reassigning an identical primitive to a $state as a no-op, so a
+    // redundant ICE callback doesn't churn the dispatcher. An earlier revision
+    // added the guard but it altered timing in a way that contributed to
+    // effect_update_depth_exceeded; keep main's behavior.
     if (prevState === 'playing' && next !== 'playing') captureFreezeFrame();
     if (next === 'playing') {
       if (prevState !== 'playing' && frozenFrameUrl) clearFreezeFrame();

--- a/web/src/lib/__tests__/stream-selection.test.ts
+++ b/web/src/lib/__tests__/stream-selection.test.ts
@@ -353,4 +353,40 @@ describe('buildCandidateChain', () => {
     const chain = buildCandidateChain(cam, null, EMPTY_CAPS, { legacyDefault: 'flv' });
     expect(chain.map((c) => c.mode)).toEqual(['flv']);
   });
+
+  // ─── Issue #107: !resp must not collapse H.265 onto HLS ────────────────────
+  // When /protocols transiently fails (resp=null) the old code returned a forced
+  // single-`hls` chain REGARDLESS of codec. For an H.265 camera that's a death
+  // sentence: hls.js feeds hvc1 to MSE, which claims isTypeSupported but silently
+  // fails to decode → permanent black screen + the loading↔buffering state
+  // oscillation that froze browsers. When the browser can actually decode H.265
+  // (WebCodecs/wasm), prefer the wasm mode instead — a single-element chain that
+  // can't demote into the HLS trap.
+  it('returns a single-element wasm chain for H.265 + WebCodecs when resp is null (no HLS trap)', () => {
+    const cam = makeCamera({ protocol: 'onvif', encoding: 'h265' });
+    const chain = buildCandidateChain(cam, null, { h265MSE: false, webCodecs: true, wasmH265: false });
+    expect(chain.map((c) => c.mode)).toEqual(['wasm']);
+  });
+
+  it('returns a single-element wasm chain for H.265 + libde265 WASM when resp is null', () => {
+    const cam = makeCamera({ protocol: 'onvif', encoding: 'h265' });
+    const chain = buildCandidateChain(cam, null, { h265MSE: false, webCodecs: false, wasmH265: true });
+    expect(chain.map((c) => c.mode)).toEqual(['wasm']);
+  });
+
+  it('falls back to HLS for H.265 when resp is null AND no H.265 decode path exists', () => {
+    // No WebCodecs, no wasm → there is no good option. HLS at least avoids the
+    // oscillation (the player will fail fast). This preserves pre-fix behavior
+    // for the rare browser that can't decode H.265 at all.
+    const cam = makeCamera({ protocol: 'onvif', encoding: 'h265' });
+    const chain = buildCandidateChain(cam, null, { h265MSE: false, webCodecs: false, wasmH265: false });
+    expect(chain.map((c) => c.mode)).toEqual(['hls']);
+  });
+
+  it('still returns HLS for H.264 when resp is null (unchanged behavior)', () => {
+    // Regression guard: the !resp H.265 fix must NOT change H.264 behavior.
+    const cam = makeCamera({ protocol: 'rtsp', encoding: 'h264' });
+    const chain = buildCandidateChain(cam, null, EMPTY_CAPS);
+    expect(chain.map((c) => c.mode)).toEqual(['hls']);
+  });
 });

--- a/web/src/lib/player/__tests__/dispatch.test.ts
+++ b/web/src/lib/player/__tests__/dispatch.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createStateDispatcher, DEBOUNCE_MS, type PlayerState } from '$lib/player/dispatch';
+
+// The dispatcher uses real setTimeout by default; tests inject a controllable
+// scheduler so the debounce timing is deterministic without vitest fake timers
+// (either works; the injected form makes the assertions explicit about which
+// timer fired and is easier to reason about for the "playing cancels pending"
+// case).
+
+interface FakeTimer {
+  fn: () => void;
+  ms: number;
+  fired: boolean;
+}
+let queue: FakeTimer[] = [];
+
+function sched(fn: () => void, ms: number): FakeTimer {
+  const t: FakeTimer = { fn, ms, fired: false };
+  queue.push(t);
+  return t;
+}
+function clear(t: FakeTimer): void {
+  const i = queue.indexOf(t);
+  if (i >= 0) queue.splice(i, 1);
+}
+/** Advance fake time, firing timers whose delay has elapsed (in insertion order). */
+function advance(ms: number): void {
+  const ready = queue.filter((t) => t.ms <= ms).sort((a, b) => a.ms - b.ms);
+  for (const t of ready) {
+    if (t.fired) continue;
+    t.fired = true;
+    const i = queue.indexOf(t);
+    if (i >= 0) queue.splice(i, 1);
+    t.fn();
+  }
+}
+function pendingCount(): number {
+  return queue.length;
+}
+
+beforeEach(() => {
+  queue = [];
+});
+
+afterEach(() => {
+  queue = [];
+});
+
+describe('createStateDispatcher — dedupe', () => {
+  it('does not emit when the same state is reported twice in a row', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('buffering');
+    advance(DEBOUNCE_MS);
+    d.report('buffering'); // identical → deduped
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual(['buffering']);
+  });
+
+  it('does not emit a duplicate even before the trailing timer fires', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('buffering');
+    // Immediately report buffering again WITHOUT advancing — pending state is
+    // 'buffering', so the second call is a no-op.
+    d.report('buffering');
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual(['buffering']);
+    expect(pendingCount()).toBe(0);
+  });
+});
+
+describe('createStateDispatcher — debounce', () => {
+  it('coalesces a burst of distinct non-playing states into the last one', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    // Simulate the hls.js oscillation: buffering → loading → buffering within
+    // the debounce window. Only the final 'buffering' should be emitted.
+    d.report('buffering');
+    d.report('loading');
+    d.report('buffering');
+    d.report('loading');
+    d.report('buffering');
+    expect(emitted).toEqual([]); // nothing yet — all debounced
+    expect(pendingCount()).toBe(1); // exactly one trailing timer
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual(['buffering']); // only the last
+  });
+
+  it('emits once per debounce window, not per report (the issue #107 storm guard)', () => {
+    // The bug: 7428 statechange events in 55s. With a 500ms debounce the worst
+    // case is ~110 events in 55s even if a new state arrives every tick.
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    for (let i = 0; i < 1000; i++) {
+      // Alternate to bypass dedupe but stay within the window.
+      d.report(i % 2 === 0 ? 'buffering' : 'loading');
+    }
+    advance(DEBOUNCE_MS);
+    expect(emitted.length).toBe(1);
+  });
+
+  it('reports a genuinely later state change after the window elapses', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('buffering');
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual(['buffering']);
+    d.report('error');
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual(['buffering', 'error']);
+  });
+});
+
+describe('createStateDispatcher — playing flushes immediately', () => {
+  it('emits playing synchronously (no debounce) so recovery is reported at once', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('playing');
+    expect(emitted).toEqual(['playing']);
+    expect(pendingCount()).toBe(0);
+  });
+
+  it('cancels a pending trailing dispatch when playing arrives (recovery supersedes it)', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('buffering'); // arms a trailing timer
+    expect(pendingCount()).toBe(1);
+    d.report('playing'); // flush + cancel
+    expect(emitted).toEqual(['playing']);
+    expect(pendingCount()).toBe(0);
+    advance(DEBOUNCE_MS); // would have fired the buffered 'buffering' — must NOT
+    expect(emitted).toEqual(['playing']);
+  });
+
+  it('dedupes consecutive playing reports (no spurious duplicate)', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('playing');
+    d.report('playing'); // duplicate → no-op
+    d.report('playing'); // duplicate → no-op
+    expect(emitted).toEqual(['playing']);
+  });
+});
+
+describe('createStateDispatcher — dispose', () => {
+  it('cancels the pending trailing dispatch on dispose', () => {
+    const emitted: PlayerState[] = [];
+    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    d.report('buffering');
+    expect(pendingCount()).toBe(1);
+    d.dispose();
+    expect(pendingCount()).toBe(0);
+    advance(DEBOUNCE_MS);
+    expect(emitted).toEqual([]);
+  });
+});

--- a/web/src/lib/player/__tests__/dispatch.test.ts
+++ b/web/src/lib/player/__tests__/dispatch.test.ts
@@ -1,157 +1,199 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { createStateDispatcher, DEBOUNCE_MS, type PlayerState } from '$lib/player/dispatch';
 
-// The dispatcher uses real setTimeout by default; tests inject a controllable
-// scheduler so the debounce timing is deterministic without vitest fake timers
-// (either works; the injected form makes the assertions explicit about which
-// timer fired and is easier to reason about for the "playing cancels pending"
-// case).
+// The dispatcher defers EVERY emit out of the synchronous stack (microtask for
+// 'playing', setTimeout for the debounced trailing flush) so the downstream
+// orchestrator state writes cannot run inside a Svelte effect flush (the fix
+// for effect_update_depth_exceeded). To make the async ordering deterministic
+// WITHOUT fighting vitest's fake-timer/microtask interplay, tests inject:
+//   - `sched`: a manually-flushed queue standing in for the microtask path
+//     (used by 'playing'), AND
+//   - `clear` + a controllable `setTimeout`-style trailing timer.
+// Both are driven by explicit flush helpers below.
 
 interface FakeTimer {
   fn: () => void;
-  ms: number;
   fired: boolean;
 }
-let queue: FakeTimer[] = [];
+let microtasks: Array<() => void> = [];
+let timers: FakeTimer[] = [];
 
-function sched(fn: () => void, ms: number): FakeTimer {
-  const t: FakeTimer = { fn, ms, fired: false };
-  queue.push(t);
+beforeEach(() => {
+  microtasks = [];
+  timers = [];
+});
+
+// Inject a microtask-style scheduler: collects callbacks to flush explicitly.
+function schedMicrotask(fn: () => void): void {
+  microtasks.push(fn);
+}
+function flushMicrotasks(): void {
+  // Drain the queue (microtasks may queue more microtasks).
+  while (microtasks.length > 0) {
+    const fn = microtasks.shift()!;
+    fn();
+  }
+}
+// Trailing-edge setTimeout stand-in: collect + manual advance.
+function schedTimer(fn: () => void): FakeTimer {
+  const t: FakeTimer = { fn, fired: false };
+  timers.push(t);
   return t;
 }
-function clear(t: FakeTimer): void {
-  const i = queue.indexOf(t);
-  if (i >= 0) queue.splice(i, 1);
+function clearTimer(t: FakeTimer): void {
+  const i = timers.indexOf(t);
+  if (i >= 0) timers.splice(i, 1);
 }
-/** Advance fake time, firing timers whose delay has elapsed (in insertion order). */
-function advance(ms: number): void {
-  const ready = queue.filter((t) => t.ms <= ms).sort((a, b) => a.ms - b.ms);
+/** Fire every trailing timer whose delay has elapsed (we don't model ms precisely;
+ *  calling this stands in for `advanceTimersByTime(DEBOUNCE_MS)`). */
+function flushTrailing(): void {
+  // Snapshot then clear, since firing may re-arm.
+  const ready = [...timers];
+  timers = [];
   for (const t of ready) {
     if (t.fired) continue;
     t.fired = true;
-    const i = queue.indexOf(t);
-    if (i >= 0) queue.splice(i, 1);
     t.fn();
   }
+  // Firing the trailing callback is itself synchronous; microtasks queued
+  // during it are not part of this model (the real impl uses setTimeout, so
+  // microtasks drain between macrotasks — not our concern here).
 }
-function pendingCount(): number {
-  return queue.length;
+function pendingTrailing(): number {
+  return timers.length;
 }
 
-beforeEach(() => {
-  queue = [];
-});
-
-afterEach(() => {
-  queue = [];
-});
+function newDispatcher(emit: (s: PlayerState) => void) {
+  return createStateDispatcher(emit, {
+    sched: schedMicrotask,
+    schedTrailing: (fn) => schedTimer(fn),
+    clear: clearTimer,
+  });
+}
 
 describe('createStateDispatcher — dedupe', () => {
   it('does not emit when the same state is reported twice in a row', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering');
-    advance(DEBOUNCE_MS);
+    flushTrailing();
     d.report('buffering'); // identical → deduped
-    advance(DEBOUNCE_MS);
+    flushTrailing();
     expect(emitted).toEqual(['buffering']);
   });
 
   it('does not emit a duplicate even before the trailing timer fires', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering');
-    // Immediately report buffering again WITHOUT advancing — pending state is
-    // 'buffering', so the second call is a no-op.
-    d.report('buffering');
-    advance(DEBOUNCE_MS);
+    d.report('buffering'); // pending === 'buffering' → no-op
+    flushTrailing();
     expect(emitted).toEqual(['buffering']);
-    expect(pendingCount()).toBe(0);
   });
 });
 
 describe('createStateDispatcher — debounce', () => {
   it('coalesces a burst of distinct non-playing states into the last one', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
-    // Simulate the hls.js oscillation: buffering → loading → buffering within
-    // the debounce window. Only the final 'buffering' should be emitted.
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering');
     d.report('loading');
     d.report('buffering');
     d.report('loading');
     d.report('buffering');
     expect(emitted).toEqual([]); // nothing yet — all debounced
-    expect(pendingCount()).toBe(1); // exactly one trailing timer
-    advance(DEBOUNCE_MS);
+    expect(pendingTrailing()).toBe(1); // exactly one trailing timer
+    flushTrailing();
     expect(emitted).toEqual(['buffering']); // only the last
   });
 
   it('emits once per debounce window, not per report (the issue #107 storm guard)', () => {
-    // The bug: 7428 statechange events in 55s. With a 500ms debounce the worst
-    // case is ~110 events in 55s even if a new state arrives every tick.
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     for (let i = 0; i < 1000; i++) {
-      // Alternate to bypass dedupe but stay within the window.
       d.report(i % 2 === 0 ? 'buffering' : 'loading');
     }
-    advance(DEBOUNCE_MS);
+    flushTrailing();
     expect(emitted.length).toBe(1);
   });
 
   it('reports a genuinely later state change after the window elapses', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering');
-    advance(DEBOUNCE_MS);
+    flushTrailing();
     expect(emitted).toEqual(['buffering']);
     d.report('error');
-    advance(DEBOUNCE_MS);
+    flushTrailing();
     expect(emitted).toEqual(['buffering', 'error']);
   });
 });
 
-describe('createStateDispatcher — playing flushes immediately', () => {
-  it('emits playing synchronously (no debounce) so recovery is reported at once', () => {
+describe('createStateDispatcher — playing flushes asynchronously (never synchronous)', () => {
+  it('does NOT emit playing synchronously (must defer out of any effect flush)', () => {
+    // THE regression guard for effect_update_depth_exceeded: emit must run on a
+    // microtask, not in the report() call stack.
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('playing');
+    expect(emitted).toEqual([]); // not yet — microtask not flushed
+    flushMicrotasks();
     expect(emitted).toEqual(['playing']);
-    expect(pendingCount()).toBe(0);
+  });
+
+  it('playing emits before the 500ms debounce window (microtask is near-immediate)', () => {
+    const emitted: PlayerState[] = [];
+    const d = newDispatcher((s) => emitted.push(s));
+    d.report('playing');
+    flushMicrotasks();
+    expect(emitted).toEqual(['playing']);
+    expect(pendingTrailing()).toBe(0);
   });
 
   it('cancels a pending trailing dispatch when playing arrives (recovery supersedes it)', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering'); // arms a trailing timer
-    expect(pendingCount()).toBe(1);
-    d.report('playing'); // flush + cancel
+    expect(pendingTrailing()).toBe(1);
+    d.report('playing'); // microtask flush + cancel trailing
+    flushMicrotasks();
     expect(emitted).toEqual(['playing']);
-    expect(pendingCount()).toBe(0);
-    advance(DEBOUNCE_MS); // would have fired the buffered 'buffering' — must NOT
+    expect(pendingTrailing()).toBe(0);
+    flushTrailing(); // would have fired the buffered 'buffering' — must NOT
     expect(emitted).toEqual(['playing']);
   });
 
-  it('dedupes consecutive playing reports (no spurious duplicate)', () => {
+  it('coalesces consecutive playing reports into a single microtask flush', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('playing');
-    d.report('playing'); // duplicate → no-op
-    d.report('playing'); // duplicate → no-op
-    expect(emitted).toEqual(['playing']);
+    d.report('playing'); // deduped — microtask already queued
+    d.report('playing');
+    flushMicrotasks();
+    expect(emitted).toEqual(['playing']); // exactly one emit
+  });
+
+  it('uses DEBOUNCE_MS constant value 500 (documents the storm-bounding window)', () => {
+    expect(DEBOUNCE_MS).toBe(500);
   });
 });
 
 describe('createStateDispatcher — dispose', () => {
   it('cancels the pending trailing dispatch on dispose', () => {
     const emitted: PlayerState[] = [];
-    const d = createStateDispatcher((s) => emitted.push(s), { sched, clear });
+    const d = newDispatcher((s) => emitted.push(s));
     d.report('buffering');
-    expect(pendingCount()).toBe(1);
     d.dispose();
-    expect(pendingCount()).toBe(0);
-    advance(DEBOUNCE_MS);
+    flushTrailing();
+    expect(emitted).toEqual([]);
+  });
+
+  it('makes a queued playing microtask a no-op on dispose', () => {
+    const emitted: PlayerState[] = [];
+    const d = newDispatcher((s) => emitted.push(s));
+    d.report('playing');
+    d.dispose(); // clear the queued state before the microtask runs
+    flushMicrotasks();
     expect(emitted).toEqual([]);
   });
 });

--- a/web/src/lib/player/__tests__/orchestrator.test.ts
+++ b/web/src/lib/player/__tests__/orchestrator.test.ts
@@ -169,6 +169,42 @@ describe('PlayerOrchestrator — degrade', () => {
     expect(o.activeMode('cam-1')).toBe('hls'); // chain exhausted
     o.dispose();
   });
+
+  // ─── Issue #107 regression: the orchestrator must survive a state storm ───
+  // Before the dispatch debounce, hls.js's buffering↔playing oscillation fed
+  // thousands of reportHealth calls per second. This test proves the orchestrator
+  // itself does NOT cascade-demote under that load: the degrade debounce timer
+  // arms once (not per call) and a return to 'ok' cancels it. Combined with the
+  // dispatcher's dedupe/debounce at the component layer, the storm is bounded.
+  it('does NOT demote during a high-frequency buffering↔playing oscillation that returns to ok', () => {
+    const o = createPlayerOrchestrator();
+    o.registerCamera(reg());
+    // Simulate 1 second of sub-second oscillation, never staying degraded long
+    // enough to cross DEGRADE_THRESHOLD_MS (8000ms), ending healthy.
+    for (let i = 0; i < 100; i++) {
+      o.reportHealth('cam-1', health('degraded', 'buffering'));
+      vi.advanceTimersByTime(5);
+      o.reportHealth('cam-1', health('ok'));
+      vi.advanceTimersByTime(5);
+    }
+    expect(o.activeMode('cam-1')).toBe('wasm'); // never demoted
+    o.dispose();
+  });
+
+  it('does NOT arm multiple degrade timers for repeated degraded reports (debounce is idempotent)', () => {
+    const o = createPlayerOrchestrator();
+    o.registerCamera(reg());
+    // Spam degraded — only the first arms a timer; subsequent calls are no-ops
+    // until it fires (the reportHealth degraded branch checks `!it.degradeTimer`).
+    for (let i = 0; i < 50; i++) {
+      o.reportHealth('cam-1', health('degraded', 'buffering'));
+    }
+    // Still in the debounce window → still on the head of the chain.
+    expect(o.activeMode('cam-1')).toBe('wasm');
+    vi.advanceTimersByTime(8000); // threshold elapses → single demotion
+    expect(o.activeMode('cam-1')).toBe('webrtc');
+    o.dispose();
+  });
 });
 
 describe('PlayerOrchestrator — upgrade (anti-flap)', () => {

--- a/web/src/lib/player/__tests__/orchestrator.test.ts
+++ b/web/src/lib/player/__tests__/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPlayerOrchestrator, makeRegistration, type CameraRegistration } from '$lib/player/orchestrator.svelte';
 import { health } from '$lib/player/health';
+import { invalidateCaps } from '$lib/player/capabilities-cache';
 import type { Camera, ProtocolsResponse } from '$lib/stream-selection';
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
@@ -59,6 +60,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  // Clear the in-memory caps cache so a test that called probeCaps() with
+  // custom caps (e.g. the H80 regression test forcing mseH265=false) doesn't
+  // leak into subsequent tests. beforeEach re-seeds sessionStorage; clearing
+  // inMemory here makes getCaps() pick up the fresh seed next time.
+  invalidateCaps();
   try {
     sessionStorage.removeItem('mibee_nvr_device_caps');
   } catch {
@@ -167,6 +173,78 @@ describe('PlayerOrchestrator — degrade', () => {
     expect(o.activeMode('cam-1')).toBe('hls');
     o.reportHealth('cam-1', health('failed'));
     expect(o.activeMode('cam-1')).toBe('hls'); // chain exhausted
+    o.dispose();
+  });
+
+  // ─── Issue #107/#108 H80 regression: no slots churn on repeated equal health ─
+  // An H.265 camera whose WS returns 401 never reaches steady-state 'playing'.
+  // It repeatedly reports 'failed' (noMediaTimer / connect-failures / onFallback).
+  // healthFromStreamState('error') returns a NEW object each call (since=now),
+  // so a reference equality check would NOT short-circuit. Before this fix,
+  // every report reassigned the reactive `slots` map → every $derived(mode)
+  // consumer re-ran → player $effects that read mode re-entered →
+  // effect_update_depth_exceeded froze the whole page. The fix: skip the slots
+  // write when (status, reason) are unchanged.
+  it('does NOT rewrite slots when the same (status, reason) is reported repeatedly (H80 regression)', () => {
+    // Build a single-element wasm chain (H.265 + no MSE → only wasm usable),
+    // mirroring cam-608e6966's real topology. Force mseH265=false (and keep
+    // webCodecs/wasmH265 true) so HLS/FLV are excluded by the codec gate while
+    // wasm stays usable → chain=['wasm']. We seed sessionStorage and invalidate
+    // the in-memory cache so getCaps() (called inside makeRegistration) picks
+    // up our values; we do NOT call probeCaps() because it would re-run the
+    // real detect* probes and overwrite our seed.
+    invalidateCaps();
+    try {
+      sessionStorage.setItem(
+        'mibee_nvr_device_caps',
+        JSON.stringify({
+          webCodecs: true, hevcDecode: true, webgpu: true, webgl2: true,
+          mseH265: false, wasmH265: true, probedAt: Date.now(),
+        }),
+      );
+    } catch { /* sessionStorage may be unavailable */ }
+    const o = createPlayerOrchestrator();
+    const H265_CAM: Camera = { id: 'cam-h80', name: 'H80', protocol: 'onvif', encoding: 'h265' } as Camera;
+    const H265_RESP: ProtocolsResponse = {
+      encoding: 'h265',
+      default: 'hls',
+      protocols: [
+        { Protocol: 'hls', Available: true, Reason: '' },
+        { Protocol: 'll-hls', Available: true, Reason: '' },
+        { Protocol: 'wasm', Available: true, Reason: '' },
+        { Protocol: 'webrtc', Available: false, Reason: 'H.265' },
+        { Protocol: 'flv', Available: false, Reason: 'H.265' },
+      ],
+    };
+    // No MSE H.265 → only wasm is usable → single-element chain, like H80.
+    o.registerCamera(
+      makeRegistration(H265_CAM, H265_RESP, {
+        override: null,
+        isHlsCapable: true,
+        isUnsupported: false,
+      }),
+    );
+    expect(o.activeMode('cam-h80')).toBe('wasm');
+
+    // First 'failed' report: demote attempts, chain exhausted, returns false.
+    // The slot IS written once (health changed from initial 'ok' to 'failed').
+    o.reportHealth('cam-h80', health('failed', 'fatal-error'));
+    expect(o.activeMode('cam-h80')).toBe('wasm'); // still wasm (exhausted)
+    const slotAfterFirst = o.slot('cam-h80')!;
+
+    // Repeated identical (status, reason) reports — healthFromStreamState would
+    // produce new objects with different `since` timestamps in production. The
+    // orchestrator must treat these as equal and NOT rewrite the slot object.
+    for (let i = 0; i < 50; i++) {
+      // New object each iteration (mimics since=Date.now() differing).
+      o.reportHealth('cam-h80', health('failed', 'fatal-error'));
+    }
+    const slotAfterLoop = o.slot('cam-h80')!;
+    expect(o.activeMode('cam-h80')).toBe('wasm'); // never changed
+    // The slot object reference must be STABLE across repeated equal reports —
+    // a new reference would churn every $derived(mode) dependent (the root cause
+    // of effect_update_depth_exceeded).
+    expect(slotAfterLoop).toBe(slotAfterFirst);
     o.dispose();
   });
 

--- a/web/src/lib/player/dispatch.ts
+++ b/web/src/lib/player/dispatch.ts
@@ -1,5 +1,5 @@
 /**
- * Debounced + deduped player-state dispatch.
+ * Debounced + deduped + ASYNC player-state dispatch.
  *
  * Why this exists (issue #107): every player adapter (Video/Flv/Wasm/WebRTC)
  * fed its `streamState` through a Svelte `$effect` that fired a `statechange`
@@ -7,25 +7,39 @@
  * `buffering ↔ playing` (its `FRAG_LOADED → 'playing'` vs fatal
  * `NETWORK_ERROR → 'buffering'`), the effect re-ran thousands of times per
  * second, each dispatch synchronously reaching the orchestrator's
- * `reportHealth` (which reassigns the reactive `slots` map) → Svelte's
- * scheduler was flooded and the console froze.
+ * `reportHealth` (which reassigns the reactive `slots` map) → Svelte scheduler
+ * overload → console freeze (7428 events/55s observed).
  *
- * This module provides a tiny, framework-agnostic dispatcher that:
- *  1. **Dedupes** — a state equal to the last one dispatched is a no-op.
- *     (The old `updateState` assigned `streamState = state` unconditionally,
- *      so even a redundant assignment re-triggered the effect.)
- *  2. **Debounces** — non-recovered states (`loading`/`buffering`/`error`) are
- *     coalesced into a single trailing dispatch within DEBOUNCE_MS, so a burst
- *     of oscillation collapses to one event per window.
- *  3. **Flushes `playing` immediately** — recovery must be reported at once
- *     (a debounced "playing" would leave the orchestrator in `degraded` and
- *      needlessly arm/keep the degrade timer); any pending trailing dispatch
- *      is cancelled because the immediate `playing` supersedes it.
+ * ## Architecture: why EVERY emit must be asynchronous (the synchronous-emit trap)
  *
- * It is intentionally DOM-light: the caller passes an `emit` callback that
- * performs the actual `CustomEvent` dispatch on its own root element. Keeping
- * this pure (no Svelte, no DOM access of its own) makes it unit-testable
- * without jsdom event plumbing.
+ * The player's `$effect` reads `streamState` and calls `dispatchStateChange`.
+ * That dispatch flows to `orchestrator.reportHealth`, which **unconditionally
+ * reassigns the reactive `slots` `$state`** (a new object every call — see
+ * orchestrator.svelte.ts `setSlot`). `slots` is read by CameraPlayer's
+ * `mode = $derived(orchestrator.activeMode(...))`. When `reportHealth` triggers
+ * a `demote`/`upgrade`, `activeIndex` changes → `mode` changes → CameraPlayer
+ * unmounts one player and mounts another → the new player's `$effect` runs on
+ * mount → calls `dispatchStateChange('loading')` → ...
+ *
+ * If `emit()` were SYNCHRONOUS (called directly inside the player's `$effect`),
+ * that whole chain executes WITHIN Svelte's current effect-flush stack. The
+ * `slots` write during an effect's execution makes Svelte immediately re-process
+ * queued effects; combined with a remount, the new player's `$effect` re-enters
+ * the same path synchronously → `effect_update_depth_exceeded` (the regression
+ * observed when this module's first revision flushed `'playing'` synchronously
+ * while debouncing the other states — out-of-order delivery flipped
+ * `activeIndex` during a synchronous flush window).
+ *
+ * **The fix: every emit is deferred out of the current synchronous stack** via
+ * `queueMicrotask` (for `'playing'`, near-immediate recovery) or `setTimeout`
+ * (for the debounced non-recovery states). This guarantees the DOM
+ * `dispatchEvent` → `reportHealth` → `setSlot` chain runs in a fresh task,
+ * NEVER inside Svelte's effect flush. No synchronous `$state` write can happen
+ * during an effect → no depth recursion → no crash. The debounce still bounds
+ * the storm; the async deferral preserves Svelte's effect quiescence.
+ *
+ * This module is intentionally DOM-light and Svelte-free: the caller passes an
+ * `emit` callback. Keeping it pure makes it unit-testable without jsdom.
  */
 
 /**
@@ -33,11 +47,11 @@
  * than a closed union so each adapter's own (slightly diverging) state type —
  * WasmPlayer adds `'disconnected' | 'offline'`, others widen StreamState with
  * `'loading'` — can flow through unchanged. Only `'playing'` has special
- * semantics (immediate flush); every other value is debounced identically.
+ * semantics (low-latency microtask flush); every other value is debounced.
  */
 export type PlayerState = string;
 
-/** The single state value that bypasses the debounce (immediate recovery flush). */
+/** The single state value that bypasses the debounce (near-immediate flush). */
 export const IMMEDIATE_STATE = 'playing';
 
 /**
@@ -50,64 +64,103 @@ export const IMMEDIATE_STATE = 'playing';
 export const DEBOUNCE_MS = 500;
 
 export interface StateDispatcher {
-  /** Report a new state. Deduped + debounced per the rules above. */
+  /** Report a new state. Deduped + debounced + async-deferred per the rules above. */
   report(state: PlayerState): void;
-  /** Cancel any pending trailing dispatch. Call on unmount. */
+  /** Cancel any pending dispatch. Call on unmount. */
   dispose(): void;
 }
 
 /**
- * Create a debounced + deduped state dispatcher.
+ * Create a debounced + deduped + async state dispatcher.
  *
  * @param emit  Receives the (possibly coalesced) state to actually dispatch.
- *              Called synchronously for `playing`, on a timer otherwise.
- * @param sched Injectable timer scheduler for tests (defaults to `setTimeout`).
- * @param clear Injectable timer clearer for tests (defaults to `clearTimeout`).
+ *              ALWAYS called from a microtask/timer — never synchronously from
+ *              `report()`, so the caller's CustomEvent dispatch (and the
+ *              downstream orchestrator state writes) cannot run inside a
+ *              Svelte effect flush.
+ * @param opts.sched        Injectable ASYNC scheduler for the `'playing'`
+ *                          (near-immediate) path. Must defer the call out of
+ *                          the current synchronous stack (microtask/macrotask).
+ *                          Defaults to `queueMicrotask`.
+ * @param opts.schedTrailing Injectable timer for the debounced trailing flush.
+ *                          Signature mirrors `setTimeout(fn, ms)`. Defaults to
+ *                          the global `setTimeout`.
+ * @param opts.clear        Injectable clearer for the trailing timer. Defaults
+ *                          to the global `clearTimeout`.
+ * @param opts.debounceMs   Trailing debounce window. Defaults to DEBOUNCE_MS.
  */
 export function createStateDispatcher(
   emit: (state: PlayerState) => void,
   opts: {
-    sched?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
-    clear?: (id: ReturnType<typeof setTimeout>) => void;
+    sched?: (fn: () => void) => void;
+    schedTrailing?: (fn: () => void, ms: number) => unknown;
+    clear?: (handle: unknown) => void;
     debounceMs?: number;
   } = {},
 ): StateDispatcher {
-  const sched = opts.sched ?? setTimeout;
-  const clear = opts.clear ?? clearTimeout;
   const debounceMs = opts.debounceMs ?? DEBOUNCE_MS;
+  // `sched` is used for the IMMEDIATE ('playing') path — it must defer the call
+  // out of the current synchronous stack. Default to a microtask so recovery is
+  // reported as fast as possible WITHOUT being synchronous.
+  const schedImmediate = opts.sched ?? ((fn: () => void) => queueMicrotask(fn));
+  // The trailing debounce timer uses setTimeout (a real delay).
+  const schedTrailing = opts.schedTrailing ?? globalThis.setTimeout.bind(globalThis);
+  const clearTimeoutFn = opts.clear ?? globalThis.clearTimeout.bind(globalThis);
 
   let lastDispatched: PlayerState | null = null;
   let pending: PlayerState | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  let trailingTimer: unknown | null = null;
+  let immediateQueued = false;
+  let immediateState: PlayerState | null = null;
+
+  function clearTrailing(): void {
+    if (trailingTimer !== null) {
+      clearTimeoutFn(trailingTimer);
+      trailingTimer = null;
+    }
+  }
 
   function report(state: PlayerState): void {
     // (1) Dedupe: identical to whatever we last emitted OR have pending → no-op.
-    // This is the cheap fix that stops the storm when hls.js reports the SAME
-    // state repeatedly (the old code reassigned streamState unconditionally,
-    // re-triggering the effect each time).
-    if (state === lastDispatched && pending === null) return;
+    // This is the cheap guard that stops the storm when hls.js reports the SAME
+    // state repeatedly. (The player's own Svelte $state equality check also
+    // dedupes identical-primitive reassignment, but this covers the dispatcher's
+    // internal pending/immediate queues too.)
+    if (state === lastDispatched && pending === null && !immediateQueued) return;
     if (state === pending) return;
 
-    // (2) `playing` (recovery) flushes immediately and cancels any trailing
-    // dispatch — a pending degraded state is stale the moment media flows.
-    // (Reached here only when not already playing, per the dedupe above.)
+    // (2) `playing` (recovery) flushes on a microtask (near-immediate, but NOT
+    // synchronous) and cancels any pending trailing dispatch — a pending
+    // degraded state is stale the moment media flows. We coalesce repeated
+    // 'playing' reports into a single microtask flush.
     if (state === IMMEDIATE_STATE) {
-      if (timer !== null) {
-        clear(timer);
-        timer = null;
-      }
+      clearTrailing();
       pending = null;
-      lastDispatched = state;
-      emit(state);
+      if (immediateQueued) {
+        // Already a 'playing' flush scheduled — nothing more to do.
+        return;
+      }
+      immediateQueued = true;
+      immediateState = state;
+      schedImmediate(() => {
+        immediateQueued = false;
+        const s = immediateState;
+        immediateState = null;
+        if (s !== null) {
+          lastDispatched = s;
+          emit(s);
+        }
+      });
       return;
     }
 
     // (3) Non-playing: coalesce into a trailing dispatch. Replace whatever was
-    // pending (the latest state wins) and (re)arm the timer.
+    // pending (the latest state wins) and (re)arm the timer. The emit happens
+    // asynchronously via the timer, so it cannot run inside a Svelte flush.
     pending = state;
-    if (timer !== null) clear(timer);
-    timer = sched(() => {
-      timer = null;
+    clearTrailing();
+    trailingTimer = schedTrailing(() => {
+      trailingTimer = null;
       if (pending !== null) {
         const s = pending;
         pending = null;
@@ -118,10 +171,12 @@ export function createStateDispatcher(
   }
 
   function dispose(): void {
-    if (timer !== null) {
-      clear(timer);
-      timer = null;
-    }
+    clearTrailing();
+    // Can't cancel a queued microtask, but zeroing the state makes it a no-op
+    // when it fires (post-unmount emit is harmless anyway — the DOM node is
+    // gone and dispatchEvent on a detached parent is a silent no-op).
+    immediateQueued = false;
+    immediateState = null;
     pending = null;
   }
 

--- a/web/src/lib/player/dispatch.ts
+++ b/web/src/lib/player/dispatch.ts
@@ -1,0 +1,129 @@
+/**
+ * Debounced + deduped player-state dispatch.
+ *
+ * Why this exists (issue #107): every player adapter (Video/Flv/Wasm/WebRTC)
+ * fed its `streamState` through a Svelte `$effect` that fired a `statechange`
+ * CustomEvent on every transition. When hls.js oscillated between
+ * `buffering ↔ playing` (its `FRAG_LOADED → 'playing'` vs fatal
+ * `NETWORK_ERROR → 'buffering'`), the effect re-ran thousands of times per
+ * second, each dispatch synchronously reaching the orchestrator's
+ * `reportHealth` (which reassigns the reactive `slots` map) → Svelte's
+ * scheduler was flooded and the console froze.
+ *
+ * This module provides a tiny, framework-agnostic dispatcher that:
+ *  1. **Dedupes** — a state equal to the last one dispatched is a no-op.
+ *     (The old `updateState` assigned `streamState = state` unconditionally,
+ *      so even a redundant assignment re-triggered the effect.)
+ *  2. **Debounces** — non-recovered states (`loading`/`buffering`/`error`) are
+ *     coalesced into a single trailing dispatch within DEBOUNCE_MS, so a burst
+ *     of oscillation collapses to one event per window.
+ *  3. **Flushes `playing` immediately** — recovery must be reported at once
+ *     (a debounced "playing" would leave the orchestrator in `degraded` and
+ *      needlessly arm/keep the degrade timer); any pending trailing dispatch
+ *      is cancelled because the immediate `playing` supersedes it.
+ *
+ * It is intentionally DOM-light: the caller passes an `emit` callback that
+ * performs the actual `CustomEvent` dispatch on its own root element. Keeping
+ * this pure (no Svelte, no DOM access of its own) makes it unit-testable
+ * without jsdom event plumbing.
+ */
+
+/**
+ * Player state strings the adapters report. Kept open-ended (`string`) rather
+ * than a closed union so each adapter's own (slightly diverging) state type —
+ * WasmPlayer adds `'disconnected' | 'offline'`, others widen StreamState with
+ * `'loading'` — can flow through unchanged. Only `'playing'` has special
+ * semantics (immediate flush); every other value is debounced identically.
+ */
+export type PlayerState = string;
+
+/** The single state value that bypasses the debounce (immediate recovery flush). */
+export const IMMEDIATE_STATE = 'playing';
+
+/**
+ * Window within which consecutive non-`playing` states are coalesced into a
+ * single trailing dispatch. 500ms is short enough that a genuine state change
+ * (loading → error) is still reported promptly, but long enough that hls.js's
+ * sub-second buffering↔playing oscillation collapses to one event. Tuned to
+ * match the docs/known-issues-h265-multicam.md recommendation.
+ */
+export const DEBOUNCE_MS = 500;
+
+export interface StateDispatcher {
+  /** Report a new state. Deduped + debounced per the rules above. */
+  report(state: PlayerState): void;
+  /** Cancel any pending trailing dispatch. Call on unmount. */
+  dispose(): void;
+}
+
+/**
+ * Create a debounced + deduped state dispatcher.
+ *
+ * @param emit  Receives the (possibly coalesced) state to actually dispatch.
+ *              Called synchronously for `playing`, on a timer otherwise.
+ * @param sched Injectable timer scheduler for tests (defaults to `setTimeout`).
+ * @param clear Injectable timer clearer for tests (defaults to `clearTimeout`).
+ */
+export function createStateDispatcher(
+  emit: (state: PlayerState) => void,
+  opts: {
+    sched?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+    clear?: (id: ReturnType<typeof setTimeout>) => void;
+    debounceMs?: number;
+  } = {},
+): StateDispatcher {
+  const sched = opts.sched ?? setTimeout;
+  const clear = opts.clear ?? clearTimeout;
+  const debounceMs = opts.debounceMs ?? DEBOUNCE_MS;
+
+  let lastDispatched: PlayerState | null = null;
+  let pending: PlayerState | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function report(state: PlayerState): void {
+    // (1) Dedupe: identical to whatever we last emitted OR have pending → no-op.
+    // This is the cheap fix that stops the storm when hls.js reports the SAME
+    // state repeatedly (the old code reassigned streamState unconditionally,
+    // re-triggering the effect each time).
+    if (state === lastDispatched && pending === null) return;
+    if (state === pending) return;
+
+    // (2) `playing` (recovery) flushes immediately and cancels any trailing
+    // dispatch — a pending degraded state is stale the moment media flows.
+    // (Reached here only when not already playing, per the dedupe above.)
+    if (state === IMMEDIATE_STATE) {
+      if (timer !== null) {
+        clear(timer);
+        timer = null;
+      }
+      pending = null;
+      lastDispatched = state;
+      emit(state);
+      return;
+    }
+
+    // (3) Non-playing: coalesce into a trailing dispatch. Replace whatever was
+    // pending (the latest state wins) and (re)arm the timer.
+    pending = state;
+    if (timer !== null) clear(timer);
+    timer = sched(() => {
+      timer = null;
+      if (pending !== null) {
+        const s = pending;
+        pending = null;
+        lastDispatched = s;
+        emit(s);
+      }
+    }, debounceMs);
+  }
+
+  function dispose(): void {
+    if (timer !== null) {
+      clear(timer);
+      timer = null;
+    }
+    pending = null;
+  }
+
+  return { report, dispose };
+}

--- a/web/src/lib/player/orchestrator.svelte.ts
+++ b/web/src/lib/player/orchestrator.svelte.ts
@@ -101,6 +101,15 @@ export interface PlayerOrchestrator {
   setTabVisible(visible: boolean): void;
   /** The mode CameraPlayer should render right now (reactive read). */
   activeMode(cameraId: string): CameraMode | null;
+  /**
+   * The recorder-probed codec for a camera (e.g. 'h265'), authoritative over
+   * the possibly-stale DB `camera.encoding`. CameraPlayer feeds this to the
+   * player components so they configure the correct decoder (H.264 vs H.265)
+   * for the ACTUAL stream — passing the DB encoding to a player whose chain
+   * was built from the probed encoding produces a misconfigured decoder and a
+   * black screen (issue #108: H80 stored as h264 but streaming h265).
+   */
+  resolvedEncoding(cameraId: string): string;
   /** Reactive snapshot for debugging / the upgrade badge. */
   slot(cameraId: string): CameraSlot | null;
   /** Subscribe to degrade/upgrade events (for toasts). */
@@ -435,6 +444,16 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
     return slot.chain[slot.activeIndex]?.mode ?? null;
   }
 
+  function resolvedEncoding(cameraId: string): string {
+    // The chain was built from the recorder-probed resp.encoding (authoritative)
+    // via resolveEncoding; return that same resolution so CameraPlayer can feed
+    // the ACTUAL codec to the player decoder config. Returns '' when the camera
+    // isn't registered yet — CameraPlayer falls back to camera.encoding then.
+    const it = internal.get(cameraId);
+    if (!it) return '';
+    return resolveEncoding(it.lastRegistration.camera, it.lastRegistration.resp);
+  }
+
   function slot(cameraId: string): CameraSlot | null {
     return slots[cameraId] ?? null;
   }
@@ -460,6 +479,7 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
     requestUpgrade,
     setTabVisible,
     activeMode,
+    resolvedEncoding,
     slot,
     onModeChange,
     coordinator,

--- a/web/src/lib/player/orchestrator.svelte.ts
+++ b/web/src/lib/player/orchestrator.svelte.ts
@@ -265,8 +265,22 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
       return;
     }
 
-    // Refresh the slot's health reactively.
-    setSlot(cameraId, { health: h }, slot);
+    // Refresh the slot's health reactively — BUT only when the (status, reason)
+    // actually changed. Cameras that can never reach steady-state 'playing'
+    // (e.g. an H.265 camera whose WS returns 401) repeatedly report 'failed',
+    // and `healthFromStreamState('error')` returns a NEW object every call
+    // (`since: Date.now()` differs). Without this short-circuit, every report
+    // reassigned `slots` to a new object, which invalidated every `$derived(mode)`
+    // consumer and — combined with player `$effect`s that read `mode` — drove an
+    // unbounded synchronous effect chain (`effect_update_depth_exceeded`).
+    // The `since` timestamp refreshing is NOT worth churning every dependent;
+    // timers/demote below use `it` (internal, non-reactive) bookkeeping, so
+    // skipping the slots write here does not affect adaptive decisions.
+    const cur = slot.health;
+    const healthUnchanged = cur.status === h.status && cur.reason === h.reason;
+    if (!healthUnchanged) {
+      setSlot(cameraId, { health: h }, slot);
+    }
 
     if (h.status === 'failed') {
       // Immediate demote. Cancel any pending upgrade/probe.
@@ -313,7 +327,11 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
       clearTimeout(it.probeTimer);
       it.probeTimer = null;
     }
-    setSlot(cameraId, { health: h }, slots[cameraId]);
+    // NOTE: the health was already written to the slot above (line 269's setSlot,
+    // gated by the healthUnchanged short-circuit). Do NOT redundantly rewrite
+    // slots here — that would churn every $derived(mode) dependent on every
+    // 'ok' report and re-arm the effect_update_depth_exceeded loop for cameras
+    // that oscillate around the ok/degraded boundary.
   }
 
   function demote(cameraId: string, reason: string): boolean {

--- a/web/src/lib/stream-selection.ts
+++ b/web/src/lib/stream-selection.ts
@@ -332,7 +332,19 @@ export function buildCandidateChain(
         },
       ];
     }
-    // No legacy default either — HLS is the universal last resort.
+    // No legacy default either. HLS is the universal last resort for H.264, but
+    // for an H.265 camera it is a DEATH SENTENCE in most browsers: hls.js feeds
+    // hvc1 to MSE which claims isTypeSupported but silently fails to decode →
+    // permanent black screen + the loading↔buffering state-oscillation that
+    // froze consoles in issue #107. When the browser can actually decode H.265
+    // (WebCodecs on HTTPS, or libde265 WASM on HTTP), prefer the wasm mode —
+    // the WS endpoint exists in every NVR build (WSStreamHandler is always
+    // registered) and a single-element chain avoids the demote-to-HLS trap.
+    // Only fall back to HLS if the browser genuinely can't decode H.265 (the
+    // user will see a black screen either way, but at least no oscillation).
+    if (enc === 'h265' && (caps.webCodecs || caps.wasmH265)) {
+      return [{ mode: 'wasm', backendProtocol: undefined, pinned: false }];
+    }
     return [{ mode: 'hls', backendProtocol: 'hls', pinned: false }];
   }
 

--- a/web/src/routes/LiveView.svelte
+++ b/web/src/routes/LiveView.svelte
@@ -27,6 +27,16 @@
   let playerContainer: HTMLDivElement | undefined = $state();
   let protocolsMap = $state<Map<string, ProtocolInfo>>(buildProtocolsMap(DEFAULT_PROTOCOLS));
   let switchingProtocol = $state(false);
+  // Probed per-camera protocol response (the authoritative encoding lives here,
+  // corrected from the live recorder — NOT the possibly-stale DB `camera.encoding`).
+  // Hoisted to component scope so the ProtocolSwitcher's H.265 UI reads the
+  // REAL codec (issue #108: an H.265 camera stored as h264 in the DB must still
+  // show the H.265 badge / hide WebRTC etc.).
+  let cameraProtocolsResp = $state<ProtocolsResponse | null>(null);
+  // True once loadCamera() has attempted its first registerCamera — guards the
+  // protocolsMap re-registration below from firing before the primary
+  // registration (with the real resp) has happened.
+  let cameraRegistered = false;
 
   // Player orchestrator — owns the candidate chain + adaptive degrade/upgrade
   // for this single camera. Provided to CameraPlayer via context.
@@ -104,7 +114,11 @@
       } catch {
         resp = null; // /protocols unreachable — orchestrator falls back to HLS
       }
+      // Persist the probed response so the ProtocolSwitcher can read the REAL
+      // (recorder-probed) encoding instead of the possibly-stale DB value.
+      cameraProtocolsResp = resp;
       if (camera) {
+        cameraRegistered = true;
         orchestrator.registerCamera(
           makeRegistration(camera, resp, {
             override: getCameraProtocolOverride(camera.id),
@@ -172,13 +186,28 @@
 
     loadCamera();
     document.addEventListener('fullscreenchange', handleFullscreenChange);
-    // Load protocol capabilities, then re-register the camera so the
-    // orchestrator's chain reflects the (possibly now-non-HLS-capable) protocol.
+    // Fetch the GLOBAL protocol capability list (does this NVR build offer
+    // webrtc/flv/hls/mjpeg for this protocol type?) — feeds isHlsSupported() /
+    // PTZ gating via protocolsMap. This is SEPARATE from the per-camera
+    // /protocols ranking (already fetched in loadCamera with the authoritative
+    // encoding) and must NOT re-register the camera: re-registering with
+    // resp=null collapses the orchestrator's chain to a forced single-`hls`
+    // candidate (buildCandidateChain's !resp branch), which for an H.265 camera
+    // means HLS gets selected against the codec gate → black screen / state
+    // oscillation (issue #108). The two fetches race (loadCamera does 3 awaits,
+    // this does 1), so the null-registration often landed LAST and clobbered
+    // the good chain. The protocolsMap it builds is enough on its own.
     listProtocols().then(list => {
       if (list && list.length > 0) protocolsMap = buildProtocolsMap(list);
-      if (camera) {
+      // protocolsMap drives isHlsSupported(); if the global list changed the
+      // camera's HLS capability vs. the DEFAULT_PROTOCOLS seed used during the
+      // first registration in loadCamera, re-register now with the SAME probed
+      // resp (NOT null — null would collapse the chain to forced HLS, issue
+      // #108). Guarded by cameraRegistered so we don't re-register before
+      // loadCamera's primary registration has happened.
+      if (cameraRegistered && camera) {
         orchestrator.registerCamera(
-          makeRegistration(camera, null, {
+          makeRegistration(camera, cameraProtocolsResp, {
             override: getCameraProtocolOverride(camera.id),
             isHlsCapable: isHlsSupported(camera),
             isUnsupported: false,
@@ -252,7 +281,7 @@
                  pins the chain via setOverride. -->
             <ProtocolSwitcher
               cameraId={camera.id}
-              cameraEncoding={camera.encoding || camera.stream_encoding || ''}
+              cameraEncoding={cameraProtocolsResp?.encoding || camera.encoding || camera.stream_encoding || ''}
               selected={(activeMode ?? 'auto') as StreamingProtocol}
               onchange={handleProtocolChange}
             />


### PR DESCRIPTION
## Summary

Fixes the two most severe open issues — the H.265 multi-camera grid that could **freeze the browser console** (#107), and the H.265 camera LiveView **black screen** (#108). The fix turned out to span four commits as each layer revealed the next root cause.

## Issue #107 — state-oscillation storm

Every player adapter dispatched a `statechange` CustomEvent from a Svelte `$effect` on **every** `streamState` transition, with no dedupe/debounce. When hls.js oscillated `buffering ↔ playing`, the effect re-ran thousands of times per second, each dispatch synchronously reaching `orchestrator.reportHealth` (which reassigns the reactive `slots` map) → Svelte scheduler overload → console freeze (7428 events/55s observed).

## Issue #108 — H.265 LiveView black screen

H80 (cam-608e6966) is stored as `h264` in the DB but its recorder streams `h265`. The orchestrator correctly built a wasm/WebCodecs chain from the **probed** h265, but `CameraPlayer` fed the player `codec='h264'` (from the DB) → the player configured an H.264 decoder that silently failed to decode the H.265 NALUs. WS data was flowing fine (101 + binary frames) — the black screen was purely a decoder-config mismatch.

## Changes (4 commits)

### `ebe7bd8` — CameraPlayer uses recorder-probed codec (the H80 black-screen fix)
- `orchestrator.svelte.ts`: expose `resolvedEncoding(cameraId)` — returns the same recorder-probed codec (`resp.encoding`) the candidate chain was built from.
- `CameraPlayer.svelte`: `codec = orchestrator.resolvedEncoding(id) || camera.encoding || camera.stream_encoding`. The player decoder now matches the ACTUAL stream. Generic — any camera whose DB encoding drifted benefits.

### `a761f34` — orchestrator reportHealth short-circuit (the effect_update_depth root cause)
- `reportHealth` previously called `setSlot` (→ `slots = { ...slots }`, a new object) on EVERY report, even when `(status, reason)` were unchanged. `healthFromStreamState('error')` returns a new object each call (`since: Date.now()`), so reference equality couldn't short-circuit. An H.265 camera that never reaches steady-state `'playing'` (WS 401 / unreachable) reports `'failed'` repeatedly → each report churned `slots` → every `$derived(mode)` re-ran → player `$effect`s re-entered → `effect_update_depth_exceeded`. Fix: skip the reactive write when `slot.health.{status,reason}` equals the incoming health. Timers/demote use non-reactive bookkeeping, unaffected.
- Also removed a redundant trailing `setSlot` on the `'ok'` path.

### `d45b716` — dispatch fully async (fixes the regression the first revision introduced)
- The first revision of `dispatch.ts` flushed `'playing'` SYNCHRONOUSLY while debouncing other states. A synchronous emit inside the player `$effect` reached `reportHealth → setSlot` during Svelte's effect flush; combined with a remount this produced `effect_update_depth_exceeded`. Fix: **every emit is deferred** — `queueMicrotask` for `'playing'`, `setTimeout` for the debounced trailing flush. The DOM dispatch → reportHealth → setSlot chain always runs in a fresh task, never inside an effect flush.
- Removed the assignment-side dedupe guards added in the first revision (they altered timing and were redundant with Svelte 5's primitive-equality check).

### `e8135f1` — initial debounce + LiveView/chain fixes
- New `web/src/lib/player/dispatch.ts`: dedupe + 500ms trailing debounce.
- `LiveView.svelte`: drop the duplicate `null`-resp `registerCamera` (raced the real registration, collapsed chain to forced HLS); re-register with the SAME probed resp; ProtocolSwitcher reads probed encoding.
- `stream-selection.ts` `buildCandidateChain` `!resp` branch: H.265 + WebCodecs/wasm → `[{wasm}]` instead of forced `[{hls}]`.

## Tests
- `dispatch.test.ts` (new, 12): dedupe, debounce, **`'playing'` must NOT emit synchronously** (the effect_update_depth guard), dispose.
- `orchestrator.test.ts` (+3): oscillation→ok does NOT demote; repeated degraded arms one timer; **repeated `'failed'` on exhausted chain does NOT rewrite `slots`** (H80 regression — slot reference stable across 50 identical reports).
- `stream-selection.test.ts` (+4): `!resp` + H.265 → `[{wasm}]`; H.264 unchanged.
- Full suite: **456 tests pass** (24 files).

## Verification (Banana Pi M5, real cameras — PR gate)
- **#107**: 4-camera H.265 grid stable after 30s+ soak; click 100–200ms; all cameras stayed on WebCodecs.
- **effect_update_depth_exceeded**: H80 added to grid + 60s soak (past 30s noMediaTimer + reconnects); no freeze; drag/expand responsive.
- **#108 H80 black screen**: LiveView now shows **"实时" (live)** on WebCodecs with correct H.265 decoder (was "快照模式"/black). ProtocolSwitcher shows "H.265 WebCodecs". WS confirmed working (101 + binary H.265 frames).
- Backend logs clean; 9 cameras recording; no regressions.

## Files
- `web/src/lib/player/dispatch.ts` (new)
- `web/src/lib/player/__tests__/dispatch.test.ts` (new)
- `web/src/lib/player/orchestrator.svelte.ts` (resolvedEncoding + reportHealth short-circuit)
- `web/src/components/CameraPlayer.svelte` (probed codec prop)
- `web/src/components/{VideoPlayer,FlvPlayer,WasmPlayer,WebRTCPlayer}.svelte` (async dispatch)
- `web/src/routes/LiveView.svelte` (drop null-resp re-register; probed encoding for switcher)
- `web/src/lib/stream-selection.ts` (!resp H.265 → wasm)
- `web/src/lib/__tests__/stream-selection.test.ts`, `web/src/lib/player/__tests__/orchestrator.test.ts`
- `docs/known-issues-h265-multicam.md` (postmortem)