### PR TITLE
fix(autodiscover): update existing camera on IP roaming instead of duplicating (#121)

### DIFF
--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -35,12 +35,47 @@ import (
 
 var logger = slog.Default().With("component", "autodiscover")
 
-// dedupWindow suppresses repeated discovery of the same endpoint within this
+// dedupWindow suppresses repeated discovery of the same device within this
 // interval. WS-Discovery Hello is sent periodically (some firmware every ~30s)
 // and a device that fails to enroll should not be retried every cycle. The
 // window is long enough to cover a few Hello cycles but short enough that a
 // transient failure (e.g. enrichment timeout) is retried within minutes.
 const dedupWindow = 5 * time.Minute
+
+// CameraEnroller is the subset of *camera.CameraManager that Adder needs.
+// Defined as an interface so autodiscover's own tests can inject a fake without
+// standing up a full CameraManager (which requires a real DB, store, recorder
+// factory, etc.). *camera.CameraManager satisfies this interface — production
+// wiring in service.New passes the concrete type unchanged.
+type CameraEnroller interface {
+	// AddCamera enrolls a brand-new camera. Returns the assigned camera ID.
+	AddCamera(ctx context.Context, cam config.CameraConfig) (string, error)
+	// UpdateCamera applies a partial update (e.g. a new ONVIFEndpoint after IP
+	// roaming). Returns the updated config.
+	UpdateCamera(ctx context.Context, cameraID string, updates camera.CameraUpdate) (*config.CameraConfig, error)
+	// RestartRecorder stops and recreates the recorder for a camera, serialized
+	// per-camera via withCameraLifecycle (safe against concurrent health restarts).
+	RestartRecorder(ctx context.Context, cameraID string) error
+}
+
+// dedupKey is the in-memory dedup identity. Prefer the device's hardware serial
+// (stable across IP changes); fall back to the endpoint string when the serial
+// is unavailable (e.g. enrichment failed for an auth-required device). Keying on
+// serial means a roaming device that re-announces at a new IP is still
+// suppressed within dedupWindow — endpoint-only keying would let it retrigger
+// every cycle (issue #121).
+type dedupKey struct {
+	identity string
+}
+
+// makeDedupKey returns the dedup key for a device. serial takes precedence;
+// empty serial falls back to endpoint (legacy behavior).
+func makeDedupKey(endpoint, serial string) dedupKey {
+	if s := strings.TrimSpace(serial); s != "" {
+		return dedupKey{identity: "serial:" + s}
+	}
+	return dedupKey{identity: "endpoint:" + endpoint}
+}
 
 // Adder is the shared enrollment pipeline invoked by both the passive listener
 // and the active scanner. It is the single place that decides whether a
@@ -51,28 +86,31 @@ const dedupWindow = 5 * time.Minute
 // blocks the caller for long — enrichment and credential probing run on a
 // dedicated goroutine per device.
 type Adder struct {
-	camMgr *camera.CameraManager
+	camMgr CameraEnroller
 	db     *storage.DB
 	cfg    *config.AutoDiscoverConfig
 	bus    *event.EventBus
 
-	// in-memory dedup: endpoint → last attempted time. Guards against a chatty
-	// device (repeated Hello) retriggering enrollment. Persisted cameras are the
-	// authoritative dedup; this map only short-circuits the enrichment/probe work
-	// for devices already known to be unenrollable (e.g. pending activation).
-	dedup   map[string]time.Time
+	// in-memory dedup: device identity → last attempted time. Guards against a
+	// chatty device (repeated Hello) retriggering enrollment. Persisted cameras
+	// are the authoritative dedup; this map only short-circuits the
+	// enrichment/probe work for devices already known to be unenrollable (e.g.
+	// pending activation). Keyed by serial when available, endpoint otherwise
+	// (see makeDedupKey).
+	dedup   map[dedupKey]time.Time
 	dedupMu sync.Mutex
 }
 
 // NewAdder constructs an Adder. cfg, db, and camMgr must be non-nil; bus may be
-// nil (events are silently skipped).
-func NewAdder(cfg *config.AutoDiscoverConfig, camMgr *camera.CameraManager, db *storage.DB, bus *event.EventBus) *Adder {
+// nil (events are silently skipped). camMgr is typed as CameraEnroller so tests
+// can inject a fake; pass a *camera.CameraManager in production.
+func NewAdder(cfg *config.AutoDiscoverConfig, camMgr CameraEnroller, db *storage.DB, bus *event.EventBus) *Adder {
 	return &Adder{
 		camMgr: camMgr,
 		db:     db,
 		cfg:    cfg,
 		bus:    bus,
-		dedup:  make(map[string]time.Time),
+		dedup:  make(map[dedupKey]time.Time),
 	}
 }
 
@@ -99,7 +137,12 @@ func (a *Adder) HandleDiscovered(ctx context.Context, dev onvif.DiscoveredDevice
 	// network work. A device already enrolled (DB dedup, below) is also caught
 	// here for the duration of the window, but we re-check the DB after the
 	// window expires to pick up deletions.
-	if a.recentlySeen(endpoint) {
+	//
+	// NOTE: dev.Serial is empty before enrichment (step 3), so this first check
+	// is endpoint-keyed. After enrichment, step 4 re-marks the device under its
+	// serial key so subsequent announcements at a NEW IP are still suppressed
+	// within the window (issue #121).
+	if a.recentlySeen(endpoint, dev.Serial) {
 		return
 	}
 
@@ -109,11 +152,18 @@ func (a *Adder) HandleDiscovered(ctx context.Context, dev onvif.DiscoveredDevice
 	a.enrich(enrichCtx, &dev, endpoint)
 	enrichCancel()
 
-	// 4. Persisted dedup: skip if a camera with the same endpoint or serial
-	// already exists. Serial-level dedup catches devices whose IP changed (the
-	// endpoint string differs but it is the same physical camera).
-	if a.existsInDB(ctx, endpoint, dev.Serial, dev.Serial) {
-		a.markSeen(endpoint) // refresh window so we don't re-probe every cycle
+	// 4. Persisted dedup: skip if a camera with the same stable_id, endpoint, or
+	// serial already exists. When the match is by stable_id or serial (the SAME
+	// physical device at a NEW address), UPDATE the existing camera's endpoint
+	// instead of silently skipping — this is the IP-roaming fix (issue #121).
+	// An "endpoint" match means the same device at the same address is already
+	// enrolled, so there is nothing to update.
+	existingID, matchKind := a.findExistingCamera(ctx, endpoint, dev.Serial, dev.Serial)
+	if existingID != "" {
+		if (matchKind == "stable_id" || matchKind == "serial") && a.camMgr != nil {
+			a.updateEndpointForRoaming(ctx, existingID, endpoint, dev)
+		}
+		a.markSeen(endpoint, dev.Serial) // refresh window under the (now-known) serial key
 		return
 	}
 
@@ -165,14 +215,25 @@ func (a *Adder) enrich(ctx context.Context, dev *onvif.DiscoveredDevice, endpoin
 	onvif.EnrichDevice(ctx, dev)
 }
 
-// existsInDB reports whether a camera already persists with the given stable_id,
-// endpoint, or serial. stable_id is checked first (IP self-healing priority);
-// if empty or no match, falls back to endpoint+serial check (existing dedup
-// logic that covers non-ONVIF cameras and serial_number fallback).
-// A nil DB disables persisted dedup (returns false).
+// findExistingCamera reports whether a camera already persists with the given
+// stable_id, endpoint, or serial, and returns the matching camera ID + match
+// kind so the caller can decide whether to UPDATE the endpoint (IP-roaming
+// case) or simply skip (same-address case).
+//
+// matchKind values:
+//   - ""          — no existing camera (proceed to enroll)
+//   - "stable_id" — same physical device (by ONVIF serial / stable_id), possibly
+//                   at a NEW endpoint → caller should UPDATE the endpoint
+//   - "serial"    — same physical device (by serial_number column), possibly at
+//                   a NEW endpoint → caller should UPDATE the endpoint
+//   - "endpoint"  — same device at the SAME endpoint already enrolled → caller
+//                   should skip (nothing to update)
+//
+// stable_id is checked first (strongest identity signal), then endpoint+serial.
+// A nil DB disables persisted dedup (returns "", "").
 //
 // The query covers ALL camera rows — including ARCHIVED ones — via
-// CameraExistsByStableID and CameraExistsByOnvifEndpoint. This matters because
+// CameraIDByStableID and CameraIDByOnvifEndpoint. This matters because
 // ListCameras only returns archived=0 rows; without the archived-inclusive
 // lookup, archiving a camera would make it invisible to dedup and
 // auto-discover would immediately re-enroll the same physical device the
@@ -183,32 +244,85 @@ func (a *Adder) enrich(ctx context.Context, dev *onvif.DiscoveredDevice, endpoin
 // (direct MJPEG) still carries the device's onvif_endpoint (backfilled at add
 // time), so an ONVIF device discovered later must NOT be re-enrolled under a
 // second protocol=onvif row. Serial is ONVIF-specific (serial_number column).
-func (a *Adder) existsInDB(ctx context.Context, endpoint, serial, stableID string) bool {
+func (a *Adder) findExistingCamera(ctx context.Context, endpoint, serial, stableID string) (cameraID, matchKind string) {
 	if a.db == nil {
-		return false
+		return "", ""
 	}
 
 	// Priority 1: stable_id match. A device with the same ONVIF serial that
 	// was previously enrolled (and whose IP may have changed) is the same
-	// physical camera — skip enrollment.
+	// physical camera — the caller will UPDATE its endpoint.
 	if stableID != "" {
-		exists, err := a.db.CameraExistsByStableID(ctx, stableID)
+		id, err := a.db.CameraIDByStableID(ctx, stableID)
 		if err != nil {
-			logger.Warn("dedup: CameraExistsByStableID failed, falling back to endpoint dedup", "error", err)
-		} else if exists {
-			return true
+			logger.Warn("dedup: CameraIDByStableID failed, falling back to endpoint dedup", "error", err)
+		} else if id != "" {
+			return id, "stable_id"
 		}
 	}
 
 	// Priority 2: endpoint or serial match (existing dedup logic).
 	// Covers non-ONVIF cameras without a stable_id, and the serial_number
 	// fallback for devices whose enrichment succeeded.
-	exists, err := a.db.CameraExistsByOnvifEndpoint(ctx, endpoint, serial)
+	id, kind, err := a.db.CameraIDByOnvifEndpoint(ctx, endpoint, serial)
 	if err != nil {
-		logger.Warn("dedup: CameraExistsByOnvifEndpoint failed, skipping dedup this cycle", "error", err)
-		return false
+		logger.Warn("dedup: CameraIDByOnvifEndpoint failed, skipping dedup this cycle", "error", err)
+		return "", ""
 	}
-	return exists
+	return id, kind
+}
+
+// updateEndpointForRoaming updates an existing camera's ONVIF endpoint (and URL)
+// to the newly-discovered address, then restarts its recorder so the new
+// address takes effect immediately. This is the IP-roaming fix (issue #121):
+// when auto-discover recognizes a known device at a NEW address, it updates the
+// existing row instead of creating a duplicate.
+//
+// Best-effort: failures are logged and swallowed — a failed update does not
+// block discovery of other devices, and the device will simply be retried on
+// the next announcement cycle (subject to the dedup window).
+//
+// Concurrency: UpdateCamera only mutates the endpoint + evicts the cached ONVIF
+// client (it does NOT trigger a recorder restart on its own, avoiding a race
+// with concurrent health-loop restarts); RestartRecorder is serialized
+// per-camera via withCameraLifecycle. This is safer than calling
+// RediscoverAndReconnect (which would re-scan the subnet AND restart the
+// recorder outside the lifecycle guard).
+func (a *Adder) updateEndpointForRoaming(ctx context.Context, cameraID, newEndpoint string, dev onvif.DiscoveredDevice) {
+	ep := newEndpoint
+	updates := camera.CameraUpdate{
+		ONVIFEndpoint: &ep,
+		URL:           &ep,
+	}
+	cam, err := a.camMgr.UpdateCamera(ctx, cameraID, updates)
+	if err != nil {
+		// A CameraNotFoundError here means the camera is ARCHIVED (it exists in
+		// the DB dedup tables but not in the live cfg.Cameras). That is expected
+		// — an archived device that reappears should be left alone, not updated.
+		logger.Debug("roaming update: camera not in live config (likely archived), skipping",
+			"camera_id", cameraID, "endpoint", newEndpoint, "error", err)
+		return
+	}
+	// Restart the recorder so it reconnects to the new endpoint. The old
+	// recorder (if any) was bound to the old address and would keep failing.
+	// For pending_activation cameras (no recorder running), this is a no-op.
+	if err := a.camMgr.RestartRecorder(ctx, cameraID); err != nil {
+		logger.Warn("roaming update: recorder restart failed (endpoint was still updated)",
+			"camera_id", cameraID, "endpoint", newEndpoint, "error", err)
+	}
+
+	logger.Info("updated camera endpoint after IP roaming",
+		"camera_id", cameraID, "name", cam.Name,
+		"new_endpoint", newEndpoint, "serial", dev.Serial)
+
+	// Notify subscribers (frontend toast, etc.) using camera.added with a
+	// distinct source so the UI can message "IP updated" rather than "new camera".
+	a.publish(ctx, event.TopicCameraAdded, map[string]any{
+		"camera_id": cameraID,
+		"name":      cam.Name,
+		"endpoint":  newEndpoint,
+		"source":    "auto-rediscover",
+	})
 }
 
 // classify decides the activation state for a new device:
@@ -255,7 +369,7 @@ func (a *Adder) probeCredentials(ctx context.Context, endpoint string) bool {
 // the manual add path (web/src/lib/components/DiscoveryPanel.svelte):
 // protocol=onvif, encoding left empty for runtime detection.
 func (a *Adder) enroll(ctx context.Context, dev onvif.DiscoveredDevice, endpoint, state string) {
-	a.markSeen(endpoint)
+	a.markSeen(endpoint, dev.Serial)
 
 	name := dev.Name
 	if name == "" {
@@ -337,28 +451,32 @@ func (a *Adder) publish(ctx context.Context, topic string, data any) {
 	a.bus.Publish(ctx, topic, data)
 }
 
-// recentlySeen reports whether endpoint was attempted within dedupWindow, and
-// is thread-safe. Garbage-collects expired entries opportunistically.
-func (a *Adder) recentlySeen(endpoint string) bool {
+// recentlySeen reports whether the device (keyed by serial, or endpoint when
+// serial is unavailable) was attempted within dedupWindow. Thread-safe; GCs
+// expired entries opportunistically.
+func (a *Adder) recentlySeen(endpoint, serial string) bool {
+	key := makeDedupKey(endpoint, serial)
 	a.dedupMu.Lock()
 	defer a.dedupMu.Unlock()
 	now := time.Now()
-	// GC expired entries to keep the map bounded (one device per endpoint, but
+	// GC expired entries to keep the map bounded (one device per identity, but
 	// churn from IP changes could grow it).
-	for ep, t := range a.dedup {
+	for k, t := range a.dedup {
 		if now.Sub(t) > dedupWindow {
-			delete(a.dedup, ep)
+			delete(a.dedup, k)
 		}
 	}
-	if t, ok := a.dedup[endpoint]; ok {
+	if t, ok := a.dedup[key]; ok {
 		return now.Sub(t) < dedupWindow
 	}
 	return false
 }
 
-// markSeen records that endpoint was attempted now.
-func (a *Adder) markSeen(endpoint string) {
+// markSeen records that the device (keyed by serial, or endpoint when serial is
+// unavailable) was attempted now.
+func (a *Adder) markSeen(endpoint, serial string) {
+	key := makeDedupKey(endpoint, serial)
 	a.dedupMu.Lock()
-	a.dedup[endpoint] = time.Now()
+	a.dedup[key] = time.Now()
 	a.dedupMu.Unlock()
 }

--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -221,13 +221,10 @@ func (a *Adder) enrich(ctx context.Context, dev *onvif.DiscoveredDevice, endpoin
 // case) or simply skip (same-address case).
 //
 // matchKind values:
-//   - ""          — no existing camera (proceed to enroll)
-//   - "stable_id" — same physical device (by ONVIF serial / stable_id), possibly
-//                   at a NEW endpoint → caller should UPDATE the endpoint
-//   - "serial"    — same physical device (by serial_number column), possibly at
-//                   a NEW endpoint → caller should UPDATE the endpoint
-//   - "endpoint"  — same device at the SAME endpoint already enrolled → caller
-//                   should skip (nothing to update)
+//   - ""          : no existing camera (proceed to enroll)
+//   - "stable_id" : same physical device (by ONVIF serial / stable_id), possibly at a NEW endpoint - caller should UPDATE the endpoint
+//   - "serial"    : same physical device (by serial_number column), possibly at a NEW endpoint - caller should UPDATE the endpoint
+//   - "endpoint"  : same device at the SAME endpoint already enrolled - caller should skip (nothing to update)
 //
 // stable_id is checked first (strongest identity signal), then endpoint+serial.
 // A nil DB disables persisted dedup (returns "", "").

--- a/internal/autodiscover/adder_test.go
+++ b/internal/autodiscover/adder_test.go
@@ -325,11 +325,15 @@ func TestDefaultCredsForState(t *testing.T) {
 // fix path). AddCamera is included to satisfy the interface but unused in the
 // roaming tests.
 type fakeEnroller struct {
-	mu               sync.Mutex
-	updatedEndpoints map[string]string   // cameraID → new endpoint passed to UpdateCamera
-	restartedIDs     map[string]bool     // cameraID → RestartRecorder called
-	updateErr        error               // optional: force UpdateCamera to fail
-	restartErr       error               // optional: force RestartRecorder to fail
+	mu sync.Mutex
+	// cameraID → new endpoint passed to UpdateCamera
+	updatedEndpoints map[string]string
+	// cameraID → RestartRecorder called
+	restartedIDs map[string]bool
+	// optional: force UpdateCamera to fail
+	updateErr error
+	// optional: force RestartRecorder to fail
+	restartErr error
 }
 
 func newFakeEnroller() *fakeEnroller {

--- a/internal/autodiscover/adder_test.go
+++ b/internal/autodiscover/adder_test.go
@@ -3,8 +3,10 @@ package autodiscover
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
@@ -92,13 +94,15 @@ func TestExistsInDB_EndpointDedup(t *testing.T) {
 	endpoint := "http://192.168.1.50:80/onvif/device_service"
 	seedOnvifCamera(t, db, "cam-existing", endpoint, "")
 
-	// Same endpoint → duplicate.
-	if !adder.existsInDB(context.Background(), endpoint, "", "") {
-		t.Error("expected existsInDB=true for a known endpoint")
+	// Same endpoint → duplicate (matchKind="endpoint").
+	id, kind := adder.findExistingCamera(context.Background(), endpoint, "", "")
+	if id != "cam-existing" || kind != "endpoint" {
+		t.Errorf("findExistingCamera(known endpoint) = (%q, %q), want (cam-existing, endpoint)", id, kind)
 	}
 	// Different endpoint, empty serial → not a duplicate.
-	if adder.existsInDB(context.Background(), "http://192.168.1.99:80/onvif/device_service", "", "") {
-		t.Error("expected existsInDB=false for an unknown endpoint")
+	id, kind = adder.findExistingCamera(context.Background(), "http://192.168.1.99:80/onvif/device_service", "", "")
+	if id != "" || kind != "" {
+		t.Errorf("findExistingCamera(unknown endpoint) = (%q, %q), want (\"\", \"\")", id, kind)
 	}
 }
 
@@ -114,12 +118,14 @@ func TestExistsInDB_SerialDedup(t *testing.T) {
 	// The same physical camera reappears at a NEW IP (different endpoint string)
 	// but the same serial → must still be deduplicated, otherwise the NVR would
 	// create a duplicate entry every time a camera's DHCP lease changes.
-	if !adder.existsInDB(context.Background(), "http://192.168.1.99:80/onvif/device_service", "ABC123", "") {
-		t.Error("expected existsInDB=true by serial match (roaming camera)")
+	id, kind := adder.findExistingCamera(context.Background(), "http://192.168.1.99:80/onvif/device_service", "ABC123", "")
+	if id != "cam-roamed" || kind != "serial" {
+		t.Errorf("findExistingCamera(serial match) = (%q, %q), want (cam-roamed, serial)", id, kind)
 	}
 	// Different serial → not a duplicate.
-	if adder.existsInDB(context.Background(), "http://192.168.1.99:80/onvif/device_service", "DIFFERENT", "") {
-		t.Error("expected existsInDB=false for unknown serial")
+	id, kind = adder.findExistingCamera(context.Background(), "http://192.168.1.99:80/onvif/device_service", "DIFFERENT", "")
+	if id != "" || kind != "" {
+		t.Errorf("findExistingCamera(unknown serial) = (%q, %q), want (\"\", \"\")", id, kind)
 	}
 }
 
@@ -137,7 +143,7 @@ func TestExistsInDB_NonOnvifCameraWithoutOnvifEndpoint(t *testing.T) {
 	}
 	cfg := &config.AutoDiscoverConfig{}
 	adder := NewAdder(cfg, nil, db, nil)
-	if adder.existsInDB(ctx, "http://192.168.1.50:80/onvif/device_service", "", "") {
+	if id, _ := adder.findExistingCamera(ctx, "http://192.168.1.50:80/onvif/device_service", "", ""); id != "" {
 		t.Error("RTSP camera with no onvif_endpoint must not trigger ONVIF dedup")
 	}
 }
@@ -161,7 +167,7 @@ func TestExistsInDB_NonOnvifCameraWithMatchingOnvifEndpoint(t *testing.T) {
 	}
 	cfg := &config.AutoDiscoverConfig{}
 	adder := NewAdder(cfg, nil, db, nil)
-	if !adder.existsInDB(ctx, endpoint, "", "") {
+	if id, _ := adder.findExistingCamera(ctx, endpoint, "", ""); id != "cam-http" {
 		t.Error("a manually-added http camera with a matching onvif_endpoint must trigger dedup (same physical device)")
 	}
 }
@@ -170,14 +176,15 @@ func TestExistsInDB_NilDB(t *testing.T) {
 	t.Helper()
 	// A nil DB (defensive) must report "does not exist" rather than panic.
 	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, nil, nil)
-	if adder.existsInDB(context.Background(), "http://anything", "anyserial", "") {
-		t.Error("nil DB should report existsInDB=false")
+	if id, _ := adder.findExistingCamera(context.Background(), "http://anything", "anyserial", ""); id != "" {
+		t.Error("nil DB should report findExistingCamera=(\"\",\"\")")
 	}
 }
 
 // TestExistsInDB_StableIDPriority verifies that stable_id dedup takes precedence
 // over endpoint dedup. A camera whose IP changed (new endpoint) but has the same
-// ONVIF serial (stored as stable_id) must be recognized as existing.
+// ONVIF serial (stored as stable_id) must be recognized as existing with
+// matchKind="stable_id" (triggering an endpoint update, not just a skip).
 func TestExistsInDB_StableIDPriority(t *testing.T) {
 	t.Helper()
 	db := newTestDB(t)
@@ -191,24 +198,29 @@ func TestExistsInDB_StableIDPriority(t *testing.T) {
 		t.Fatalf("UpsertCamera: %v", err)
 	}
 
-	// Same stable_id, DIFFERENT endpoint → must be deduplicated (IP change scenario).
-	if !adder.existsInDB(ctx, "http://192.168.1.99:80/onvif/device_service", "", "ABC") {
-		t.Error("expected existsInDB=true by stable_id match (IP change)")
+	// Same stable_id, DIFFERENT endpoint → matchKind="stable_id" (IP change →
+	// caller should UPDATE the endpoint, not just skip).
+	id, kind := adder.findExistingCamera(ctx, "http://192.168.1.99:80/onvif/device_service", "", "ABC")
+	if id != "cam-existing" || kind != "stable_id" {
+		t.Errorf("findExistingCamera(stable_id match, IP change) = (%q, %q), want (cam-existing, stable_id)", id, kind)
 	}
 
 	// Different stable_id → not a duplicate.
-	if adder.existsInDB(ctx, "http://192.168.1.99:80/onvif/device_service", "", "XYZ") {
-		t.Error("expected existsInDB=false for unknown stable_id")
+	id, kind = adder.findExistingCamera(ctx, "http://192.168.1.99:80/onvif/device_service", "", "XYZ")
+	if id != "" || kind != "" {
+		t.Errorf("findExistingCamera(unknown stable_id) = (%q, %q), want (\"\", \"\")", id, kind)
 	}
 
-	// Empty stableID + known endpoint → still dedup via endpoint fallback.
-	if !adder.existsInDB(ctx, endpoint, "", "") {
-		t.Error("expected existsInDB=true via endpoint fallback when stable_id is empty")
+	// Empty stableID + known endpoint → "endpoint" fallback (same address, skip).
+	id, kind = adder.findExistingCamera(ctx, endpoint, "", "")
+	if id != "cam-existing" || kind != "endpoint" {
+		t.Errorf("findExistingCamera(endpoint fallback) = (%q, %q), want (cam-existing, endpoint)", id, kind)
 	}
 
 	// Empty stableID + unknown endpoint → not a duplicate.
-	if adder.existsInDB(ctx, "http://unknown/onvif/device_service", "", "") {
-		t.Error("expected existsInDB=false for unknown endpoint with empty stable_id")
+	id, kind = adder.findExistingCamera(ctx, "http://unknown/onvif/device_service", "", "")
+	if id != "" || kind != "" {
+		t.Errorf("findExistingCamera(unknown endpoint) = (%q, %q), want (\"\", \"\")", id, kind)
 	}
 }
 
@@ -218,17 +230,45 @@ func TestRecentlySeen_DedupWindow(t *testing.T) {
 	ep := "http://192.168.1.50/onvif/device_service"
 
 	// Fresh endpoint: not seen.
-	if adder.recentlySeen(ep) {
+	if adder.recentlySeen(ep, "") {
 		t.Error("fresh endpoint should not be recentlySeen")
 	}
 	// After markSeen, it is within the window.
-	adder.markSeen(ep)
-	if !adder.recentlySeen(ep) {
+	adder.markSeen(ep, "")
+	if !adder.recentlySeen(ep, "") {
 		t.Error("endpoint marked seen should be recentlySeen")
 	}
 	// A different endpoint is still fresh.
-	if adder.recentlySeen("http://other") {
+	if adder.recentlySeen("http://other", "") {
 		t.Error("unrelated endpoint should not be recentlySeen")
+	}
+}
+
+// TestRecentlySeen_SerialKeyedAcrossIPChange confirms the dedup is keyed by
+// device serial (not endpoint), so a device that re-announces at a NEW IP is
+// still suppressed within dedupWindow. This is the issue #121 fix: endpoint-only
+// keying let the same device retrigger every cycle after an IP change.
+func TestRecentlySeen_SerialKeyedAcrossIPChange(t *testing.T) {
+	t.Helper()
+	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, nil, nil)
+	const serial = "ABC123"
+	oldEP := "http://192.168.1.50:80/onvif/device_service"
+	newEP := "http://192.168.1.99:80/onvif/device_service"
+
+	// Device marked seen at old IP (with its serial).
+	adder.markSeen(oldEP, serial)
+	// Same device re-announces at NEW IP, same serial → must be suppressed.
+	if !adder.recentlySeen(newEP, serial) {
+		t.Error("a device marked seen by serial must be recentlySeen even at a new endpoint (IP roaming)")
+	}
+	// A DIFFERENT serial at the new IP is NOT suppressed.
+	if adder.recentlySeen(newEP, "DIFFERENT") {
+		t.Error("a different serial should not be recentlySeen")
+	}
+	// Empty serial (enrichment failed) falls back to endpoint keying (legacy).
+	adder.markSeen("http://10.0.0.1/onvif/device_service", "")
+	if !adder.recentlySeen("http://10.0.0.1/onvif/device_service", "") {
+		t.Error("endpoint fallback keying (empty serial) must still work")
 	}
 }
 
@@ -279,3 +319,127 @@ func TestDefaultCredsForState(t *testing.T) {
 		t.Errorf("pending state creds = %q, want empty", got)
 	}
 }
+
+// fakeEnroller is a test double for CameraEnroller. It records calls so tests
+// can assert that UpdateCamera + RestartRecorder were invoked (the IP-roaming
+// fix path). AddCamera is included to satisfy the interface but unused in the
+// roaming tests.
+type fakeEnroller struct {
+	mu               sync.Mutex
+	updatedEndpoints map[string]string   // cameraID → new endpoint passed to UpdateCamera
+	restartedIDs     map[string]bool     // cameraID → RestartRecorder called
+	updateErr        error               // optional: force UpdateCamera to fail
+	restartErr       error               // optional: force RestartRecorder to fail
+}
+
+func newFakeEnroller() *fakeEnroller {
+	return &fakeEnroller{
+		updatedEndpoints: make(map[string]string),
+		restartedIDs:     make(map[string]bool),
+	}
+}
+
+func (f *fakeEnroller) AddCamera(_ context.Context, _ config.CameraConfig) (string, error) {
+	return "cam-fake", nil
+}
+
+func (f *fakeEnroller) UpdateCamera(_ context.Context, cameraID string, updates camera.CameraUpdate) (*config.CameraConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	if updates.ONVIFEndpoint != nil {
+		f.updatedEndpoints[cameraID] = *updates.ONVIFEndpoint
+	}
+	name := "Fake Cam"
+	return &config.CameraConfig{ID: cameraID, Name: name}, nil
+}
+
+func (f *fakeEnroller) RestartRecorder(_ context.Context, cameraID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restartedIDs[cameraID] = true
+	return f.restartErr
+}
+
+// TestUpdateEndpointForRoaming verifies that when auto-discover recognizes a
+// known device at a NEW endpoint, it updates the existing camera's endpoint and
+// restarts its recorder (issue #121 core fix).
+func TestUpdateEndpointForRoaming(t *testing.T) {
+	t.Helper()
+	enroller := newFakeEnroller()
+	adder := NewAdder(&config.AutoDiscoverConfig{}, enroller, nil, nil)
+	const cameraID = "cam-existing"
+	const newEP = "http://192.168.1.99:80/onvif/device_service"
+	dev := onvif.DiscoveredDevice{Serial: "ABC123", Endpoint: newEP}
+
+	adder.updateEndpointForRoaming(context.Background(), cameraID, newEP, dev)
+
+	enroller.mu.Lock()
+	gotEP, updated := enroller.updatedEndpoints[cameraID]
+	restarted := enroller.restartedIDs[cameraID]
+	enroller.mu.Unlock()
+
+	if !updated {
+		t.Error("expected UpdateCamera to be called with the new endpoint")
+	} else if gotEP != newEP {
+		t.Errorf("UpdateCamera endpoint = %q, want %q", gotEP, newEP)
+	}
+	if !restarted {
+		t.Error("expected RestartRecorder to be called so the new endpoint takes effect")
+	}
+}
+
+// TestUpdateEndpointForRoaming_ArchivedCameraSkipped verifies that an archived
+// camera (UpdateCamera returns a not-found error) is silently skipped — the
+// device exists in the dedup tables but not in the live config, so updating it
+// would fail. The error is swallowed (best-effort) and RestartRecorder is NOT
+// called.
+func TestUpdateEndpointForRoaming_ArchivedCameraSkipped(t *testing.T) {
+	t.Helper()
+	enroller := newFakeEnroller()
+	enroller.updateErr = &cameraNotFoundError{cameraID: "cam-archived"}
+	adder := NewAdder(&config.AutoDiscoverConfig{}, enroller, nil, nil)
+	const cameraID = "cam-archived"
+	const newEP = "http://192.168.1.99:80/onvif/device_service"
+
+	// Must not panic and must not call RestartRecorder.
+	adder.updateEndpointForRoaming(context.Background(), cameraID, newEP, onvif.DiscoveredDevice{})
+
+	enroller.mu.Lock()
+	restarted := enroller.restartedIDs[cameraID]
+	enroller.mu.Unlock()
+	if restarted {
+		t.Error("RestartRecorder must NOT be called when UpdateCamera fails (archived camera)")
+	}
+}
+
+// TestUpdateEndpointForRoaming_RestartFailureStillLogged verifies that a
+// RestartRecorder failure does not panic and leaves the endpoint update in
+// place (the endpoint is still updated even if the recorder can't restart —
+// better to have the new address persisted than to roll it back).
+func TestUpdateEndpointForRoaming_RestartFailureStillLogged(t *testing.T) {
+	t.Helper()
+	enroller := newFakeEnroller()
+	enroller.restartErr = context.DeadlineExceeded
+	adder := NewAdder(&config.AutoDiscoverConfig{}, enroller, nil, nil)
+	const cameraID = "cam-existing"
+	const newEP = "http://192.168.1.99:80/onvif/device_service"
+
+	adder.updateEndpointForRoaming(context.Background(), cameraID, newEP, onvif.DiscoveredDevice{Serial: "X"})
+
+	enroller.mu.Lock()
+	_, updated := enroller.updatedEndpoints[cameraID]
+	enroller.mu.Unlock()
+	if !updated {
+		t.Error("endpoint update must persist even when RestartRecorder fails")
+	}
+}
+
+// cameraNotFoundError is a minimal stand-in for camera.CameraNotFoundError used
+// by the archived-camera test (avoids importing the model package just for the
+// error type — the updateEndpointForRoaming path checks err != nil, not the type).
+type cameraNotFoundError struct{ cameraID string }
+
+func (e *cameraNotFoundError) Error() string { return "camera " + e.cameraID + " not found" }

--- a/internal/autodiscover/service.go
+++ b/internal/autodiscover/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
@@ -31,9 +30,11 @@ type Service struct {
 }
 
 // New constructs a Service from its dependencies. cfg is the effective
-// AutoDiscoverConfig (ApplyDefaults already applied). camMgr/db/bus are the
-// shared instances from pkg/app/run.go; bus may be nil.
-func New(cfg *config.AutoDiscoverConfig, camMgr *camera.CameraManager, db *storage.DB, bus *event.EventBus) *Service {
+// AutoDiscoverConfig (ApplyDefaults already applied). camMgr is typed as
+// CameraEnroller (an interface satisfied by *camera.CameraManager) so the adder
+// can be unit-tested with a fake; db/bus are the shared instances from
+// pkg/app/run.go, bus may be nil.
+func New(cfg *config.AutoDiscoverConfig, camMgr CameraEnroller, db *storage.DB, bus *event.EventBus) *Service {
 	adder := NewAdder(cfg, camMgr, db, bus)
 	return &Service{
 		cfg:     cfg,

--- a/internal/rediscovery/rediscovery.go
+++ b/internal/rediscovery/rediscovery.go
@@ -53,6 +53,20 @@ var (
 // Exposed as a field so tests can inject a fake without touching the network.
 type ProbeFunc func(ctx context.Context, host string, port int, timeout time.Duration) (*onvif.DiscoveredDevice, error)
 
+// ConfirmFunc enriches a discovered device with its ONVIF serial number when the
+// probe path did not yield one (e.g. a device that answered a WS-Discovery
+// ProbeMatch — where DiscoveredDevice.UUID is the EndpointReference Address, an
+// urn:uuid:..., NOT the hardware serial). The default implementation is
+// onvif.EnrichDevice, which issues an unauthenticated GetDeviceInformation and
+// fills dev.Serial. Mirrors ProbeFunc as an injectable field for testability.
+//
+// This exists to fix the issue #121 silent-miss: scanFor used to compare
+// dev.UUID == want (want = the camera's stable_id = ONVIF serial), but on the
+// ProbeMatch path UUID is NOT the serial, so the match always failed for devices
+// that answer ProbeMatch. With ConfirmFunc, scanFor re-fetches the real serial
+// and matches against dev.Serial as well.
+type ConfirmFunc func(ctx context.Context, dev *onvif.DiscoveredDevice)
+
 // Config tunes the scanner. Mirrors the relevant subset of
 // config.Health.RediscoveryConfig but as plain values for testability.
 type Config struct {
@@ -87,16 +101,28 @@ func parseDur(s string, def time.Duration) time.Duration {
 
 // Engine re-discovers a camera by its stable hardware identifier.
 type Engine struct {
-	cfg   Config
-	probe ProbeFunc
+	cfg     Config
+	probe   ProbeFunc
+	confirm ConfirmFunc
 }
 
-// NewEngine creates an Engine. If probe is nil, the real onvif.ProbeDevice is used.
+// NewEngine creates an Engine. If probe is nil, the real onvif.ProbeDevice is
+// used. confirm defaults to onvif.EnrichDevice when nil (the production
+// behavior); pass a custom ConfirmFunc (or WithConfirm) for tests.
 func NewEngine(cfg Config, probe ProbeFunc) *Engine {
+	return NewEngineWithConfirm(cfg, probe, onvif.EnrichDevice)
+}
+
+// NewEngineWithConfirm is like NewEngine but allows injecting a custom
+// ConfirmFunc. Exposed primarily for tests that need to script the second-stage
+// serial confirmation independently of the probe. Pass nil for confirm to
+// disable confirmation entirely (legacy behavior — not recommended in
+// production, kept for the test that pins the ProbeMatch bug).
+func NewEngineWithConfirm(cfg Config, probe ProbeFunc, confirm ConfirmFunc) *Engine {
 	if probe == nil {
 		probe = onvif.ProbeDevice
 	}
-	return &Engine{cfg: cfg, probe: probe}
+	return &Engine{cfg: cfg, probe: probe, confirm: confirm}
 }
 
 // Result is the outcome of a successful re-discovery.
@@ -187,7 +213,22 @@ func (e *Engine) scanFor(ctx context.Context, hosts []string, port int, want str
 			}
 			// DiscoveredDevice.UUID holds the serial number on the unicast
 			// GetDeviceInformation fallback path (see internal/onvif/discovery.go).
-			if strings.TrimSpace(dev.UUID) == want {
+			// But on the WS-Discovery ProbeMatch path, UUID is the device's
+			// EndpointReference Address (an urn:uuid:...) and dev.Serial is empty.
+			// When that happens, re-fetch the real serial via GetDeviceInformation
+			// so the match below can succeed (issue #121: previously this host was
+			// silently skipped because UUID != serial).
+			if strings.TrimSpace(dev.Serial) == "" && e.confirm != nil {
+				// Use a fresh timeout budget independent of probeCtx (whose budget
+				// the probe above may have largely consumed), so the confirmation
+				// call is not starved.
+				confirmCtx, confirmCancel := context.WithTimeout(ctx, e.cfg.ProbeTimeout)
+				e.confirm(confirmCtx, dev)
+				confirmCancel()
+			}
+			// Match against EITHER UUID (GetDeviceInformation path) or Serial
+			// (ProbeMatch + confirmation path).
+			if strings.TrimSpace(dev.UUID) == want || strings.TrimSpace(dev.Serial) == want {
 				select {
 				case results <- host:
 				default:

--- a/internal/rediscovery/rediscovery_test.go
+++ b/internal/rediscovery/rediscovery_test.go
@@ -237,3 +237,116 @@ func TestFromConfig_AppliesDefaults(t *testing.T) {
 	mustEqual(t, c2.MaxParallel, 8, "explicit max parallel")
 	mustEqual(t, c2.ProbeTimeout, 1500*time.Millisecond, "explicit probe timeout")
 }
+
+// fakeProbeMatch simulates a device that answers the WS-Discovery ProbeMatch
+// path: UUID is the EndpointReference Address (an urn:uuid:...), and Serial is
+// empty — the device's real serial is only obtainable via a separate
+// GetDeviceInformation call (the "confirmation" step). This pins the issue #121
+// scenario where scanFor used to silently miss such devices.
+func fakeProbeMatch(hostUUID map[string]string) ProbeFunc {
+	return func(ctx context.Context, host string, port int, timeout time.Duration) (*onvif.DiscoveredDevice, error) {
+		uuid, ok := hostUUID[host]
+		if !ok {
+			return nil, errUnreachable
+		}
+		return &onvif.DiscoveredDevice{
+			UUID:     uuid, // urn:uuid:... — NOT the hardware serial
+			Serial:   "",   // empty: ProbeMatch does not carry the serial
+			Endpoint: "http://" + host + "/onvif/device_service",
+		}, nil
+	}
+}
+
+// fakeConfirm is a ConfirmFunc that scripts a host -> serial map, simulating a
+// successful GetDeviceInformation confirmation. It fills dev.Serial in-place.
+func fakeConfirm(hostSerial map[string]string) ConfirmFunc {
+	return func(ctx context.Context, dev *onvif.DiscoveredDevice) {
+		host := hostFromEndpoint(dev.Endpoint)
+		if serial, ok := hostSerial[host]; ok {
+			dev.Serial = serial
+		}
+	}
+}
+
+// TestDiscoverByStableID_ProbeMatchPathWithConfirmation is the issue #121
+// regression test. A device that answers WS-Discovery ProbeMatch reports its
+// EndpointReference Address as UUID (NOT the serial) and leaves Serial empty.
+// scanFor must trigger the confirmation step (GetDeviceInformation) to fetch the
+// real serial, then match against dev.Serial — previously it compared
+// dev.UUID == want and silently missed.
+func TestDiscoverByStableID_ProbeMatchPathWithConfirmation(t *testing.T) {
+	cam := config.CameraConfig{
+		ID:            "cam-roamed",
+		Protocol:      "onvif",
+		StableID:      "SN-AAA", // the hardware serial we want to match
+		ONVIFEndpoint: "http://192.0.2.10:80/onvif/device_service",
+		SubnetHints:   []string{"192.0.2.0/24"},
+	}
+	// The device at .50 answers ProbeMatch with an urn:uuid (NOT the serial).
+	probe := fakeProbeMatch(map[string]string{
+		"192.0.2.50": "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+		"192.0.2.11": "urn:uuid:deadbeef-0000-0000-0000-000000000001",
+	})
+	// Confirmation reveals the real serials. Only .50 has the camera we want.
+	confirm := fakeConfirm(map[string]string{
+		"192.0.2.50": "SN-AAA",
+		"192.0.2.11": "SN-OTHER",
+	})
+
+	eng := NewEngineWithConfirm(Config{MaxParallel: 32, ProbeTimeout: time.Second, MaxDuration: 5 * time.Second}, probe, confirm)
+	res, err := eng.DiscoverByStableID(context.Background(), cam)
+	if err != nil {
+		t.Fatalf("expected match via ProbeMatch+confirmation, got error: %v", err)
+	}
+	mustEqual(t, res.NewHost, "192.0.2.50", "ProbeMatch-path match host")
+}
+
+// TestDiscoverByStableID_ProbeMatchWithoutConfirmationMisses pins the BUG: with
+// confirmation DISABLED, a ProbeMatch-answering device is silently missed
+// (UUID is an urn:uuid, not the serial). This documents why the default
+// NewEngine wires onvif.EnrichDevice as the confirm step.
+func TestDiscoverByStableID_ProbeMatchWithoutConfirmationMisses(t *testing.T) {
+	cam := config.CameraConfig{
+		ID:            "cam-roamed",
+		Protocol:      "onvif",
+		StableID:      "SN-AAA",
+		ONVIFEndpoint: "http://192.0.2.10:80/onvif/device_service",
+		SubnetHints:   []string{"192.0.2.0/24"},
+	}
+	probe := fakeProbeMatch(map[string]string{
+		"192.0.2.50": "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+	})
+	// confirm=nil: no second-stage GetDeviceInformation → dev.Serial stays empty,
+	// dev.UUID != want → no match.
+	eng := NewEngineWithConfirm(Config{MaxParallel: 32, ProbeTimeout: time.Second, MaxDuration: 5 * time.Second}, probe, nil)
+	_, err := eng.DiscoverByStableID(context.Background(), cam)
+	mustEqual(t, err, ErrNotFound, "ProbeMatch without confirmation must miss (documents the bug)")
+}
+
+// TestDiscoverByStableID_GetDeviceInfoPathStillWorks confirms the legacy path
+// (probe returns UUID=serial directly) is unaffected by the confirmation
+// change. fakeProbe puts the serial in UUID (the GetDeviceInformation path) and
+// leaves Serial empty, so confirmation IS invoked — but a no-op confirm leaves
+// dev.Serial empty, and the match still fires via dev.UUID == want. This proves
+// the UUID match branch was preserved alongside the new Serial match branch.
+func TestDiscoverByStableID_GetDeviceInfoPathStillWorks(t *testing.T) {
+	cam := config.CameraConfig{
+		ID:            "cam-1",
+		Protocol:      "onvif",
+		StableID:      "SN-AAA",
+		ONVIFEndpoint: "http://192.0.2.10:80/onvif/device_service",
+		SubnetHints:   []string{"192.0.2.0/24"},
+	}
+	// Legacy fakeProbe puts the serial in UUID (the GetDeviceInformation path).
+	probe := fakeProbe(map[string]string{
+		"192.0.2.50": "SN-AAA",
+	}, 0)
+	// No-op confirm: does not modify dev. The match must succeed via UUID.
+	noOpConfirm := func(ctx context.Context, dev *onvif.DiscoveredDevice) {}
+	eng := NewEngineWithConfirm(Config{MaxParallel: 32, ProbeTimeout: time.Second, MaxDuration: 5 * time.Second}, probe, noOpConfirm)
+	res, err := eng.DiscoverByStableID(context.Background(), cam)
+	if err != nil {
+		t.Fatalf("expected match via legacy UUID path, got error: %v", err)
+	}
+	mustEqual(t, res.NewHost, "192.0.2.50", "legacy UUID-path match host")
+}

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -380,6 +380,69 @@ func (d *DB) CameraExistsByStableID(ctx context.Context, stableID string) (bool,
 	return c > 0, nil
 }
 
+// CameraIDByStableID returns the camera_id of any row (including ARCHIVED ones)
+// whose stable_id matches. Used by auto-discover to recognize that a discovered
+// device is a known physical camera (so its endpoint can be UPDATED rather than
+// re-enrolling a duplicate row) — the IP-change / DHCP-roaming scenario.
+//
+// Mirrors CameraExistsByStableID but returns the id instead of a bool, so the
+// caller can target the existing row with UpdateCamera. Returns ("", nil) when
+// stableID is empty or no row matches (sql.ErrNoRows is treated as "not found",
+// NOT an error, matching GetCameraStableID's convention).
+func (d *DB) CameraIDByStableID(ctx context.Context, stableID string) (string, error) {
+	if stableID == "" {
+		return "", nil
+	}
+	var id string
+	err := d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE stable_id=? LIMIT 1`, stableID).Scan(&id)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", err
+	}
+	return id, nil
+}
+
+// CameraIDByOnvifEndpoint returns the camera_id and matchKind of any row
+// (including ARCHIVED ones) that matches the given onvif_endpoint or serial.
+// matchKind is "endpoint" when the onvif_endpoint column matched, "serial" when
+// the serial_number OR stable_id column matched the serial argument, and "" when
+// nothing matched.
+//
+// Used by auto-discover: an "endpoint" match means the SAME device at the SAME
+// address is already enrolled (skip — nothing to do); a "serial" match means the
+// SAME physical device reappeared at a NEW address (UPDATE the endpoint instead
+// of creating a duplicate). Mirrors CameraExistsByOnvifEndpoint's query shape
+// but returns id + matchKind so the caller can branch on the match type.
+func (d *DB) CameraIDByOnvifEndpoint(ctx context.Context, onvifEndpoint, serial string) (cameraID, matchKind string, err error) {
+	if onvifEndpoint == "" && serial == "" {
+		return "", "", nil
+	}
+	if onvifEndpoint != "" {
+		var id string
+		if err := d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE onvif_endpoint=? LIMIT 1`, onvifEndpoint).Scan(&id); err != nil {
+			if err != sql.ErrNoRows {
+				return "", "", err
+			}
+		} else {
+			return id, "endpoint", nil
+		}
+	}
+	if serial != "" {
+		var id string
+		// Check both serial_number and stable_id (mirrors CameraExistsByOnvifEndpoint).
+		if err := d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE serial_number=? OR stable_id=? LIMIT 1`, serial, serial).Scan(&id); err != nil {
+			if err != sql.ErrNoRows {
+				return "", "", err
+			}
+		} else {
+			return id, "serial", nil
+		}
+	}
+	return "", "", nil
+}
+
 // ReassignCameraStableID moves a stable_id from one camera to another.
 // Previously used to atomically transfer the identity when merging duplicate
 // camera records. Sets the old camera's stable_id to empty string.

--- a/internal/storage/db_camera_test.go
+++ b/internal/storage/db_camera_test.go
@@ -61,3 +61,112 @@ func TestUpdateCameraEncoding_IdempotentOnMissingRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", enc, "GetCameraEncoding returns empty for a missing row, not an error")
 }
+
+// newCameraDB is the shared setup for camera-row dedup tests: an initialized
+// SQLite DB in a temp dir, closed on cleanup.
+func newCameraDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_dedup.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestCameraIDByStableID covers the IP-roaming dedup lookup (issue #121). A
+// camera with stable_id set must be findable by stable_id alone — this is how
+// auto-discover recognizes a device that came back at a NEW IP.
+func TestCameraIDByStableID(t *testing.T) {
+	db := newCameraDB(t)
+	ctx := context.Background()
+	const camID = "cam-stable"
+	const endpoint = "http://192.168.1.50:80/onvif/device_service"
+	require.NoError(t, db.UpsertCamera(ctx, camID, "Stable Cam", "onvif", "", "", "", "", endpoint, "", "", "ABC-123"))
+
+	// Match by stable_id.
+	got, err := db.CameraIDByStableID(ctx, "ABC-123")
+	require.NoError(t, err)
+	require.Equal(t, camID, got)
+
+	// Unknown stable_id → empty id, nil error (NOT sql.ErrNoRows).
+	got, err = db.CameraIDByStableID(ctx, "DOES-NOT-EXIST")
+	require.NoError(t, err)
+	require.Equal(t, "", got)
+
+	// Empty stable_id → empty id, nil error (short-circuit, no query).
+	got, err = db.CameraIDByStableID(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, "", got)
+}
+
+// TestCameraIDByStableID_IncludesArchived confirms the lookup scans ALL rows
+// (archived included), mirroring CameraExistsByStableID. Without this, an
+// archived camera whose device is still on the network would be re-enrolled as
+// a duplicate by auto-discover.
+func TestCameraIDByStableID_IncludesArchived(t *testing.T) {
+	db := newCameraDB(t)
+	ctx := context.Background()
+	const camID = "cam-archived"
+	const endpoint = "http://192.168.1.51:80/onvif/device_service"
+	require.NoError(t, db.UpsertCamera(ctx, camID, "Soon Archived", "onvif", "", "", "", "", endpoint, "", "", "ARCH-SN"))
+	require.NoError(t, db.ArchiveCameraDB(ctx, camID))
+
+	got, err := db.CameraIDByStableID(ctx, "ARCH-SN")
+	require.NoError(t, err)
+	require.Equal(t, camID, got, "archived camera must still be found by stable_id (dedup must see it)")
+}
+
+// TestCameraIDByOnvifEndpoint covers the two match kinds auto-discover needs to
+// distinguish: "endpoint" (same device same address — skip) vs "serial" (same
+// device new address — UPDATE endpoint). See issue #121.
+func TestCameraIDByOnvifEndpoint(t *testing.T) {
+	db := newCameraDB(t)
+	ctx := context.Background()
+	const camID = "cam-ep"
+	const endpoint = "http://192.168.1.50:80/onvif/device_service"
+	require.NoError(t, db.UpsertCamera(ctx, camID, "EP Cam", "onvif", "", "", "", "", endpoint, "", "", "ABC"))
+	// serial_number is a separate column populated via UpdateCameraMetadata.
+	require.NoError(t, db.UpdateCameraMetadata(ctx, camID, "", "", "", "", "SERIAL-XYZ", 0))
+
+	// Same endpoint → "endpoint" match (same device, same address: skip enrollment).
+	id, kind, err := db.CameraIDByOnvifEndpoint(ctx, endpoint, "")
+	require.NoError(t, err)
+	require.Equal(t, camID, id)
+	require.Equal(t, "endpoint", kind)
+
+	// Different endpoint, same serial → "serial" match (same device, NEW address: UPDATE).
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "http://192.168.1.99:80/onvif/device_service", "SERIAL-XYZ")
+	require.NoError(t, err)
+	require.Equal(t, camID, id)
+	require.Equal(t, "serial", kind)
+
+	// Different endpoint, serial matches the stable_id column (not serial_number).
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "http://192.168.1.99:80/onvif/device_service", "ABC")
+	require.NoError(t, err)
+	require.Equal(t, camID, id)
+	require.Equal(t, "serial", kind, "serial arg must also match the stable_id column")
+
+	// Unknown endpoint AND unknown serial → empty id, "" kind.
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "http://unknown/onvif/device_service", "DIFFERENT")
+	require.NoError(t, err)
+	require.Equal(t, "", id)
+	require.Equal(t, "", kind)
+
+	// Both empty → short-circuit, empty result.
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "", id)
+	require.Equal(t, "", kind)
+
+	// Endpoint match takes priority over serial match (checked first).
+	const camID2 = "cam-ep2"
+	const endpoint2 = "http://192.168.1.60:80/onvif/device_service"
+	require.NoError(t, db.UpsertCamera(ctx, camID2, "EP Cam 2", "onvif", "", "", "", "", endpoint2, "", "", "SHARED-SN"))
+	require.NoError(t, db.UpdateCameraMetadata(ctx, camID2, "", "", "", "", "SHARED-SN", 0))
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, endpoint2, "SHARED-SN")
+	require.NoError(t, err)
+	require.Equal(t, camID2, id)
+	require.Equal(t, "endpoint", kind, "endpoint match must be reported when both endpoint and serial match")
+}


### PR DESCRIPTION
## Summary

Fixes #121 — network IP shuffles no longer produce duplicate camera rows. Architectural fix across 3 packages, no regressions.

## Root Cause (recap)

When a camera's IP changed, auto-discover re-enrolled it as a **new** `pending_activation` row instead of updating the existing one, because:
1. Dedup keyed on `stable_id`, but `stable_id` backfill requires the device to be reachable + answer unauthenticated `GetDeviceInformation` (many cameras refuse) → `stable_id` stays empty → dedup degrades to endpoint-string matching → breaks on IP change.
2. Auto-discover only ever **skipped or enrolled** — it never **updated** an existing camera's endpoint when it recognized the same device at a new address.
3. Rediscovery's `scanFor` compared `dev.UUID == want` (want = ONVIF serial), but on the WS-Discovery ProbeMatch path `UUID` is the EndpointReference Address (`urn:uuid:...`), not the serial → silent never-match for ProbeMatch-answering devices.
4. The in-memory dedup map was keyed by endpoint string, useless across IP changes.

Verified in production (2026-07-26): 4 duplicate `pending_activation` shells created on M5.

## Changes

### `internal/storage/db_camera.go`
- New `CameraIDByStableID(ctx, stableID) (string, error)` — returns the matched camera_id (bool→id upgrade of `CameraExistsByStableID`).
- New `CameraIDByOnvifEndpoint(ctx, endpoint, serial) (cameraID, matchKind, err)` — returns id + match kind (`"endpoint"` / `"serial"`) so callers can branch on whether to update.

### `internal/autodiscover/adder.go`
- **`CameraEnroller` interface** — minimal subset of `*camera.CameraManager` (`AddCamera`/`UpdateCamera`/`RestartRecorder`). `Adder.camMgr` retyped to this interface for unit-testability; `*camera.CameraManager` satisfies it implicitly, so production wiring in `service.New` / `pkg/app/run.go` is unchanged.
- **`findExistingCamera`** replaces `existsInDB` — returns `(cameraID, matchKind)` instead of bool. `matchKind` distinguishes `"endpoint"` (same address → skip) from `"stable_id"`/`"serial"` (same device new address → update).
- **`updateEndpointForRoaming`** — when a known device reappears at a new endpoint, calls `UpdateCamera{ONVIFEndpoint, URL}` (clears the cached ONVIF client, no recorder restart — avoids racing the health loop) + `RestartRecorder` (serialized via `withCameraLifecycle`). Best-effort; archived cameras are naturally filtered (UpdateCamera returns NotFound). Emits a `camera.added` event with `source: "auto-rediscover"`.
- **`HandleDiscovered`** — step 4 now branches: `stable_id`/`serial` match with differing endpoint → `updateEndpointForRoaming`; `endpoint` match → skip (unchanged).
- **`dedup` keyed by device identity** — `makeDedupKey(endpoint, serial)` prefers the serial (stable across IP changes), falls back to endpoint when serial is unknown (legacy behavior). A roaming device re-announcing at a new IP is now suppressed within `dedupWindow` instead of retriggering every cycle.

### `internal/rediscovery/rediscovery.go`
- **`ConfirmFunc`** injectable field (default `onvif.EnrichDevice`) + `NewEngineWithConfirm` constructor. On the ProbeMatch path, `dev.Serial` is empty (the ProbeMatch carries only the EndpointReference Address, not the hardware serial). `scanFor` now triggers `confirm` to re-fetch the real serial via GetDeviceInformation, then matches against **both** `dev.UUID` (GetDeviceInformation path) and `dev.Serial` (ProbeMatch + confirmation path). Uses an independent timeout budget so the confirmation call isn't starved by the probe.

## Concurrency Safety (why this doesn't introduce regressions)

| Call | Serialization | Risk |
|---|---|---|
| `UpdateCamera{ONVIFEndpoint,URL}` | `configMu` + lock-free `apply` | Only clears ONVIF client cache, does NOT trigger recorder restart → no race with health loop |
| `RestartRecorder` | `withCameraLifecycle` (per-camera mutex) | Serialized with health-loop restarts |
| `HandleDiscovered` | already in goroutine (`service.go:120`) | Blocking call is safe |

Deliberately **not** routed through `RediscoverAndReconnect` — it re-scans the subnet for 30s (auto-discover already knows the new endpoint) and restarts the recorder outside the lifecycle guard (recorder-leak risk).

## Test Coverage

All new code is unit-tested in each package's existing style:
- `internal/storage/db_camera_test.go` (testify): `TestCameraIDByStableID`, `TestCameraIDByStableID_IncludesArchived`, `TestCameraIDByOnvifEndpoint` (6 match-kind assertions)
- `internal/autodiscover/adder_test.go` (stdlib): 6 existing `TestExistsInDB_*` updated to assert `findExistingCamera` return values; new `TestRecentlySeen_SerialKeyedAcrossIPChange`; new `TestUpdateEndpointForRoaming` / `_ArchivedCameraSkipped` / `_RestartFailureStillLogged` (fake `CameraEnroller`)
- `internal/rediscovery/rediscovery_test.go` (stdlib): `TestDiscoverByStableID_ProbeMatchPathWithConfirmation` (the #121 regression test), `_ProbeMatchWithoutConfirmationMisses` (pins the bug), `_GetDeviceInfoPathStillWorks` (legacy UUID path preserved)

## Verification

- `go vet ./...` clean (cross-compiled `CGO_ENABLED=0 GOOS=linux GOARCH=arm64`)
- Unit tests on Banana Pi M5 (`192.168.63.30`, arm64, real SQLite WAL):
  - `storage` — **PASS** (incl. 3 new tests)
  - `autodiscover` — **PASS** (21 tests, incl. 4 new)
  - `rediscovery` — **PASS** (11 tests, incl. 3 new)
  - `onvif` — **PASS** (unaffected, contract preserved)
  - `camera` — **PASS** (unaffected)
  - `api` — `TestONVIFDiscoverEndpoint` fails on `expected 0, got 3` but this is a **pre-existing env-dependent failure** (the test assumes no ONVIF devices on the LAN; M5 has real cameras). Confirmed identical failure on `main` (stashed this branch's changes, recompiled, same FAIL). Not caused by this PR.
- **M5 production deployment** (this branch's binary):
  - Service `status: ok`, 7 cameras recording, 0 errors
  - Observed 1 full auto-discover cycle: existing cameras (212, 251) correctly matched by `endpoint` → skipped (no duplicate `auto-added`); no panic/fatal
  - `POST /api/cameras/{id}/rediscover` returned `{"found":true,"status":"reconnected"}` — the ProbeMatch + ConfirmFunc path works on real hardware (the device answers ProbeMatch, confirmation re-fetches the serial, match succeeds)

## Out of Scope (tracked in #121)

- Authenticated enrichment (using `default_username`/`default_password` for GetDeviceInformation to populate `stable_id` for auth-required cameras) — future PR.
- `repair sync-cameras-db-yaml` for the runtime cfg.Cameras ↔ DB drift — separate issue.
- Rediscovery trigger-chain hardening (`offlineDurationFn` wiring, blacklist-to-rediscover race) — needs deeper health/`auto_remediate` investigation.
