### PR TITLE
fix(autodiscover): stop recorder storm when device re-announces at unchanged endpoint (#122 regression)

### DIFF
--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -153,17 +153,22 @@ func (a *Adder) HandleDiscovered(ctx context.Context, dev onvif.DiscoveredDevice
 	enrichCancel()
 
 	// 4. Persisted dedup: skip if a camera with the same stable_id, endpoint, or
-	// serial already exists. When the match is by stable_id or serial (the SAME
-	// physical device at a NEW address), UPDATE the existing camera's endpoint
-	// instead of silently skipping — this is the IP-roaming fix (issue #121).
-	// An "endpoint" match means the same device at the same address is already
-	// enrolled, so there is nothing to update.
+	// serial already exists. When the match is by stable_id or serial AND the
+	// endpoint actually changed, UPDATE the existing camera's endpoint — this is
+	// the IP-roaming fix (issue #121). If the endpoint is UNCHANGED (the device
+	// simply re-announced at its current address), skip the update to avoid
+	// pointlessly restarting the recorder every discovery cycle.
 	existingID, matchKind := a.findExistingCamera(ctx, endpoint, dev.Serial, dev.Serial)
 	if existingID != "" {
-		if (matchKind == "stable_id" || matchKind == "serial") && a.camMgr != nil {
+		if (matchKind == "stable_id" || matchKind == "serial") && a.camMgr != nil && a.endpointChanged(ctx, existingID, endpoint) {
 			a.updateEndpointForRoaming(ctx, existingID, endpoint, dev)
 		}
-		a.markSeen(endpoint, dev.Serial) // refresh window under the (now-known) serial key
+		// Mark BOTH keys seen (endpoint + serial) so the next announcement is
+		// suppressed regardless of whether its serial is known yet (before
+		// enrichment the serial is empty, so only the endpoint key would match;
+		// after enrichment only the serial key would match — marking both closes
+		// the gap that let chatty devices retrigger every cycle).
+		a.markSeenBothKeys(endpoint, dev.Serial)
 		return
 	}
 
@@ -269,6 +274,30 @@ func (a *Adder) findExistingCamera(ctx context.Context, endpoint, serial, stable
 	return id, kind
 }
 
+// endpointChanged reports whether the discovered endpoint differs from the
+// existing camera's current onvif_endpoint. This guards the roaming-update path
+// against the common case of a device simply re-announcing at its CURRENT
+// address (WS-Discovery Hello is sent periodically, and the active scanner
+// probes every cycle). Without this check, every discovery cycle would restart
+// the recorder — disrupting recording and live preview (regression introduced
+// by the initial #121 fix, where a stable_id match unconditionally triggered
+// updateEndpointForRoaming).
+//
+// Comparison normalizes trailing slashes (mirrors AddCamera's endpoint dedup).
+// On DB error or missing row, returns true (fail-open: attempt the update, which
+// is idempotent and will no-op if the endpoint is in fact unchanged).
+func (a *Adder) endpointChanged(ctx context.Context, cameraID, discoveredEndpoint string) bool {
+	if a.db == nil {
+		return true // can't check, fail-open
+	}
+	existing, err := a.db.GetCameraOnvifEndpoint(ctx, cameraID)
+	if err != nil {
+		logger.Warn("roaming check: failed to read existing endpoint, failing open", "camera_id", cameraID, "error", err)
+		return true
+	}
+	return strings.TrimRight(existing, "/") != strings.TrimRight(discoveredEndpoint, "/")
+}
+
 // updateEndpointForRoaming updates an existing camera's ONVIF endpoint (and URL)
 // to the newly-discovered address, then restarts its recorder so the new
 // address takes effect immediately. This is the IP-roaming fix (issue #121):
@@ -366,7 +395,7 @@ func (a *Adder) probeCredentials(ctx context.Context, endpoint string) bool {
 // the manual add path (web/src/lib/components/DiscoveryPanel.svelte):
 // protocol=onvif, encoding left empty for runtime detection.
 func (a *Adder) enroll(ctx context.Context, dev onvif.DiscoveredDevice, endpoint, state string) {
-	a.markSeen(endpoint, dev.Serial)
+	a.markSeenBothKeys(endpoint, dev.Serial)
 
 	name := dev.Name
 	if name == "" {
@@ -451,6 +480,13 @@ func (a *Adder) publish(ctx context.Context, topic string, data any) {
 // recentlySeen reports whether the device (keyed by serial, or endpoint when
 // serial is unavailable) was attempted within dedupWindow. Thread-safe; GCs
 // expired entries opportunistically.
+//
+// Note: the lookup key depends on whether the serial is known at the call site.
+// Before enrichment the serial is empty, so this queries the endpoint key;
+// after enrichment it queries the serial key. markSeenBothKeys therefore marks
+// BOTH keys so the suppression holds across the enrich boundary (otherwise a
+// chatty device re-announcing every cycle would retrigger after the serial
+// becomes known — the second #121-fix regression).
 func (a *Adder) recentlySeen(endpoint, serial string) bool {
 	key := makeDedupKey(endpoint, serial)
 	a.dedupMu.Lock()
@@ -469,11 +505,18 @@ func (a *Adder) recentlySeen(endpoint, serial string) bool {
 	return false
 }
 
-// markSeen records that the device (keyed by serial, or endpoint when serial is
-// unavailable) was attempted now.
-func (a *Adder) markSeen(endpoint, serial string) {
-	key := makeDedupKey(endpoint, serial)
+// markSeenBothKeys records the device as attempted now under BOTH its endpoint
+// key and (when the serial is known) its serial key. This is necessary because
+// recentlySeen's lookup key depends on whether the serial is populated at query
+// time: the next announcement starts with an empty serial (endpoint key) and
+// only gains it after enrichment (serial key). Marking just one would let the
+// other lookup miss, retriggering enrichment/enrollment every cycle.
+func (a *Adder) markSeenBothKeys(endpoint, serial string) {
+	now := time.Now()
 	a.dedupMu.Lock()
-	a.dedup[key] = time.Now()
+	a.dedup[makeDedupKey(endpoint, "")] = now // endpoint key (pre-enrichment lookups)
+	if s := strings.TrimSpace(serial); s != "" {
+		a.dedup[makeDedupKey(endpoint, s)] = now // serial key (post-enrichment lookups)
+	}
 	a.dedupMu.Unlock()
 }

--- a/internal/autodiscover/adder_test.go
+++ b/internal/autodiscover/adder_test.go
@@ -233,8 +233,8 @@ func TestRecentlySeen_DedupWindow(t *testing.T) {
 	if adder.recentlySeen(ep, "") {
 		t.Error("fresh endpoint should not be recentlySeen")
 	}
-	// After markSeen, it is within the window.
-	adder.markSeen(ep, "")
+	// After markSeenBothKeys, it is within the window.
+	adder.markSeenBothKeys(ep, "")
 	if !adder.recentlySeen(ep, "") {
 		t.Error("endpoint marked seen should be recentlySeen")
 	}
@@ -256,7 +256,7 @@ func TestRecentlySeen_SerialKeyedAcrossIPChange(t *testing.T) {
 	newEP := "http://192.168.1.99:80/onvif/device_service"
 
 	// Device marked seen at old IP (with its serial).
-	adder.markSeen(oldEP, serial)
+	adder.markSeenBothKeys(oldEP, serial)
 	// Same device re-announces at NEW IP, same serial → must be suppressed.
 	if !adder.recentlySeen(newEP, serial) {
 		t.Error("a device marked seen by serial must be recentlySeen even at a new endpoint (IP roaming)")
@@ -266,9 +266,31 @@ func TestRecentlySeen_SerialKeyedAcrossIPChange(t *testing.T) {
 		t.Error("a different serial should not be recentlySeen")
 	}
 	// Empty serial (enrichment failed) falls back to endpoint keying (legacy).
-	adder.markSeen("http://10.0.0.1/onvif/device_service", "")
+	adder.markSeenBothKeys("http://10.0.0.1/onvif/device_service", "")
 	if !adder.recentlySeen("http://10.0.0.1/onvif/device_service", "") {
 		t.Error("endpoint fallback keying (empty serial) must still work")
+	}
+}
+
+// TestRecentlySeen_PreEnrichmentEndpointLookupHits is the regression test for
+// the second #121-fix bug: the passive listener + active scanner re-discover a
+// device every cycle. The FIRST lookup (step 2) happens BEFORE enrichment, with
+// an empty serial, so it queries the endpoint key. markSeenBothKeys must have
+// marked the endpoint key (not just the serial key) on the previous cycle, or
+// the device retriggered every time — disrupting recording/preview with endless
+// recorder restarts. Verified in production: 212/251 were restarted ~10x/hour.
+func TestRecentlySeen_PreEnrichmentEndpointLookupHits(t *testing.T) {
+	t.Helper()
+	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, nil, nil)
+	const ep = "http://192.168.1.50:80/onvif/device_service"
+	const serial = "ABC123"
+
+	// Simulate a completed discovery cycle: device processed with its serial.
+	adder.markSeenBothKeys(ep, serial)
+	// Next cycle re-announces the SAME device, but recentlySeen is called BEFORE
+	// enrichment (serial unknown at this point) → endpoint-keyed lookup.
+	if !adder.recentlySeen(ep, "") {
+		t.Error("endpoint-keyed lookup (pre-enrichment) must hit after markSeenBothKeys — chatty devices would retrigger every cycle otherwise")
 	}
 }
 
@@ -365,6 +387,41 @@ func (f *fakeEnroller) RestartRecorder(_ context.Context, cameraID string) error
 	defer f.mu.Unlock()
 	f.restartedIDs[cameraID] = true
 	return f.restartErr
+}
+
+// TestEndpointChanged is the regression test for the recorder-storm bug: a
+// device that re-announces at its CURRENT address must NOT trigger a roaming
+// update (which restarts the recorder). Only a genuine endpoint change should.
+// In production, the missing check restarted 212/251's recorder ~10x/hour,
+// disrupting recording and live preview.
+func TestEndpointChanged(t *testing.T) {
+	t.Helper()
+	db := newTestDB(t)
+	ctx := context.Background()
+	const camID = "cam-existing"
+	const ep = "http://192.168.63.212:80/onvif/device_service"
+	require := func(cond bool, msg string) {
+		t.Helper()
+		if !cond {
+			t.Error(msg)
+		}
+	}
+
+	// Seed a camera at ep.
+	if err := db.UpsertCamera(ctx, camID, "Cam", "onvif", "", "", "", "", ep, "", "", "ABC"); err != nil {
+		t.Fatalf("UpsertCamera: %v", err)
+	}
+	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, db, nil)
+
+	// Same endpoint (with trailing slash variant) → NOT changed.
+	require(!adder.endpointChanged(ctx, camID, ep), "identical endpoint must report unchanged")
+	require(!adder.endpointChanged(ctx, camID, ep+"/"), "trailing-slash variant must report unchanged (normalized)")
+
+	// Genuinely different endpoint → changed.
+	require(adder.endpointChanged(ctx, camID, "http://192.168.63.99:80/onvif/device_service"), "different IP must report changed")
+
+	// Unknown camera ID → fail-open (true), so the update is attempted.
+	require(adder.endpointChanged(ctx, camID+"-nope", ep), "unknown camera must fail-open (true)")
 }
 
 // TestUpdateEndpointForRoaming verifies that when auto-discover recognizes a

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -404,6 +404,23 @@ func (d *DB) CameraIDByStableID(ctx context.Context, stableID string) (string, e
 	return id, nil
 }
 
+// GetCameraOnvifEndpoint returns the onvif_endpoint of a camera by ID. Used by
+// auto-discover's roaming check to compare the discovered endpoint against the
+// existing one without loading the full CameraRow. Returns ("", nil) when the
+// camera does not exist (sql.ErrNoRows treated as "not found", not an error),
+// mirroring GetCameraStableID's convention.
+func (d *DB) GetCameraOnvifEndpoint(ctx context.Context, cameraID string) (string, error) {
+	var ep string
+	err := d.readConn().QueryRowContext(ctx, `SELECT COALESCE(onvif_endpoint, '') FROM cameras WHERE id=? LIMIT 1`, cameraID).Scan(&ep)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", err
+	}
+	return ep, nil
+}
+
 // CameraIDByOnvifEndpoint returns the camera_id and matchKind of any row
 // (including ARCHIVED ones) that matches the given onvif_endpoint or serial.
 // matchKind is "endpoint" when the onvif_endpoint column matched, "serial" when


### PR DESCRIPTION
## Summary

Fixes a **regression introduced by #122** (the #121 fix): every discovery cycle restarted the recorder for devices that simply re-announced at their *current* address, disrupting recording and live preview (212/251 restarted ~10x/hour on M5, preview broke).

## Root Cause

Two bugs in the #122 fix:

### Bug A — Roaming update fired even when endpoint was unchanged
`HandleDiscovered` called `updateEndpointForRoaming` on any `stable_id`/`serial` match, without checking whether the discovered endpoint actually differed from the camera's current one. WS-Discovery Hello (passive) + the active scanner re-discover the same device every cycle (default 60s), so every cycle: `findExistingCamera` → stable_id match → `updateEndpointForRoaming` → `UpdateCamera` + `RestartRecorder`. The recorder restart killed the in-flight preview stream.

**Production evidence**: M5 logs showed 23 `updated camera endpoint after IP roaming` events in 1 hour — 9 for 212 (视通), 10 for 251 (工作室内) — each time with the *same* endpoint (no actual IP change). 212's recorder restarted 12x/hour.

### Bug B — Dedup window didn't suppress across the enrich boundary
`recentlySeen(endpoint, serial)` queries the **endpoint key** before enrichment (serial empty) and the **serial key** after enrichment. But `markSeen` only set ONE key per call. So:
1. Cycle N post-enrichment: `markSeen(endpoint, serial)` set only the serial key.
2. Cycle N+1 pre-enrichment: `recentlySeen(endpoint, "")` queries the endpoint key → **miss** → device retriggered the full pipeline.

The suppression window was effectively useless for chatty devices.

## Fix

### `endpointChanged` guard (Bug A)
New `internal/storage/db_camera.go:GetCameraOnvifEndpoint` (lightweight single-column SELECT, mirrors `GetCameraStableID`). New `Adder.endpointChanged(ctx, cameraID, discoveredEndpoint)` compares (trailing-slash normalized) before calling `updateEndpointForRoaming`. Fail-open on DB error (the update is idempotent). `HandleDiscovered` now gates the roaming update on `endpointChanged`.

### `markSeenBothKeys` (Bug B)
Replaces `markSeen`. Marks **both** the endpoint key (pre-enrichment lookups) and the serial key (post-enrichment lookups) so the suppression holds regardless of which stage the next announcement is at.

## Test Coverage

- `TestEndpointChanged` — regression test: identical endpoint (incl. trailing-slash variant) → unchanged; different IP → changed; unknown camera → fail-open.
- `TestRecentlySeen_PreEnrichmentEndpointLookupHits` — regression test for Bug B: after `markSeenBothKeys(ep, serial)`, a pre-enrichment `recentlySeen(ep, "")` lookup must hit (this is the exact scenario that failed before).
- Existing `TestRecentlySeen_*` updated to use `markSeenBothKeys`.

## Verification (M5, real hardware)

| Metric | Before hotfix (1 hour) | After hotfix (90s) |
|---|---|---|
| `updated camera endpoint after IP roaming` | 23 (212: 9, 251: 10) | **0** |
| Recorder restarts | 212: 12 | **0** |
| `enriched device info` (devices still discovered) | normal | normal (3) |
| 212 (视通) preview | broken | **实时, health 100, all protocols available** |

- Unit tests on M5: `autodiscover` PASS, `storage` PASS
- `go vet ./...` clean
- Browser verification: 212 single-camera view shows status "实时" (real-time), health score 100, WebCodecs player loaded

## Why this is a hotfix

#122 is already merged to main and deployed to M5 (production test env with real data). This regression breaks preview for *every* autodiscover-managed ONVIF camera that re-announces normally — not just 212. Needs to merge + redeploy promptly.
