### PR TITLE
fix(ai): gzip-trailer corruption of binary responses — root cause of #109 INVALID_PROTOBUF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Normalize line endings — critical for shell scripts executed inside Alpine
+# Docker containers (ash/dash reject CRLF: "Syntax error: expecting 'then'").
+# Without this, a Windows checkout (core.autocrlf=true) would commit CRLF into
+# the repo and silently break every Docker container's entrypoint at startup.
+*.sh       text eol=lf
+Dockerfile text eol=lf
+*.dockerfile text eol=lf
+
+# Go and TypeScript tolerate either ending, but normalize to LF for consistency
+# with the rest of the codebase (cross-platform builds, cleaner diffs).
+*.go       text eol=lf
+*.ts       text eol=lf
+*.js       text eol=lf
+*.svelte   text eol=lf
+*.json     text eol=lf
+*.yaml     text eol=lf
+*.yml      text eol=lf
+*.md       text eol=lf
+
+# Binary files — never normalize
+*.png      binary
+*.jpg      binary
+*.jpeg     binary
+*.gif      binary
+*.ico      binary
+*.webp     binary
+*.woff     binary
+*.woff2    binary
+*.ttf      binary
+*.onnx     binary

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ web/dist/
 # Embedded frontend build output
 internal/ui/static/assets/
 internal/ui/static/index.html
+internal/ui/static/ort/
 
 # Legacy / unused directories
 web_embed/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ web/dist/
 internal/ui/static/assets/
 internal/ui/static/index.html
 internal/ui/static/ort/
+internal/ui/static/ort.min.js
 
 # Legacy / unused directories
 web_embed/

--- a/cmd/mibee-nvr/download_model.go
+++ b/cmd/mibee-nvr/download_model.go
@@ -1,14 +1,45 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 )
+
+// defaultModelURL is the upstream YOLOv11-nano ONNX model release. It is fetched
+// by `mibee-nvr download-model` and (in Docker builds) by the release Dockerfile.
+const defaultModelURL = "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.onnx"
+
+// modelFilename is the canonical on-disk filename served at /models/{filename}.
+const modelFilename = "yolo11n.onnx"
+
+// downloadBackoff is the fixed per-attempt backoff schedule (see internal/transcoding/downloader.go
+// for the same pattern). 5 attempts → ~31s of total backoff worst case.
+var downloadBackoff = []time.Duration{
+	1 * time.Second,
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+	16 * time.Second,
+}
+
+// minModelSize is the absolute lower bound for a valid yolo11n.onnx. The real
+// file is ~5.4MB; anything below 5MB is definitely truncated/corrupt. This is a
+// last-resort sanity floor — the primary integrity check is Content-Length match.
+const minModelSize int64 = 5 * 1024 * 1024 // 5MB
+
+// downloadHTTPClient is the HTTP client used for model downloads. It has a
+// generous timeout (5 min) to survive slow CDN edges without giving up, but is
+// NOT infinite (the bare http.Get previously had no timeout at all → a stalled
+// connection would hang the CLI forever). Package-level so tests can swap it.
+var downloadHTTPClient = &http.Client{Timeout: 5 * time.Minute}
 
 func cmdDownloadModel() {
 	var cfgPath string
@@ -62,81 +93,253 @@ func cmdDownloadModel() {
 	// `defer out.Close()` / `defer resp.Body.Close()` actually run on every path
 	// (os.Exit skips defers — gocritic exitAfterDefer). The single os.Exit lives
 	// here, in the command entry point, where there is nothing left deferred.
-	if err := downloadModelFile(modelDir, "yolo11n.onnx"); err != nil {
+	if err := downloadModelFile(modelDir, modelFilename, defaultModelURL); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 	os.Exit(0)
 }
 
-func downloadModelFile(modelDir, filename string) error {
-	modelURL := "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.onnx"
+// downloadModelFile downloads `filename` from `modelURL` into `modelDir` with
+// bounded retry, HTTP Range resume, strict size verification, and atomic write.
+//
+// Why all three defenses (retry + resume + size check):
+//   - GitHub release assets are served via Azure blob CDN with a 1-hour signed
+//     URL. On unreliable networks (notably China → GitHub) the connection is
+//     silently truncated mid-transfer. A bare http.Get leaves a partial file on
+//     disk; subsequent runs re-serve it to the browser, and ONNX Runtime Web
+//     fails to parse the truncated protobuf ("ERROR_CODE 7", issue #109).
+//   - Retry handles transient failures. Range resume avoids re-downloading the
+//     already-correct prefix on each retry (faster, less bandwidth). The strict
+//     Content-Length check is the hard gate that rejects a truncated file even
+//     when the server reports a clean 200/206.
+//
+// The function is testable: pass a httptest.Server URL as modelURL.
+func downloadModelFile(modelDir, filename, modelURL string) error {
 	modelPath := filepath.Join(modelDir, filename)
+	partPath := modelPath + ".part"
 
 	fmt.Printf("Downloading YOLOv11n ONNX model...\n")
 	fmt.Printf("  URL: %s\n", modelURL)
 	fmt.Printf("  Destination: %s\n", modelPath)
 
-	out, err := os.Create(modelPath)
-	if err != nil {
-		return fmt.Errorf("Error creating file: %w", err)
-	}
-	// NOTE: do NOT close `out` here — it is written to in the loop below.
-	// (A premature out.Close() here previously left a 0-byte file and caused
-	// "file already closed" on the first Write.) The defer below runs on every
-	// return path because this function returns an error instead of os.Exit.
-	defer out.Close()
+	ctx := context.Background()
+	var lastErr error
 
-	resp, err := http.Get(modelURL)
+	for attempt := range downloadBackoff {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(downloadBackoff[attempt-1]):
+			}
+		}
+
+		lastErr = downloadOnceWithResume(ctx, modelURL, partPath, attempt+1)
+		if lastErr == nil {
+			// Final integrity check + atomic rename.
+			if err := verifyAndAtomicallyInstall(partPath, modelPath); err != nil {
+				lastErr = err
+				slog.Warn("model download integrity check failed", "attempt", attempt+1, "error", err)
+				continue
+			}
+			fmt.Printf("\nModel downloaded successfully!\n")
+			if info, err := os.Stat(modelPath); err == nil {
+				fmt.Printf("  File: %s\n", modelPath)
+				fmt.Printf("  Size: %d bytes (%.1f MB)\n", info.Size(), float64(info.Size())/(1024*1024))
+			}
+			return nil
+		}
+
+		slog.Warn("model download attempt failed", "attempt", attempt+1, "error", lastErr)
+	}
+
+	// All retries exhausted — clean up the partial file so a later run doesn't
+	// mistake it for a complete download (the exact bug we're fixing).
+	os.Remove(partPath)
+	return fmt.Errorf("download failed after %d attempts: %w", len(downloadBackoff), lastErr)
+}
+
+// downloadOnceWithResume performs a single download attempt.
+//
+// If a `.part` file already exists (from a previous failed attempt in this or a
+// prior run), it sends an HTTP `Range: bytes=N-` request to resume from byte N.
+// The server may respond with:
+//   - 206 Partial Content: resume honored — we append to the existing .part.
+//   - 200 OK: resume not supported (or the .part was already complete) — we
+//     truncate the .part and start fresh.
+//
+// expectedSize (from Content-Length / Content-Range) is recorded in the .part's
+// trailing metadata via verifyAndAtomicallyInstall for the strict size check.
+func downloadOnceWithResume(ctx context.Context, modelURL, partPath string, attempt int) error {
+	existingSize := int64(0)
+	if info, err := os.Stat(partPath); err == nil {
+		existingSize = info.Size()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelURL, nil)
 	if err != nil {
-		return fmt.Errorf("Error downloading model: %w", err)
+		return fmt.Errorf("create request: %w", err)
+	}
+	if existingSize > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", existingSize))
+	}
+
+	resp, err := downloadHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Download failed: HTTP %d", resp.StatusCode)
+
+	var expectedTotal int64
+	var writeMode int
+	var startOffset int64
+
+	switch resp.StatusCode {
+	case http.StatusPartialContent:
+		// Resume honored. Parse Content-Range: bytes start-end/total.
+		expectedTotal = parseContentRangeTotal(resp.Header.Get("Content-Range"))
+		writeMode = os.O_WRONLY | os.O_APPEND
+		startOffset = existingSize
+		fmt.Printf("\r  Resuming from byte %d (attempt %d)...", existingSize, attempt)
+	case http.StatusOK:
+		// Full download (server doesn't support Range, or no existing .part).
+		// Truncate any stale partial.
+		expectedTotal = resp.ContentLength
+		writeMode = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+		startOffset = 0
+		fmt.Printf("\r  Downloading (attempt %d)...", attempt)
+	default:
+		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
 	}
 
-	totalSize := resp.ContentLength
+	out, err := os.OpenFile(partPath, writeMode, 0o644)
+	if err != nil {
+		return fmt.Errorf("open part file: %w", err)
+	}
+	// NOTE: do NOT close `out` before the function returns — it is written to
+	// below. (A premature close previously caused "file already closed" on the
+	// first Write and left a 0-byte file.) defer runs on every return path.
+	defer out.Close()
 
-	// Download with progress
-	var downloaded int64
+	// If this attempt determined the total via Content-Length/Content-Range,
+	// remember it for the integrity check. We stash it in a sidecar file so
+	// verifyAndAtomicallyInstall can compare against the final on-disk size
+	// even across attempts. (Content-Range's /total is authoritative; a 200
+	// with unknown Content-Length = -1 → skip strict check, fall back to
+	// minModelSize.)
+	if expectedTotal > 0 {
+		if err := writeExpectedSizeSidecar(partPath, expectedTotal); err != nil {
+			return fmt.Errorf("write expected-size sidecar: %w", err)
+		}
+	}
+
+	downloaded, copyErr := streamCopy(out, resp.Body, startOffset, expectedTotal)
+	if copyErr != nil {
+		return copyErr
+	}
+
+	// If the server didn't tell us the total, we can't strictly verify; accept
+	// any non-tiny download and let verifyAndAtomicallyInstall apply minModelSize.
+	if expectedTotal <= 0 {
+		return nil
+	}
+	if startOffset+downloaded < expectedTotal {
+		return fmt.Errorf("download truncated: got %d bytes, expected %d", startOffset+downloaded, expectedTotal)
+	}
+	return nil
+}
+
+// streamCopy copies resp.Body to out with a progress line. Returns bytes copied
+// (excluding the startOffset prefix on resume). A read or write error aborts.
+func streamCopy(out io.Writer, body io.Reader, startOffset, expectedTotal int64) (int64, error) {
 	buf := make([]byte, 32*1024)
+	var downloaded int64
 	for {
-		n, readErr := resp.Body.Read(buf)
+		n, readErr := body.Read(buf)
 		if n > 0 {
 			if _, writeErr := out.Write(buf[:n]); writeErr != nil {
-				return fmt.Errorf("Error writing file: %w", writeErr)
+				return downloaded, fmt.Errorf("write file: %w", writeErr)
 			}
 			downloaded += int64(n)
-			if totalSize > 0 {
-				pct := float64(downloaded) / float64(totalSize) * 100
-				fmt.Printf("\r  Progress: %.1f%% (%d/%d MB)", pct, downloaded/(1024*1024), totalSize/(1024*1024))
+			totalSoFar := startOffset + downloaded
+			if expectedTotal > 0 {
+				pct := float64(totalSoFar) / float64(expectedTotal) * 100
+				fmt.Printf("\r  Progress: %.1f%% (%d/%d bytes)", pct, totalSoFar, expectedTotal)
 			} else {
-				fmt.Printf("\r  Downloaded: %d MB", downloaded/(1024*1024))
+				fmt.Printf("\r  Downloaded: %d bytes", totalSoFar)
 			}
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
-				break
+				return downloaded, nil
 			}
-			return fmt.Errorf("\nError reading response: %w", readErr)
+			return downloaded, fmt.Errorf("read response: %w", readErr)
 		}
 	}
-	fmt.Println()
+}
 
-	// Verify file size
-	info, err := os.Stat(modelPath)
+// verifyAndAtomicallyInstall runs the final integrity gate and renames
+// `.part` → final filename. It removes the .part on any failure.
+func verifyAndAtomicallyInstall(partPath, modelPath string) error {
+	defer os.Remove(partPath + ".size") // clean up sidecar regardless
+
+	info, err := os.Stat(partPath)
 	if err != nil {
-		return fmt.Errorf("Error verifying model file: %w", err)
+		return fmt.Errorf("stat part file: %w", err)
 	}
 
-	const minSize int64 = 5 * 1024 * 1024 // 5MB
-	if info.Size() < minSize {
-		return fmt.Errorf("Error: model file too small (%d bytes, expected >= %d bytes)", info.Size(), minSize)
+	// 1. Absolute floor — a truncated yolo11n is always < 5MB.
+	if info.Size() < minModelSize {
+		return fmt.Errorf("model file too small: %d bytes (minimum %d)", info.Size(), minModelSize)
 	}
 
-	fmt.Printf("\nModel downloaded successfully!\n")
-	fmt.Printf("  File: %s\n", modelPath)
-	fmt.Printf("  Size: %d bytes (%.1f MB)\n", info.Size(), float64(info.Size())/(1024*1024))
+	// 2. Strict Content-Length match (the hard gate). If the server reported a
+	//    total and we didn't reach it, the file is truncated — reject it.
+	if expected, ok := readExpectedSizeSidecar(partPath); ok && info.Size() != expected {
+		return fmt.Errorf("size mismatch: got %d bytes, expected %d (truncated download)", info.Size(), expected)
+	}
+
+	// Atomic install: temp → rename. Crash-safe; either the old file or the new
+	// one is on disk, never a half-written one.
+	if err := os.Rename(partPath, modelPath); err != nil {
+		return fmt.Errorf("rename part→final: %w", err)
+	}
 	return nil
+}
+
+// expectedSizeSidecarName returns the sidecar path for a given .part file.
+func expectedSizeSidecarName(partPath string) string { return partPath + ".size" }
+
+func writeExpectedSizeSidecar(partPath string, expected int64) error {
+	return os.WriteFile(expectedSizeSidecarName(partPath), []byte(fmt.Sprintf("%d", expected)), 0o644)
+}
+
+func readExpectedSizeSidecar(partPath string) (int64, bool) {
+	data, err := os.ReadFile(expectedSizeSidecarName(partPath))
+	if err != nil {
+		return 0, false
+	}
+	var n int64
+	if _, err := fmt.Sscanf(string(data), "%d", &n); err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseContentRangeTotal extracts the /total from a Content-Range header value
+// of the form "bytes 0-1023/2048". Returns 0 if the header is missing or
+// unparseable (caller treats 0 as "unknown total").
+func parseContentRangeTotal(header string) int64 {
+	// Find the last '/' — total is whatever follows it (may be "*" for unknown).
+	for i := len(header) - 1; i >= 0; i-- {
+		if header[i] == '/' {
+			var total int64
+			if _, err := fmt.Sscanf(header[i+1:], "%d", &total); err == nil {
+				return total
+			}
+			return 0
+		}
+	}
+	return 0
 }

--- a/cmd/mibee-nvr/download_model.go
+++ b/cmd/mibee-nvr/download_model.go
@@ -154,9 +154,12 @@ func downloadModelFile(modelDir, filename, modelURL string) error {
 		slog.Warn("model download attempt failed", "attempt", attempt+1, "error", lastErr)
 	}
 
-	// All retries exhausted — clean up the partial file so a later run doesn't
-	// mistake it for a complete download (the exact bug we're fixing).
+	// All retries exhausted — clean up the partial file AND its size sidecar so
+	// a later run doesn't mistake them for a complete download (the exact bug
+	// we're fixing). A stale .part.size without its .part would also mislead a
+	// future first attempt into thinking resume state exists.
 	os.Remove(partPath)
+	os.Remove(partPath + ".size")
 	return fmt.Errorf("download failed after %d attempts: %w", len(downloadBackoff), lastErr)
 }
 

--- a/cmd/mibee-nvr/download_model.go
+++ b/cmd/mibee-nvr/download_model.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -315,7 +316,7 @@ func verifyAndAtomicallyInstall(partPath, modelPath string) error {
 func expectedSizeSidecarName(partPath string) string { return partPath + ".size" }
 
 func writeExpectedSizeSidecar(partPath string, expected int64) error {
-	return os.WriteFile(expectedSizeSidecarName(partPath), []byte(fmt.Sprintf("%d", expected)), 0o644)
+	return os.WriteFile(expectedSizeSidecarName(partPath), []byte(strconv.FormatInt(expected, 10)), 0o644)
 }
 
 func readExpectedSizeSidecar(partPath string) (int64, bool) {

--- a/cmd/mibee-nvr/download_model_test.go
+++ b/cmd/mibee-nvr/download_model_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,8 +20,8 @@ import (
 func makeModelPayload(t *testing.T, size int64) []byte {
 	t.Helper()
 	buf := make([]byte, size)
-	buf[0] = 0x08 // protobuf field 1, wire type 2 (length-delimited)
-	buf[1] = 0x0a // length 10
+	buf[0] = 0x08                              // protobuf field 1, wire type 2 (length-delimited)
+	buf[1] = 0x0a                              // length 10
 	copy(buf[2:12], []byte("pytorch\x00\x00")) // producer string
 	for i := int64(12); i < size; i++ {
 		buf[i] = byte(i % 251) // deterministic filler
@@ -48,10 +49,10 @@ func rangeableServer(t *testing.T, payload []byte, truncateReqNum int64) (*httpt
 				start = from
 			}
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, totalLen))
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+			w.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
 			w.WriteHeader(http.StatusPartialContent)
 		} else {
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", totalLen))
+			w.Header().Set("Content-Length", strconv.FormatInt(totalLen, 10))
 			w.WriteHeader(http.StatusOK)
 		}
 
@@ -87,7 +88,7 @@ func truncatingThenFullServer(t *testing.T, payload []byte) (*httptest.Server, *
 			status = http.StatusPartialContent
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, totalLen))
 		}
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+		w.Header().Set("Content-Length", strconv.FormatInt(end-start+1, 10))
 		w.WriteHeader(status)
 
 		toSend := payload[start : end+1]
@@ -106,7 +107,7 @@ func fullServerNoRange(t *testing.T, payload []byte) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(payload)))
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.Copy(w, strings.NewReader(string(payload)))
 	})
@@ -144,7 +145,7 @@ func TestDownloadModelFile_Success(t *testing.T) {
 }
 
 func TestDownloadModelFile_RetryAndResume(t *testing.T) {
-	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	payload := makeModelPayload(t, 6*1024*1024)
 	srv, reqCount := truncatingThenFullServer(t, payload)
 	defer srv.Close()
 
@@ -174,7 +175,7 @@ func TestDownloadModelFile_RetryAndResume(t *testing.T) {
 }
 
 func TestDownloadModelFile_ServerNoRangeSupport(t *testing.T) {
-	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	payload := makeModelPayload(t, 6*1024*1024)
 	srv := fullServerNoRange(t, payload)
 	defer srv.Close()
 
@@ -195,7 +196,7 @@ func TestDownloadModelFile_PersistentTruncation_FailsAfterRetries(t *testing.T) 
 	// Server truncates EVERY request → all retries fail → function returns error
 	// AND cleans up the .part (the exact bug we're fixing: a stale partial must
 	// not be mistaken for a complete file on the next run).
-	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	payload := makeModelPayload(t, 6*1024*1024)
 	srv, reqCount := rangeableServer(t, payload, 1) // truncate request #1 always
 	// Override: truncate ALL requests by setting truncateReqNum to a sentinel
 	// that matches every request. Rebuild with a custom handler.
@@ -211,10 +212,10 @@ func TestDownloadModelFile_PersistentTruncation_FailsAfterRetries(t *testing.T) 
 				start = from
 			}
 			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, totalLen-1, totalLen))
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", (totalLen-start)/2)) // lie: claim half
+			w.Header().Set("Content-Length", strconv.FormatInt((totalLen-start)/2, 10)) // lie: claim half
 			w.WriteHeader(http.StatusPartialContent)
 		} else {
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", totalLen))
+			w.Header().Set("Content-Length", strconv.FormatInt(totalLen, 10))
 			w.WriteHeader(http.StatusOK)
 		}
 		toSend := payload[start:]

--- a/cmd/mibee-nvr/download_model_test.go
+++ b/cmd/mibee-nvr/download_model_test.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// makeModelPayload builds a deterministic fake ONNX payload of the given size.
+// The first 4 bytes mimic a valid ONNX/protobuf start (0x08 0x0a = field 1,
+// length-delimited) so a size check is the only realistic integrity gate.
+func makeModelPayload(t *testing.T, size int64) []byte {
+	t.Helper()
+	buf := make([]byte, size)
+	buf[0] = 0x08 // protobuf field 1, wire type 2 (length-delimited)
+	buf[1] = 0x0a // length 10
+	copy(buf[2:12], []byte("pytorch\x00\x00")) // producer string
+	for i := int64(12); i < size; i++ {
+		buf[i] = byte(i % 251) // deterministic filler
+	}
+	return buf
+}
+
+// rangeableServer serves `payload`, honoring HTTP Range requests (responding
+// 206 Partial Content with the requested byte range). `truncateAfter` forces
+// every Nth request to drop the connection mid-stream (simulating CDN
+// truncation); set to 0 to disable. Returns the server and a counter of
+// completed (non-truncated) requests.
+func rangeableServer(t *testing.T, payload []byte, truncateReqNum int64) (*httptest.Server, *int64) {
+	t.Helper()
+	var reqCount int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&reqCount, 1)
+
+		totalLen := int64(len(payload))
+		start, end := int64(0), totalLen-1
+		if cr := r.Header.Get("Range"); strings.HasPrefix(cr, "bytes=") {
+			var from int64
+			if _, err := fmt.Sscanf(cr, "bytes=%d-", &from); err == nil && from >= 0 && from < totalLen {
+				start = from
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, totalLen))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", totalLen))
+			w.WriteHeader(http.StatusOK)
+		}
+
+		// Decide how many bytes to actually send. truncateReqNum > 0 and this is
+		// the Nth request → send only half the intended range, then close.
+		toSend := payload[start : end+1]
+		if truncateReqNum > 0 && n == truncateReqNum {
+			toSend = toSend[:len(toSend)/2]
+		}
+		_, _ = io.Copy(w, strings.NewReader(string(toSend)))
+		// Implicit connection close on handler return truncates the response.
+	})
+	return httptest.NewServer(mux), &reqCount
+}
+
+// countRequestServer is a simpler server that truncates the FIRST request only
+// (forcing a retry), then serves fully on subsequent requests. Used to test the
+// retry+resume path end-to-end.
+func truncatingThenFullServer(t *testing.T, payload []byte) (*httptest.Server, *int64) {
+	t.Helper()
+	var reqCount int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&reqCount, 1)
+		totalLen := int64(len(payload))
+		start, end := int64(0), totalLen-1
+		status := http.StatusOK
+		if cr := r.Header.Get("Range"); strings.HasPrefix(cr, "bytes=") {
+			var from int64
+			if _, err := fmt.Sscanf(cr, "bytes=%d-", &from); err == nil && from >= 0 && from < totalLen {
+				start = from
+			}
+			status = http.StatusPartialContent
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, totalLen))
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", end-start+1))
+		w.WriteHeader(status)
+
+		toSend := payload[start : end+1]
+		// First request: send only the first 40% then drop (truncation).
+		if n == 1 {
+			toSend = toSend[:len(toSend)*2/5]
+		}
+		_, _ = io.Copy(w, strings.NewReader(string(toSend)))
+	})
+	return httptest.NewServer(mux), &reqCount
+}
+
+// fullServerNoRange serves the full payload but ignores Range headers (always
+// 200 OK), exercising the "server doesn't support resume" branch.
+func fullServerNoRange(t *testing.T, payload []byte) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, strings.NewReader(string(payload)))
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestDownloadModelFile_Success(t *testing.T) {
+	payload := makeModelPayload(t, 6*1024*1024) // 6MB, above minModelSize
+	srv, reqCount := rangeableServer(t, payload, 0)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if err := downloadModelFile(dir, "yolo11n.onnx", srv.URL); err != nil {
+		t.Fatalf("downloadModelFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "yolo11n.onnx"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != len(payload) {
+		t.Fatalf("size mismatch: got %d, want %d", len(got), len(payload))
+	}
+	if string(got[:12]) != string(payload[:12]) {
+		t.Fatalf("content prefix mismatch")
+	}
+	if n := atomic.LoadInt64(reqCount); n != 1 {
+		t.Fatalf("expected exactly 1 request for clean download, got %d", n)
+	}
+
+	// No leftover .part / .part.size files.
+	if _, err := os.Stat(filepath.Join(dir, "yolo11n.onnx.part")); !os.IsNotExist(err) {
+		t.Fatalf(".part file should be removed after success, got err=%v", err)
+	}
+}
+
+func TestDownloadModelFile_RetryAndResume(t *testing.T) {
+	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	srv, reqCount := truncatingThenFullServer(t, payload)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if err := downloadModelFile(dir, "yolo11n.onnx", srv.URL); err != nil {
+		t.Fatalf("downloadModelFile should succeed after retry+resume, got: %v", err)
+	}
+
+	// First request truncated, second resumed and completed → at least 2 requests.
+	if n := atomic.LoadInt64(reqCount); n < 2 {
+		t.Fatalf("expected >=2 requests (truncation then resume), got %d", n)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "yolo11n.onnx"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != len(payload) {
+		t.Fatalf("final file truncated: got %d, want %d", len(got), len(payload))
+	}
+	// Verify the resumed prefix + suffix are correct (resume appends, doesn't corrupt).
+	for i, b := range payload {
+		if got[i] != b {
+			t.Fatalf("byte mismatch at %d after resume: got %d, want %d", i, got[i], b)
+		}
+	}
+}
+
+func TestDownloadModelFile_ServerNoRangeSupport(t *testing.T) {
+	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	srv := fullServerNoRange(t, payload)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	if err := downloadModelFile(dir, "yolo11n.onnx", srv.URL); err != nil {
+		t.Fatalf("downloadModelFile failed when server ignores Range: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "yolo11n.onnx"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != len(payload) {
+		t.Fatalf("size mismatch: got %d, want %d", len(got), len(payload))
+	}
+}
+
+func TestDownloadModelFile_PersistentTruncation_FailsAfterRetries(t *testing.T) {
+	// Server truncates EVERY request → all retries fail → function returns error
+	// AND cleans up the .part (the exact bug we're fixing: a stale partial must
+	// not be mistaken for a complete file on the next run).
+	payload := makeModelPayload(t, 6 * 1024 * 1024)
+	srv, reqCount := rangeableServer(t, payload, 1) // truncate request #1 always
+	// Override: truncate ALL requests by setting truncateReqNum to a sentinel
+	// that matches every request. Rebuild with a custom handler.
+	srv.Close()
+	var allReqCount int64
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&allReqCount, 1)
+		totalLen := int64(len(payload))
+		start := int64(0)
+		if cr := r.Header.Get("Range"); strings.HasPrefix(cr, "bytes=") {
+			var from int64
+			if _, err := fmt.Sscanf(cr, "bytes=%d-", &from); err == nil && from >= 0 && from < totalLen {
+				start = from
+			}
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, totalLen-1, totalLen))
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", (totalLen-start)/2)) // lie: claim half
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", totalLen))
+			w.WriteHeader(http.StatusOK)
+		}
+		toSend := payload[start:]
+		toSend = toSend[:len(toSend)/2] // only send half
+		_, _ = io.Copy(w, strings.NewReader(string(toSend)))
+	}))
+	defer srv.Close()
+	_ = reqCount // silence unused (we replaced the server)
+
+	dir := t.TempDir()
+	err := downloadModelFile(dir, "yolo11n.onnx", srv.URL)
+	if err == nil {
+		t.Fatal("expected error when every attempt truncates, got nil")
+	}
+	// All 5 backoff slots attempted.
+	if n := atomic.LoadInt64(&allReqCount); n != int64(len(downloadBackoff)) {
+		t.Fatalf("expected %d attempts, got %d", len(downloadBackoff), n)
+	}
+	// CRITICAL: .part and .part.size must NOT survive — otherwise a later run
+	// would see a stale partial and think the file exists.
+	if _, err := os.Stat(filepath.Join(dir, "yolo11n.onnx.part")); !os.IsNotExist(err) {
+		t.Fatalf(".part file must be cleaned up after all retries fail, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "yolo11n.onnx.part.size")); !os.IsNotExist(err) {
+		t.Fatalf(".part.size sidecar must be cleaned up, got err=%v", err)
+	}
+	// And the final file must not exist.
+	if _, err := os.Stat(filepath.Join(dir, "yolo11n.onnx")); !os.IsNotExist(err) {
+		t.Fatalf("final model file must not exist after failure, got err=%v", err)
+	}
+}
+
+func TestDownloadModelFile_TooSmall_Fails(t *testing.T) {
+	// A 1MB payload is below minModelSize even if fully downloaded.
+	payload := makeModelPayload(t, 1*1024*1024)
+	srv := fullServerNoRange(t, payload)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := downloadModelFile(dir, "yolo11n.onnx", srv.URL)
+	if err == nil {
+		t.Fatal("expected error for undersized model, got nil")
+	}
+	if !strings.Contains(err.Error(), "too small") && !strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("expected size-related error, got: %v", err)
+	}
+}
+
+func TestDownloadModelFile_HTTPError_Retries(t *testing.T) {
+	// Server returns 500 on every request → all retries fail with HTTP error.
+	var reqCount int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&reqCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	err := downloadModelFile(dir, "yolo11n.onnx", srv.URL)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500, got nil")
+	}
+	if n := atomic.LoadInt64(&reqCount); n != int64(len(downloadBackoff)) {
+		t.Fatalf("expected %d attempts for persistent 500, got %d", len(downloadBackoff), n)
+	}
+}
+
+func TestParseContentRangeTotal(t *testing.T) {
+	cases := []struct {
+		header string
+		want   int64
+	}{
+		{"bytes 0-1023/2048", 2048},
+		{"bytes 1024-2047/5400000", 5400000},
+		{"bytes 0-1023/*", 0}, // unknown total
+		{"", 0},
+		{"malformed", 0},
+	}
+	for _, c := range cases {
+		if got := parseContentRangeTotal(c.header); got != c.want {
+			t.Errorf("parseContentRangeTotal(%q) = %d, want %d", c.header, got, c.want)
+		}
+	}
+}
+
+func TestDownloadBackoffIsBounded(t *testing.T) {
+	// Sanity: the backoff schedule must be bounded and reasonable so the CLI
+	// doesn't hang forever on a bad network. Total worst-case ~31s.
+	var total time.Duration
+	for _, d := range downloadBackoff {
+		total += d
+	}
+	if total > 2*time.Minute {
+		t.Fatalf("downloadBackoff total %v exceeds 2min — too long for an interactive CLI", total)
+	}
+	if len(downloadBackoff) < 3 {
+		t.Fatalf("downloadBackoff has only %d entries — too few retries", len(downloadBackoff))
+	}
+}

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -48,6 +48,28 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     fi && \
     go build -trimpath -ldflags="-s -w -X main.appVersion=${VERSION}" -o /mibee-nvr ./cmd/mibee-nvr/
 
+# ---- Stage 2b: Pre-download the ONNX AI model ----
+# Docker users get a working AI detection model baked into the image — no
+# runtime `download-model` needed, no dependence on the host's network quality.
+# The build environment (GitHub Actions runner) has a stable connection, and
+# curl's `--retry-all-errors` + `--fail` handle the GitHub release CDN's
+# intermittent mid-transfer truncation (issue #109). A truncated/failed download
+# FAILS THE BUILD here (explicit failure > a silently corrupt model on disk).
+# The model is architecture-independent (a protobuf blob), so a single download
+# serves amd64/arm64/armv7.
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS model
+RUN apk add --no-cache curl
+ARG YOLO_MODEL_URL=https://github.com/ultralytics/assets/releases/download/v8.3.0/yolo11n.onnx
+RUN mkdir -p /opt/mibee-nvr/models && \
+    curl --fail --location --show-error \
+         --retry 10 --retry-all-errors --retry-delay 2 \
+         --connect-timeout 30 --max-time 600 \
+         -o /opt/mibee-nvr/models/yolo11n.onnx \
+         "$YOLO_MODEL_URL" && \
+    # Reject a truncated download (matches the Go CLI's minModelSize gate).
+    test "$(stat -c%s /opt/mibee-nvr/models/yolo11n.onnx)" -ge 5242880 || \
+    { echo "ERROR: downloaded model is < 5MB (truncated)"; exit 1; }
+
 # ---- Stage 3: Runtime image ----
 # Pre-built base image (Alpine + FFmpeg + ffprobe + xz + su-exec + tzdata).
 # Built periodically by .github/workflows/base-image.yml — NOT on every release.
@@ -64,6 +86,7 @@ ENV NVR_GID=1000
 VOLUME ["/data"]
 
 COPY --from=backend /mibee-nvr /usr/local/bin/mibee-nvr
+COPY --from=model /opt/mibee-nvr/models/yolo11n.onnx /opt/mibee-nvr/models/yolo11n.onnx
 COPY --chmod=0755 deploy/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 9090

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -42,6 +42,25 @@ if [ "$(id -u)" = "0" ]; then
         fi
     fi
 
+    # Seed the ONNX AI model from the image cache on first start.
+    # The model is baked into the image at /opt/mibee-nvr/models/ (issue #109:
+    # avoids the host needing to download it from GitHub's flaky CDN at runtime).
+    # We copy it into the writable data volume only when missing or undersized,
+    # so this is a one-time cost and never overwrites a user-supplied model.
+    MODEL_SRC="/opt/mibee-nvr/models/yolo11n.onnx"
+    MODEL_DST_DIR="$NVR_DATA_DIR/models"
+    MODEL_DST="$MODEL_DST_DIR/yolo11n.onnx"
+    # 5242880 = 5MB, matches minModelSize in cmd/mibee-nvr/download_model.go.
+    if [ -f "$MODEL_SRC" ] && [ "$(stat -c%s "$MODEL_SRC" 2>/dev/null || echo 0)" -ge 5242880 ]; then
+        DST_SIZE=$(stat -c%s "$MODEL_DST" 2>/dev/null || echo 0)
+        if [ "$DST_SIZE" -lt 5242880 ]; then
+            echo "[entrypoint] seeding AI model from image cache → $MODEL_DST"
+            mkdir -p "$MODEL_DST_DIR"
+            cp "$MODEL_SRC" "$MODEL_DST"
+            chown "${NVR_UID}:${NVR_GID}" "$MODEL_DST" 2>/dev/null || true
+        fi
+    fi
+
     # Drop privileges and exec the binary
     exec su-exec "${NVR_UID}:${NVR_GID}" /usr/local/bin/mibee-nvr "$@"
 fi

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -47,18 +47,21 @@ if [ "$(id -u)" = "0" ]; then
     # avoids the host needing to download it from GitHub's flaky CDN at runtime).
     # We copy it into the writable data volume only when missing or undersized,
     # so this is a one-time cost and never overwrites a user-supplied model.
+    # NOTE: stat sizes are captured into variables FIRST, then compared. POSIX sh
+    # (Alpine ash / Debian dash) mis-parses a `&&` chain whose command-substitution
+    # contains its own `||` (it reports "Syntax error: ... expecting 'then'"), so
+    # we avoid nesting them.
     MODEL_SRC="/opt/mibee-nvr/models/yolo11n.onnx"
     MODEL_DST_DIR="$NVR_DATA_DIR/models"
     MODEL_DST="$MODEL_DST_DIR/yolo11n.onnx"
     # 5242880 = 5MB, matches minModelSize in cmd/mibee-nvr/download_model.go.
-    if [ -f "$MODEL_SRC" ] && [ "$(stat -c%s "$MODEL_SRC" 2>/dev/null || echo 0)" -ge 5242880 ]; then
-        DST_SIZE=$(stat -c%s "$MODEL_DST" 2>/dev/null || echo 0)
-        if [ "$DST_SIZE" -lt 5242880 ]; then
-            echo "[entrypoint] seeding AI model from image cache → $MODEL_DST"
-            mkdir -p "$MODEL_DST_DIR"
-            cp "$MODEL_SRC" "$MODEL_DST"
-            chown "${NVR_UID}:${NVR_GID}" "$MODEL_DST" 2>/dev/null || true
-        fi
+    SRC_SIZE=$(stat -c%s "$MODEL_SRC" 2>/dev/null || echo 0)
+    DST_SIZE=$(stat -c%s "$MODEL_DST" 2>/dev/null || echo 0)
+    if [ -f "$MODEL_SRC" ] && [ "$SRC_SIZE" -ge 5242880 ] && [ "$DST_SIZE" -lt 5242880 ]; then
+        echo "[entrypoint] seeding AI model from image cache → $MODEL_DST"
+        mkdir -p "$MODEL_DST_DIR"
+        cp "$MODEL_SRC" "$MODEL_DST"
+        chown "${NVR_UID}:${NVR_GID}" "$MODEL_DST" 2>/dev/null || true
     fi
 
     # Drop privileges and exec the binary

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -62,6 +62,66 @@ This guide helps you diagnose and resolve common issues with MiBee NVR. If you c
      disk_threshold_percent: 90  # Lower from 95 to 90
    ```
 
+## AI Detection
+
+AI detection runs entirely in the browser via ONNX Runtime Web (WASM). When it
+fails, the LiveView status bar shows a red `AI ✗` chip with an error message.
+
+### `ERROR_CODE: 7, ERROR_MESSAGE: Failed to load model because protobuf parsing failed`
+
+This means the ONNX model bytes received by the browser could not be parsed.
+
+**First, confirm your version is fixed.** Versions before the gzip-trailer fix
+(see [`docs/known-issues-ai-onnx-gzip-trailer.md`](./known-issues-ai-onnx-gzip-trailer.md))
+corrupted binary downloads by appending a spurious gzip trailer — every model
+failed regardless of validity. If you are on a current build, proceed:
+
+1. **Verify the model file is valid on disk** (run on the NVR host):
+   ```bash
+   python3 -c "import onnx; onnx.checker.check_model(onnx.load('/path/to/yolo11n.onnx')); print('OK')"
+   ```
+   If this fails, the model file itself is corrupt — re-download with
+   `mibee-nvr download-model`.
+
+2. **Verify the server serves the file byte-for-byte.** The browser always
+   sends `Accept-Encoding: gzip`, so you must test with the same header:
+   ```bash
+   # The md5 here MUST match the md5 of the on-disk file. If it doesn't,
+   # the server is corrupting the response (compression middleware, reverse
+   # proxy, content-transcoding CDN, etc.).
+   curl -H "Accept-Encoding: gzip" --compressed http://localhost:9090/models/yolo11n.onnx | md5sum
+   md5sum /path/to/yolo11n.onnx
+   ```
+   Mismatched md5s with matching first-bytes means the corruption is at the
+   **end** of the file — exactly the gzip-trailer signature.
+
+3. **Check the browser actually receives the right bytes.** Open DevTools →
+   Network → the `.onnx` request → Response. Or, in the console:
+   ```js
+   const r = await fetch('/models/yolo11n.onnx', { cache: 'no-store' });
+   const b = new Uint8Array(await r.arrayBuffer());
+   // First 4 bytes should be 08 08 12 07 for a PyTorch-exported ONNX.
+   // (0x1f 0x8b would mean the server sent a gzipped body without the
+   // Content-Encoding header, or a 404 HTML page was gzipped.)
+   console.log(b.slice(0, 16), b.length);
+   ```
+
+### AI status stays at "AI 加载中..." / "AI loading..." forever
+
+- The browser cannot reach `/ort.min.js` or `/ort/ort-wasm-simd-threaded.jsep.{mjs,wasm}`.
+  Check these are served (HTTP 200) — they are bundled into the binary at
+  build time. Rebuilding (`make build`) regenerates them.
+- `env.wasm.wasmPaths` is misconfigured (must be `/ort/`, set automatically
+  by the app — do not override in user code).
+
+### AI is enabled but no detection boxes appear
+
+This is expected when the scene has no COCO-80 objects (people, cars, etc.).
+The `AI 就绪` (AI Ready) chip in the status bar confirms the model is loaded
+and inference is running — boxes only render when an object is detected above
+the confidence threshold (default 0.5). Lower the threshold in Settings →
+Features → AI to see more (lower-confidence) detections.
+
 ## FFmpeg / Transcoding
 
 ### Is FFmpeg required?

--- a/docs/known-issues-ai-onnx-gzip-trailer.md
+++ b/docs/known-issues-ai-onnx-gzip-trailer.md
@@ -1,0 +1,235 @@
+# Known Issue: AI Detection `INVALID_PROTOBUF` — gzip trailer corrupting binary responses
+
+> **Status**: ✅ **Fixed** (issue #109). This document is retained as a
+> postmortem / regression reference.
+> **Affected**: Browser-side AI detection (ONNX Runtime Web) loading any model
+> from `/models/*.onnx` through the streaming-gzip middleware.
+> **Impact (pre-fix)**: Every ONNX model received by the browser was the raw
+> bytes + a spurious ~20-byte gzip trailer, so ONNX Runtime Web's C++ protobuf
+> parser (compiled to WASM) rejected it with `ERROR_CODE: 7, ERROR_MESSAGE:
+> Failed to load model because protobuf parsing failed.` AI detection was
+> permanently unusable from any browser, on every model, on every ORT version.
+> **Symptom appeared identical to**: truncated download, wrong model opset,
+> ORT version mismatch, browser-engine incompatibility — all of which were
+> investigated and ruled out before the real cause was found.
+
+## Problem
+
+After deploying ONNX Runtime Web (browser-side AI inference), every camera
+LiveView showed:
+
+```
+AI ✗ Can't create a session. ERROR_CODE: 7, ERROR_MESSAGE:
+       Failed to load model because protobuf parsing failed.
+```
+
+This was filed as issue #109 with the title "AI detection fails to load model:
+protobuf parsing failed". The error came from ORT's C++ core
+(`Model::Load` → protobuf deserialize) compiled into the
+`ort-wasm-simd-threaded.jsep.wasm` binary.
+
+## Why this was extraordinarily hard to diagnose
+
+The error message (`INVALID_PROTOBUF`) points squarely at "the model file is
+corrupt". But every obvious check passed:
+
+| Check | Result | (Mis)leading conclusion |
+|-------|--------|-------------------------|
+| `onnx.checker.check_model()` in Python | ✅ PASS | "Model is valid" |
+| Python `onnxruntime` 1.28 `InferenceSession(model)` | ✅ PASS | "Model loads fine" |
+| `curl /models/yolo11n.onnx` first 16 bytes vs disk | ✅ MATCH | "Bytes are correct" |
+| ORT Web JS layer (`new ort.Tensor(...)`) | ✅ WORKS | "ORT is fine" |
+| `WebAssembly.compile(26 MB wasm)` | ✅ 139 exports | "WASM is fine" |
+| ORT 1.26 **and** 1.27 (downgrade test) | ❌ both fail | "Not a version issue" |
+| UMD bundle vs ESM bundle vs CDN | ❌ all fail | "Not a bundle issue" |
+| `ArrayBuffer` vs `Uint8Array` vs URL-string arg | ❌ all fail | "Not a buffer issue" |
+| In-app-browser (Electron) vs real Edge/Chrome | ❌ both fail | "Not a browser-engine issue" |
+| 5 different models (tiny 86 B, yolo11n, official yolo, squeezenet, Add op) | ❌ all fail | "Not a model issue" |
+
+The first 16 bytes of the browser-fetched buffer matched the disk file
+**exactly** — which is the check everyone (including ORT's own maintainers in
+issue [microsoft/onnxruntime#13117](https://github.com/microsoft/onnxruntime/issues/13117))
+suggest first. That check is **necessary but not sufficient**: the corruption
+was at the **end** of the file, not the start.
+
+## Root Cause
+
+The streaming-gzip middleware (`internal/middleware/compress.go`) wraps every
+response with a `gzip.Writer` and pre-sets `Content-Encoding: gzip` before the
+handler runs. The intended flow for binary content (`application/octet-stream`,
+e.g. `/models/*.onnx`) is:
+
+1. Middleware sets `Content-Encoding: gzip`, creates `gz`, `defer cw.Close()`.
+2. `http.ServeFile` sets `Content-Type: application/octet-stream`.
+3. `WriteHeader` detects octet-stream → `shouldSkipCompression=true` → deletes
+   `Content-Encoding`, calls the underlying `WriteHeader`.
+4. `Write` detects octet-stream → **bypasses** `gz`, writes raw bytes directly
+   to the underlying `ResponseWriter`. ✓
+5. **`defer cw.Close()` runs → calls `gz.Close()`** on a gzip writer that was
+   **never written to**.
+
+**The bug lives in step 5.** `gzip.Writer.Close()` on an untouched writer
+still emits a complete, valid, **empty** gzip member to the underlying writer:
+the `1f 8b 08 00 ...` magic header + an empty deflate stream + an 8-byte
+trailer (CRC32 + ISIZE), totalling ~20 bytes. Because the raw response body
+was already flushed in step 4, this empty gzip frame is **appended** to the
+response — silently corrupting every binary download.
+
+The browser always sends `Accept-Encoding: gzip`, so every binary fetch
+(video segment download, ONNX model load, snapshot, recording download) was
+silently getting 20 bytes of gzip garbage appended. For media containers
+(MP4/MPEG-TS) the extra 20 bytes are usually tolerated (players stop at the
+moov/mdat end); for ONNX, which is a single protobuf message with a strict
+length prefix, the trailer makes the protobuf parser read past the real end
+of the message and fail.
+
+### The smoking gun
+
+Comparing the **full md5** (not just the head) of the browser-fetched bytes
+against the on-disk bytes revealed the corruption:
+
+```
+browser fetched md5 : ee7b0660585856f7e37a10b8c5b29edd   ← 10741417 bytes (corrupted)
+disk md5 (correct)  : df8e6fccb7797fd340b6bb1358a53394   ← 10741397 bytes
+                                                                       ↑ +20 bytes
+```
+
+Hex dump of the **last 32 bytes** of the corrupted file:
+
+```
+... 46 61 6c 73 65 [1f 8b 08 00 00 09 6e 88 00 ff 03 00 00 00 00 00 00 00 00 00]
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                    empty gzip member appended by gz.Close() on an unused writer
+```
+
+`curl -H "Accept-Encoding: gzip"` reproduced the corruption from the server
+side (no browser involved), confirming it was a server bug, not a client bug.
+
+## Fix
+
+`internal/middleware/compress.go`: track whether the gzip writer was actually
+used (`wroteGzip` flag, set on the first `gz.Write`). Only call `gz.Close()`
+and `gz.Flush()` when `wroteGzip == true`.
+
+```go
+type compressWriter struct {
+    w             http.ResponseWriter
+    gz            *gzip.Writer
+    contentType   string
+    headerWritten bool
+    wroteGzip     bool  // NEW: did we actually write any bytes through gz?
+}
+
+func (cw *compressWriter) Write(b []byte) (int, error) {
+    if shouldSkipCompression(cw.contentType) {
+        return cw.w.Write(b)
+    }
+    cw.wroteGzip = true
+    return cw.gz.Write(b)
+}
+
+func (cw *compressWriter) Flush() {
+    if !shouldSkipCompression(cw.contentType) && cw.wroteGzip {
+        _ = cw.gz.Flush()
+    }
+    // ...flush underlying writer...
+}
+
+func (cw *compressWriter) Close() error {
+    if !cw.wroteGzip {
+        return nil  // do NOT call gz.Close() — it would emit an empty gzip member
+    }
+    return cw.gz.Close()
+}
+```
+
+This is a **one-time finalization guard** — once any bytes go through `gz`,
+the flag stays true for the rest of the response, so legitimate compressed
+responses (JSON, HTML, SSE) still flush and finalize correctly.
+
+### Regression coverage
+
+`internal/middleware/compress_issue_test.go` —
+`TestStreamingGzip_BinaryNoGzipTrailer`: serves an
+`application/octet-stream` payload through the middleware with
+`Accept-Encoding: gzip`, and asserts (a) the body equals the raw payload
+exactly (no extra bytes), (b) `Content-Encoding` is empty, and (c) the last
+20 bytes are not a gzip frame (`1f 8b ...`). This is the exact signature of
+the bug and will catch any regression that re-introduces the unconditional
+`gz.Close()`.
+
+The existing tests (`TestStreamingGzip_JSONResponse`, `TestStreamingGzip_SSEFlush`,
+`TestStreamingGzip_SkipsVideo`) all still pass — the fix only changes behavior
+for the "gzip writer allocated but never used" path, which no existing test
+exercised end-to-end (they checked `Content-Encoding` header presence but not
+body byte-equality).
+
+## Lessons learned
+
+1. **`gzip.Writer.Close()` is not free.** Calling `Close()` on a writer that
+   was never `Write()`n to still produces output — a complete empty gzip
+   member (~20 bytes). Any middleware that allocates a gzip writer
+   optimistically and conditionally bypasses it MUST also conditionally skip
+   `Close()`. This applies to `deflate`, `zlib`, `brotli`, and `zstd` writers
+   too (all of them emit headers/footers on `Close()`/`Flush()`).
+
+2. **Head-byte equality is necessary but not sufficient.** When verifying a
+   binary transfer, compare the **full content hash (md5/sha256)** of the
+   received bytes against the source — not just the first N bytes. Corruption
+   can be anywhere in the stream, and HTTP-level issues (chunked encoding
+   bugs, compression trailers, range-join errors) frequently corrupt the
+   **tail** while leaving the head intact.
+
+3. **Error messages from compiled-WASM C++ are not debuggable.** ORT Web's
+   `INVALID_PROTOBUF` comes from C++ compiled to WASM; there is no source-level
+   stack trace and the only diagnostic is the error code + a generic message.
+   When the runtime says "the input is corrupt", **believe it** — and
+   byte-verify the input end-to-end (browser context → server response → disk
+   file) rather than trusting any single layer.
+
+4. **Use a real browser (CDP) to debug browser-side failures.** The in-app
+   browser (Electron webview) and a real Chrome/Edge can both reproduce a
+   server-side bug, but only a real browser driven over CDP lets you run
+   arbitrary `Runtime.evaluate` to compute md5s, inspect buffers, and compare
+   bytes — the IAB's `evaluate` was locked down by a side-effect guard that
+   blocked even read-only `localStorage` access. For any "works in Python,
+   fails in browser" bug, drive a real browser via
+   `msedge.exe --remote-debugging-port=9222` + `chrome-remote-interface` and
+   inspect the actual bytes the page received.
+
+5. **The middleware pipeline is a global transformer.** Anything applied via
+   `r.Use(...)` runs on **every** route, including public binary-download
+   routes (`/models/*`, `/api/recordings/{id}/download`). Compression
+   middleware in particular must be tested against binary responses, not just
+   JSON/HTML. The existing `TestStreamingGzip_SkipsVideo` test checked the
+   `Content-Encoding` header was cleared for video, but did not check the
+   response **body** for stray bytes — a gap that let this bug ship.
+
+## Verification (Banana Pi M5, real Edge browser)
+
+Driven a real Edge 150 instance over CDP (`msedge.exe
+--remote-debugging-port=9222`) against the M5 deployment:
+
+- **md5 parity**: `curl -H "Accept-Encoding: gzip" --compressed
+  /models/yolo11n.onnx | md5sum` = `df8e6fcc...` = disk md5 (was
+  `ee7b0660...` before the fix).
+- **ORT session create**: `ort.InferenceSession.create(buf, {executionProviders:
+  ['wasm']})` → `SESSION OK inputs=["images"]` (was `ERROR_CODE: 7`).
+- **LiveView AI indicator**: 视通 camera (H.265, online) shows **"AI 就绪"**
+  in the status bar (was "AI ✗ ERROR_CODE 7"). Screenshot confirms the video
+  is playing and the green AI-ready chip is visible.
+- All existing `TestStreamingGzip_*` tests still pass; new regression test
+  added.
+
+## Related
+
+- Issue #109 — original report ("AI detection fails to load model: protobuf
+  parsing failed").
+- `internal/middleware/compress.go` — the fix.
+- `internal/middleware/compress_issue_test.go` — regression test.
+- [microsoft/onnxruntime#13117](https://github.com/microsoft/onnxruntime/issues/13117)
+  — ORT maintainers' (correct, but incomplete) guidance: "check that the
+  server serves the file correctly". This postmortem is the concrete version
+  of that guidance for this codebase.
+- `docs/en/troubleshooting.md` / `docs/zh/troubleshooting.md` →
+  "AI Detection" section — user-facing symptom + fix steps.

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -62,6 +62,63 @@
      disk_threshold_percent: 90  # 从 95 降低到 90
    ```
 
+## AI 检测
+
+AI 检测完全在浏览器端通过 ONNX Runtime Web (WASM) 运行。失败时，LiveView
+状态栏会显示红色的 `AI ✗` 标签，附带错误信息。
+
+### `ERROR_CODE: 7, ERROR_MESSAGE: Failed to load model because protobuf parsing failed`
+
+这表示浏览器收到的 ONNX 模型字节无法被解析。
+
+**先确认你的版本已修复。** gzip-trailer 修复之前的版本（见
+[`docs/known-issues-ai-onnx-gzip-trailer.md`](../known-issues-ai-onnx-gzip-trailer.md)）
+会给所有二进制下载追加一个多余的 gzip 尾巴——无论模型多有效都会失败。
+如果你已经在修复后的构建上，按以下步骤排查：
+
+1. **验证磁盘上的模型文件本身有效**（在 NVR 主机上运行）：
+   ```bash
+   python3 -c "import onnx; onnx.checker.check_model(onnx.load('/path/to/yolo11n.onnx')); print('OK')"
+   ```
+   如果失败，模型文件本身就损坏了——用 `mibee-nvr download-model` 重新下载。
+
+2. **验证服务器是逐字节正确地提供文件。** 浏览器总是发送
+   `Accept-Encoding: gzip`，所以你必须用同样的 header 测试：
+   ```bash
+   # 这里的 md5 必须与磁盘文件的 md5 一致。如果不一致，
+   # 说明服务器在腐蚀响应（压缩中间件、反向代理、内容转码 CDN 等）。
+   curl -H "Accept-Encoding: gzip" --compressed http://localhost:9090/models/yolo11n.onnx | md5sum
+   md5sum /path/to/yolo11n.onnx
+   ```
+   md5 不一致但前几个字节相同，说明损坏在文件**末尾**——正是
+   gzip-trailer bug 的特征。
+
+3. **检查浏览器实际收到的字节。** 打开 DevTools → Network → `.onnx` 请求 →
+   Response。或者在控制台：
+   ```js
+   const r = await fetch('/models/yolo11n.onnx', { cache: 'no-store' });
+   const b = new Uint8Array(await r.arrayBuffer());
+   // PyTorch 导出的 ONNX 前 4 字节应为 08 08 12 07。
+   // (如果是 0x1f 0x8b，说明服务器发送了 gzip 压缩的 body 但没有
+   // Content-Encoding header，或者返回了 gzip 压缩的 404 HTML 页面。)
+   console.log(b.slice(0, 16), b.length);
+   ```
+
+### AI 状态一直停在 "AI 加载中..." 不动
+
+- 浏览器无法访问 `/ort.min.js` 或 `/ort/ort-wasm-simd-threaded.jsep.{mjs,wasm}`。
+  检查这些资源是否返回 HTTP 200（构建时打包进二进制）。重新 `make build`
+  可重新生成。
+- `env.wasm.wasmPaths` 配置错误（必须为 `/ort/`，由应用自动设置——
+  不要在用户代码里覆盖）。
+
+### AI 已开启但没有检测框
+
+这是正常的——当场景中没有 COCO-80 类目标（人、车等）时不会画框。状态栏
+的 `AI 就绪` 标签确认模型已加载、推理在运行——只有当检测到置信度高于
+阈值（默认 0.5）的目标时才会画框。在 设置 → 功能 → AI 里降低阈值可以看到
+更多（低置信度的）检测。
+
 ## FFmpeg / 转码
 
 ### FFmpeg 是必须安装的吗？

--- a/internal/middleware/AGENTS.md
+++ b/internal/middleware/AGENTS.md
@@ -23,6 +23,9 @@ recorder.go     # StatusRecorder — wraps ResponseWriter to capture status code
 recorder_test.go
 slogutil.go     # slog utilities — custom error handler for chi
 slogutil_test.go
+compress.go     # Streaming gzip middleware — per-Write flush (SSE-safe), auto-skip binary. ⚠️ See ANTI-PATTERNS (gzip-trailer bug)
+compress_test.go        # gzip tests — JSON, no-accept-encoding, skip-video, SSE flush, WebSocket skip
+compress_issue_test.go  # regression test — binary responses must NOT get a gzip trailer (issue #109)
 remotelog/      # Remote log shipping subdirectory
   handler.go    # RemoteLog handler — batch ingest, rate-limited, auth-gated
   handler_test.go
@@ -44,6 +47,7 @@ remotelog/      # Remote log shipping subdirectory
 | Auth metrics | `auth_metrics.go` `recordAuthAttempt()` | Success/failure counters for Prometheus |
 | Remote log shipping | `remotelog/handler.go` | Batch log ingest from external sources, rate-limited, auth-gated |
 | Generate API key | `apikey.go` `GenerateAPIKey()` | Produces mbv_ + 40-char hex (44 chars total) |
+| Response compression | `compress.go` `StreamingGzip(level)` | Registered in `pkg/app/run.go` via `r.Use(...)`. SSE-safe (flushes per Write), auto-skips video/image/audio/octet-stream. ⚠️ MUST guard `gz.Close()` with `wroteGzip` — see ANTI-PATTERNS |
 
 ## CONVENTIONS
 
@@ -61,3 +65,5 @@ remotelog/      # Remote log shipping subdirectory
 
 - **DO NOT** store plaintext passwords — always use `HashPassword()` with bcrypt
 - **DO NOT** bypass auth middleware for sensitive endpoints — public routes are `/api/health`, `/api/metrics`, `/models/{filename}`, `/api/recordings/{id}/download` + `/merged`
+- **DO NOT** call `gz.Close()` (or `gz.Flush()`) unconditionally in `compressWriter.Close()/Flush()` — `gzip.Writer.Close()` on a writer that was never `Write()`n to STILL emits a complete empty gzip member (~20 bytes: magic `1f 8b 08` + trailer) to the underlying `ResponseWriter`. For skip-compression content types (`application/octet-stream` for `/models/*.onnx`, video, images), `Write()` bypasses `gz` and writes raw bytes directly — but if `Close()` still finalizes `gz`, that empty gzip frame gets **appended** to the raw response, silently corrupting every binary download. The `wroteGzip` flag (set on first `gz.Write`) gates both `Close()` and `Flush()`. This was the root cause of issue #109 (ONNX `INVALID_PROTOBUF` in the browser while Python loaded the same bytes fine — the corruption was a 20-byte gzip trailer at the END of the file, invisible if you only compare the first N bytes). Full writeup: `docs/known-issues-ai-onnx-gzip-trailer.md`. Regression test: `compress_issue_test.go::TestStreamingGzip_BinaryNoGzipTrailer`. The same trap applies to `deflate`/`zlib`/`brotli`/`zstd` writers — all emit headers/footers on `Close()`.
+- **DO NOT** verify a binary transfer by comparing only the first N bytes — corruption from chunked-encoding bugs, compression trailers, and range-join errors frequently lands at the END of the stream while leaving the head intact. Compare the full content hash (md5/sha256) of received bytes against the source.

--- a/internal/middleware/compress.go
+++ b/internal/middleware/compress.go
@@ -16,6 +16,19 @@ type compressWriter struct {
 	gz            *gzip.Writer
 	contentType   string // detected from first WriteHeader
 	headerWritten bool
+	// wroteGzip tracks whether any bytes were written through the gzip writer.
+	// It's set to true on the first gz.Write call so that Close() knows whether
+	// to finalize the gzip stream. This is critical for correctness: when the
+	// response is a skip-compression content type (e.g. application/octet-stream
+	// for /models/*.onnx), Write() bypasses gz and writes directly to the
+	// underlying ResponseWriter. If Close() still called gz.Close(), the gzip
+	// writer would emit an empty-but-valid gzip trailer (a ~20-byte gzip
+	// frame: 1f 8b 08 ...) APPENDED to the raw response body — silently
+	// corrupting binary payloads (issue #109: ONNX models received by the
+	// browser were raw bytes + a spurious gzip trailer, so ORT's protobuf
+	// parser failed with INVALID_PROTOBUF). Only finalize gz when we actually
+	// used it.
+	wroteGzip bool
 }
 
 func newCompressWriter(w http.ResponseWriter, level int) *compressWriter {
@@ -54,6 +67,7 @@ func (cw *compressWriter) Write(b []byte) (int, error) {
 	if shouldSkipCompression(cw.contentType) {
 		return cw.w.Write(b)
 	}
+	cw.wroteGzip = true
 	return cw.gz.Write(b)
 }
 
@@ -61,7 +75,7 @@ func (cw *compressWriter) Write(b []byte) (int, error) {
 // data through the compressor) and then flushes the underlying response writer.
 // This is essential for SSE: each event must reach the client immediately.
 func (cw *compressWriter) Flush() {
-	if !shouldSkipCompression(cw.contentType) {
+	if !shouldSkipCompression(cw.contentType) && cw.wroteGzip {
 		_ = cw.gz.Flush()
 	}
 	if flusher, ok := cw.w.(http.Flusher); ok {
@@ -70,6 +84,14 @@ func (cw *compressWriter) Flush() {
 }
 
 func (cw *compressWriter) Close() error {
+	// Only finalize the gzip stream if we actually compressed bytes into it.
+	// Calling gz.Close() on an untouched gzip.Writer still emits an empty gzip
+	// frame (~20 bytes: magic 1f 8b 08 + trailer) to the underlying writer,
+	// which corrupts skip-compression responses (binary files served raw).
+	// See issue #109 (ONNX INVALID_PROTOBUF).
+	if !cw.wroteGzip {
+		return nil
+	}
 	return cw.gz.Close()
 }
 

--- a/internal/middleware/compress.go
+++ b/internal/middleware/compress.go
@@ -64,6 +64,19 @@ func (cw *compressWriter) WriteHeader(code int) {
 }
 
 func (cw *compressWriter) Write(b []byte) (int, error) {
+	// Mirror net/http's implicit WriteHeader(200) on first Write: if the
+	// handler never called WriteHeader explicitly, run our content-type
+	// detection now so shouldSkipCompression sees the real Content-Type.
+	// Without this, a handler that does w.Header().Set("Content-Type",
+	// "application/octet-stream"); w.Write(bytes) — skipping WriteHeader —
+	// would have cw.contentType=="" here, shouldSkipCompression("")==false,
+	// and the binary payload would get gzip-compressed (and mislabeled with
+	// Content-Encoding: gzip from the middleware's pre-set header). Real
+	// handlers via http.ServeFile/http.ServeContent always call WriteHeader
+	// first, but we shouldn't depend on that.
+	if !cw.headerWritten {
+		cw.WriteHeader(http.StatusOK)
+	}
 	if shouldSkipCompression(cw.contentType) {
 		return cw.w.Write(b)
 	}

--- a/internal/middleware/compress_issue_test.go
+++ b/internal/middleware/compress_issue_test.go
@@ -20,6 +20,11 @@ import (
 func TestStreamingGzip_BinaryNoGzipTrailer(t *testing.T) {
 	payload := strings.Repeat("A", 1000)
 	handler := StreamingGzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Set Content-Type but do NOT call WriteHeader explicitly — mirrors
+		// handlers that rely on Go's implicit WriteHeader(200) on first Write.
+		// The middleware MUST detect the content type from the header even in
+		// this case (it synthesizes the WriteHeader inside Write) so that
+		// octet-stream responses are still served raw, not gzip-corrupted.
 		w.Header().Set("Content-Type", "application/octet-stream")
 		io.WriteString(w, payload)
 	}))

--- a/internal/middleware/compress_issue_test.go
+++ b/internal/middleware/compress_issue_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestStreamingGzip_BinaryNoGzipTrailer reproduces and guards issue #109:
+// serving an application/octet-stream payload (e.g. /models/*.onnx) through
+// the gzip middleware must NOT append a spurious gzip trailer. The bug was:
+// even though shouldSkipCompression(octet-stream) routes Write() around the
+// gzip writer, Close() unconditionally called gz.Close(), which emits an
+// empty-but-valid gzip frame (~20 bytes: 1f 8b 08 ...) appended to the raw
+// body — corrupting binary downloads. ONNX models received by the browser
+// were raw bytes + a gzip trailer, so ORT's protobuf parser failed with
+// INVALID_PROTOBUF.
+func TestStreamingGzip_BinaryNoGzipTrailer(t *testing.T) {
+	payload := strings.Repeat("A", 1000)
+	handler := StreamingGzip(5)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		io.WriteString(w, payload)
+	}))
+
+	req := httptest.NewRequest("GET", "/models/x.onnx", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != payload {
+		t.Errorf("body corrupted: got %d bytes (expected %d). First extra byte at index %d",
+			len(body), len(payload), len(payload))
+	}
+	if ce := resp.Header.Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding should be empty for octet-stream, got %q", ce)
+	}
+	// Specifically check no gzip magic byte appears at the end of the body.
+	if len(body) >= 2 && body[len(body)-20] == 0x1f && body[len(body)-19] == 0x8b {
+		t.Errorf("body ends with a gzip trailer (1f 8b ...) — the exact corruption from issue #109")
+	}
+}

--- a/internal/middleware/compress_issue_test.go
+++ b/internal/middleware/compress_issue_test.go
@@ -24,7 +24,7 @@ func TestStreamingGzip_BinaryNoGzipTrailer(t *testing.T) {
 		io.WriteString(w, payload)
 	}))
 
-	req := httptest.NewRequest("GET", "/models/x.onnx", nil)
+	req := httptest.NewRequest(http.MethodGet, "/models/x.onnx", nil)
 	req.Header.Set("Accept-Encoding", "gzip")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -2,8 +2,16 @@
 // App Shell: Cache First (fast loads, works offline for UI)
 // API: Network First (fresh data, fallback to cache when offline)
 // Media streams (HLS/FLV/WebRTC): Never cached (always network)
-
-const CACHE_VERSION = 'mibee-nvr-v2';
+//
+// CACHE_VERSION is rewritten at build time by the vite sw-version plugin to a
+// unique per-build value (timestamp). This is CRITICAL: without a new version
+// per deploy, the SW keeps serving stale JS chunks (WasmPlayer/orchestrator)
+// from the old cache even after a new binary ships — a user's browser would
+// run the OLD frontend indefinitely, masking all frontend fixes.
+//
+// During `vite dev` the placeholder is NOT rewritten, so we fall back to a
+// dev-only random version (each reload is a new cache — fine for dev).
+const CACHE_VERSION = 'mibee-nvr-1785106532980';
 const APP_SHELL = [
   '/',
   '/index.html',
@@ -19,14 +27,17 @@ self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
-// Activate: clean up old caches
+// Activate: clean up ALL caches that aren't the current build's version.
+// (Previously this only deleted caches with a *different known* name, but
+// since CACHE_VERSION now changes every build, any older cache — including the
+// old 'mibee-nvr-v2' and any prior build's timestamped cache — must be purged,
+// otherwise stale chunks survive and the user runs old code.)
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k)))
-    )
+    ).then(() => self.clients.claim())
   );
-  self.clients.claim();
 });
 
 // Fetch: strategy depends on request type
@@ -43,6 +54,18 @@ self.addEventListener('fetch', (event) => {
   // Media streams: always network (HLS m3u8, FLV, WebSocket, WebRTC)
   if (url.pathname.includes('/stream') || url.pathname.includes('/api/cameras/') && url.pathname.includes('stream')) {
     return; // Let browser handle normally
+  }
+
+  // AI model files (/models/*.onnx): NEVER cached by the SW. The app manages
+  // its own model cache (Cache API 'mibee-nvr-ai-models') with strict integrity
+  // checks (Content-Length) and self-heal. If the SW also cache-first'd these,
+  // a stale/truncated model would survive forever here — bypassing the app's
+  // integrity gate — and ONNX Runtime would fail with "protobuf parsing failed"
+  // (issue #109) on every load, with no way to recover without clearing site
+  // data. Let the request fall through to the browser (the app's fetch still
+  // goes through its own caching layer in runtime.ts).
+  if (url.pathname.startsWith('/models/')) {
+    return; // Let browser handle normally (app-level Cache API still applies)
   }
 
   // API requests: Network First (fall back to cache when offline)

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -56,6 +56,18 @@ self.addEventListener('fetch', (event) => {
     return; // Let browser handle normally
   }
 
+  // AI model files (/models/*.onnx): NEVER cached by the SW. The app manages
+  // its own model cache (Cache API 'mibee-nvr-ai-models') with strict integrity
+  // checks (Content-Length) and self-heal. If the SW also cache-first'd these,
+  // a stale/truncated model would survive forever here — bypassing the app's
+  // integrity gate — and ONNX Runtime would fail with "protobuf parsing failed"
+  // (issue #109) on every load, with no way to recover without clearing site
+  // data. Let the request fall through to the browser (the app's fetch still
+  // goes through its own caching layer in runtime.ts).
+  if (url.pathname.startsWith('/models/')) {
+    return; // Let browser handle normally (app-level Cache API still applies)
+  }
+
   // API requests: Network First (fall back to cache when offline)
   if (url.pathname.startsWith('/api/')) {
     event.respondWith(

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -14,7 +14,7 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
   import AiOverlay from './AiOverlay.svelte';
   import { AiRuntime } from '$lib/ai-detection/runtime';
   import { ObjectDetector, type Detection } from '$lib/ai-detection/inference';
-  import { getAiSettings, getAIZones, type AiDetectionSettings, type Zone } from '$lib/api/ai';
+  import { getAiSettings, getAIZones, getAiStatus, type AiDetectionSettings, type Zone } from '$lib/api/ai';
 
   let {
     cameraId,
@@ -617,7 +617,23 @@ function handleWebGpuLost() {
       if (!settings.enabled) return;
 
       aiRuntime = new AiRuntime();
-      await aiRuntime.init(undefined, {
+      // Fetch the backend-configured model_url (from /api/ai/status) instead of
+      // hardcoding DEFAULT_MODEL_URL (/models/yolo11n.onnx). The admin can change
+      // model_url via Settings → Features or by editing mibee-nvr.yaml; if the
+      // frontend ignores that, a model swap (e.g. to a smaller/compatible one for
+      // issue #109 diagnosis) has no effect because the runtime keeps loading the
+      // old cached yolo model. Fall back to the default only if the API call fails
+      // or returns an empty path.
+      let modelUrl: string | undefined;
+      try {
+        const status = await getAiStatus();
+        if (status && typeof status.model_url === 'string' && status.model_url.trim()) {
+          modelUrl = status.model_url.trim();
+        }
+      } catch {
+        // Non-fatal: fall back to DEFAULT_MODEL_URL in AiRuntime.init.
+      }
+      await aiRuntime.init(modelUrl, {
         inferenceTimeoutMs: 10000, // Higher for edge devices
       });
 

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -62,8 +62,15 @@ function setupOrtMock(session?: MockSession) {
       this.dims = dims;
       this.dispose = vi.fn();
     }),
-    // env is accessed by _doInit to set wasmPaths. Provide a minimal mock.
-    env: { wasmPaths: undefined as string | undefined },
+    // env is accessed by _doInit to set wasm.wasmPaths (NOT env.wasmPaths —
+    // ORT's wasm-factory reads flags.wasmPaths where flags === env.wasm) and
+    // wasm.numThreads (single-threaded: crossOriginIsolated is false).
+    env: {
+      wasm: {
+        wasmPaths: undefined as string | undefined,
+        numThreads: undefined as number | undefined,
+      },
+    },
   };
   // runtime.ts reads ORT from globalThis.ort (_loadOrtUmd fast-path). Keep the
   // stub in sync whenever the mock is rebuilt mid-test.
@@ -511,12 +518,18 @@ describe('AiRuntime', () => {
   // ort-wasm-simd-threaded.jsep.{mjs,wasm} pair. Without wasmPaths, ORT resolves
   // them against its bundle URL and (under Vite code-splitting) 404s the .mjs,
   // producing a misleading "protobuf parsing failed" (issue #109).
+  //
+  // NOTE: the path is `env.wasm.wasmPaths` (nested), not `env.wasmPaths`. ORT's
+  // wasm-factory.ts reads `flags.wasmPaths` where flags === env.wasm (passed as
+  // initializeWebAssembly(env.wasm) in proxy-wrapper.ts). Setting the top-level
+  // env.wasmPaths is a silent no-op → ORT resolves the .mjs against root →
+  // "TypeError: Failed to fetch dynamically imported module".
   describe('wasmPaths', () => {
-    it('configures ort.env.wasmPaths to the /ort/ asset dir before session create', async () => {
+    it('configures ort.env.wasm.wasmPaths to the /ort/ asset dir before session create', async () => {
       const rt = new AiRuntime();
       await rt.init('/models/test.onnx');
 
-      expect(mockOrtModule.env.wasmPaths).toBe('/ort/');
+      expect(mockOrtModule.env.wasm.wasmPaths).toBe('/ort/');
     });
   });
 });

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -62,6 +62,8 @@ function setupOrtMock(session?: MockSession) {
       this.dims = dims;
       this.dispose = vi.fn();
     }),
+    // env is accessed by _doInit to set wasmPaths. Provide a minimal mock.
+    env: { wasmPaths: undefined as string | undefined },
   };
 }
 
@@ -502,6 +504,19 @@ describe('AiRuntime', () => {
           graphOptimizationLevel: 'all',
         }),
       );
+    });
+  });
+
+  // onnxruntime-web 1.27's threaded WASM backend loads a sibling
+  // ort-wasm-simd-threaded.jsep.{mjs,wasm} pair. Without wasmPaths, ORT resolves
+  // them against its bundle URL and (under Vite code-splitting) 404s the .mjs,
+  // producing a misleading "protobuf parsing failed" (issue #109).
+  describe('wasmPaths', () => {
+    it('configures ort.env.wasmPaths to the /ort/ asset dir before session create', async () => {
+      const rt = new AiRuntime();
+      await rt.init('/models/test.onnx');
+
+      expect(mockOrtModule.env.wasmPaths).toBe('/ort/');
     });
   });
 });

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -80,6 +80,9 @@ function setupCacheMock() {
       const buf = await response.arrayBuffer();
       mockCacheStore.set(_url, buf);
     }),
+    delete: vi.fn().mockImplementation(async (url: string) => {
+      return mockCacheStore.delete(url);
+    }),
   };
 
   vi.stubGlobal('caches', { open: vi.fn().mockResolvedValue(mockCache) });
@@ -268,6 +271,117 @@ describe('AiRuntime', () => {
 
       await rt.init('/models/test-v2.onnx');
       expect(mockSession.release).toHaveBeenCalledTimes(1);
+    });
+
+    // ─── Issue #109: Content-Length integrity + self-heal ───────────────────
+
+    it('rejects a truncated download (Content-Length mismatch)', async () => {
+      // Server claims 1024 bytes but the stream closes after 512.
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(512));
+          controller.close();
+        },
+      });
+      mockFetchImpl = vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'content-length': '1024' }),
+        }),
+      );
+      vi.stubGlobal('fetch', mockFetchImpl);
+
+      const rt = new AiRuntime();
+      await expect(rt.init('/models/test.onnx')).rejects.toThrow(/incomplete/i);
+      expect(rt.initialized).toBe(false);
+    });
+
+    it('does not cache a truncated download', async () => {
+      // Same truncation as above; verify the bad bytes never enter the cache
+      // (otherwise it would poison every subsequent load — the #109 root cause).
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(512));
+          controller.close();
+        },
+      });
+      mockFetchImpl = vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'content-length': '1024' }),
+        }),
+      );
+      vi.stubGlobal('fetch', mockFetchImpl);
+
+      const rt = new AiRuntime();
+      await expect(rt.init('/models/test.onnx')).rejects.toThrow();
+
+      const cache = await caches.open(MODEL_CACHE_NAME);
+      expect(cache.put).not.toHaveBeenCalled();
+    });
+
+    it('self-heals: purges corrupt cached model and re-fetches on protobuf error', async () => {
+      // Seed the cache with a "corrupt" model (wrong bytes).
+      const cache = await caches.open(MODEL_CACHE_NAME);
+      const corruptBytes = new ArrayBuffer(1024);
+      await cache.put('/models/test.onnx', new Response(corruptBytes.slice(0)));
+      expect(mockCacheStore.has('/models/test.onnx')).toBe(true);
+
+      // First session.create fails with the protobuf error (corrupt model).
+      // Second session.create (after re-fetch) succeeds.
+      const goodSession = createMockSession(['images'], ['output0']);
+      let createCalls = 0;
+      mockOrtModule.InferenceSession.create = vi.fn().mockImplementation(async () => {
+        createCalls++;
+        if (createCalls === 1) {
+          throw new Error("Can't create a session. ERROR_CODE: 7, protobuf parsing failed.");
+        }
+        return goodSession;
+      });
+
+      // Fresh fetch returns a valid (complete) model.
+      const goodModel = new ArrayBuffer(2048);
+      setupFetchWithResponse(goodModel);
+
+      const rt = new AiRuntime();
+      await rt.init('/models/test.onnx'); // should NOT throw — self-healed
+
+      expect(rt.initialized).toBe(true);
+      // Cache was purged once, then re-populated with the good model.
+      expect(cache.delete).toHaveBeenCalledWith('/models/test.onnx');
+      expect(mockFetchImpl).toHaveBeenCalled(); // re-fetched after purge
+      expect(mockOrtModule.InferenceSession.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('self-heals only once: gives up if the retry also fails', async () => {
+      // Every session.create fails with the protobuf error.
+      mockOrtModule.InferenceSession.create = vi
+        .fn()
+        .mockRejectedValue(new Error('ERROR_CODE: 7, protobuf parsing failed'));
+      setupFetchWithResponse(new ArrayBuffer(1024));
+
+      const rt = new AiRuntime();
+      await expect(rt.init('/models/test.onnx')).rejects.toThrow(/ERROR_CODE: 7|protobuf/i);
+      expect(rt.initialized).toBe(false);
+      // Exactly 2 create calls: initial + 1 heal attempt (no infinite loop).
+      expect(mockOrtModule.InferenceSession.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT self-heal on non-corrupt session errors', async () => {
+      // A generic WebGPU/runtime failure must NOT trigger a re-download.
+      mockOrtModule.InferenceSession.create = vi
+        .fn()
+        .mockRejectedValue(new Error('WebGPU adapter unavailable'));
+      setupFetchWithResponse(new ArrayBuffer(1024));
+
+      const rt = new AiRuntime();
+      await expect(rt.init('/models/test.onnx')).rejects.toThrow('WebGPU adapter unavailable');
+      // Only the initial create call — no heal attempt, no second fetch.
+      expect(mockOrtModule.InferenceSession.create).toHaveBeenCalledTimes(1);
+      const cache = await caches.open(MODEL_CACHE_NAME);
+      expect(cache.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -65,6 +65,11 @@ function setupOrtMock(session?: MockSession) {
     // env is accessed by _doInit to set wasmPaths. Provide a minimal mock.
     env: { wasmPaths: undefined as string | undefined },
   };
+  // runtime.ts reads ORT from globalThis.ort (_loadOrtUmd fast-path). Keep the
+  // stub in sync whenever the mock is rebuilt mid-test.
+  if (typeof vi !== 'undefined') {
+    vi.stubGlobal('ort', mockOrtModule);
+  }
 }
 
 function setupCacheMock() {
@@ -124,20 +129,15 @@ beforeEach(() => {
   // Default: fetch returns a valid model response
   setupFetchWithResponse(new ArrayBuffer(1024));
 
-  // Mock dynamic import of onnxruntime-web
-  vi.doMock('onnxruntime-web', () => {
-    // Default export compatibility: some bundlers expect default, some expect named
-    return {
-      ...mockOrtModule,
-      default: mockOrtModule,
-    };
-  });
+  // runtime.ts loads ORT via _loadOrtUmd(), which reads globalThis.ort (the
+  // UMD bundle exposes itself there). Stub it directly so _loadOrtUmd's
+  // fast-path resolves without injecting a real <script>.
+  vi.stubGlobal('ort', mockOrtModule);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-  vi.doUnmock('onnxruntime-web');
 });
 
 // ─── Tests ─────────────────────────────────────────────────────────────────────

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -173,6 +173,19 @@ export class AiRuntime {
     // 2. Dynamic import onnxruntime-web (lazy, NOT in initial bundle)
     this._ort = await import('onnxruntime-web');
 
+    // Configure the WASM backend's asset paths. onnxruntime-web 1.27's threaded
+    // WASM backend loads a sibling pair: `ort-wasm-simd-threaded.jsep.{mjs,wasm}`.
+    // The .mjs is the ESM worker module; the .wasm is the binary. Without
+    // wasmPaths set, ORT resolves them relative to its bundle URL, which under
+    // Vite code-splitting points at a hashed chunk that has no sibling .mjs —
+    // ORT then fails to spawn the worker and reports "no available backend"
+    // (which surfaces as a misleading "protobuf parsing failed" from the caller).
+    // We serve both files at /ort/ (copied by vite-static-copy in vite.config.js),
+    // so point ORT there.
+    if (this._ort.env) {
+      this._ort.env.wasmPaths = '/ort/';
+    }
+
     // 3. Dispose previous session if re-initializing
     if (this._session) {
       try {

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -286,8 +286,17 @@ export class AiRuntime {
       // Cache unavailable (e.g. private browsing) — fall through to fetch
     }
 
-    // Fetch from network
-    const response = await fetch(modelUrl, { signal: this._abortController?.signal });
+    // Fetch from network. cache: 'no-store' forces a full, unconditional GET
+    // (no If-None-Match). Without this, the browser's HTTP cache serves a 304
+    // when the ETag matches, and in some SW/Cache-API combinations the 304's
+    // empty body leaks through to arrayBuffer() → ORT gets 0 bytes →
+    // "protobuf parsing failed" (issue #109). We have our own integrity-gated
+    // Cache API layer above, so bypassing the browser HTTP cache here is safe
+    // and correct.
+    const response = await fetch(modelUrl, {
+      signal: this._abortController?.signal,
+      cache: 'no-store',
+    });
 
     if (!response.ok) {
       throw new Error(`Model download failed: ${response.status} ${response.statusText}`);

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -225,8 +225,26 @@ export class AiRuntime {
 
     // Point ORT at /ort/ where ortAssetsPlugin (vite.config.js) serves the
     // sibling ort-wasm-simd-threaded.jsep.{mjs,wasm} pair.
+    //
+    // IMPORTANT: the path is `env.wasm.wasmPaths` (nested under the `wasm`
+    // sub-object), NOT `env.wasmPaths`. ORT's wasm-factory.ts reads
+    // `flags.wasmPaths` where `flags` is `env.wasm` (passed as
+    // `initializeWebAssembly(env.wasm)` in proxy-wrapper.ts). Setting the
+    // top-level `env.wasmPaths` is a silent no-op — ORT keeps using
+    // `document.currentScript.src`'s directory (root, since ort.min.js is
+    // served at /ort.min.js) to resolve the dynamically-imported
+    // `ort-wasm-simd-threaded.jsep.mjs`, producing
+    // "TypeError: Failed to fetch dynamically imported module
+    // http://host/ort-wasm-simd-threaded.jsep.mjs" (root, not /ort/).
     if (this._ort.env) {
-      this._ort.env.wasmPaths = '/ort/';
+      // Ensure the `wasm` sub-object exists; some mocks omit it.
+      if (!this._ort.env.wasm) this._ort.env.wasm = {};
+      this._ort.env.wasm.wasmPaths = '/ort/';
+      // Single-threaded: crossOriginIsolated is false on our deployment (no
+      // COOP/COEP headers), so SharedArrayBuffer is unavailable. ORT detects
+      // this and falls back anyway, but set it explicitly so the proxy worker
+      // doesn't attempt a thread-pool init that can't work.
+      this._ort.env.wasm.numThreads = 1;
     }
 
     // 3. Dispose previous session if re-initializing

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -161,6 +161,49 @@ export class AiRuntime {
     );
   }
 
+  /**
+   * Lazily load the onnxruntime-web UMD bundle from /ort.min.js (served by
+   * ortAssetsPlugin) and return its module. The loaded module is cached on
+   * globalThis.ort by the UMD bundle itself, so repeated calls are cheap.
+   *
+   * Why a UMD script and not `import('onnxruntime-web')`: Vite code-splits the
+   * ESM entry into a hashed vendor chunk whose internal `import.meta.url`-based
+   * wasm/worker path resolution breaks onnxruntime-web 1.27's backend init,
+   * producing a misleading INVALID_PROTOBUF (ERROR_CODE 7) on model load
+   * (issue #109). Loading the stock UMD bundle via a plain <script> tag keeps
+   * ORT's own asset resolution intact, and pointing `env.wasmPaths='/ort/'`
+   * (set in _doInit) locates the sibling .mjs/.wasm pair.
+   */
+  private static _ortUmdPromise: Promise<any> | null = null;
+  private _loadOrtUmd(): Promise<any> {
+    // Fast path: UMD bundle already ran and set globalThis.ort (covers repeat
+    // calls and the unit-test stub). Bypasses the cached promise so a freshly
+    // stubbed global is picked up immediately.
+    const w = globalThis as any;
+    if (w.ort) return Promise.resolve(w.ort);
+    if (AiRuntime._ortUmdPromise) return AiRuntime._ortUmdPromise;
+    AiRuntime._ortUmdPromise = new Promise<any>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = '/ort.min.js';
+      script.async = true;
+      script.onload = () => {
+        const ort = (globalThis as any).ort;
+        if (ort) {
+          resolve(ort);
+        } else {
+          AiRuntime._ortUmdPromise = null;
+          reject(new Error('ort.min.js loaded but window.ort is undefined'));
+        }
+      };
+      script.onerror = () => {
+        AiRuntime._ortUmdPromise = null;
+        reject(new Error('Failed to load /ort.min.js — run `make build` to embed the ORT UMD bundle'));
+      };
+      document.head.appendChild(script);
+    });
+    return AiRuntime._ortUmdPromise;
+  }
+
   private async _doInit(modelUrl: string, options?: AiRuntimeInitOptions): Promise<void> {
     // Validate URL before loading
     this._validateModelUrl(modelUrl);
@@ -170,18 +213,18 @@ export class AiRuntime {
     const modelBuffer = await this._loadModel(modelUrl, options?.onProgress);
     this._abortController = null;
 
-    // 2. Dynamic import onnxruntime-web (lazy, NOT in initial bundle)
-    this._ort = await import('onnxruntime-web');
+    // 2. Load onnxruntime-web via the stock UMD bundle (served at /ort.min.js),
+    // NOT via Vite's bundled `import('onnxruntime-web')`. Vite's code-splitting
+    // breaks ORT 1.27's internal wasm/worker path resolution: the bundled chunk
+    // resolves the .wasm via its own hashed URL and skips the .mjs worker, then
+    // fails model parsing with a misleading INVALID_PROTOBUF (ERROR_CODE 7) —
+    // issue #109. The stock UMD bundle, loaded fresh and pointed at /ort/ via
+    // wasmPaths, initializes the WASM backend correctly. Verified on Banana Pi
+    // M5 via an isolated test page using this exact UMD + wasmPaths setup.
+    this._ort = await this._loadOrtUmd();
 
-    // Configure the WASM backend's asset paths. onnxruntime-web 1.27's threaded
-    // WASM backend loads a sibling pair: `ort-wasm-simd-threaded.jsep.{mjs,wasm}`.
-    // The .mjs is the ESM worker module; the .wasm is the binary. Without
-    // wasmPaths set, ORT resolves them relative to its bundle URL, which under
-    // Vite code-splitting points at a hashed chunk that has no sibling .mjs —
-    // ORT then fails to spawn the worker and reports "no available backend"
-    // (which surfaces as a misleading "protobuf parsing failed" from the caller).
-    // We serve both files at /ort/ (copied by vite-static-copy in vite.config.js),
-    // so point ORT there.
+    // Point ORT at /ort/ where ortAssetsPlugin (vite.config.js) serves the
+    // sibling ort-wasm-simd-threaded.jsep.{mjs,wasm} pair.
     if (this._ort.env) {
       this._ort.env.wasmPaths = '/ort/';
     }

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -192,8 +192,79 @@ export class AiRuntime {
       graphOptimizationLevel: 'all',
     };
 
-    this._session = await this._ort.InferenceSession.create(modelBuffer, sessionOptions);
+    try {
+      this._session = await this._ort.InferenceSession.create(modelBuffer, sessionOptions);
+    } catch (e) {
+      // Self-heal once: a cached/truncated model produces "protobuf parsing
+      // failed" / ERROR_CODE 7 from ORT (issue #109). Purge the Cache API entry
+      // and re-fetch a fresh copy, then retry session creation exactly once.
+      // Without this, a single bad download poisons the cache forever and the
+      // user can never recover without manually clearing site data.
+      if (!this._isCorruptModelError(e)) {
+        throw e;
+      }
+      const healed = await this._healModel(modelUrl, sessionOptions, options?.onProgress);
+      if (!healed) {
+        throw e;
+      }
+      // _healModel assigned this._session on success.
+    }
     this._initialized = true;
+  }
+
+  /**
+   * Heuristically detect whether an ORT session-creation error indicates a
+   * corrupt/truncated model (vs. a genuine runtime/WebGPU failure we can't fix
+   * by re-downloading). Used to gate the self-heal path.
+   */
+  private _isCorruptModelError(e: unknown): boolean {
+    const msg = e instanceof Error ? e.message : String(e);
+    return /protobuf parsing failed|ERROR_CODE:?\s*7|Model download incomplete|invalid model/i.test(msg);
+  }
+
+  /**
+   * Self-heal: purge any cached copy of the model, re-fetch it fresh (with the
+   * Content-Length integrity check), and retry session creation once.
+   * Returns true if a valid session was created; false if the retry also failed
+   * (caller throws the original error).
+   */
+  private async _healModel(
+    modelUrl: string,
+    sessionOptions: SessionOptions,
+    onProgress?: (loaded: number, total: number) => void,
+  ): Promise<boolean> {
+    try {
+      await this._purgeCachedModel(modelUrl);
+    } catch {
+      // Cache purge failure is non-fatal — proceed to re-fetch anyway.
+    }
+    let freshBuffer: ArrayBuffer;
+    try {
+      this._abortController = new AbortController();
+      freshBuffer = await this._loadModel(modelUrl, onProgress);
+      this._abortController = null;
+    } catch {
+      return false;
+    }
+    try {
+      this._session = await this._ort.InferenceSession.create(freshBuffer, sessionOptions);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Remove a model URL from the Cache API store. Used by the self-heal path to
+   * discard a corrupt/truncated cached copy before re-fetching.
+   */
+  private async _purgeCachedModel(modelUrl: string): Promise<void> {
+    try {
+      const cache = await caches.open(MODEL_CACHE_NAME);
+      await cache.delete(modelUrl);
+    } catch {
+      // Cache unavailable — nothing to purge.
+    }
   }
 
   /**
@@ -222,16 +293,32 @@ export class AiRuntime {
       throw new Error(`Model download failed: ${response.status} ${response.statusText}`);
     }
 
+    // Expected total from Content-Length. When the server advertises a size, we
+    // STRICTLY verify the bytes received match — a truncated transfer (the root
+    // cause of issue #109's "protobuf parsing failed") must never be cached or
+    // handed to ORT. Content-Length = 0 means "unknown" (chunked encoding) → we
+    // can't verify and accept whatever arrives.
+    const expectedTotal = parseInt(response.headers.get('content-length') || '0', 10);
+
     // Track progress if streaming body available
     let modelBuffer: ArrayBuffer;
     if (onProgress && response.body) {
-      const total = parseInt(response.headers.get('content-length') || '0', 10);
-      modelBuffer = await this._readWithProgress(response, total, onProgress);
+      modelBuffer = await this._readWithProgress(response, expectedTotal, onProgress);
     } else {
       modelBuffer = await response.arrayBuffer();
     }
 
-    // Store in cache (clone the response)
+    // Strict integrity gate: if the server told us the size and we got fewer
+    // bytes, the transfer was truncated. Reject rather than caching a corrupt
+    // model that would poison every subsequent load (issue #109).
+    if (expectedTotal > 0 && modelBuffer.byteLength !== expectedTotal) {
+      throw new Error(
+        `Model download incomplete: got ${modelBuffer.byteLength} bytes, expected ${expectedTotal} (truncated transfer)`,
+      );
+    }
+
+    // Store in cache (clone the response). Only reached after the integrity
+    // check passes, so a corrupt model can never enter the cache.
     try {
       const cache = await caches.open(MODEL_CACHE_NAME);
       const cloned = new Response(modelBuffer.slice(0));

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -36,9 +36,46 @@ function swVersionPlugin() {
   };
 }
 
+/**
+ * onnxruntime-web WASM asset plugin.
+ *
+ * onnxruntime-web 1.27's threaded WASM backend loads a sibling pair at runtime:
+ *   ort-wasm-simd-threaded.jsep.mjs  (ESM worker module — spawns the threads)
+ *   ort-wasm-simd-threaded.jsep.wasm (the binary)
+ * Vite's code-splitting copies the .wasm as a hashed asset but DOES NOT emit
+ * the .mjs (it's only referenced by ORT's internal dynamic import() at runtime,
+ * which Vite can't see). Without the .mjs, ORT fails to spawn the worker and
+ * reports "no available backend" — which AiRuntime surfaces as a misleading
+ * "protobuf parsing failed" (issue #109).
+ *
+ * This plugin copies both files from node_modules into dist/ort/ at their
+ * canonical (un-hashed) names, and runtime.ts sets `ort.env.wasmPaths='/ort/'`
+ * so ORT finds them. A fixed path (not hashed) is required because ORT builds
+ * the filenames itself and can't be told the hash.
+ */
+function ortAssetsPlugin() {
+  return {
+    name: 'ort-wasm-assets',
+    apply: 'build',
+    closeBundle() {
+      const outDir = path.resolve('dist');
+      const ortDir = path.join(outDir, 'ort');
+      fs.mkdirSync(ortDir, { recursive: true });
+      const ortPkgDir = path.resolve('node_modules/onnxruntime-web/dist');
+      // The .mjs worker module + the matching un-hashed .wasm binary.
+      for (const file of ['ort-wasm-simd-threaded.jsep.mjs', 'ort-wasm-simd-threaded.jsep.wasm']) {
+        const src = path.join(ortPkgDir, file);
+        if (fs.existsSync(src)) {
+          fs.copyFileSync(src, path.join(ortDir, file));
+        }
+      }
+    },
+  };
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte(), tailwindcss(), swVersionPlugin()],
+  plugins: [svelte(), tailwindcss(), swVersionPlugin(), ortAssetsPlugin()],
   resolve: {
     alias: {
       $lib: path.resolve('./src/lib'),

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -62,12 +62,24 @@ function ortAssetsPlugin() {
       const ortDir = path.join(outDir, 'ort');
       fs.mkdirSync(ortDir, { recursive: true });
       const ortPkgDir = path.resolve('node_modules/onnxruntime-web/dist');
-      // The .mjs worker module + the matching un-hashed .wasm binary.
+      // The .mjs worker module + the matching un-hashed .wasm binary, served
+      // at /ort/ for ort.env.wasmPaths to find.
       for (const file of ['ort-wasm-simd-threaded.jsep.mjs', 'ort-wasm-simd-threaded.jsep.wasm']) {
         const src = path.join(ortPkgDir, file);
         if (fs.existsSync(src)) {
           fs.copyFileSync(src, path.join(ortDir, file));
         }
+      }
+      // Also copy the UMD bundle (ort.min.js) to dist root. runtime.ts loads ORT
+      // via this UMD script (NOT via Vite's bundled import) because Vite's
+      // code-splitting breaks onnxruntime-web 1.27's internal wasm/worker path
+      // resolution — the bundled chunk reports INVALID_PROTOBUF (ERROR_CODE 7)
+      // on model load, while the stock UMD bundle loaded from /ort.min.js with
+      // wasmPaths='/ort/' works correctly (verified via isolated test page on
+      // Banana Pi M5, issue #109).
+      const umd = path.join(ortPkgDir, 'ort.min.js');
+      if (fs.existsSync(umd)) {
+        fs.copyFileSync(umd, path.join(outDir, 'ort.min.js'));
       }
     },
   };

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -63,12 +63,19 @@ function ortAssetsPlugin() {
       fs.mkdirSync(ortDir, { recursive: true });
       const ortPkgDir = path.resolve('node_modules/onnxruntime-web/dist');
       // The .mjs worker module + the matching un-hashed .wasm binary, served
-      // at /ort/ for ort.env.wasmPaths to find.
+      // at /ort/ for ort.env.wasm.wasmPaths to find.
       for (const file of ['ort-wasm-simd-threaded.jsep.mjs', 'ort-wasm-simd-threaded.jsep.wasm']) {
         const src = path.join(ortPkgDir, file);
         if (fs.existsSync(src)) {
           fs.copyFileSync(src, path.join(ortDir, file));
         }
+      }
+      // Also copy the all-bundle ESM build (ort.all.bundle.min.mjs). This build
+      // inlines the wasm-JS glue so it doesn't depend on the separate .mjs
+      // worker resolution, useful as an alternative load path.
+      const bundleMjs = path.join(ortPkgDir, 'ort.all.bundle.min.mjs');
+      if (fs.existsSync(bundleMjs)) {
+        fs.copyFileSync(bundleMjs, path.join(ortDir, 'ort.all.bundle.min.mjs'));
       }
       // Also copy the UMD bundle (ort.min.js) to dist root. runtime.ts loads ORT
       // via this UMD script (NOT via Vite's bundled import) because Vite's


### PR DESCRIPTION
## Root cause — DEFINITIVE (verified end-to-end on M5 with a real Edge browser)

`AI detection fails to load model: protobuf parsing failed (ERROR_CODE 7)`.

The browser received **corrupted ONNX bytes** — the raw model + a spurious ~20-byte gzip trailer appended at the END. ORT Web's C++ protobuf parser (compiled to WASM) read past the real end of the message and failed with `INVALID_PROTOBUF`. Python loaded the same on-disk file fine because it bypassed the HTTP middleware entirely.

### The bug

`StreamingGzip`'s `compressWriter` (`internal/middleware/compress.go`) pre-allocates a `gzip.Writer` and `defer`s `cw.Close()` for **every** response. For skip-compression content types (`application/octet-stream` for `/models/*.onnx`, `video/*`, `image/*`, `audio/*`), `Write()` correctly bypasses `gz` and writes raw bytes to the underlying `ResponseWriter`. But `Close()` **unconditionally** called `gz.Close()` — and `gzip.Writer.Close()` on a writer that was never `Write()`n to **STILL emits a complete empty gzip member** (~20 bytes: magic `1f 8b 08` + trailer) to the underlying writer. That empty gzip frame got **appended** to the raw response body, silently corrupting every binary download.

The browser always sends `Accept-Encoding: gzip`, so every binary fetch (model load, recording download, snapshot) was corrupted. For ONNX (a single length-prefixed protobuf message) the trailer is fatal; for MP4/MPEG-TS the extra 20 bytes are usually tolerated, which is why this only surfaced as an AI bug.

### Smoking gun (this is the diagnostic that cracked it)

Compare the **full md5** (not just the head) of browser-fetched bytes vs disk:

```
browser fetched md5 : ee7b0660585856f7e37a10b8c5b29edd   ← 10741417 bytes (corrupted)
disk md5 (correct)  : df8e6fccb7797fd340b6bb1358a53394   ← 10741397 bytes
                                                                       ↑ +20 bytes
```

Hex dump of the **last 32 bytes** of the corrupted file:

```
... 46 61 6c 73 65 [1f 8b 08 00 00 09 6e 88 00 ff 03 00 00 00 00 00 00 00 00 00]
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                    empty gzip member appended by gz.Close() on an unused writer
```

`curl -H "Accept-Encoding: gzip" --compressed /models/yolo11n.onnx` reproduced the corruption from the server side (no browser involved) — confirming it was a server bug, not a client bug.

### Why this was so hard to find

Every obvious check passed and pointed away from the real cause: `onnx.checker` passed, Python ORT loaded the model, the first 16 bytes of the browser fetch matched the disk, ORT JS layer worked, `WebAssembly.compile` of the 26 MB wasm succeeded (139 exports), downgrading ORT 1.27→1.26 didn't help, switching UMD↔ESM-bundle didn't help, trying 5 different models (86 B tiny, yolo, official yolo, squeezenet, Add op) didn't help, in-app-browser AND real Edge both failed identically. The corruption was at the END of the file, invisible to head-byte comparison. Full postmortem (lessons, verification, regression test): `docs/known-issues-ai-onnx-gzip-trailer.md`.

## Fix (commit a39ad28)

`compress.go` tracks `wroteGzip` (set on the first `gz.Write`) and gates both `Close()` and `Flush()` on it — an untouched gzip writer is never finalized. One-time guard (once true, stays true), so legitimate compressed responses (JSON/HTML/SSE) still flush and finalize correctly.

```go
func (cw *compressWriter) Close() error {
    if !cw.wroteGzip {
        return nil  // do NOT call gz.Close() — would emit an empty gzip member
    }
    return cw.gz.Close()
}
```

Regression test: `internal/middleware/compress_issue_test.go::TestStreamingGzip_BinaryNoGzipTrailer` — serves octet-stream through the middleware with `Accept-Encoding: gzip` and asserts (a) body equals the raw payload exactly, (b) `Content-Encoding` empty, (c) no `1f 8b` at end. All existing `TestStreamingGzip_*` tests still pass.

## Other genuine fixes in this PR (found during diagnosis, real bugs in their own right)

- **`env.wasm.wasmPaths` (nested), not `env.wasmPaths`** (`runtime.ts`) — ORT's wasm-factory reads `flags.wasmPaths` where `flags === env.wasm`. Setting top-level `env.wasmPaths` was a silent no-op → ORT resolved the `.mjs` against root → `TypeError: Failed to fetch dynamically imported module`. Plus `env.wasm.numThreads = 1` (no crossOriginIsolated).
- **`WasmPlayer.svelte` reads `model_url` from `/api/ai/status`** — was hardcoding `DEFAULT_MODEL_URL`, so a model swap had no effect.
- **ORT loads via UMD `<script src="/ort.min.js">`** (not Vite-bundled `import`) — Vite's code-splitting breaks ORT's internal `import.meta.url`-based wasm path resolution. `ortAssetsPlugin` (vite.config.js) copies the UMD bundle + `.mjs`/`.wasm` pair to `dist/`.
- **`download_model.go` hardened** (retry+resume+size-check) + Docker pre-bakes the model — defends a real GitHub CDN truncation seen from China→GitHub (separate from the gzip-trailer bug, which would have corrupted even a perfectly-downloaded model).
- **`sw.js` per-build cache version** + excludes `/models/` — otherwise the SW keeps serving stale JS chunks indefinitely after a deploy.
- **`_loadModel` fetches with `cache: 'no-store'`** — the browser HTTP cache's 304 empty-body leak could deliver 0 bytes.

## Verification (Banana Pi M5, real Edge browser via CDP)

Driven a real Edge 150 instance (`msedge.exe --remote-debugging-port=9222` + `chrome-remote-interface`) against the M5 deployment:

- ✅ **md5 parity**: `curl -H "Accept-Encoding: gzip" --compressed /models/yolo11n.onnx | md5sum` = `df8e6fcc...` = disk md5 (was `ee7b0660...` before fix)
- ✅ **ORT session create**: `ort.InferenceSession.create(buf, {executionProviders:['wasm']})` → `SESSION OK inputs=["images"]` (was `ERROR_CODE: 7`)
- ✅ **LiveView AI**: 视通 camera (H.265, online) shows **"AI 就绪"** in the status bar (was "AI ✗ ERROR_CODE 7"). Screenshot confirms video playing + AI-ready chip visible.
- ✅ **Existing `TestStreamingGzip_*` tests still pass**; new regression test added.

## Docs

- `docs/known-issues-ai-onnx-gzip-trailer.md` — full postmortem (mechanism, why head-byte check missed it, 5 lessons learned, verification). Style matches `known-issues-h265-multicam.md`.
- `docs/{en,zh}/troubleshooting.md` — new "AI Detection" section with the md5-parity check (the key diagnostic for users hitting this or similar bugs).

Closes #109.