### PR TITLE
fix(camera/test): stop leaking backfill goroutines before t.TempDir cleanup (#125)

### DIFF
--- a/internal/camera/manager_test.go
+++ b/internal/camera/manager_test.go
@@ -63,10 +63,27 @@ func testConfig() *config.Config {
 
 func newTestManager(t *testing.T) (*CameraManager, *storage.Manager, *storage.DB, string) {
 	t.Helper()
+	return newTestManagerWithCfg(t, testConfig())
+}
+
+// newTestManagerWithCfg wires up a CameraManager against a fresh temp dir + DB
+// for the given config, registering teardown in the correct order:
+//
+//  1. store.CleanupTempFiles()  (registered first → runs last)
+//  2. db.Close()
+//  3. mgr.Stop()               (registered last → runs first)
+//
+// mgr.Stop() runs FIRST (LIFO) so that the startup backfill goroutines
+// (backfillStableIDs, backfillEncoding — both touch cm.db) have fully exited
+// before the DB file is closed and the temp dir is deleted. Any test that
+// calls Start() MUST go through this helper (or replicate the ordering):
+// leaking those goroutines races against t.TempDir() cleanup →
+// "directory not empty" / "disk I/O error" (flaky under -race, see #112, #124).
+func newTestManagerWithCfg(t *testing.T, cfg *config.Config) (*CameraManager, *storage.Manager, *storage.DB, string) {
+	t.Helper()
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
-	cfg := testConfig()
 	cfg.Storage.RootDir = filepath.Join(tmpDir, "storage")
 	require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
 	require.NoError(t, config.Save(configPath, cfg))
@@ -84,13 +101,6 @@ func newTestManager(t *testing.T) (*CameraManager, *storage.Manager, *storage.DB
 	t.Cleanup(func() { store.CleanupTempFiles() })
 
 	mgr := NewCameraManager(cfg, store, db, configPath)
-	// Stop the manager BEFORE the db.Close() / t.TempDir() cleanups run (LIFO
-	// order: this is registered last, so it runs first). Stop() waits on
-	// backfillWg, ensuring the startup backfill goroutines (backfillStableIDs,
-	// backfillEncoding — both touch cm.db) have fully exited before the DB file
-	// is closed and the temp dir is deleted. Without this, a test that calls
-	// Start() races the goroutine against t.TempDir() cleanup →
-	// "directory not empty" / "disk I/O error" (flaky under -race, see #112).
 	t.Cleanup(func() { _ = mgr.Stop() })
 	return mgr, store, db, configPath
 }
@@ -134,10 +144,8 @@ func TestStart_EnabledCameras(t *testing.T) {
 }
 
 func TestStart_HTTPJPEGRecorderCreated(t *testing.T) {
-	tmpDir := t.TempDir()
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
-			RootDir:         filepath.Join(tmpDir, "storage"),
 			SegmentDuration: "1m",
 		},
 		Cameras: []config.CameraConfig{
@@ -148,24 +156,12 @@ func TestStart_HTTPJPEGRecorderCreated(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
-
-	dbPath := filepath.Join(tmpDir, "test.db")
-	db, err := storage.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_ = db.Init(ctx)
-
-	store, err := storage.NewManager(cfg.Storage.RootDir)
-	require.NoError(t, err)
-	defer store.CleanupTempFiles()
-
-	mgr := NewCameraManager(cfg, store, db, "")
-	err = mgr.Start(ctx)
+	err := mgr.Start(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 1, mgr.RecorderCount())
 	_, hasJPEG := mgr.Status()["cam-1"]
@@ -342,10 +338,8 @@ func TestGracefulShutdown(t *testing.T) {
 }
 
 func TestStart_UnknownProtocol(t *testing.T) {
-	tmpDir := t.TempDir()
 	cfg := &config.Config{
 		Storage: config.StorageConfig{
-			RootDir:         filepath.Join(tmpDir, "storage"),
 			SegmentDuration: "1m",
 		},
 		Cameras: []config.CameraConfig{
@@ -356,24 +350,12 @@ func TestStart_UnknownProtocol(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
-
-	dbPath := filepath.Join(tmpDir, "test.db")
-	db, err := storage.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_ = db.Init(ctx)
-
-	store, err := storage.NewManager(cfg.Storage.RootDir)
-	require.NoError(t, err)
-	defer store.CleanupTempFiles()
-
-	mgr := NewCameraManager(cfg, store, db, "")
-	err = mgr.Start(ctx)
+	err := mgr.Start(ctx)
 	require.NoError(t, err) // should not fail, just skip unknown protocol
 	assert.Equal(t, 0, mgr.RecorderCount())
 }


### PR DESCRIPTION
## Root cause

The latest CI run on `main` failed (run [30234109549](https://github.com/Mi-Bee-Studio/MiBeeNvr/actions/runs/30234109549)):

```
--- FAIL: TestStart_HTTPJPEGRecorderCreated (0.08s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat
    /tmp/TestStart_HTTPJPEGRecorderCreated4216559012/001: directory not empty
```

`CameraManager.Start()` spawns two background goroutines when `cm.db != nil` — `backfillStableIDs` and `backfillEncoding` ([manager.go:446-464](https://github.com/Mi-Bee-Studio/MiBeeNvr/blob/main/internal/camera/manager.go#L446-L464)). Both touch `cm.db` and the temp dir. `Stop()` joins them via `backfillWg.Wait()` ([manager.go:508](https://github.com/Mi-Bee-Studio/MiBeeNvr/blob/main/internal/camera/manager.go#L508)).

`TestStart_HTTPJPEGRecorderCreated` and `TestStart_UnknownProtocol` both called `Start()` but **never** `Stop()` — they used `defer db.Close()` / `defer store.CleanupTempFiles()`. Those defers run before `t.TempDir()`'s `RemoveAll`, but the backfill goroutines outlive all of them and keep writing files under the temp dir → `directory not empty` during cleanup (flaky under `-race`).

This is the same class of bug already fixed for `newTestManager` (see the LIFO `t.Cleanup` ordering comment there, ref #112).

## Fix

Extract `newTestManagerWithCfg(t, cfg)` so any test with a custom config gets the correct teardown order:

1. `store.CleanupTempFiles()` (registered first → runs last)
2. `db.Close()`
3. `mgr.Stop()` (registered last → runs first — joins the backfill goroutines before the DB is closed and the dir removed)

Migrate `TestStart_HTTPJPEGRecorderCreated` and `TestStart_UnknownProtocol` to use it. `newTestManager` now delegates to the new helper, so no behavior change there. Net −18 lines.

> Note: `TestStart_InvalidSegmentDuration` shares the inline-DB pattern but is unaffected — `Start()` returns an error before the backfill goroutines are launched, so no leak.

## Verification

```bash
# The two affected tests, 20 iterations each — stable
go test -race -run 'TestStart_HTTPJPEGRecorderCreated|TestStart_UnknownProtocol' -count=20 ./internal/camera/

# Full package, no regression
go test -race -count=2 ./internal/camera/   # 122s, PASS
```

The local flake was not reproducible on my machine (count=5 passed in 184s), but the root cause is unambiguous in the code and the CI failure is a direct match.

## Checklist
- [x] Root cause identified and explained
- [x] Fix addresses the failure class (not just the one symptom)
- [x] Tests pass locally (`-race -count`)
- [x] No production code changed (test-only)
- [x] Comment explains the ordering contract for future authors