### PR TITLE
cleanup(settings): remove dead streaming.default_protocol field (#127)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -599,27 +599,21 @@ func (h *Handler) handleCameraProtocols(w http.ResponseWriter, r *http.Request) 
 		protocols = []ProtocolDetail{}
 	}
 
-	// Determine default protocol: prefer user-configured default, then fallback order
+	// Determine default protocol by latency-optimal fallback order. The global
+	// streaming.default_protocol config was removed — the frontend Player
+	// Orchestrator now auto-selects per camera based on this hint + browser
+	// capability, demoting on health failure. Per-camera overrides remain via
+	// the Protocol Switcher on each camera's LiveView page.
 	defaultProto := ""
-	if h.config != nil && h.config.Streaming.DefaultProtocol != "" {
+	for _, preferred := range []string{"webrtc", "flv", "ll-hls", "hls", "mjpeg"} {
 		for _, p := range protocols {
-			if p.Protocol == h.config.Streaming.DefaultProtocol && p.Available {
-				defaultProto = h.config.Streaming.DefaultProtocol
+			if p.Protocol == preferred && p.Available {
+				defaultProto = preferred
 				break
 			}
 		}
-	}
-	if defaultProto == "" {
-		for _, preferred := range []string{"webrtc", "flv", "ll-hls", "hls", "mjpeg"} {
-			for _, p := range protocols {
-				if p.Protocol == preferred && p.Available {
-					defaultProto = preferred
-					break
-				}
-			}
-			if defaultProto != "" {
-				break
-			}
+		if defaultProto != "" {
+			break
 		}
 	}
 

--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -597,7 +597,6 @@ func (h *Handler) handleGetStreamingSettings(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"default_protocol": h.config.Streaming.DefaultProtocol,
 		"webrtc": map[string]any{
 			"enabled":      h.config.Streaming.WebRTC.Enabled != nil && *h.config.Streaming.WebRTC.Enabled,
 			"max_viewers":  h.config.Streaming.WebRTC.MaxViewers,
@@ -622,8 +621,7 @@ func (h *Handler) handleUpdateStreamingSettings(w http.ResponseWriter, r *http.R
 	}
 
 	var body struct {
-		DefaultProtocol *string `json:"default_protocol"`
-		WebRTC          *struct {
+		WebRTC *struct {
 			Enabled     *bool   `json:"enabled"`
 			MaxViewers  *int    `json:"max_viewers"`
 			IdleTimeout *string `json:"idle_timeout"`
@@ -642,10 +640,6 @@ func (h *Handler) handleUpdateStreamingSettings(w http.ResponseWriter, r *http.R
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
 		return
-	}
-
-	if body.DefaultProtocol != nil {
-		h.config.Streaming.DefaultProtocol = *body.DefaultProtocol
 	}
 
 	if body.WebRTC != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -398,10 +398,17 @@ type HLSConfig struct {
 }
 
 // StreamingConfig configures streaming protocol options (WebRTC, FLV, etc.)
+//
+// NOTE: a global default_protocol field was removed — the frontend Player
+// Orchestrator now auto-selects the best protocol per camera (probes
+// /api/cameras/{id}/protocols, folds in codec + browser capability, demotes
+// on health failure). A stale default_protocol key in existing YAML is
+// silently ignored (unknown fields are not strict-decoded). Per-camera
+// overrides remain available via the Protocol Switcher on each camera's
+// LiveView page.
 type StreamingConfig struct {
-	DefaultProtocol string       `yaml:"default_protocol"` // webrtc | flv | hls | ll-hls (default "hls")
-	WebRTC          WebRTCConfig `yaml:"webrtc"`
-	FLV             FLVConfig    `yaml:"flv"`
+	WebRTC WebRTCConfig `yaml:"webrtc"`
+	FLV    FLVConfig    `yaml:"flv"`
 }
 
 // WebRTCConfig configures WebRTC WHEP streaming
@@ -1147,9 +1154,6 @@ func Validate(cfg *Config) error {
 	}
 
 	// Validate streaming configuration
-	if cfg.Streaming.DefaultProtocol != "webrtc" && cfg.Streaming.DefaultProtocol != "flv" && cfg.Streaming.DefaultProtocol != "hls" && cfg.Streaming.DefaultProtocol != "ll-hls" {
-		return fmt.Errorf("streaming.default_protocol invalid: %s (must be webrtc/flv/hls/ll-hls)", cfg.Streaming.DefaultProtocol)
-	}
 	if cfg.Streaming.WebRTC.MaxViewers < 1 || cfg.Streaming.WebRTC.MaxViewers > 10 {
 		return fmt.Errorf("streaming.webrtc.max_viewers must be between 1 and 10, got %d", cfg.Streaming.WebRTC.MaxViewers)
 	}
@@ -1364,9 +1368,6 @@ func (cfg *Config) ApplyDefaults() {
 	}
 
 	// Streaming defaults
-	if strings.TrimSpace(cfg.Streaming.DefaultProtocol) == "" {
-		cfg.Streaming.DefaultProtocol = "hls"
-	}
 	if cfg.Streaming.WebRTC.Enabled == nil {
 		cfg.Streaming.WebRTC.Enabled = new(bool)
 		*cfg.Streaming.WebRTC.Enabled = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -911,7 +911,6 @@ func TestValidateONVIFEndpointAutoPopulated(t *testing.T) {
 func TestStreamingDefaults(t *testing.T) {
 	cfg := &Config{}
 	cfg.ApplyDefaults()
-	require.Equal(t, "hls", cfg.Streaming.DefaultProtocol)
 	require.NotNil(t, cfg.Streaming.WebRTC.Enabled)
 	require.True(t, *cfg.Streaming.WebRTC.Enabled)
 	require.Equal(t, 2, cfg.Streaming.WebRTC.MaxViewers)
@@ -923,12 +922,24 @@ func TestStreamingDefaults(t *testing.T) {
 	require.Equal(t, 1, cfg.Streaming.FLV.GOPCacheSize)
 }
 
-func TestStreamingDefaultProtocolInvalid(t *testing.T) {
-	cfg := &Config{Streaming: StreamingConfig{DefaultProtocol: "rtmp"}}
-	cfg.ApplyDefaults()
-	err := Validate(cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "streaming.default_protocol")
+// TestStreamingDefaultProtocolBackwardCompat ensures a YAML config carrying
+// the removed streaming.default_protocol key still loads cleanly (unknown
+// fields are ignored, not strict-decoded). The field was removed because the
+// frontend Player Orchestrator now auto-selects the protocol per camera.
+func TestStreamingDefaultProtocolBackwardCompat(t *testing.T) {
+	const yamlStr = `
+storage: {root_dir: /tmp/nvr}
+auth: {username: u, password_hash: "$2a$10$x"}
+streaming:
+  default_protocol: webrtc
+  webrtc: {max_viewers: 3}
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(yamlStr), 0o600))
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, 3, cfg.Streaming.WebRTC.MaxViewers)
 }
 
 func TestWebRTCMaxViewersTooLow(t *testing.T) {

--- a/internal/config/config_webrtc_test.go
+++ b/internal/config/config_webrtc_test.go
@@ -84,7 +84,6 @@ func TestWebRTCICEServersRoundTrip(t *testing.T) {
 		Storage: StorageConfig{RootDir: "/tmp/nvr"},
 		Auth:    AuthConfig{Username: "u", PasswordHash: "$2a$10$x"},
 		Streaming: StreamingConfig{
-			DefaultProtocol: "hls",
 			WebRTC: WebRTCConfig{
 				ICEServers: []ICEServerConfig{
 					{URLs: []string{"stun:stun.l.google.com:19302"}},

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -55,7 +55,6 @@ export interface SRTConfig {
 }
 
 export interface StreamingConfig {
-  default_protocol: string; // webrtc | flv | hls | ll-hls
   webrtc: WebRTCConfig;
   flv: FLVStreamingConfig;
   hls: HLSStreamingConfig;

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1033,8 +1033,6 @@
   "settings.saving": "Saving...",
   "settings.streaming": "Streaming Protocols",
   "settings.streaming.error": "Failed to save streaming settings",
-  "settings.streaming.fallbackProtocol": "Fallback streaming protocol",
-  "settings.streaming.fallbackProtocolHint": "The surveillance grid auto-selects the best protocol per camera. This is used only as a fallback when the camera's capabilities can't be queried.",
   "settings.streaming.flv": "HTTP-FLV",
   "settings.streaming.flv.gopCache": "GOP Cache Size",
   "settings.streaming.flv.gopCacheHint": "Keyframe cache for faster seeking (frames).",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1033,8 +1033,6 @@
   "settings.saving": "保存中...",
   "settings.streaming": "流媒体协议",
   "settings.streaming.error": "保存流媒体设置失败",
-  "settings.streaming.fallbackProtocol": "备用直播协议",
-  "settings.streaming.fallbackProtocolHint": "监控大屏会按摄像头自动选择最佳协议。此项仅在无法查询摄像头能力时作为备用。",
   "settings.streaming.flv": "HTTP-FLV",
   "settings.streaming.flv.gopCache": "GOP 缓存大小",
   "settings.streaming.flv.gopCacheHint": "关键帧缓存，用于加速定位（帧数）。",

--- a/web/src/routes/settings/AdvancedTab.svelte
+++ b/web/src/routes/settings/AdvancedTab.svelte
@@ -171,10 +171,9 @@
         batch_limit: mergeBatchLimit,
       });
 
-      // Save streaming settings (preserve default_protocol from existing config)
-      const existingStreaming = await getStreamingSettings().catch(() => ({ default_protocol: 'hls' }));
+      // Save streaming settings. Note: default_protocol was removed — the
+      // Player Orchestrator auto-selects per camera.
       await updateStreamingSettings({
-        default_protocol: existingStreaming.default_protocol || 'hls',
         webrtc: {
           enabled: streamingWebrtcEnabled,
           max_viewers: streamingWebrtcMaxViewers,

--- a/web/src/routes/settings/GeneralTab.svelte
+++ b/web/src/routes/settings/GeneralTab.svelte
@@ -31,12 +31,11 @@
   ]);
   let itemsPerPage = $state(getItemsPerPage());
   let autoRefresh = $state(getAutoRefresh());
-  // NOTE: the "fallback protocol" selector was removed — the Player Orchestrator
-  // now auto-selects the best protocol per camera (codec + browser caps), so
-  // there's nothing for a new user to configure here. The backend
-  // `streaming.default_protocol` field is preserved for backward compat but no
-  // longer has a UI (the orchestrator's buildCandidateChain ignores it, falling
-  // back to the universal HLS candidate when /protocols is unreachable).
+  // NOTE: there is no global "fallback protocol" selector here — the Player
+  // Orchestrator auto-selects the best protocol per camera (probes
+  // /protocols, folds in codec + browser capability, demotes on health
+  // failure). Per-camera overrides remain available via the Protocol Switcher
+  // on each camera's LiveView page.
 
   // Disk info from stats API
   let diskInfo = $state<StorageStats | null>(null);


### PR DESCRIPTION
## What

Removes the global `streaming.default_protocol` config field and all its plumbing. The frontend Player Orchestrator now fully auto-selects the best protocol per camera, so the field only adds config-cognition overhead for users.

Closes #127.

## Why

`default_protocol` was not pure dead code — it flowed through one live path:

```
config.Streaming.DefaultProtocol
  → handler.go  /api/cameras/{id}/protocols "default" field
  → stream-selection.ts buildCandidateChain reads backendDefault
  → candidate-chain first preference (when no per-camera override)
```

But the Player Orchestrator already adapts at runtime: probes `/protocols`, folds in codec + browser capability, demotes on health failure, upgrades after stability. The global default only set the **initial** preference when the user hadn't pinned a protocol via the per-camera Protocol Switcher. With the orchestrator in place, a global default is redundant cognitive load.

## Removed (10 files, +46/−54)

**Backend:**
- `config.go`: `StreamingConfig.DefaultProtocol` field + `Validate` check + `ApplyDefaults` default
- `handler.go`: `/protocols` "prefer user-configured default" branch → now purely latency-optimal fallback order (`webrtc > flv > ll-hls > hls > mjpeg`)
- `handlers_system.go`: `GET/SET /settings/streaming` `default_protocol` field
- `config_test.go`: removed `TestStreamingDefaultProtocolInvalid`, trimmed `TestStreamingDefaults`, **added** `TestStreamingDefaultProtocolBackwardCompat` (stale YAML key still loads)
- `config_webrtc_test.go`: removed `DefaultProtocol: "hls"` from fixture

**Frontend:**
- `AdvancedTab.svelte`: round-trip save of `default_protocol` removed
- `settings.ts`: `StreamingConfig.default_protocol` type field removed
- `i18n/en.json` + `zh.json`: orphaned `settings.streaming.fallbackProtocol{,Hint}` keys removed (selector was already deleted from GeneralTab earlier)
- `GeneralTab.svelte`: stale comment updated

## Behavior change (intentional, surfaced for review)

H.264 cameras with no per-camera override now prefer **WebRTC** over HLS when both are available, instead of honoring a global `default_protocol: hls`. This matches the latency-optimal order the orchestrator already uses for the `/protocols.default` hint. Per-camera overrides via the Protocol Switcher are unaffected.

## Backward compatibility

- Existing YAML with a stale `streaming.default_protocol` key **still loads** (`yaml.Unmarshal` ignores unknown fields) — verified by new `TestStreamingDefaultProtocolBackwardCompat`.
- The `/protocols` response still carries a `default` field (now sourced from the hardcoded preference order), so the orchestrator's `backendDefault` read path is unchanged.

## Not removed (deliberately)

- `stream-selection.ts`'s `legacyDefault` parameter — harmless dead branch (no production caller passes it), covered by 4 existing tests. Removing it would churn tests for no behavioral gain. Documented in commit message.

## Validation

- [x] `go build ./...` ✅
- [x] `go vet ./...` ✅
- [x] `go test ./...` — **4060 tests passed** ✅
- [x] `npm run build` (tsc + vite) ✅
- [x] `npm test` (vitest) — **462 tests passed** ✅
- [x] Backward-compat test for stale YAML key ✅
- [ ] CI (this PR)

## Related

- Companion cleanup PR for dead code: #141 (TUTK dtls/, 1420 lines)
- Both are low-risk, independently mergeable.