### PR TITLE
fix(test): service-layer goroutine joins — root cause of #143 TempDir flake

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -147,8 +147,8 @@ type Handler struct {
 	mergeCancel context.CancelFunc // set by initMergeCtx
 	mergeWg     sync.WaitGroup
 	isClosed    bool // guarded by mergeMu; prevents new merges after Close
-	aiHandler         *AIHandler
-	relayMgr          *relay.Manager
+	aiHandler   *AIHandler
+	relayMgr    *relay.Manager
 	// frameListCache memoizes sorted file-name listings for MJPEG/timelapse frame
 	// directories so repeated ?frame=N / list-frames requests don't os.ReadDir + sort
 	// the whole directory on every hit. Keyed by dir path; invalidated by mtime + TTL.
@@ -169,7 +169,7 @@ type frameListEntry struct {
 const frameListCacheTTL = 500 * time.Millisecond
 
 func NewHandler(db *storage.DB, store *storage.Manager, authMW func(http.Handler) http.Handler, cfg *config.Config, camMgr *camera.CameraManager, hlsMgr *hls.Manager, configPath string, mergeMgr *merge.MergeManager, cloudProxy CloudAuthProxy, mergeScheduler *timelapse.MergeScheduler) *Handler {
-		return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler}
+	return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler}
 }
 
 // startMergeGoroutine launches fn on a tracked background goroutine using the

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -136,6 +136,17 @@ type Handler struct {
 	timelapseMergeMgr *timelapse.RollingMergeManager
 	mergeScheduler    *timelapse.MergeScheduler
 	activeMerges      sync.Map
+	// mergeWg tracks the goroutines spawned by handleTimelapseMerge and
+	// handleTimelapseBatchMerge (which run PeriodicMergeManager.Run in the
+	// background). mergeCtx/mergeCancel let Close propagate shutdown to them.
+	// Close waits on mergeWg so in-flight merges finish (or observe ctx cancel)
+	// before the caller (App.Stop / a test's t.TempDir cleanup) tears down the
+	// storage tree — prevents the TempDir "directory not empty" flake (#143/#125).
+	mergeMu     sync.Mutex
+	mergeCtx    context.Context    // set by initMergeCtx; nil ⇒ fall back to context.Background()
+	mergeCancel context.CancelFunc // set by initMergeCtx
+	mergeWg     sync.WaitGroup
+	isClosed    bool // guarded by mergeMu; prevents new merges after Close
 	aiHandler         *AIHandler
 	relayMgr          *relay.Manager
 	// frameListCache memoizes sorted file-name listings for MJPEG/timelapse frame
@@ -158,7 +169,62 @@ type frameListEntry struct {
 const frameListCacheTTL = 500 * time.Millisecond
 
 func NewHandler(db *storage.DB, store *storage.Manager, authMW func(http.Handler) http.Handler, cfg *config.Config, camMgr *camera.CameraManager, hlsMgr *hls.Manager, configPath string, mergeMgr *merge.MergeManager, cloudProxy CloudAuthProxy, mergeScheduler *timelapse.MergeScheduler) *Handler {
-	return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler}
+		return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler}
+}
+
+// startMergeGoroutine launches fn on a tracked background goroutine using the
+// Handler's merge context. It returns false (without launching) if Close has
+// already been called, so shutdown isn't racing with a brand-new merge. The
+// mergeWg/Add happens here (under mergeMu, before the `go`) to satisfy
+// sync.WaitGroup's "Add before Wait when counter is zero" contract — Close's
+// Wait cannot observe a zero counter while a new merge is being registered.
+//
+// This replaces the prior `go func() { ctx := context.Background(); mgr.Run(...) }()`
+// pattern in handleTimelapseMerge/handleTimelapseBatchMerge that leaked
+// goroutines past test/App teardown (root cause of the #143 TempDir flake).
+func (h *Handler) startMergeGoroutine(fn func(ctx context.Context)) bool {
+	h.mergeMu.Lock()
+	defer h.mergeMu.Unlock()
+	if h.isClosed {
+		return false
+	}
+	if h.mergeCtx == nil {
+		// Lazy-init: derive from Background so merges run independent of any
+		// single HTTP request's lifetime, but remain cancellable via Close.
+		h.mergeCtx, h.mergeCancel = context.WithCancel(context.Background())
+	}
+	ctx := h.mergeCtx
+	h.mergeWg.Add(1)
+	go func() {
+		defer h.mergeWg.Done()
+		fn(ctx)
+	}()
+	return true
+}
+
+// Close cancels any in-flight timelapse merge goroutines and waits for them to
+// exit. It must be called during application shutdown (after the HTTP server
+// stops accepting requests) so merges don't outlive the storage tree — the
+// App.Service contract requires all goroutines be released, and tests using
+// t.TempDir for the storage root will otherwise hit "directory not empty"
+// during RemoveAll (#143 / #125 class). Idempotent.
+func (h *Handler) Close() {
+	h.mergeMu.Lock()
+	if h.isClosed {
+		h.mergeMu.Unlock()
+		return
+	}
+	h.isClosed = true
+	cancel := h.mergeCancel
+	h.mergeMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	// Wait outside mergeMu: merges may still call back into handler methods
+	// (e.g. reading config) that don't take mergeMu, and holding the lock while
+	// waiting risks deadlock if a merge ever does take it.
+	h.mergeWg.Wait()
 }
 
 // Routes returns a chi.Router with all routes registered.

--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -470,13 +470,22 @@ func (h *Handler) handleTimelapseMergeWithDuration(w http.ResponseWriter, r *htt
 		timelapse.WithIntermediateMP4Pruner(h.db),
 	)
 
-	go func() {
+	// Run the merge on a Handler-tracked goroutine (mergeWg + mergeCtx) so
+	// Handler.Close can cancel + join it during shutdown. Previously this used
+	// an untracked goroutine with context.Background(), which leaked past
+	// App.Stop / t.TempDir cleanup — root cause of the #143 TempDir flake.
+	launched := h.startMergeGoroutine(func(ctx context.Context) {
 		defer h.activeMerges.Delete(cameraID)
-		ctx := context.Background()
 		if err := mgr.Run(ctx, cameraID, refTime); err != nil {
 			logger.Warn("timelapse merge failed", "camera_id", cameraID, "duration", durationStr, "error", err)
 		}
-	}()
+	})
+	if !launched {
+		// Handler is shutting down — release the dedup slot and 409-style reject.
+		h.activeMerges.Delete(cameraID)
+		WriteError(w, http.StatusServiceUnavailable, "server is shutting down")
+		return
+	}
 
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"status":    "merge_initiated",
@@ -874,13 +883,12 @@ func (h *Handler) handleTimelapseBatchMerge(w http.ResponseWriter, r *http.Reque
 			timelapse.WithIntermediateMP4Pruner(h.db),
 		)
 
-		// Launch merge in background
-		go func(camID string, mgr *timelapse.PeriodicMergeManager, ref time.Time) {
-			ctx := context.Background()
-			if err := mgr.Run(ctx, camID, ref); err != nil {
-				logger.Warn("timelapse batch merge failed", "camera_id", camID, "duration", body.Duration, "error", err)
+		// Launch merge in background (Handler-tracked so Close can join it).
+		h.startMergeGoroutine(func(ctx context.Context) {
+			if err := mgr.Run(ctx, cameraID, refTime); err != nil {
+				logger.Warn("timelapse batch merge failed", "camera_id", cameraID, "duration", body.Duration, "error", err)
 			}
-		}(cameraID, mgr, refTime)
+		})
 
 		triggered++
 		results = append(results, batchResult{

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -144,6 +144,15 @@ type RollingMergeCoordinator struct {
 	eventBus  *event.EventBus
 	eventCh   chan event.Event
 	cancelSub context.CancelFunc
+
+	// wg tracks ALL goroutines spawned by Start (eventLoop, backfillOnStartup,
+	// backfillLoop) AND the per-camera mergeSegments goroutines fan-out by
+	// eventLoop. Stop waits on wg so that, once Stop returns, no goroutine is
+	// still writing to the storage tree — required by the App.Service contract
+	// ("must release all goroutines ... resources") and prevents the TempDir
+	// cleanup race (issue #143 / #125 class) where outlived goroutines write
+	// files after t.TempDir() RemoveAll begins.
+	wg sync.WaitGroup
 }
 
 // bucketInfo tracks the accumulated merge state for a camera's current window.
@@ -234,6 +243,11 @@ func (r *RollingMergeCoordinator) Start(ctx context.Context) error {
 		return fmt.Errorf("rolling merge: subscribe to segment.completed: %w", err)
 	}
 
+	// wg.Add BEFORE the `go` statement (not inside the goroutine) is required by
+	// sync.WaitGroup's contract: "Calls with a positive delta that start when the
+	// counter is zero must happen before a Wait." Otherwise a fast Stop's Wait
+	// could observe counter==0 and return before the goroutine's Add runs.
+	r.wg.Add(3)
 	go r.eventLoop(ctx)
 
 	// One-shot backfill: drain historical pending segments for rolling-enabled cameras.
@@ -254,6 +268,7 @@ func (r *RollingMergeCoordinator) Start(ctx context.Context) error {
 // cameras and merges them into window buckets. This ensures that recordings that existed
 // before rolling merge was enabled get the same quasi-real-time treatment retroactively.
 func (r *RollingMergeCoordinator) backfillOnStartup(ctx context.Context) {
+	defer r.wg.Done() // paired with r.wg.Add(3) in Start
 	// Check if any camera has rolling enabled — skip entirely if none.
 	hasRolling := false
 	for _, cam := range r.cameras() {
@@ -352,6 +367,7 @@ func (r *RollingMergeCoordinator) backfillOnStartup(ctx context.Context) {
 // (default 10m) it processes up to `rolling_backfill_batch` (default 500) pending
 // segments, using try-locks to yield to real-time events.
 func (r *RollingMergeCoordinator) backfillLoop(ctx context.Context) {
+	defer r.wg.Done() // paired with r.wg.Add(3) in Start
 	global := r.getGlobalCfg()
 	interval := time.Duration(0)
 	if global.RollingBackfillInterval != "" && global.RollingBackfillInterval != "0" {
@@ -1035,7 +1051,11 @@ func (r *RollingMergeCoordinator) mergeBatchSegments(ctx context.Context, camera
 	return len(recs), nil
 }
 
-// Stop unsubscribes and signals the event loop to exit.
+// Stop unsubscribes, signals all goroutines to exit via ctx cancellation, and
+// WAITS for them to fully return before returning itself. This honors the
+// App.Service contract ("must release all goroutines") and prevents the
+// TempDir cleanup race (#143/#125 class) where outlived goroutines write files
+// after the caller (e.g. a test's t.TempDir) begins cleanup.
 func (r *RollingMergeCoordinator) Stop() {
 	if r.cancelSub != nil {
 		r.cancelSub()
@@ -1043,17 +1063,34 @@ func (r *RollingMergeCoordinator) Stop() {
 	if r.eventBus != nil {
 		r.eventBus.Unsubscribe(event.TopicSegmentCompleted, r.eventCh)
 	}
+	// Wait for eventLoop + backfillOnStartup + backfillLoop + any in-flight
+	// mergeSegments goroutines fan-out by eventLoop to fully exit.
+	r.wg.Wait()
 }
 
 // eventLoop drains SegmentCompleted events and dispatches per-camera merge goroutines.
 // It applies debounce per camera: rapid segment closes (e.g. short segment dur with
 // reconnects) get batched into a single merge.
+//
+// All wg.Add calls for the mergeSegments fan-out happen inside this goroutine (in the
+// fireCh select case), so once ctx is cancelled the loop exits via ctx.Done and no
+// further Add can race with a concurrent Stop's Wait (which would violate sync.WaitGroup's
+// "Add with positive delta must happen before Wait when counter is zero" rule).
+// The debounce timers only send a non-blocking signal on fireCh; they never touch wg.
 func (r *RollingMergeCoordinator) eventLoop(ctx context.Context) {
+	defer r.wg.Done() // paired with r.wg.Add(3) in Start
 	pendingMu := sync.Mutex{}
 	pending := make(map[string][]pendingSegmentInfo) // cameraID → queued segments
 	timers := make(map[string]*time.Timer)
 
-	processCamera := func(cameraID string) {
+	// fireCh carries cameraIDs whose debounce timer elapsed. Buffered so a timer
+	// callback virtually never blocks; the per-camera dedup in pending (delete on
+	// dispatch) keeps semantics correct if multiple signals queue. Dispatch is
+	// non-blocking (only wg.Add + go), so drain is fast and the buffer is rarely
+	// more than lightly populated.
+	fireCh := make(chan string, 256)
+
+	dispatch := func(cameraID string) {
 		pendingMu.Lock()
 		segs := pending[cameraID]
 		delete(pending, cameraID)
@@ -1064,8 +1101,14 @@ func (r *RollingMergeCoordinator) eventLoop(ctx context.Context) {
 			return
 		}
 
-		// Launch async merge — never block the event loop.
-		go r.mergeSegments(ctx, cameraID, segs)
+		// Launch async merge — never block the event loop. Tracked by wg so Stop
+		// waits for in-flight merges too (prevents merge goroutines from outliving
+		// t.TempDir cleanup — issue #143).
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			r.mergeSegments(ctx, cameraID, segs)
+		}()
 	}
 
 	for {
@@ -1077,6 +1120,9 @@ func (r *RollingMergeCoordinator) eventLoop(ctx context.Context) {
 			}
 			pendingMu.Unlock()
 			return
+
+		case cameraID := <-fireCh:
+			dispatch(cameraID)
 
 		case evt := <-r.eventCh:
 			sc, ok := evt.Data.(event.SegmentCompleted)
@@ -1096,7 +1142,7 @@ func (r *RollingMergeCoordinator) eventLoop(ctx context.Context) {
 				continue
 			}
 
-			// Parse the segment's started_at time for window calculation.
+			// Parse the segment's startedAt time for window calculation.
 			startedAt, err := time.Parse(time.RFC3339Nano, sc.StartedAt)
 			if err != nil {
 				// Fallback: use now.
@@ -1116,12 +1162,23 @@ func (r *RollingMergeCoordinator) eventLoop(ctx context.Context) {
 			pendingMu.Lock()
 			pending[sc.CameraID] = append(pending[sc.CameraID], seg)
 
-			// Reset or create the debounce timer.
+			// Reset or create the debounce timer. The timer callback only signals
+			// fireCh (non-blocking); the actual wg.Add/dispatch happens in the
+			// eventLoop's fireCh select case, keeping all wg mutation on this goroutine.
 			if existing, ok := timers[sc.CameraID]; ok {
 				existing.Stop()
 			}
+			camID := sc.CameraID
 			t := time.AfterFunc(cfg.Debounce, func() {
-				processCamera(sc.CameraID)
+				// Non-blocking send: if fireCh is full OR the event loop has exited
+				// (ctx cancelled, no reader), the signal is dropped. Dropping is safe
+				// during shutdown — pending segments stay in the DB and are picked up
+				// by the next process start's backfill. This also guarantees the timer
+				// callback never leaks a goroutine blocked on a channel send.
+				select {
+				case fireCh <- camID:
+				default:
+				}
 			})
 			timers[sc.CameraID] = t
 			pendingMu.Unlock()

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -1037,4 +1039,58 @@ func TestAdaptiveBatchPause(t *testing.T) {
 				tc.pending, tc.diskFree, got, want, base, tc.wantFactor)
 		})
 	}
+}
+
+// TestRollingMerge_StopJoinsGoroutines is a regression test for #143:
+// RollingMergeCoordinator.Start spawns 3 goroutines (eventLoop,
+// backfillOnStartup, backfillLoop) and eventLoop fans out a mergeSegments
+// goroutine per debounced camera. Stop must join ALL of them (via r.wg.Wait)
+// so none outlive the caller and keep writing the storage tree — that was the
+// root cause of the TempDir "directory not empty" flake (#143 / #125 class).
+//
+// We assert deterministically by inspecting goroutine stacks: after Stop, no
+// live goroutine should have a frame rooted in RollingMergeCoordinator. Counting
+// NumGoroutine is unreliable under -race (detector injects helper goroutines).
+func TestRollingMerge_StopJoinsGoroutines(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping goroutine-leak test in short mode")
+	}
+
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "10ms",
+	}
+	r := newTestRollingCoordinator(env, cfg, bus)
+	require.NoError(t, r.Start(context.Background()))
+
+	// Exercise the eventLoop + a fan-out mergeSegments goroutine by publishing
+	// a segment-completed event for a (synthetic) MP4 segment. The merge will
+	// fail to find the file, but the goroutine still launches — that's what we
+	// want to verify gets joined.
+	now := time.Now()
+	publishSegmentCompleted(t, bus, "leak-cam", "rec1", "/nonexistent/path.mp4", "h264", now)
+	// Let the debounce timer fire and the mergeSegments goroutine launch.
+	time.Sleep(80 * time.Millisecond)
+
+	r.Stop()
+
+	// Poll: after Stop, no goroutine should be running our coordinator code.
+	leakMarker := "merge.(*RollingMergeCoordinator)"
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		buf := make([]byte, 1<<16)
+		n := runtime.Stack(buf, true)
+		if !strings.Contains(string(buf[:n]), leakMarker) {
+			return // pass
+		}
+	}
+
+	buf := make([]byte, 1<<18)
+	n := runtime.Stack(buf, true)
+	t.Errorf("goroutine leak after Stop: RollingMergeCoordinator goroutine still alive. Stacks:\n%s", buf[:n])
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -265,10 +266,22 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// storage trees (100k+ files) the walk can take 20+ seconds, and leftover
 	// .tmp files are harmless to delay (each new segment uses a unique uuid).
 	// CleanupIncomplete below is a single SQL DELETE (ms-scale) and stays sync.
+	//
+	// These two goroutines are tracked by startupBgWG + observe startupBgCtx so
+	// that the startup-bg service's Stop (registered below) can cancel them and
+	// join before App returns. Previously they used context.Background() with
+	// no tracking, leaking past App.Stop / t.TempDir cleanup — root cause of
+	// the #143 TempDir flake for TestRunFree_DoesNotBlockOnStorageScan.
+	startupBgCtx, startupBgCancel := context.WithCancel(ctx)
+	var startupBgWG sync.WaitGroup
+	startupBgWG.Add(1)
 	go func() {
+		defer startupBgWG.Done()
 		start := time.Now()
 		if err := store.CleanupTempFiles(); err != nil {
-			slog.Warn("background temp cleanup", "error", err)
+			if startupBgCtx.Err() == nil {
+				slog.Warn("background temp cleanup", "error", err)
+			}
 			return
 		}
 		slog.Info("background temp cleanup done", "duration", time.Since(start))
@@ -286,11 +299,15 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	for _, cam := range cfg.Cameras {
 		cameraIDs[cam.ID] = true
 	}
+	startupBgWG.Add(1)
 	go func() {
+		defer startupBgWG.Done()
 		start := time.Now()
-		reconciled, err := store.ReconcileOrphanedFiles(ctx, db, cameraIDs)
+		reconciled, err := store.ReconcileOrphanedFiles(startupBgCtx, db, cameraIDs)
 		if err != nil {
-			slog.Error("background orphan reconciliation failed", "error", err)
+			if startupBgCtx.Err() == nil {
+				slog.Error("background orphan reconciliation failed", "error", err)
+			}
 			return
 		}
 		slog.Info("background orphan reconciliation done",
@@ -656,6 +673,7 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// Step 8: Cleanup manager
 	cleanupMgr, err := cleanup.NewCleanupManager(db, store, cfg.Cleanup, metrics)
 	if err != nil {
+		startupBgCancel()
 		db.Close()
 		return nil, fmt.Errorf("cleanup: %w", err)
 	}
@@ -779,6 +797,7 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// ---- Build HTTP router ----
 	r, err := buildRouter(cfg, authMW, handler, metrics, davHandler, uploadHandler)
 	if err != nil {
+		startupBgCancel()
 		return nil, err
 	}
 
@@ -806,10 +825,31 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 			return nil
 		},
 	}); err != nil {
+		startupBgCancel()
 		return nil, fmt.Errorf("register db: %w", err)
 	}
 
-	// 2. camera — relay folded in (relay starts before camera, stops before camera)
+	// 2. startup-bg — join the two background goroutines launched above
+	// (CleanupTempFiles + ReconcileOrphanedFiles). Registered right after db so
+	// its Stop runs just before db.Close in the reverse-order teardown: cancel
+	// their ctx + wait for them to exit, so they're not still walking/writing
+	// the storage tree (t.TempDir) when cleanup proceeds. See #143 / #125.
+	if err := a.Register(&serviceFunc{
+		name: "startup-bg",
+		startFunc: func(_ context.Context) error {
+			return nil
+		},
+		stopFunc: func() error {
+			startupBgCancel()
+			startupBgWG.Wait()
+			return nil
+		},
+	}); err != nil {
+		startupBgCancel()
+		return nil, fmt.Errorf("register startup-bg: %w", err)
+	}
+
+	// 3. camera — relay folded in (relay starts before camera, stops before camera)
 	if err := a.Register(&serviceFunc{
 		name: "camera",
 		startFunc: func(ctx context.Context) error {
@@ -868,25 +908,33 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// 4. merge — run in background goroutine with its own cancel
 	{
 		var mergeCancel context.CancelFunc
+		var mergeDone chan struct{}
 		if err := a.Register(&serviceFunc{
-			name: "merge",
-			startFunc: func(ctx context.Context) error {
-				var runCtx context.Context
-				runCtx, mergeCancel = context.WithCancel(ctx)
-				go func() {
-					if cfg.Merge.Enabled {
-						mergeMgr.Run(runCtx)
-						slog.Info("merge-manager stopped")
-					}
-				}()
-				return nil
-			},
-			stopFunc: func() error {
-				if mergeCancel != nil {
-					mergeCancel()
+		name: "merge",
+		startFunc: func(ctx context.Context) error {
+			var runCtx context.Context
+			runCtx, mergeCancel = context.WithCancel(ctx)
+			mergeDone = make(chan struct{})
+			go func() {
+				defer close(mergeDone)
+				if cfg.Merge.Enabled {
+					mergeMgr.Run(runCtx)
+					slog.Info("merge-manager stopped")
 				}
-				return nil
-			},
+			}()
+			return nil
+		},
+		stopFunc: func() error {
+			if mergeCancel != nil {
+				mergeCancel()
+			}
+			// Join the Run goroutine so it's not still walking/writing the
+			// storage tree after App.Stop returns (#143 / #125 class).
+			if mergeDone != nil {
+				<-mergeDone
+			}
+			return nil
+		},
 		}); err != nil {
 			return nil, fmt.Errorf("register merge: %w", err)
 		}
@@ -949,17 +997,27 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 	// 7. cleanup — run in background goroutine with its own cancel
 	{
 		var cleanupCancel context.CancelFunc
+		var cleanupDone chan struct{}
 		if err := a.Register(&serviceFunc{
 			name: "cleanup",
 			startFunc: func(ctx context.Context) error {
 				var runCtx context.Context
 				runCtx, cleanupCancel = context.WithCancel(ctx)
-				go cleanupMgr.Run(runCtx)
+				cleanupDone = make(chan struct{})
+				go func() {
+					defer close(cleanupDone)
+					cleanupMgr.Run(runCtx)
+				}()
 				return nil
 			},
 			stopFunc: func() error {
 				if cleanupCancel != nil {
 					cleanupCancel()
+				}
+				// Join the Run goroutine so it's not still deleting files under
+				// the storage tree after App.Stop returns (#143 / #125 class).
+				if cleanupDone != nil {
+					<-cleanupDone
 				}
 				return nil
 			},
@@ -1101,7 +1159,26 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 		return nil, fmt.Errorf("register hls: %w", err)
 	}
 
-	// 15. remoteLog (optional) — registered last so it stops first
+	// 15. api-handler — close tracked timelapse-merge goroutines spawned by
+	// handleTimelapseMerge / handleTimelapseBatchMerge. Registered after the
+	// streaming services so its Stop (reverse order) runs BEFORE db close but
+	// AFTER ws/webrtc/hls — by then the HTTP server (stopped by main.go before
+	// a.Stop) has drained in-flight requests, so no new merges can start, and
+	// we only wait for already-running merges to finish. See #143 / #125.
+	if err := a.Register(&serviceFunc{
+		name: "api-handler",
+		startFunc: func(_ context.Context) error {
+			return nil
+		},
+		stopFunc: func() error {
+			handler.Close()
+			return nil
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("register api-handler: %w", err)
+	}
+
+	// 16. remoteLog (optional) — registered last so it stops first
 	if remoteLogHandler != nil {
 		if err := a.Register(&serviceFunc{
 			name: "remoteLog",

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -910,31 +910,31 @@ func RunFree(cfg *config.Config, configPath string) (*App, error) {
 		var mergeCancel context.CancelFunc
 		var mergeDone chan struct{}
 		if err := a.Register(&serviceFunc{
-		name: "merge",
-		startFunc: func(ctx context.Context) error {
-			var runCtx context.Context
-			runCtx, mergeCancel = context.WithCancel(ctx)
-			mergeDone = make(chan struct{})
-			go func() {
-				defer close(mergeDone)
-				if cfg.Merge.Enabled {
-					mergeMgr.Run(runCtx)
-					slog.Info("merge-manager stopped")
+			name: "merge",
+			startFunc: func(ctx context.Context) error {
+				var runCtx context.Context
+				runCtx, mergeCancel = context.WithCancel(ctx)
+				mergeDone = make(chan struct{})
+				go func() {
+					defer close(mergeDone)
+					if cfg.Merge.Enabled {
+						mergeMgr.Run(runCtx)
+						slog.Info("merge-manager stopped")
+					}
+				}()
+				return nil
+			},
+			stopFunc: func() error {
+				if mergeCancel != nil {
+					mergeCancel()
 				}
-			}()
-			return nil
-		},
-		stopFunc: func() error {
-			if mergeCancel != nil {
-				mergeCancel()
-			}
-			// Join the Run goroutine so it's not still walking/writing the
-			// storage tree after App.Stop returns (#143 / #125 class).
-			if mergeDone != nil {
-				<-mergeDone
-			}
-			return nil
-		},
+				// Join the Run goroutine so it's not still walking/writing the
+				// storage tree after App.Stop returns (#143 / #125 class).
+				if mergeDone != nil {
+					<-mergeDone
+				}
+				return nil
+			},
 		}); err != nil {
 			return nil, fmt.Errorf("register merge: %w", err)
 		}

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -157,10 +159,12 @@ func TestRunFree_ServiceOrder(t *testing.T) {
 	t.Logf("service count = %d", len(svcs))
 
 	// With all optionals disabled, expected core services:
-	// db, camera, health, merge, rolling-merge, mergeScheduler, cleanup, ws, hls
+	// db, startup-bg, camera, health, merge, rolling-merge, mergeScheduler, cleanup, ws, hls, api-handler
 	// (health is always created even when Health.Enabled=false)
 	// (rolling-merge is always registered but only does work when Merge.RollingEnabled=true)
-	expected := []string{"db", "camera", "health", "merge", "rolling-merge", "mergeScheduler", "cleanup", "ws", "hls"}
+	// (startup-bg joins the two RunFree background goroutines; api-handler closes
+	// tracked timelapse-merge goroutines — both added for #143 TempDir flake fix)
+	expected := []string{"db", "startup-bg", "camera", "health", "merge", "rolling-merge", "mergeScheduler", "cleanup", "ws", "hls", "api-handler"}
 	if len(svcs) != len(expected) {
 		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
 	}
@@ -203,6 +207,76 @@ func TestRunFree_SmokeStartStop(t *testing.T) {
 	if err := a.Stop(); err != nil {
 		t.Fatalf("Stop: %v", err)
 	}
+}
+
+// TestRunFree_StopJoinsBackgroundGoroutines is a regression test for #143:
+// RunFree spawns background goroutines (CleanupTempFiles, ReconcileOrphanedFiles,
+// merge.Run, cleanup.Run, rolling-merge eventLoop/backfillLoop) that previously
+// outlived App.Stop and kept writing to the storage tree (t.TempDir), causing
+// "directory not empty" flakes during RemoveAll.
+//
+// We assert the deterministic property: after Stop (+ brief drain), no live
+// goroutine has a stack frame rooted in RunFree's background loops. Counting
+// NumGoroutine is unreliable under -race (race detector injects helper
+// goroutines), so we inspect runtime.Stack output for our code's frames.
+func TestRunFree_StopJoinsBackgroundGoroutines(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping goroutine-leak test in short mode")
+	}
+
+	cfg, dir := minimalConfig(t)
+	configPath := filepath.Join(dir, "mibee-nvr.yaml")
+	if err := config.Save(configPath, cfg); err != nil {
+		t.Fatalf("config.Save: %v", err)
+	}
+
+	a, err := RunFree(cfg, configPath)
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := a.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := a.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// Give just-exited goroutines a moment to be reaped, then dump all stacks.
+	// Poll for up to 3s — if our goroutines are still alive, fail with the stack.
+	// These substrings identify the background loops RunFree spawns.
+	leakMarkers := []string{
+		"app.(*App).RunFree.func",          // startup CleanupTempFiles/Reconcile goroutines
+		"merge.(*RollingMergeCoordinator)", // rolling-merge eventLoop/backfill loops
+		"merge.(*MergeManager).Run",        // merge service loop
+		"cleanup.(*CleanupManager).Run",    // cleanup service loop
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		buf := make([]byte, 1<<16)
+		n := runtime.Stack(buf, true)
+		stacks := string(buf[:n])
+		leaked := ""
+		for _, m := range leakMarkers {
+			if strings.Contains(stacks, m) {
+				leaked = m
+				break
+			}
+		}
+		if leaked == "" {
+			return // pass: no background loop still alive
+		}
+		// keep polling — some loops may need a tick to observe ctx cancel
+		_ = leaked
+	}
+
+	// Final failure: dump the offending stacks for diagnosis.
+	buf := make([]byte, 1<<18)
+	n := runtime.Stack(buf, true)
+	t.Errorf("goroutine leak after Stop: background loop still alive. Stacks:\n%s", buf[:n])
 }
 
 // TestRunFree_DoesNotBlockOnStorageScan is a regression test for the startup


### PR DESCRIPTION
## What

Fixes the TempDir "directory not empty" CI flake (#143, same class as the earlier #125) at the **service layer** so production callers benefit, not just tests.

Closes #143.

## Root cause

Several `app.Service` implementations violated their own contract (`pkg/app/app.go:26`: _"Stop must release all goroutines"_). Their `Stop()` signaled cancellation but returned **before** spawned goroutines exited, so the goroutines kept writing to `cfg.Storage.RootDir` (= `t.TempDir()`) after `App.Stop` / test teardown began. Under `-race` + CI parallelism this raced `RemoveAll` → flaky.

This blocked every PR's CI (e.g. #141 needed a rebase to dodge it).

## Fixes (3 areas)

### 1. `RollingMergeCoordinator` (prime suspect — "backfill loop started" logs)

`internal/merge/rolling.go`. `Start()` spawns 3 goroutines (eventLoop, backfillOnStartup, backfillLoop); eventLoop fans out a `mergeSegments` goroutine per debounced camera. Previously `Stop()` only called `cancelSub()` — fire-and-forget.

- struct gains `wg sync.WaitGroup`
- `Start` does `wg.Add(3)` **before** the 3 `go` statements (sync.WaitGroup contract: _"Add with positive delta must happen before Wait when counter is zero"_ — doing Add inside the goroutine races a fast Stop's Wait; the race detector caught this during dev)
- each loop has `defer r.wg.Done()`
- eventLoop's debounce fan-out reworked: instead of `time.AfterFunc` calling `processCamera` directly (which `wg.Add`'d inside the timer callback, racing Stop's Wait), timers send a non-blocking signal on a buffered `fireCh` consumed by eventLoop's select. All `wg.Add` for mergeSegments now happens inside the eventLoop goroutine, so `ctx.Done → loop exit` guarantees no further Add can race a concurrent `Stop.Wait`
- `Stop()` cancels ctx + `wg.Wait()`, joining eventLoop + both backfill loops + any in-flight mergeSegments

### 2. `api.Handler` — tracked timelapse-merge goroutines

`internal/api/handlers_timelapse.go`: `handleTimelapseMerge` + `handleTimelapseBatchMerge` spawned `go func() { ctx := context.Background(); mgr.Run(ctx, ...) }()` — completely untracked, never cancellable. Handler had no `Close()` at all.

- Handler gains `mergeWg` + `mergeCtx`/`mergeCancel` + `isClosed`
- new `startMergeGoroutine(fn)` helper: lazy-inits `mergeCtx`, `wg.Add(1)` under `mergeMu` **before** the `go`, refuses if `Close`'d
- both handlers route through it; `Close()` cancels + waits
- `pkg/app/run.go` registers an `api-handler` service whose `stopFunc` calls `handler.Close()`. `main.go` stops the HTTP server **before** `a.Stop`, so no new merges start while we wait

### 3. `pkg/app/run.go` — startup-bg + merge + cleanup joins

- RunFree's two bare goroutines (`CleanupTempFiles`, `ReconcileOrphanedFiles`) used `context.Background()` with no tracking. Now use cancellable `startupBgCtx` + `startupBgWG`, joined by a new `startup-bg` service registered right after `db` (stops just before `db.Close`). All 4 RunFree error-return paths between goroutine launch and service registration now call `startupBgCancel()` (fixes `lostcancel` vet warning)
- `merge` service `stopFunc` was cancel-only; now waits on `mergeDone` channel
- `cleanup` service `stopFunc` was cancel-only; now waits on `cleanupDone` channel

## Tests

- `TestRunFree_ServiceOrder`: expected service list updated (added `startup-bg` after `db`, `api-handler` after `hls`)
- `TestRunFree_StopJoinsBackgroundGoroutines` + `TestRollingMerge_StopJoinsGoroutines`: new regression tests. Inspect `runtime.Stack` for our code's frames after Stop (deterministic; `NumGoroutine` is unreliable under `-race` — the detector injects helper goroutines). These guard against a complete Stop-joins-nothing regression; the #143 timing flake itself is verified by CI green under `-race` + parallel pressure

## Out of scope (lower risk, follow-up if they flake)

`srt`/`ftp`/`mqtt`/`autodiscover` `Stop()`s are also cancel-only but write `t.TempDir` rarely. The merge/rolling/api.Handler fixes above cover the two confirmed-failing tests and the highest-I/O paths.

## Validation

- [x] `go build ./...` ✅
- [x] `go vet ./...` ✅ (no `lostcancel` warnings)
- [x] `go test ./...` — **4062 tests pass**, 48 packages ✅
- [x] stress: `pkg/app` + `internal/merge` + `internal/api`, `-race -count=4`, green ✅
- [x] WaitGroup race caught by `-race` during dev and fixed (Add moved before `go`) — lesson captured in `rolling.go` comments
- [ ] CI (this PR)