### PR TITLE
docs: 0.10.0 upgrade guide — breaking changes, migration steps, reclaim-orphan-merges (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Perfect for homelab enthusiasts. Self-hosted, no subscriptions, works with any R
 | Document | Description |
 |----------|-------------|
 | [Getting Started](docs/en/getting-started.md) | Installation, first camera setup |
+| [Upgrade Guide](docs/en/upgrade-guide.md) | Breaking changes & migration steps between versions |
+| [升级指南](docs/zh/upgrade-guide.md) | 版本间的破坏性变更与迁移步骤 |
 | [Configuration](docs/en/configuration.md) | Full config reference |
 | [API Reference](docs/en/api/README.md) | REST API documentation |
 | [MediaMTX Guide](docs/en/mediamtx-guide.md) | MediaMTX integration for CSI cameras |

--- a/docs/en/upgrade-guide.md
+++ b/docs/en/upgrade-guide.md
@@ -1,0 +1,166 @@
+# Upgrade Guide
+
+This guide covers upgrade paths and breaking changes between MiBee NVR releases. Always back up your database and config before upgrading.
+
+## Quick path table
+
+| From → To | Status | Action required |
+|-----------|--------|-----------------|
+| **v0.9.1 → 0.10.0** | 🟡 **Action required** | Fix combined `protocol` strings; optional disk-space reclaim. See [v0.9.1 → 0.10.0](#v091--v01000). |
+| v0.9.0 → v0.9.1 | 🟢 Transparent | None. |
+| v0.8.x → v0.9.x | 🟡 Back up first | Large storage-layer refactor. Back up the DB, then upgrade. |
+| v0.8.x → 0.10.0 | 🟡 Two hops | Upgrade to v0.9.x first, then to 0.10.0. |
+| **< v0.9.x → 0.10.0** | 🔴 **Not supported (direct)** | You **must** upgrade to 0.9.x first — see [below](#below-v09x--v01000-not-supported-direct) for why. |
+
+---
+
+## v0.9.1 → v0.10.0
+
+0.10.0 is a large release (H.265 WASM live playback, Timelapse v3, stateless auth tokens, MJPEG-over-WebSocket, AI model integrity hardening, and a 0.10.0 architecture cleanup). It contains a few **breaking changes** that require a one-time config or post-deploy step.
+
+### 🔴 Step 1 — Split any combined `protocol` strings (REQUIRED, blocks startup)
+
+0.10.0 rejects combined protocol strings like `"rtsp_h264"` at config validation. This is a **hard error** — the binary will refuse to start until you fix it.
+
+**Check your config:**
+
+```bash
+grep -nE 'protocol:\s*".*_(h264|h265|mjpeg|jpeg)"' /path/to/mibee-nvr.yaml
+```
+
+**If any line matches, split it into separate fields:**
+
+```yaml
+# ❌ Before (0.9.x accepted this, 0.10.0 rejects it)
+- id: "front-door"
+  protocol: "rtsp_h264"
+  url: "rtsp://..."
+
+# ✅ After
+- id: "front-door"
+  protocol: "rtsp"
+  encoding: "h264"
+  url: "rtsp://..."
+```
+
+The exact startup error you'll see if you forget this:
+
+```
+camera[0].protocol "rtsp_h264": combined format is no longer supported in
+0.10.0+; split into separate protocol ("rtsp") and encoding fields
+```
+
+This applies to every camera whose `protocol` contains an underscore (`rtsp_h264`, `rtsp_h265`, `rtsp_mjpeg`, `http_jpeg`, `onvif_jpeg`, …).
+
+### 🔴 Step 2 — Back up your database (RECOMMENDED)
+
+The migration from schema v28 → v29 **automatically** creates a backup via `VACUUM INTO` at `<db>.pre-v29-backup` before dropping the legacy `recordings.merged` column. A manual backup is a cheap extra insurance:
+
+```bash
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-upgrade
+```
+
+The migration:
+1. Backs up the DB to `<db>.pre-v29-backup` (best-effort; failures only log a warning).
+2. Updates `merge_status='merged'` for any row with the old `merged=1` flag (safety net).
+3. Drops the `merged` column (`merge_status` is now the single source of truth).
+
+This is transparent for v0.9.x users. The v0.10.0 DB schema is at baseline **v29**.
+
+### 🟡 Step 3 — Reclaim leaked merge MP4 files (post-deploy, OPTIONAL but recommended)
+
+A bug fixed in 0.10.0 (#117/#119) meant that deleting a recording through the web UI before this fix did **not** delete its merged-output MP4 file on disk. The fix covers future deletes, but **files leaked before the upgrade are still on disk**. Reclaim them with the repair CLI:
+
+```bash
+# 1. Dry-run first — see how much space is reclaimable
+./mibee-nvr repair reclaim-orphan-merges --dry-run
+
+# 2. Apply (default throttle is 20ms between deletes — USB-HDD friendly)
+./mibee-nvr repair reclaim-orphan-merges --execute
+
+# Optional: limit to one camera, cap the count
+./mibee-nvr repair reclaim-orphan-merges --execute --camera front-door --limit 1000
+```
+
+Only `.mp4` files that no recording row references (neither as `file_path` nor `merge_path`) are removed. Source frame directories and raw segments are never touched. `--dry-run` is the default.
+
+### 🟡 Step 4 — Note changed defaults (affects you only if you left these unset)
+
+| Setting | v0.9.1 default | 0.10.0 default | Notes |
+|---------|----------------|----------------|-------|
+| `cleanup.disk_threshold_percent` | 95 | **85** | Triggers cleanup earlier, avoiding the HDD performance cliff that starts around 90% full. Only applies if your config leaves it at `0`/unset — an explicit value is preserved. |
+| `cameras[].timelapse.merge_duration` | `"1h"` | **`"natural-day"`** | Per-camera timelapse now defaults to a midnight-aligned 24h window (in your configured timezone). The previous 1h hard cap is removed; `8h`/`12h`/`24h`/`7d`/`30d`/`natural-day` and arbitrary durations ≤ 30d are accepted. Note: **rolling-window merge** (`merge.rolling_window`) is still capped at 1h. |
+
+### 🟢 Removed API endpoints (affects external scripts only)
+
+Two timelapse endpoints were removed (the underlying gallery feature was replaced by Timelapse v3 periodic merges):
+
+| Removed (0.10.0 returns 404) | Replacement |
+|-------------------------------|-------------|
+| `GET /api/timelapse/{id}/thumbnail` | `GET /api/timelapse/merges` + `GET /api/timelapse/merges/{id}` |
+| `GET /api/timelapse/{id}/preview` | `GET /api/timelapse/merges/{id}/download` (sets `X-Timelapse-Codec` header so the frontend picks `<video>` vs JPEG cycler) |
+
+If you have external scripts or bookmarks pointing at the old endpoints, migrate them. The NVR's own frontend already uses the new endpoints.
+
+### 🟢 `streaming.default_protocol` field removed (silent — stale YAML keys are ignored)
+
+The global `streaming.default_protocol` config field was removed. The frontend's Player Orchestrator now auto-selects the best protocol per camera (probes `/api/cameras/{id}/protocols`, folds in codec + browser capability, demotes on health failure, upgrades after stability). A global default only added config-cognition overhead.
+
+- **You don't need to do anything.** A stale `default_protocol:` key in your existing YAML is **silently ignored** (YAML decoding does not strict-check unknown fields). No startup error.
+- Per-camera overrides remain available via the Protocol Switcher on each camera's LiveView page.
+- **Behavior change for H.264 cameras with no per-camera override:** the initial protocol preference is now the latency-optimal order (`webrtc > flv > ll-hls > hls > mjpeg`), instead of a global default (usually `hls`). The orchestrator still adapts at runtime — this only changes the first choice.
+
+### 🟢 New config fields (all backward-compatible, safe defaults)
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `merge.rolling_backfill_concurrency` | `0` (auto: 1 if ≤2GB RAM, else 3) | Bounds concurrent cameras during rolling-merge backfill. |
+| `streaming.webrtc.ice_servers` | `[]` (LAN-only) | STUN/TURN servers for cross-network WebRTC. Empty = LAN-only (old behavior). |
+| `cameras[].timelapse.retain_intermediate_mp4` | `false` | Keep rolling-merge intermediate MP4 files after a periodic merge folds them in (default: clean up to save disk — ~1.5GB/day/camera). |
+
+### Pre-flight checklist
+
+```bash
+# 1. Fix combined protocol strings (REQUIRED — blocks startup otherwise)
+grep -nE 'protocol:\s*".*_(h264|h265|mjpeg|jpeg)"' mibee-nvr.yaml
+#   → split every match into protocol + encoding
+
+# 2. Back up the DB (cheap insurance on top of the auto v29 backup)
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-upgrade
+
+# 3. Deploy the new binary, start the service, confirm health
+curl http://localhost:9090/api/health
+
+# 4. After deploy: reclaim pre-fix leaked merge MP4s (one-time)
+./mibee-nvr repair reclaim-orphan-merges --dry-run     # review
+./mibee-nvr repair reclaim-orphan-merges --execute     # apply
+```
+
+### Notes for self-builders (not release binaries)
+
+If you build the binary yourself rather than using a release artifact:
+
+- **Build the frontend before the Go binary.** The embedded SPA (`internal/ui/static/`) must be regenerated with `cd web && npm run build` (or `make build`, which does this for you). A stale embedded UI bundle may still reference removed endpoints and produce 404s in the browser.
+- Release binaries are built with a fresh frontend; this only affects local/custom builds.
+
+---
+
+## < v0.9.x → v0.10.0: NOT supported (direct)
+
+You **cannot** upgrade directly from below v0.9.x to 0.10.0. There is no startup-time version guard that aborts the process, but you will hit one of these failures instead:
+
+- **DB timestamp parsing fails.** 0.10.0 removed support for legacy Go `time.Time.String()` formats — the monotonic-clock suffix (`m=+...`) and timezone abbreviations (`CST`). Rows containing these formats become zero-time. v0.9.x rewrote these to canonical SQLite timestamps; you must run v0.9.x first to normalize them.
+- **DB schema is too old.** The v28→v29 migration assumes the v28 schema (produced by v0.9.x). Earlier schemas lack columns the migration expects.
+
+**Correct path:** upgrade to the latest v0.9.x first, let it run once to normalize the DB, then upgrade to 0.10.0.
+
+---
+
+## General upgrade best practices
+
+1. **Always back up** `nvr.db` and `mibee-nvr.yaml` before upgrading.
+2. **Read the release notes** for the version you're targeting — this guide covers structural changes; release notes cover features and fixes.
+3. **Stop the service** before replacing the binary (`systemctl stop mibee-nvr`), then start it again after.
+4. **Check health** after deploy: `curl http://localhost:9090/api/health` should return `{"status":"ok",...}`.
+5. **Watch the logs** for the first few minutes: `journalctl -u mibee-nvr -f`.
+6. **Roll back** if needed: `make rollback RPi_HOST=user@host` restores the previous binary. The DB backup lets you restore the data if necessary.

--- a/docs/zh/upgrade-guide.md
+++ b/docs/zh/upgrade-guide.md
@@ -1,0 +1,166 @@
+# 升级指南
+
+本指南覆盖 MiBee NVR 各版本间的升级路径与破坏性变更。**升级前务必备份数据库与配置文件。**
+
+## 升级路径速查表
+
+| 起始 → 目标 | 状态 | 需要的操作 |
+|------------|------|----------|
+| **v0.9.1 → 0.10.0** | 🟡 **需要操作** | 拆分组合 `protocol` 字符串；可选的磁盘回收。详见 [v0.9.1 → 0.10.0](#v091--v0100)。 |
+| v0.9.0 → v0.9.1 | 🟢 透明升级 | 无需操作。 |
+| v0.8.x → v0.9.x | 🟡 先备份 | 大型存储层重构。备份数据库后升级。 |
+| v0.8.x → 0.10.0 | 🟡 两步走 | 先升级到 v0.9.x，再升级到 0.10.0。 |
+| **< v0.9.x → 0.10.0** | 🔴 **不支持（直升级）** | **必须**先升级到 0.9.x —— 原因见 [下文](#低于-v09x--v0100-不支持直升级)。 |
+
+---
+
+## v0.9.1 → v0.10.0
+
+0.10.0 是一次大版本发布（H.265 WASM 直播、Timelapse v3、无状态签名 token、MJPEG 走 WebSocket、AI 模型完整性加固、0.10.0 架构清理）。其中包含几项**破坏性变更**，需要一次性的配置修改或部署后处理。
+
+### 🔴 第 1 步 —— 拆分组合协议字符串（必做，否则无法启动）
+
+0.10.0 在配置校验阶段**拒绝**组合协议字符串（如 `"rtsp_h264"`）。这是**硬错误**——不修复就无法启动。
+
+**检查你的配置：**
+
+```bash
+grep -nE 'protocol:\s*".*_(h264|h265|mjpeg|jpeg)"' /path/to/mibee-nvr.yaml
+```
+
+**如有命中，拆成两个字段：**
+
+```yaml
+# ❌ 升级前（0.9.x 接受，0.10.0 拒绝）
+- id: "front-door"
+  protocol: "rtsp_h264"
+  url: "rtsp://..."
+
+# ✅ 升级后
+- id: "front-door"
+  protocol: "rtsp"
+  encoding: "h264"
+  url: "rtsp://..."
+```
+
+漏改时启动会报：
+
+```
+camera[0].protocol "rtsp_h264": combined format is no longer supported in
+0.10.0+; split into separate protocol ("rtsp") and encoding fields
+```
+
+适用于所有 `protocol` 含下划线的相机（`rtsp_h264`、`rtsp_h265`、`rtsp_mjpeg`、`http_jpeg`、`onvif_jpeg` 等）。
+
+### 🔴 第 2 步 —— 备份数据库（强烈建议）
+
+v28 → v29 的 schema 迁移会**自动**通过 `VACUUM INTO` 在删除旧的 `recordings.merged` 列之前备份到 `<db>.pre-v29-backup`。手动备份是多一层保险：
+
+```bash
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-upgrade
+```
+
+迁移流程：
+1. 备份数据库到 `<db>.pre-v29-backup`（尽力而为；失败只记 warning）。
+2. 为旧 `merged=1` 标志的行更新 `merge_status='merged'`（安全网）。
+3. 删除 `merged` 列（`merge_status` 现在是唯一真相源）。
+
+对 v0.9.x 用户**透明**。0.10.0 的 DB schema 基线为 **v29**。
+
+### 🟡 第 3 步 —— 回收泄漏的合并 MP4 文件（部署后，可选但推荐）
+
+0.10.0 修复了一个 bug（#117/#119）：在该修复之前，通过 Web UI 删除录像时**不会**删除磁盘上的合并产物 MP4。修复覆盖未来的删除，但**升级前已泄漏的文件仍在磁盘**。用 repair CLI 回收：
+
+```bash
+# 1. 先 dry-run 看能回收多少空间
+./mibee-nvr repair reclaim-orphan-merges --dry-run
+
+# 2. 执行（删除间隔默认 20ms，对 USB HDD 友好）
+./mibee-nvr repair reclaim-orphan-merges --execute
+
+# 可选：限定单个相机、限制数量
+./mibee-nvr repair reclaim-orphan-merges --execute --camera front-door --limit 1000
+```
+
+只删除**没有任何录像行引用**（既不在 `file_path` 也不在 `merge_path`）的 `.mp4` 文件。原始帧目录和原始分段不会被触碰。`--dry-run` 是默认行为。
+
+### 🟡 第 4 步 —— 注意默认值变化（仅影响留空的配置项）
+
+| 配置项 | v0.9.1 默认 | 0.10.0 默认 | 说明 |
+|--------|------------|------------|------|
+| `cleanup.disk_threshold_percent` | 95 | **85** | 更早触发清理，避免 HDD 90%+ 满时的性能悬崖。仅当配置留空（`0`）时生效——显式设置的值会被保留。 |
+| `cameras[].timelapse.merge_duration` | `"1h"` | **`"natural-day"`** | 单相机 timelapse 默认改为按配置时区对齐到午夜的 24h 窗口。之前的 1h 硬上限已移除；支持 `8h`/`12h`/`24h`/`7d`/`30d`/`natural-day` 以及任意 ≤ 30d 的时长。注意：**rolling-window 合并**（`merge.rolling_window`）仍硬限制 1h。 |
+
+### 🟢 移除的 API 端点（仅影响外部脚本）
+
+两个 timelapse 端点被移除（底层的 gallery 功能被 Timelapse v3 周期合并取代）：
+
+| 移除（0.10.0 返回 404） | 替代 |
+|------------------------|------|
+| `GET /api/timelapse/{id}/thumbnail` | `GET /api/timelapse/merges` + `GET /api/timelapse/merges/{id}` |
+| `GET /api/timelapse/{id}/preview` | `GET /api/timelapse/merges/{id}/download`（响应带 `X-Timelapse-Codec` 头，前端据此选择 `<video>` 播放器或 JPEG 轮播） |
+
+如有外部脚本或书签指向旧端点，请迁移。NVR 自身的前端已使用新端点。
+
+### 🟢 `streaming.default_protocol` 字段移除（静默——旧 YAML key 会被忽略）
+
+全局 `streaming.default_protocol` 配置字段已移除。前端 Player Orchestrator 现在按相机自动选择最佳协议（探测 `/api/cameras/{id}/protocols`、结合 codec + 浏览器能力、运行时根据健康状态降级/升级）。全局默认值只增加用户的配置认知负担。
+
+- **无需任何操作。** 旧 YAML 里的 `default_protocol:` key 会被**静默忽略**（YAML 解码不严格校验未知字段），不会报错。
+- 每相机的覆盖仍可通过各相机 LiveView 页的协议切换器设置。
+- **行为变更（针对未设覆盖的 H.264 相机）：** 初始协议偏好改为延迟最优顺序（`webrtc > flv > ll-hls > hls > mjpeg`），而非全局默认（通常是 `hls`）。Orchestrator 仍会运行时自适应——这仅改变首选。
+
+### 🟢 新增配置字段（全部向后兼容，默认值安全）
+
+| 字段 | 默认值 | 用途 |
+|------|--------|------|
+| `merge.rolling_backfill_concurrency` | `0`（自动：≤2GB RAM 用 1，否则 3） | 限制滚动合并回填时的并发相机数。 |
+| `streaming.webrtc.ice_servers` | `[]`（仅局域网） | 跨网 WebRTC 的 STUN/TURN 服务器。空 = 仅局域网（旧行为）。 |
+| `cameras[].timelapse.retain_intermediate_mp4` | `false` | 周期合并折叠后是否保留滚动合并的中间 MP4 文件（默认清理以节省磁盘——约 1.5GB/天/相机）。 |
+
+### 升级前清单
+
+```bash
+# 1. 拆分组合协议字符串（必做——否则无法启动）
+grep -nE 'protocol:\s*".*_(h264|h265|mjpeg|jpeg)"' mibee-nvr.yaml
+#   → 每个命中项拆为 protocol + encoding
+
+# 2. 备份数据库（在自动 v29 备份基础上多一层保险）
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-upgrade
+
+# 3. 部署新二进制，启动服务，确认健康
+curl http://localhost:9090/api/health
+
+# 4. 部署后：回收修复前泄漏的合并 MP4（一次性）
+./mibee-nvr repair reclaim-orphan-merges --dry-run     # 检查
+./mibee-nvr repair reclaim-orphan-merges --execute     # 执行
+```
+
+### 自行构建者须知（非 release 二进制）
+
+如果你自己构建二进制而非使用 release 产物：
+
+- **Go 二进制构建前必须先构建前端。** 嵌入的 SPA（`internal/ui/static/`）必须用 `cd web && npm run build`（或 `make build`，它已包含此步）重新生成。过期的嵌入 UI bundle 可能仍引用已移除的端点，导致浏览器报 404。
+- Release 二进制是用全新前端构建的；这只影响本地/自定义构建。
+
+---
+
+## 低于 v0.9.x → v0.10.0：不支持直升级
+
+**不能**从低于 v0.9.x 的版本直接升级到 0.10.0。代码里没有启动时的版本 guard 来中断进程，但你会遇到以下失败之一：
+
+- **DB 时间戳解析失败。** 0.10.0 移除了对旧 Go `time.Time.String()` 格式的支持——monotonic clock 后缀（`m=+...`）和时区缩写（`CST`）。含这些格式的行会变成零时间。v0.9.x 已把这些重写为规范的 SQLite 时间戳；必须先跑 v0.9.x 完成规范化。
+- **DB schema 太旧。** v28→v29 迁移假设 v28 schema（由 v0.9.x 产生）。更早的 schema 缺少迁移所需的列。
+
+**正确路径：** 先升级到最新的 v0.9.x，让它跑一次以规范化数据库，再升级到 0.10.0。
+
+---
+
+## 通用升级最佳实践
+
+1. **始终备份** `nvr.db` 和 `mibee-nvr.yaml`。
+2. **阅读目标版本的 release notes**——本指南覆盖结构性变更；release notes 覆盖功能与修复。
+3. **替换二进制前先停服务**（`systemctl stop mibee-nvr`），替换后再启动。
+4. **部署后检查健康**：`curl http://localhost:9090/api/health` 应返回 `{"status":"ok",...}`。
+5. **头几分钟观察日志**：`journalctl -u mibee-nvr -f`。
+6. **必要时回滚**：`make rollback RPi_HOST=user@host` 恢复上一个二进制。DB 备份让你在需要时能恢复数据。


### PR DESCRIPTION
## What

Adds the project's first upgrade guide (English + Chinese), covering the v0.9.1 → 0.10.0 path. Closes #128.

## Why

0.10.0 contains breaking changes that will trip up unwary upgraders — most notably the combined-protocol-string rejection that **blocks startup**. Users upgrading from v0.9.1 need a single, accurate reference with a pre-flight checklist.

## What's covered

All breaking changes were verified against the actual code on `main` (`463cc56`), not from any analysis doc.

- 🔴 **Combined protocol strings rejected** (blocks startup) — how to detect + split, with the exact startup error string
- 🔴 **DB schema v28→v29** — auto `VACUUM INTO` backup at `*.pre-v29-backup`, `UPDATE merge_status` safety net, `DROP merged` column. Transparent for 0.9.x users.
- 🟡 **`reclaim-orphan-merges` CLI** — reclaims pre-fix leaked merge MP4s (#117/#119), with dry-run/execute examples
- 🟡 **Changed defaults**: `disk_threshold_percent` 95→85, `timelapse.merge_duration` `1h`→`natural-day`
- 🟢 **Removed API endpoints**: `/api/timelapse/{id}/{thumbnail,preview}` → `/api/timelapse/merges*`
- 🟢 **`streaming.default_protocol` field removed** (silent — stale YAML ignored); the H.264 first-preference behavior change is documented
- 🟢 **New backward-compat fields**: `rolling_backfill_concurrency`, `webrtc.ice_servers`, `timelapse.retain_intermediate_mp4`
- 🔴 **`< v0.9.x → 0.10.0` not supported** — correct two-hop path explained
- **Self-builders note**: rebuild the frontend before the Go binary (stale embedded UI may 404 on removed endpoints)

README "Documentation" table updated with links to both language versions.

## Key accuracy corrections vs the original issue #128 scope

Two claims from issue #128 needed correcting after code verification:

1. **There is no code-enforced startup guard blocking `< v0.9.x` upgrades.** The practical barrier is `parseTime` rejecting legacy timestamp formats (`m=+...` monotonic suffix, `CST` timezone abbreviation). The guide states this accurately rather than claiming a hard gate.
2. **Only `timelapse.merge_duration` is uncapped.** `merge.rolling_window` is still hard-capped at 1h. The guide distinguishes the two to prevent confusion.

## Validation

- [x] All breaking-change claims verified against code on `main` (`463cc56`): config.go, db.go, handler.go, repair.go
- [x] Internal anchor links consistent (en + zh)
- [x] README Documentation table updated
- [ ] CI (this PR — docs-only, expected green)