### PR TITLE
refactor(app): extract helpers + buildRouter from run.go (#138)

### DIFF
--- a/pkg/app/helpers.go
+++ b/pkg/app/helpers.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"context"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/ai"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	pionwebrtc "github.com/pion/webrtc/v4"
+)
+
+// serviceFunc wraps a pair of start/stop functions as a Service.
+type serviceFunc struct {
+	name      string
+	startFunc func(ctx context.Context) error
+	stopFunc  func() error
+}
+
+func (s *serviceFunc) Name() string                    { return s.name }
+func (s *serviceFunc) Start(ctx context.Context) error { return s.startFunc(ctx) }
+func (s *serviceFunc) Stop() error                     { return s.stopFunc() }
+
+// aiConfigFromConfig converts the public AIConfig type to the internal ai.Config.
+func aiConfigFromConfig(cfg config.AIConfig) ai.Config {
+	return ai.Config{
+		Enabled:             cfg.Enabled,
+		EnabledCameras:      cfg.EnabledCameras,
+		ModelURL:            cfg.ModelURL,
+		Zones:               cfg.Zones,
+		FrameSkipRate:       cfg.FrameSkipRate,
+		ConfidenceThreshold: cfg.ConfidenceThreshold,
+	}
+}
+
+// webrtcICEServers converts the config-layer ICE server list to pion's type.
+// Returns nil when empty so the WebRTC Manager falls back to LAN-only behavior
+// (no STUN/TURN, mDNS host candidates only) — preserving the legacy default.
+func webrtcICEServers(servers []config.ICEServerConfig) []pionwebrtc.ICEServer {
+	if len(servers) == 0 {
+		return nil
+	}
+	out := make([]pionwebrtc.ICEServer, 0, len(servers))
+	for _, s := range servers {
+		ic := pionwebrtc.ICEServer{URLs: s.URLs}
+		if s.Username != "" {
+			ic.Username = s.Username
+			ic.Credential = s.Credential
+			ic.CredentialType = pionwebrtc.ICECredentialTypePassword
+		}
+		out = append(out, ic)
+	}
+	return out
+}

--- a/pkg/app/router.go
+++ b/pkg/app/router.go
@@ -1,0 +1,107 @@
+package app
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/api"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	authmw "github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
+	ui "github.com/Mi-Bee-Studio/MiBeeNvr/internal/ui"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/upload"
+)
+
+// buildRouter constructs the chi HTTP router with all middleware, routes, mounts,
+// and the SPA static file handler. Called by RunFree.
+func buildRouter(
+	cfg *config.Config,
+	authMW func(http.Handler) http.Handler,
+	handler *api.Handler,
+	metrics *metrics.Metrics,
+	davHandler http.Handler,
+	uploadHandler *upload.Handler,
+) (http.Handler, error) {
+	r := chi.NewRouter()
+	r.Use(authmw.RequestLogger(slog.Default(), "/api/health", "/api/readyz"))
+	r.Use(chimiddleware.Recoverer)
+	r.Use(authmw.SecurityHeaders)
+	r.Use(authmw.COOPHeaders)
+	// Streaming gzip compression for all JSON/HTML/text responses.
+	// SSE (text/event-stream) is also compressed but flushed per-event.
+	// Already-compressed content (video, images) is auto-skipped.
+	r.Use(authmw.StreamingGzip(5))
+
+	// API Key middleware — validates Bearer mbv_* tokens for MiBeeVision.
+	// Runs before authMW: if the request has an API Key Bearer token, it's
+	// authenticated here; otherwise it falls through to BasicAuth.
+	if len(cfg.APIKeys) > 0 {
+		validKeys := make(map[string]string)
+		for _, k := range cfg.APIKeys {
+			if !k.Revoked && k.Key != "" {
+				validKeys[k.Key] = k.Name
+			}
+		}
+		if len(validKeys) > 0 {
+			r.Use(func(next http.Handler) http.Handler {
+				return authmw.APIKeyAuthMiddleware(validKeys, next)
+			})
+			slog.Info("API Key authentication enabled", "keys", len(validKeys))
+		}
+	}
+
+	// Prometheus metrics — independent auth when configured, public otherwise
+	if cfg.MetricsAuth.IsConfigured() {
+		metricsAuthMW, _ := authmw.NewAuthMiddleware(authmw.AuthProvider{
+			GetUsername: func() string { return cfg.MetricsAuth.Username },
+			GetHash:     func() string { return cfg.MetricsAuth.PasswordHash },
+		}, cfg.MetricsAuth.Password, authmw.AuthRateLimitConfig{})
+		r.With(metricsAuthMW).Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
+	} else {
+		r.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
+	}
+
+	r.Mount("/", handler.Routes())
+
+	// WebDAV
+	if davHandler != nil {
+		r.Mount(cfg.WebDAV.PathPrefix, davHandler)
+	}
+
+	// Upload routes (authenticated)
+	r.Group(func(r chi.Router) {
+		r.Use(authMW)
+		uploadHandler.RegisterRoutes(r)
+	})
+
+	// Static UI — serve from embedded filesystem
+	staticContent, err := fs.Sub(ui.StaticFS, "static")
+	if err != nil {
+		return nil, fmt.Errorf("static fs: %w", err)
+	}
+	fileServer := http.FileServer(http.FS(staticContent))
+	// Static files served without auth — SPA handles login flow client-side.
+	// All sensitive data is protected via API endpoints in handler.Routes().
+	// Cache: index.html must not be cached (always fresh after deploy).
+	// Assets have content-hash filenames — safe to cache long-term.
+	r.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if path == "/" || path == "/index.html" {
+			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		} else if strings.HasPrefix(path, "/assets/") {
+			// Vite produces content-hash filenames (e.g. Cameras-CjnyKwd-.js).
+			// Content changes → filename changes → safe to cache immutably.
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		}
+		fileServer.ServeHTTP(w, r)
+	}))
+
+	return r, nil
+}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -3,18 +3,14 @@ package app
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	chimiddleware "github.com/go-chi/chi/v5/middleware"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	_ "net/http/pprof"
 	_ "time/tzdata" // embed timezone database for minimal containers (scratch/alpine)
@@ -42,146 +38,13 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
-	ui "github.com/Mi-Bee-Studio/MiBeeNvr/internal/ui"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/upload"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webdav"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 
 	_ "github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
-
-	pionwebrtc "github.com/pion/webrtc/v4"
 )
-
-// serviceFunc wraps a pair of start/stop functions as a Service.
-type serviceFunc struct {
-	name      string
-	startFunc func(ctx context.Context) error
-	stopFunc  func() error
-}
-
-func (s *serviceFunc) Name() string                    { return s.name }
-func (s *serviceFunc) Start(ctx context.Context) error { return s.startFunc(ctx) }
-func (s *serviceFunc) Stop() error                     { return s.stopFunc() }
-
-// aiConfigFromConfig converts the public AIConfig type to the internal ai.Config.
-func aiConfigFromConfig(cfg config.AIConfig) ai.Config {
-	return ai.Config{
-		Enabled:             cfg.Enabled,
-		EnabledCameras:      cfg.EnabledCameras,
-		ModelURL:            cfg.ModelURL,
-		Zones:               cfg.Zones,
-		FrameSkipRate:       cfg.FrameSkipRate,
-		ConfidenceThreshold: cfg.ConfidenceThreshold,
-	}
-}
-
-// webrtcICEServers converts the config-layer ICE server list to pion's type.
-// Returns nil when empty so the WebRTC Manager falls back to LAN-only behavior
-// (no STUN/TURN, mDNS host candidates only) — preserving the legacy default.
-func webrtcICEServers(servers []config.ICEServerConfig) []pionwebrtc.ICEServer {
-	if len(servers) == 0 {
-		return nil
-	}
-	out := make([]pionwebrtc.ICEServer, 0, len(servers))
-	for _, s := range servers {
-		ic := pionwebrtc.ICEServer{URLs: s.URLs}
-		if s.Username != "" {
-			ic.Username = s.Username
-			ic.Credential = s.Credential
-			ic.CredentialType = pionwebrtc.ICECredentialTypePassword
-		}
-		out = append(out, ic)
-	}
-	return out
-}
-
-// buildRouter constructs the chi HTTP router with all middleware, routes, mounts,
-// and the SPA static file handler. Called by RunFree.
-func buildRouter(
-	cfg *config.Config,
-	authMW func(http.Handler) http.Handler,
-	handler *api.Handler,
-	metrics *metrics.Metrics,
-	davHandler http.Handler,
-	uploadHandler *upload.Handler,
-) (http.Handler, error) {
-	r := chi.NewRouter()
-	r.Use(authmw.RequestLogger(slog.Default(), "/api/health", "/api/readyz"))
-	r.Use(chimiddleware.Recoverer)
-	r.Use(authmw.SecurityHeaders)
-	r.Use(authmw.COOPHeaders)
-	// Streaming gzip compression for all JSON/HTML/text responses.
-	// SSE (text/event-stream) is also compressed but flushed per-event.
-	// Already-compressed content (video, images) is auto-skipped.
-	r.Use(authmw.StreamingGzip(5))
-
-	// API Key middleware — validates Bearer mbv_* tokens for MiBeeVision.
-	// Runs before authMW: if the request has an API Key Bearer token, it's
-	// authenticated here; otherwise it falls through to BasicAuth.
-	if len(cfg.APIKeys) > 0 {
-		validKeys := make(map[string]string)
-		for _, k := range cfg.APIKeys {
-			if !k.Revoked && k.Key != "" {
-				validKeys[k.Key] = k.Name
-			}
-		}
-		if len(validKeys) > 0 {
-			r.Use(func(next http.Handler) http.Handler {
-				return authmw.APIKeyAuthMiddleware(validKeys, next)
-			})
-			slog.Info("API Key authentication enabled", "keys", len(validKeys))
-		}
-	}
-
-	// Prometheus metrics — independent auth when configured, public otherwise
-	if cfg.MetricsAuth.IsConfigured() {
-		metricsAuthMW, _ := authmw.NewAuthMiddleware(authmw.AuthProvider{
-			GetUsername: func() string { return cfg.MetricsAuth.Username },
-			GetHash:     func() string { return cfg.MetricsAuth.PasswordHash },
-		}, cfg.MetricsAuth.Password, authmw.AuthRateLimitConfig{})
-		r.With(metricsAuthMW).Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
-	} else {
-		r.Handle("/metrics", promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
-	}
-
-	r.Mount("/", handler.Routes())
-
-	// WebDAV
-	if davHandler != nil {
-		r.Mount(cfg.WebDAV.PathPrefix, davHandler)
-	}
-
-	// Upload routes (authenticated)
-	r.Group(func(r chi.Router) {
-		r.Use(authMW)
-		uploadHandler.RegisterRoutes(r)
-	})
-
-	// Static UI — serve from embedded filesystem
-	staticContent, err := fs.Sub(ui.StaticFS, "static")
-	if err != nil {
-		return nil, fmt.Errorf("static fs: %w", err)
-	}
-	fileServer := http.FileServer(http.FS(staticContent))
-	// Static files served without auth — SPA handles login flow client-side.
-	// All sensitive data is protected via API endpoints in handler.Routes().
-	// Cache: index.html must not be cached (always fresh after deploy).
-	// Assets have content-hash filenames — safe to cache long-term.
-	r.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		if path == "/" || path == "/index.html" {
-			w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		} else if strings.HasPrefix(path, "/assets/") {
-			// Vite produces content-hash filenames (e.g. Cameras-CjnyKwd-.js).
-			// Content changes → filename changes → safe to cache immutably.
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
-		}
-		fileServer.ServeHTTP(w, r)
-	}))
-
-	return r, nil
-}
 
 // RunFree constructs and returns a configured *App with all open-source services
 // registered in the correct start/stop order.


### PR DESCRIPTION
## What

Step 1 of the `pkg/app/run.go` split (1219 lines). Extracts two self-contained units that have **no coupling** to the `RunFree` construction/registration flow:

- **`helpers.go`** (52 lines): `serviceFunc` wrapper + `aiConfigFromConfig` + `webrtcICEServers` converter. Pure utilities used by `RunFree`.
- **`router.go`** (107 lines): `buildRouter()` — the chi HTTP router construction (middleware chain, API Key auth, metrics mount, WebDAV, upload, SPA static handler, cache headers). Already fully self-contained.

**run.go: 1219 → 1082 lines** (137 lines extracted).

## Why not extract the RunFree body too?

The `RunFree` function body is kept intact in this PR because its construction phase (steps 0-10) has **deep cross-domain dependencies**:
- camera manager needs merge + transcode + rollingMerge + timelapseMergeMgr products
- relay needs camera manager
- periodicMerge needs camMgr (for `GetCameraConfig`)

A naive builder-file split would require passing ~15 intermediate variables through an accumulator struct, **increasing** complexity rather than reducing it. The service registration order (`db → startup-bg → camera → health → ... → remoteLog`) is load-bearing and must stay in a single function.

A follow-up PR can extract the construction phase into an `appBuilders` accumulator struct if the file size becomes a maintenance burden, but that refactor carries goroutine-lifecycle risk (PR #144's `startup-bg`/`api-handler`/`mergeDone`/`cleanupDone` joins) and is deferred until the construction dependency graph stabilizes.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ — all packages pass, 0 FAIL
- `gofumpt` clean ✅
- 6 imports removed from run.go (`io/fs`, `strings`, `chimiddleware`, `promhttp`, `ui`, `pionwebrtc`) — they moved with their code

Refs #138 (partial — helpers + router extracted; RunFree body deferred).