### PR TITLE
refactor(web): extract merge-utils + fix getTranscodingStatus import (#136)

### DIFF
--- a/web/src/lib/recording/merge-utils.test.ts
+++ b/web/src/lib/recording/merge-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  saveMergeState,
+  clearMergeState,
+  getMergeStateForCamera,
+  computeMergeEta,
+  MERGE_STORAGE_KEY,
+} from './merge-utils';
+
+describe('merge-utils sessionStorage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('saveMergeState persists data keyed by cameraId', () => {
+    saveMergeState({ cameraId: 'cam-1', recordingId: 'rec-1', progress: 42, status: 'pending' });
+    const stored = getMergeStateForCamera('cam-1');
+    expect(stored).not.toBeNull();
+    expect(stored!.progress).toBe(42);
+    expect(stored!.status).toBe('pending');
+    expect(stored!.recordingId).toBe('rec-1');
+  });
+
+  it('saveMergeState preserves other cameras', () => {
+    saveMergeState({ cameraId: 'cam-1', recordingId: 'r1', progress: 10, status: 'pending' });
+    saveMergeState({ cameraId: 'cam-2', recordingId: 'r2', progress: 20, status: 'pending' });
+    expect(getMergeStateForCamera('cam-1')?.progress).toBe(10);
+    expect(getMergeStateForCamera('cam-2')?.progress).toBe(20);
+  });
+
+  it('clearMergeState removes only the specified camera', () => {
+    saveMergeState({ cameraId: 'cam-1', recordingId: 'r1', progress: 10, status: 'pending' });
+    saveMergeState({ cameraId: 'cam-2', recordingId: 'r2', progress: 20, status: 'pending' });
+    clearMergeState('cam-1');
+    expect(getMergeStateForCamera('cam-1')).toBeNull();
+    expect(getMergeStateForCamera('cam-2')?.progress).toBe(20);
+  });
+
+  it('clearMergeState removes the storage key entirely when empty', () => {
+    saveMergeState({ cameraId: 'cam-1', recordingId: 'r1', progress: 10, status: 'pending' });
+    clearMergeState('cam-1');
+    expect(sessionStorage.getItem(MERGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('getMergeStateForCamera returns null for unknown camera', () => {
+    expect(getMergeStateForCamera('nope')).toBeNull();
+  });
+
+  it('handles corrupted sessionStorage gracefully', () => {
+    sessionStorage.setItem(MERGE_STORAGE_KEY, '{invalid json');
+    expect(getMergeStateForCamera('cam-1')).toBeNull();
+    // Should not throw on save/clear either
+    expect(() => saveMergeState({ cameraId: 'x', recordingId: 'y', progress: 1, status: 's' })).not.toThrow();
+    expect(() => clearMergeState('x')).not.toThrow();
+  });
+});
+
+describe('computeMergeEta', () => {
+  it('returns empty string when startTime is 0', () => {
+    expect(computeMergeEta(0, 50, 1000000)).toBe('');
+  });
+
+  it('returns empty string when progress is 0 or negative', () => {
+    expect(computeMergeEta(1000, 0, 2000)).toBe('');
+    expect(computeMergeEta(1000, -5, 2000)).toBe('');
+  });
+
+  it('returns empty string when elapsed < 1 second', () => {
+    expect(computeMergeEta(1000, 50, 1500)).toBe('');
+  });
+
+  it('returns "< 1min" when remaining is under 1 minute', () => {
+    // 50% progress after 10s → total ~20s → remaining ~10s < 60s
+    expect(computeMergeEta(1000, 50, 11000)).toBe('< 1min');
+  });
+
+  it('returns "~Xm Ys" format for longer remaining times', () => {
+    // 25% progress after 30s → total ~120s → remaining ~90s → but that's <1min
+    // Let's use: 10% progress after 60s → total ~600s → remaining ~540s = 9min
+    const result = computeMergeEta(1000, 10, 61000);
+    expect(result).toMatch(/^~\d+m \d+s$/);
+    // 540s = 9m 0s
+    expect(result).toBe('~9m 0s');
+  });
+
+  it('computes correctly at high progress', () => {
+    // 90% progress after 90s → total ~100s → remaining ~10s < 60s
+    expect(computeMergeEta(1000, 90, 91000)).toBe('< 1min');
+  });
+});

--- a/web/src/lib/recording/merge-utils.ts
+++ b/web/src/lib/recording/merge-utils.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure utility functions for timelapse merge state management.
+ *
+ * Extracted from RecordingDetail.svelte (#136) to enable unit testing and
+ * reuse. These functions have NO Svelte rune dependencies — they operate on
+ * plain sessionStorage and return plain values. The component wires the return
+ * values into its $state variables.
+ */
+
+/** sessionStorage key for cross-page merge-in-progress tracking. */
+export const MERGE_STORAGE_KEY = 'mibee_nvr_merge_active';
+
+export interface MergeStateData {
+  cameraId: string;
+  recordingId: string;
+  progress: number;
+  status: string;
+}
+
+export interface StoredMergeState {
+  progress: number;
+  status: string;
+  recordingId: string;
+}
+
+/** Persist merge progress to sessionStorage so it survives navigation away. */
+export function saveMergeState(data: MergeStateData): void {
+  try {
+    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
+    all[data.cameraId] = data;
+    sessionStorage.setItem(MERGE_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // sessionStorage may be unavailable (private mode, SSR) — silently skip
+  }
+}
+
+/** Remove a camera's merge state from sessionStorage. */
+export function clearMergeState(cameraId: string): void {
+  try {
+    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
+    delete all[cameraId];
+    if (Object.keys(all).length === 0) {
+      sessionStorage.removeItem(MERGE_STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(MERGE_STORAGE_KEY, JSON.stringify(all));
+    }
+  } catch {
+    // silently skip
+  }
+}
+
+/** Read a camera's persisted merge state, or null if not found. */
+export function getMergeStateForCamera(cameraId: string): StoredMergeState | null {
+  try {
+    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
+    return all[cameraId] || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Estimate remaining time for an in-progress merge based on elapsed time and
+ * current progress percentage.
+ *
+ * @param startTime - epoch ms when the merge started (0 = not started)
+ * @param progressPct - current progress 0-100
+ * @param now - epoch ms (injectable for testing; defaults to Date.now())
+ * @returns human-readable ETA string ('< 1min', '~Xm Ys') or '' if not enough data
+ */
+export function computeMergeEta(startTime: number, progressPct: number, now: number = Date.now()): string {
+  if (!startTime || progressPct <= 0) {
+    return '';
+  }
+  const elapsed = now - startTime;
+  if (elapsed < 1000) {
+    return '';
+  }
+  const totalEstimate = (elapsed / progressPct) * 100;
+  const remaining = totalEstimate - elapsed;
+  if (remaining < 60000) {
+    return '< 1min';
+  }
+  const mins = Math.floor(remaining / 60000);
+  const secs = Math.floor((remaining % 60000) / 1000);
+  return `~${mins}m ${secs}s`;
+}

--- a/web/src/routes/RecordingDetail.svelte
+++ b/web/src/routes/RecordingDetail.svelte
@@ -20,7 +20,7 @@
     ApiRequestError
   } from '$lib/api';
   import type { ManagerStatus, TranscodeTask } from '$lib/api/transcoding';
-  import { enqueueTranscodeTask, getTranscodingTasks } from '$lib/api/transcoding';
+  import { enqueueTranscodeTask, getTranscodingStatus, getTranscodingTasks } from '$lib/api/transcoding';
   import type { Recording, TimelapseFrame, TimelapsePreviewFrame } from '$lib/api';
   import { formatDate, formatDuration, formatFileSize } from '$lib/format';
   import { AlertTriangle, HelpCircle, SkipForward, Loader2, RefreshCw, Play, Pause, ChevronLeft, ChevronRight } from 'lucide-svelte';
@@ -130,35 +130,9 @@ let timelapsePreviewFrames = $state<TimelapsePreviewFrame[]>([]);
 let timelapsePreviewLoading = $state(false);
 let timelapsePreviewError = $state('');
 
-// SessionStorage merge tracking — survives navigation away and page refresh
-const MERGE_STORAGE_KEY = 'mibee_nvr_merge_active';
-
-function saveMergeState(data: { cameraId: string; recordingId: string; progress: number; status: string }) {
-  try {
-    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
-    all[data.cameraId] = data;
-    sessionStorage.setItem(MERGE_STORAGE_KEY, JSON.stringify(all));
-  } catch {}
-}
-
-function clearMergeState(cameraId: string) {
-  try {
-    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
-    delete all[cameraId];
-    if (Object.keys(all).length === 0) {
-      sessionStorage.removeItem(MERGE_STORAGE_KEY);
-    } else {
-      sessionStorage.setItem(MERGE_STORAGE_KEY, JSON.stringify(all));
-    }
-  } catch {}
-}
-
-function getMergeStateForCamera(cameraId: string): { progress: number; status: string; recordingId: string } | null {
-  try {
-    const all = JSON.parse(sessionStorage.getItem(MERGE_STORAGE_KEY) || '{}');
-    return all[cameraId] || null;
-  } catch { return null; }
-}
+// SessionStorage merge tracking — survives navigation away and page refresh.
+// The pure helpers are extracted to $lib/recording/merge-utils.ts for unit testing.
+import { saveMergeState, clearMergeState, getMergeStateForCamera, computeMergeEta } from '$lib/recording/merge-utils';
 
 /** Restore merge state from DB or sessionStorage when returning to this page */
 function restoreMergeState(rec: Recording) {
@@ -760,24 +734,7 @@ async function handleCancelMerge() {
 
 // --- Merge ETA ---
 function updateMergeEta() {
-  if (!mergeStartTime || mergeProgressPct <= 0) {
-    mergeEta = '';
-    return;
-  }
-  const elapsed = Date.now() - mergeStartTime;
-  if (elapsed < 1000) {
-    mergeEta = '';
-    return;
-  }
-  const totalEstimate = elapsed / mergeProgressPct * 100;
-  const remaining = totalEstimate - elapsed;
-  if (remaining < 60000) {
-    mergeEta = '< 1min';
-  } else {
-    const mins = Math.floor(remaining / 60000);
-    const secs = Math.floor((remaining % 60000) / 1000);
-    mergeEta = `~${mins}m ${secs}s`;
-  }
+  mergeEta = computeMergeEta(mergeStartTime, mergeProgressPct);
 }
 
 // --- Timelapse Preview ---


### PR DESCRIPTION
## What

Two changes to `RecordingDetail.svelte` (1835 lines, the largest frontend file):

### 1. Fix latent runtime bug: missing `getTranscodingStatus` import

`getTranscodingStatus()` was called in `loadTranscodingStatus()` (line 1030) but **never imported** — the import block only pulled `ManagerStatus`, `TranscodeTask`, `enqueueTranscodeTask`, `getTranscodingTasks`. This caused a `ReferenceError` whenever the transcoding status poll ran (every 3s after page load), silently breaking the transcode-status badge.

### 2. Extract pure merge helpers to `web/src/lib/recording/merge-utils.ts` (new, 87 lines)

Extracted from inline functions in RecordingDetail.svelte:
- `saveMergeState` / `clearMergeState` / `getMergeStateForCamera` — sessionStorage cross-page merge-in-progress tracking
- `computeMergeEta` — ETA estimation from elapsed time + progress percentage

These had **zero test coverage** as inline functions. Now extracted as pure functions with **12 unit tests** (`merge-utils.test.ts`) covering:
- sessionStorage CRUD (save/clear/get for single + multiple cameras)
- corrupted-storage resilience (invalid JSON doesn't throw)
- ETA edge cases (0 progress, <1s elapsed, <1min remaining, long remaining, high progress)

**RecordingDetail.svelte: 1835 → 1792 lines** (43 lines extracted)

## Why not the full component split?

The full multi-component extraction (PlaybackPanel / TimelapsePlayer / MergePanel / RecordingInfoCard) requires visual regression testing of:
- `bind:this` imperative APIs (global keyboard handler delegates to active player)
- Cross-component state wiring (`pendingTimelineSeekOffset`, `transcodingStatus` shared state)
- SSE reconnect + sessionStorage lifecycle in MergePanel (rendered in 2 places)

This is deferred to a follow-up PR with browser-based verification. This PR delivers the safe, high-value extractions: the bug fix + testable pure helpers.

## Verification

- `npm run build` ✅ (built in 3.6s)
- `npm test` ✅ — **474 tests pass** (including 12 new merge-utils tests)
- `npm run format` ✅

Refs #136 (partial — utils extracted + bug fixed; full component split deferred).