### PR TITLE
fix(autodiscover): normalize endpoint URLs — prevent spurious recorder restarts from :80/scheme/host mismatch (#133)

### DIFF
--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -22,6 +22,7 @@ package autodiscover
 import (
 	"context"
 	"log/slog"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -69,12 +70,13 @@ type dedupKey struct {
 }
 
 // makeDedupKey returns the dedup key for a device. serial takes precedence;
-// empty serial falls back to endpoint (legacy behavior).
+// empty serial falls back to a normalized endpoint (so http://x:80 and
+// http://x produce the same key).
 func makeDedupKey(endpoint, serial string) dedupKey {
 	if s := strings.TrimSpace(serial); s != "" {
 		return dedupKey{identity: "serial:" + s}
 	}
-	return dedupKey{identity: "endpoint:" + endpoint}
+	return dedupKey{identity: "endpoint:" + normalizeEndpoint(endpoint)}
 }
 
 // Adder is the shared enrollment pipeline invoked by both the passive listener
@@ -183,14 +185,58 @@ func (a *Adder) HandleDiscovered(ctx context.Context, dev onvif.DiscoveredDevice
 // canonicalEndpoint returns the device service URL to use as the dedup key and
 // the camera's ONVIFEndpoint. Prefers the explicit Endpoint field; falls back to
 // the first XAddrs entry. Empty if neither is present (device not usable).
+//
+// The result is normalized via normalizeEndpoint so that semantically-identical
+// endpoints (e.g. http://1.2.3.4:80/... vs http://1.2.3.4/...) produce the same
+// string — critical for dedup and endpointChanged comparisons. Without this,
+// a device added via manual probe (which forces :80) would appear "changed" when
+// auto-discover later sees it via WS-Discovery Hello (device-controlled XAddr
+// format, often without :80), triggering a spurious recorder restart every
+// dedup window. Same bug class as the trailing-slash issue fixed in PR #123.
 func canonicalEndpoint(endpoint string, xaddrs []string) string {
 	if endpoint != "" {
-		return endpoint
+		return normalizeEndpoint(endpoint)
 	}
 	if len(xaddrs) > 0 {
-		return xaddrs[0]
+		return normalizeEndpoint(xaddrs[0])
 	}
 	return ""
+}
+
+// normalizeEndpoint canonicalizes an ONVIF device-service URL so that
+// semantically-identical endpoints compare equal. It:
+//   - lowercases the scheme and host (case-insensitive per RFC 3986)
+//   - elides the default port (:80 for http, :443 for https)
+//   - strips trailing slashes
+//
+// If the input is not a valid URL (unexpected for ONVIF XAddrs, but possible
+// from malformed firmware), it falls back to a best-effort strings.TrimRight
+// so the comparison never panics.
+func normalizeEndpoint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		// Fallback: at least strip trailing slashes (legacy behavior).
+		return strings.TrimRight(raw, "/")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	// Elide default ports.
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+	// Reconstruct the canonical form.
+	result := scheme + "://" + host
+	if port != "" {
+		result += ":" + port
+	}
+	path := strings.TrimRight(u.Path, "/")
+	result += path
+	return result
 }
 
 // matchesIgnoreScope reports whether any of the device's scopes contains any
@@ -283,7 +329,10 @@ func (a *Adder) findExistingCamera(ctx context.Context, endpoint, serial, stable
 // by the initial #121 fix, where a stable_id match unconditionally triggered
 // updateEndpointForRoaming).
 //
-// Comparison normalizes trailing slashes (mirrors AddCamera's endpoint dedup).
+// Comparison normalizes the URLs via normalizeEndpoint (lowercases scheme/host,
+// elides default ports :80/:443, strips trailing slashes) so that
+// semantically-identical endpoints from different discovery paths (manual probe
+// vs WS-Discovery Hello) compare equal — preventing spurious recorder restarts.
 // On DB error or missing row, returns true (fail-open: attempt the update, which
 // is idempotent and will no-op if the endpoint is in fact unchanged).
 func (a *Adder) endpointChanged(ctx context.Context, cameraID, discoveredEndpoint string) bool {
@@ -295,7 +344,7 @@ func (a *Adder) endpointChanged(ctx context.Context, cameraID, discoveredEndpoin
 		logger.Warn("roaming check: failed to read existing endpoint, failing open", "camera_id", cameraID, "error", err)
 		return true
 	}
-	return strings.TrimRight(existing, "/") != strings.TrimRight(discoveredEndpoint, "/")
+	return normalizeEndpoint(existing) != normalizeEndpoint(discoveredEndpoint)
 }
 
 // updateEndpointForRoaming updates an existing camera's ONVIF endpoint (and URL)

--- a/internal/autodiscover/adder_test.go
+++ b/internal/autodiscover/adder_test.go
@@ -424,6 +424,102 @@ func TestEndpointChanged(t *testing.T) {
 	require(adder.endpointChanged(ctx, camID+"-nope", ep), "unknown camera must fail-open (true)")
 }
 
+// TestEndpointChanged_PortAndSchemeNormalization is the regression test for the
+// port/scheme normalization gap (issue #133): a device added via manual probe
+// (which forces :80) must NOT appear "changed" when auto-discover later sees it
+// via WS-Discovery Hello with a device-controlled XAddr format (often without
+// :80). Without normalization, this triggered a spurious recorder restart every
+// dedup window — same bug class as the trailing-slash issue (PR #123).
+func TestEndpointChanged_PortAndSchemeNormalization(t *testing.T) {
+	t.Helper()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		stored     string
+		discovered string
+		changed    bool
+	}{
+		// Port normalization: :80 is default for http → same endpoint.
+		{"explicit-80 vs no-port", "http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4/onvif/device_service", false},
+		{"no-port vs explicit-80", "http://1.2.3.4/onvif/device_service", "http://1.2.3.4:80/onvif/device_service", false},
+		// Non-default port must still report changed.
+		{"port-80 vs port-81", "http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4:81/onvif/device_service", true},
+		// HTTPS default port :443.
+		{"https-443 vs no-port", "https://1.2.3.4:443/onvif/device_service", "https://1.2.3.4/onvif/device_service", false},
+		// Scheme case-insensitive.
+		{"HTTP vs http", "HTTP://1.2.3.4/onvif/device_service", "http://1.2.3.4/onvif/device_service", false},
+		// Host case-insensitive.
+		{"uppercase-host", "http://CAMERA.LOCAL/onvif/device_service", "http://camera.local/onvif/device_service", false},
+		// Trailing slash still handled.
+		{"trailing-slash", "http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4/onvif/device_service/", false},
+		// Different IP still changed.
+		{"different-ip", "http://1.2.3.4/onvif/device_service", "http://1.2.3.5/onvif/device_service", true},
+		// http vs https genuinely different (different listener).
+		{"http-vs-https", "http://1.2.3.4/onvif/device_service", "https://1.2.3.4/onvif/device_service", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			camID := "cam-norm-" + tc.name
+			if err := db.UpsertCamera(ctx, camID, "Cam", "onvif", "", "", "", "", tc.stored, "", "", "SERIAL-"+tc.name); err != nil {
+				t.Fatalf("UpsertCamera: %v", err)
+			}
+			adder := NewAdder(&config.AutoDiscoverConfig{}, nil, db, nil)
+			got := adder.endpointChanged(ctx, camID, tc.discovered)
+			if got != tc.changed {
+				t.Errorf("endpointChanged(stored=%q, discovered=%q) = %v, want %v",
+					tc.stored, tc.discovered, got, tc.changed)
+			}
+		})
+	}
+}
+
+// TestNormalizeEndpoint verifies the URL canonicalization helper directly.
+func TestNormalizeEndpoint(t *testing.T) {
+	t.Helper()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"http://1.2.3.4/onvif/device_service", "http://1.2.3.4/onvif/device_service"},
+		{"http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4/onvif/device_service"},
+		{"https://1.2.3.4:443/onvif/device_service", "https://1.2.3.4/onvif/device_service"},
+		{"http://1.2.3.4:8080/onvif/device_service", "http://1.2.3.4:8080/onvif/device_service"},
+		{"HTTP://1.2.3.4/Path", "http://1.2.3.4/Path"},
+		{"http://CAMERA.LOCAL/onvif/device_service", "http://camera.local/onvif/device_service"},
+		{"http://1.2.3.4/onvif/device_service/", "http://1.2.3.4/onvif/device_service"},
+		{"  http://1.2.3.4/onvif/device_service  ", "http://1.2.3.4/onvif/device_service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := normalizeEndpoint(tc.input)
+			if got != tc.want {
+				t.Errorf("normalizeEndpoint(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCanonicalEndpoint_Normalizes verifies that canonicalEndpoint normalizes
+// both the explicit endpoint and the XAddrs fallback path.
+func TestCanonicalEndpoint_Normalizes(t *testing.T) {
+	t.Helper()
+	// Explicit endpoint with :80 → normalized to no-port.
+	got := canonicalEndpoint("http://1.2.3.4:80/onvif/device_service", nil)
+	want := "http://1.2.3.4/onvif/device_service"
+	if got != want {
+		t.Errorf("canonicalEndpoint(endpoint=:80) = %q, want %q", got, want)
+	}
+	// Fallback to XAddrs — also normalized.
+	got = canonicalEndpoint("", []string{"http://1.2.3.4:80/onvif/device_service"})
+	if got != want {
+		t.Errorf("canonicalEndpoint(xaddrs=:80) = %q, want %q", got, want)
+	}
+}
+
 // TestUpdateEndpointForRoaming verifies that when auto-discover recognizes a
 // known device at a NEW endpoint, it updates the existing camera's endpoint and
 // restarts its recorder (issue #121 core fix).


### PR DESCRIPTION
## What

Fixes a **latent production bug** discovered while investigating issue #133:  compared ONVIF endpoint URLs as raw strings (only stripping trailing slashes), but different discovery code paths produce semantically-identical endpoints in different string formats — causing **spurious recorder restarts every ~5 minutes**.

## Root cause

Three discovery code paths format endpoints differently:

| Path | Format | Code |
|------|--------|------|
| Manual probe () | **Always** explicit  (incl. ) |  |
| WS-Discovery Hello | Device XAddr **verbatim** (often no ) |  |
| ProbeMatch sweep | Device XAddr **verbatim** |  |

So a camera added via manual probe (stored as ) that later re-announces via auto-discover () triggers:
1.  →  (strings differ)
2.  → 
3. Recording + live preview disrupted for ~5min (dedup window), then repeats

**Same bug class as the trailing-slash issue (PR #123)** — but the trailing-slash case was fixed while port/scheme/host were not.

The project's own test fixtures prove both formats occur on real devices:
-  — real ESP32: 
-  — real ProbeMatch:  (no )

## Fix

Add  that:
1. Lowercases scheme + host (case-insensitive per RFC 3986)
2. Elides default ports ( for http,  for https)
3. Strips trailing slashes
4. Falls back to  on malformed URLs (never panics)

Applied to:
-  (dedup key + stored ONVIFEndpoint)
-  (roaming check)
-  (endpoint-fallback identity)

## Tests

- : 9 table-driven cases (/no-port, , scheme case, host case, trailing slash, different IP, http-vs-https)
- : 9 direct unit cases
- : verifies both explicit + XAddrs paths normalize

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./internal/autodiscover/ -race -count=3` ✅
- `gofumpt` clean ✅

Closes #133.