### PR TITLE
fix(settings): restore SettingsStreamingCard import — #157 regression (blank Advanced tab)

### DIFF
--- a/web/src/routes/settings/AdvancedTab.svelte
+++ b/web/src/routes/settings/AdvancedTab.svelte
@@ -7,7 +7,7 @@
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
   import SettingsCard from '$lib/components/SettingsCard.svelte';
   import Toggle from '$lib/components/Toggle.svelte';
-  // SettingsStreamingCard import removed (#153) — WebRTC/FLV cards removed.
+  import SettingsStreamingCard from './SettingsStreamingCard.svelte';
 
   let loading = $state(true);
   let saving = $state(false);

--- a/web/src/routes/settings/FeaturesTab.svelte
+++ b/web/src/routes/settings/FeaturesTab.svelte
@@ -47,8 +47,7 @@
   let adSaving = $state(false);
   // Local form fields (so the toggle/inputs are reactive before save).
   let adEnabled = $state(false);
-  let adScanInterval = $state(60);
-  let adListenForHello = $state(true);
+  // adScanInterval/adListenForHello removed (#153) — backend defaults are optimal.
   let adNetworkInterface = $state('');
   let adDefaultUsername = $state('');
   let adDefaultPassword = $state(''); // only sent when the user types a new one

--- a/web/src/routes/settings/GeneralTab.svelte
+++ b/web/src/routes/settings/GeneralTab.svelte
@@ -16,7 +16,7 @@
   // Form state
   let retentionDays = $state(30);
   let diskThresholdPercent = $state(90);
-  let checkInterval = $state('1h');
+  // checkInterval removed (#153) — backend default (1h) is optimal.
   let selectedTimezone = $state('Local');
   let timezoneOptions = $derived([
     { value: 'Local', label: t('settings.timezoneLocal') },


### PR DESCRIPTION
## Hotfix for PR #157 regression

PR #157 removed the `SettingsStreamingCard` import when deleting the WebRTC/FLV viewer-count cards, but **RTMP and SRT cards still use `SettingsStreamingCard`** for their enable-toggle + port-input UI. This caused a runtime `ReferenceError: SettingsStreamingCard is not defined` on every Settings page load, making the Advanced tab completely blank.

## Root cause
The WebRTC/FLV removal was scoped to those two cards, but `SettingsStreamingCard` is a **shared component** also used by RTMP/SRT. The import removal was too aggressive — only the WebRTC/FLV `<SettingsCard>` wrappers were deleted, not the component itself.

## Fix
- **Restore** `import SettingsStreamingCard from './SettingsStreamingCard.svelte'` in AdvancedTab
- **Remove** 3 dead state variables left behind by UI removal:
  - `adScanInterval`, `adListenForHello` in FeaturesTab (no longer in save payload or dirty check)
  - `checkInterval` in GeneralTab (no longer in save payload or dirty check)

## Verification
- `npm run build` ✅
- `npm test` ✅ (481 tests pass)
- **M5 browser test** ✅ — Settings page loads, Advanced tab renders RTMP/SRT cards correctly (with toggle + port input), zero console errors
- RTMP card expanded: `switch "RTMP 接入" [checked=false]` + `spinbutton "监听端口": 1935`