### PR TITLE
fix(i18n,autodiscover,auth): Camera Offline 中文化 + autodiscover 双重 enrich + authCache 后台驱逐

### DIFF
--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -148,6 +148,20 @@ func (a *Adder) HandleDiscovered(ctx context.Context, dev onvif.DiscoveredDevice
 		return
 	}
 
+	// 2b. Reserve the endpoint in the dedup map BEFORE the (slow) enrich step.
+	// The passive listener (WS-Discovery Hello) and the active scanner (Probe)
+	// run concurrently and report the same device from two goroutines; the
+	// endpoint strings differ only by a default port (e.g. http://x:80 from
+	// probe vs http://x from Hello), which makeDedupKey normalizes to the same
+	// key. Without reserving here, the second path's recentlySeen check (above)
+	// runs while the first is still inside enrich — a classic check-then-act
+	// race — so BOTH paths call EnrichDevice (issue #161). Reserving under the
+	// endpoint key now makes the second path's recentlySeen hit on its next
+	// iteration. The serial key is still marked later (step 4 / enroll) once
+	// enrich fills it in. The reserve expires naturally after dedupWindow, so a
+	// genuinely transient enrich failure is retried within minutes.
+	a.reserveSeen(endpoint)
+
 	// 3. Enrich with GetDeviceInformation (unauthenticated). Fills Serial —
 	// needed for both the stable_id (IP self-healing) and DB dedup.
 	enrichCtx, enrichCancel := context.WithTimeout(ctx, 5*time.Second)
@@ -567,5 +581,22 @@ func (a *Adder) markSeenBothKeys(endpoint, serial string) {
 	if s := strings.TrimSpace(serial); s != "" {
 		a.dedup[makeDedupKey(endpoint, s)] = now // serial key (post-enrichment lookups)
 	}
+	a.dedupMu.Unlock()
+}
+
+// reserveSeen records ONLY the endpoint key as seen now. It is the minimal
+// pre-enrichment reservation that closes the probe/Hello race window of
+// issue #161: between recentlySeen and markSeenBothKeys lies the (hundreds of
+// ms) enrich step, during which a concurrently-reported discovery of the SAME
+// device (different endpoint string, same normalized key) would slip past the
+// recentlySeen gate. Unlike markSeenBothKeys, this intentionally does NOT mark
+// the serial key — the serial is unknown before enrichment, and the full
+// both-keys marking still happens later (in enroll, or in the existing-camera
+// branch via markSeenBothKeys). Reserve is idempotent with markSeenBothKeys,
+// which simply overwrites the endpoint key with a fresh timestamp.
+func (a *Adder) reserveSeen(endpoint string) {
+	now := time.Now()
+	a.dedupMu.Lock()
+	a.dedup[makeDedupKey(endpoint, "")] = now
 	a.dedupMu.Unlock()
 }

--- a/internal/autodiscover/adder_test.go
+++ b/internal/autodiscover/adder_test.go
@@ -294,6 +294,74 @@ func TestRecentlySeen_PreEnrichmentEndpointLookupHits(t *testing.T) {
 	}
 }
 
+// TestReserveSeen_ClosesProbeHelloRace is the regression test for issue #161:
+// the passive listener (WS-Discovery Hello) and the active scanner (Probe)
+// concurrently report the SAME device, but with endpoint strings that differ
+// only by the default port (probe forces :80, Hello often omits it). Both paths
+// enter HandleDiscovered at once; before the fix, the enrich step (hundreds of
+// ms) sat between the recentlySeen READ and the markSeenBothKeys WRITE, so the
+// second path's recentlySeen returned false and BOTH paths called EnrichDevice.
+//
+// The fix reserves the endpoint key BEFORE enrich. This test asserts the
+// critical property the fix relies on: after reserveSeen, a recentlySeen query
+// for the SAME device under a DIFFERENT endpoint string (default-port variant)
+// must hit immediately — i.e. the race window is closed. Also verifies the
+// reservation is endpoint-only (serial key NOT yet marked, since the serial is
+// unknown pre-enrichment).
+func TestReserveSeen_ClosesProbeHelloRace(t *testing.T) {
+	t.Helper()
+	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, nil, nil)
+	const probeEP = "http://192.168.1.50:80/onvif/device_service" // :80 forced by probe
+	const helloEP = "http://192.168.1.50/onvif/device_service"    // no port from Hello
+
+	// Simulate the probe path: it passed recentlySeen and reserved the endpoint
+	// before entering the slow enrich step.
+	adder.reserveSeen(probeEP)
+
+	// The Hello path now calls recentlySeen with a DIFFERENT endpoint string
+	// (no :80) but the same normalized key. It MUST hit — otherwise enrich runs
+	// twice (the issue #161 double-EnrichDevice).
+	if !adder.recentlySeen(helloEP, "") {
+		t.Error("recentlySeen must hit a reserved endpoint even when the query string omits the default port (:80) — makeDedupKey normalizes them equal; missing this is the issue #161 race")
+	}
+
+	// Reserve is endpoint-keyed only: a serial-keyed lookup (post-enrichment)
+	// must NOT hit yet, because enrich has not run and the serial is unknown.
+	// This confirms reserveSeen does not over-eagerly suppress by serial.
+	if adder.recentlySeen(helloEP, "SOME-SERIAL") {
+		t.Error("reserveSeen must mark only the endpoint key, not the serial key (serial is unknown pre-enrichment)")
+	}
+
+	// After enrichment completes, markSeenBothKeys is called and marks the
+	// serial key too — at that point the serial-keyed lookup hits. This models
+	// the normal post-enrich path that has always worked.
+	adder.markSeenBothKeys(probeEP, "SOME-SERIAL")
+	if !adder.recentlySeen(helloEP, "SOME-SERIAL") {
+		t.Error("post-enrichment markSeenBothKeys must mark the serial key so serial-keyed lookups hit")
+	}
+}
+
+// TestReserveSeen_IdempotentWithMarkSeenBothKeys verifies that reserveSeen and
+// markSeenBothKeys compose correctly: calling markSeenBothKeys after
+// reserveSeen (the normal enrich → enroll flow) simply refreshes the endpoint
+// key's timestamp and adds the serial key. There is no double-counting or stuck
+// suppression beyond dedupWindow.
+func TestReserveSeen_IdempotentWithMarkSeenBothKeys(t *testing.T) {
+	t.Helper()
+	adder := NewAdder(&config.AutoDiscoverConfig{}, nil, nil, nil)
+	const ep = "http://192.168.1.50/onvif/device_service"
+
+	adder.reserveSeen(ep)
+	adder.markSeenBothKeys(ep, "ABC") // post-enrich call
+	// Both keys now marked; both lookups hit.
+	if !adder.recentlySeen(ep, "") {
+		t.Error("endpoint key must remain marked after markSeenBothKeys")
+	}
+	if !adder.recentlySeen(ep, "ABC") {
+		t.Error("serial key must be marked after markSeenBothKeys")
+	}
+}
+
 func TestClassify_NoCredsUnauthDevice(t *testing.T) {
 	t.Helper()
 	// An unauthenticated device (ESP32 MiBeeCam): enrichment filled in

--- a/internal/autodiscover/scanner.go
+++ b/internal/autodiscover/scanner.go
@@ -55,20 +55,27 @@ func (s *Scanner) Run(ctx context.Context) {
 	}
 }
 
-// sweep performs one discovery cycle: multicast Probe + enrichment, then feed
-// each result to the Adder. The Adder owns dedup, so duplicates across sweeps
-// (or vs. the passive listener) are silently skipped.
+// sweep performs one discovery cycle: multicast Probe (no enrichment), then
+// feed each result to the Adder. The Adder owns dedup AND enrichment, so
+// duplicates across sweeps (or vs. the passive listener) are silently skipped
+// BEFORE any GetDeviceInformation call.
+//
+// We deliberately use DiscoverNoEnrich (not Discover): Discover's internal
+// enrichDevices pass runs BEFORE HandleDiscovered, so it bypasses the Adder's
+// dedup entirely and every device paid for GetDeviceInformation twice on the
+// first scan (once inside Discover, once inside HandleDiscovered.enrich). With
+// DiscoverNoEnrich, enrichment happens only inside HandleDiscovered, where
+// reserveSeen + recentlySeen gate it (issue #161).
 //
 // Each device is processed in its own goroutine so a slow/hung device does not
 // block the others — bounded only by the 5s enrichment timeout inside the Adder.
 func (s *Scanner) sweep(ctx context.Context) {
-	// 8s timeout covers a 5s multicast Probe window + a few seconds of
-	// enrichment headroom. Longer than the listener's per-device path because
-	// Discover enriches in bulk.
+	// 8s timeout covers a 5s multicast Probe window + headroom. Enrichment now
+	// happens inside the Adder (per-device goroutine), not in bulk here.
 	sweepCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
 
-	result := onvif.Discover(sweepCtx, 5*time.Second)
+	result := onvif.DiscoverNoEnrich(sweepCtx, 5*time.Second)
 	for _, dev := range result.Devices {
 		dev := dev // capture for goroutine
 		go s.adder.HandleDiscovered(ctx, dev)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -16,6 +16,10 @@ var logger = slog.Default().With("component", "auth")
 
 const (
 	authCacheTTL = 5 * time.Minute
+	// authCacheCleanupInterval is how often authCacheCleanupLoop sweeps expired
+	// authCache entries. Set to authCacheTTL so eviction stays ahead of churn;
+	// the loop mirrors RateLimiter.cleanupLoop's 2×Window cadence in spirit.
+	authCacheCleanupInterval = authCacheTTL
 )
 
 type rateLimitEntry struct {
@@ -218,9 +222,67 @@ type authCacheEntry struct {
 
 var authCache sync.Map
 
+// authCacheCleanupStarted ensures the background eviction goroutine for
+// authCache is launched at most once per process. Stale entries are otherwise
+// only evicted lazily on re-lookup (CheckPassword), so cache keys that are
+// never revisited (e.g. a one-time login from a transient client) would
+// accumulate indefinitely. The cleanup loop mirrors RateLimiter.cleanupLoop.
+var authCacheCleanupStarted sync.Once
+
+// startAuthCacheCleanup launches a background goroutine that periodically
+// evicts expired authCache entries. It is safe to call concurrently; the first
+// caller wins via authCacheCleanupStarted and subsequent calls are no-ops.
+// The goroutine runs for the lifetime of the process (authCache is process-
+// global), so it intentionally does NOT take a cancellable context — mirroring
+// the package-level authFailures rate-limiter, which is likewise never stopped.
+// The interval is a multiple of authCacheTTL so eviction stays ahead of churn
+// without excessive scanning.
+func startAuthCacheCleanup() {
+	authCacheCleanupStarted.Do(func() {
+		go authCacheCleanupLoop()
+	})
+}
+
+// authCacheCleanupLoop walks authCache every authCacheCleanupInterval and
+// deletes entries older than authCacheTTL.
+func authCacheCleanupLoop() {
+	ticker := time.NewTicker(authCacheCleanupInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		evictExpiredAuthCache(time.Now())
+	}
+}
+
+// evictExpiredAuthCache deletes every authCache entry whose verifiedAt is older
+// than authCacheTTL relative to now. Extracted from authCacheCleanupLoop so the
+// eviction logic is unit-testable without waiting on the ticker. Returns the
+// number of entries removed (useful for assertions).
+func evictExpiredAuthCache(now time.Time) int {
+	removed := 0
+	authCache.Range(func(k, v any) bool {
+		entry, ok := v.(authCacheEntry)
+		if !ok {
+			// Malformed entry (should never happen) — drop defensively.
+			authCache.Delete(k)
+			removed++
+			return true
+		}
+		if now.Sub(entry.verifiedAt) >= authCacheTTL {
+			authCache.Delete(k)
+			removed++
+		}
+		return true
+	})
+	return removed
+}
+
 // CheckPassword compares a plaintext password against a bcrypt hash.
 // Results are cached for authCacheTTL to avoid repeated bcrypt overhead.
 func CheckPassword(password, hash string) bool {
+	// Lazily start the periodic eviction goroutine on first use. Idempotent via
+	// sync.Once; subsequent calls are essentially free.
+	startAuthCacheCleanup()
+
 	if strings.TrimSpace(hash) == "" {
 		return false
 	}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -326,4 +327,98 @@ func TestRateLimiterCleanupStopsOnCancel(t *testing.T) {
 	w2 := httptest.NewRecorder()
 	handler.ServeHTTP(w2, req2)
 	require.Equal(t, http.StatusTooManyRequests, w2.Code, "second request from same IP should be blocked when MaxRequests=1")
+}
+
+// resetAuthCacheForTest wipes the package-global authCache so tests start from
+// a known state (the cache otherwise leaks between tests in the same package).
+func resetAuthCacheForTest() {
+	authCache.Range(func(k, _ any) bool {
+		authCache.Delete(k)
+		return true
+	})
+}
+
+// authCacheSize counts the current number of authCache entries (test helper).
+func authCacheSize() int {
+	n := 0
+	authCache.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// TestEvictExpiredAuthCache_RemovesStaleEntries is the regression test for
+// issue #164: authCache had no background eviction, so entries that were never
+// re-looked-up (e.g. a one-time login) accumulated indefinitely. The fix added
+// a periodic sweep; this test drives the core eviction logic directly via
+// evictExpiredAuthCache (the function the ticker calls), so it doesn't depend
+// on wall-clock timing of the 5-minute interval.
+func TestEvictExpiredAuthCache_RemovesStaleEntries(t *testing.T) {
+	resetAuthCacheForTest()
+	t.Cleanup(resetAuthCacheForTest)
+
+	now := time.Now()
+	// Seed: one fresh entry (verified just now) and one stale entry (older than TTL).
+	authCache.Store("fresh-key", authCacheEntry{hash: "h1", verifiedAt: now})
+	authCache.Store("stale-key", authCacheEntry{hash: "h2", verifiedAt: now.Add(-authCacheTTL - time.Second)})
+	require.Equal(t, 2, authCacheSize(), "precondition: two entries seeded")
+
+	// Evict at a "now" that is within TTL of fresh but past TTL of stale.
+	removed := evictExpiredAuthCache(now.Add(time.Second))
+	require.Equal(t, 1, removed, "only the stale entry should be evicted")
+	require.Equal(t, 1, authCacheSize(), "fresh entry must survive eviction")
+
+	// The surviving entry is the fresh one.
+	if _, ok := authCache.Load("fresh-key"); !ok {
+		t.Error("fresh entry should still be present after eviction")
+	}
+	if _, ok := authCache.Load("stale-key"); ok {
+		t.Error("stale entry should have been evicted")
+	}
+
+	// A second sweep at the same now does nothing (already evicted).
+	if removed := evictExpiredAuthCache(now.Add(time.Second)); removed != 0 {
+		t.Errorf("second sweep should remove nothing, got %d", removed)
+	}
+}
+
+// TestEvictExpiredAuthCache_ExpiredBoundary confirms an entry exactly at TTL is
+// evicted (>= comparison), while one just under TTL survives.
+func TestEvictExpiredAuthCache_ExpiredBoundary(t *testing.T) {
+	resetAuthCacheForTest()
+	t.Cleanup(resetAuthCacheForTest)
+
+	base := time.Now()
+	authCache.Store("at-ttl", authCacheEntry{verifiedAt: base.Add(-authCacheTTL)})                       // exactly TTL old
+	authCache.Store("under-ttl", authCacheEntry{verifiedAt: base.Add(-authCacheTTL + time.Millisecond)}) // just under
+
+	removed := evictExpiredAuthCache(base)
+	require.Equal(t, 1, removed, "entry at exactly TTL (>=) should be evicted")
+	if _, ok := authCache.Load("under-ttl"); !ok {
+		t.Error("entry under TTL should survive")
+	}
+}
+
+// TestStartAuthCacheCleanup_Idempotent verifies the cleanup goroutine is
+// launched at most once (sync.Once) regardless of how many concurrent
+// CheckPassword calls race on it. Repeated calls must be cheap no-ops and must
+// not spawn additional goroutines.
+func TestStartAuthCacheCleanup_Idempotent(t *testing.T) {
+	// sync.Once is process-global and may already be consumed by an earlier
+	// test that called CheckPassword. We assert only the documented contract:
+	// calling startAuthCacheCleanup many times concurrently never panics and
+	// returns quickly. (We cannot assert "exactly one goroutine" without
+	// goroutine counting, which is flaky; the sync.Once guarantee is unit-
+	// tested by the stdlib itself.)
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startAuthCacheCleanup() // must be a safe no-op after the first call
+		}()
+	}
+	wg.Wait()
+	// Reaching here without panicking/deadlocking is the success condition.
 }

--- a/internal/onvif/discovery.go
+++ b/internal/onvif/discovery.go
@@ -81,12 +81,37 @@ type deviceInfoEnvelope struct {
 // The enrichment runs in parallel and does not require authentication.
 // Returns a DiscoveryResult with categorized errors.
 // The result always contains a non-nil Devices slice (empty when no devices found).
+//
+// This is the variant for callers that consume the enriched fields directly
+// (e.g. the manual-scan API handler, which returns Manufacturer/Firmware to the
+// UI). Background callers that re-enrich themselves (autodiscover.Scanner →
+// Adder.HandleDiscovered) should use DiscoverNoEnrich to avoid a redundant
+// GetDeviceInformation round-trip per device (issue #161).
 func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
+	return discover(ctx, timeout, true)
+}
+
+// DiscoverNoEnrich is the same as Discover but WITHOUT the internal
+// GetDeviceInformation enrichment pass. Use it when the caller will enrich the
+// devices itself (and wants its own dedup/gating to apply BEFORE enrichment) —
+// notably autodiscover.Scanner, whose Adder.HandleDiscovered re-runs
+// EnrichDevice and would otherwise pay for GetDeviceInformation twice per
+// device on the first scan (once inside Discover, once inside HandleDiscovered).
+// The returned devices have Endpoint/XAddrs/Scopes populated but
+// Manufacturer/Model/Firmware/Serial empty (filled in later by the caller).
+func DiscoverNoEnrich(ctx context.Context, timeout time.Duration) *DiscoveryResult {
+	return discover(ctx, timeout, false)
+}
+
+// discover is the shared core of Discover / DiscoverNoEnrich. When enrich is
+// true, devices are enriched with GetDeviceInformation in parallel before
+// returning; when false, the caller owns enrichment.
+func discover(ctx context.Context, timeout time.Duration, enrich bool) *DiscoveryResult {
 	if timeout <= 0 {
 		timeout = defaultDiscoveryTimeout
 	}
 
-	logger.Info("starting ONVIF device discovery", "timeout", timeout)
+	logger.Info("starting ONVIF device discovery", "timeout", timeout, "enrich", enrich)
 
 	devices, err := discovery.Discover(ctx, timeout)
 	if err != nil {
@@ -109,14 +134,16 @@ func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
 		}
 	}
 
-	// Enrich devices with GetDeviceInformation (no auth, best-effort).
-	// Use a fresh background context with its own timeout so enrichment
-	// is not affected by the expired discovery context.
-	enrichCtx, enrichCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer enrichCancel()
-	enrichDevices(enrichCtx, result)
+	if enrich {
+		// Enrich devices with GetDeviceInformation (no auth, best-effort).
+		// Use a fresh background context with its own timeout so enrichment
+		// is not affected by the expired discovery context.
+		enrichCtx, enrichCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer enrichCancel()
+		enrichDevices(enrichCtx, result)
+	}
 
-	logger.Info("ONVIF discovery completed", "device_count", len(result))
+	logger.Info("ONVIF discovery completed", "device_count", len(result), "enriched", enrich)
 	return &DiscoveryResult{Devices: result}
 }
 

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -880,9 +880,9 @@ onDestroy(() => {
         : streamState === 'error'
           ? t('dashboard.errorState')
           : streamState === 'offline'
-            ? 'Camera Offline'
+            ? t('dashboard.cameraOffline')
             : streamState === 'disconnected'
-              ? t('live.webrtc.connecting') || 'Disconnected'
+              ? t('live.webrtc.disconnected')
               : t('dashboard.snapshotMode'),
   );
 </script>
@@ -946,7 +946,7 @@ onDestroy(() => {
       <div class="absolute inset-0 bg-black/70"></div>
       <div class="relative flex flex-col items-center gap-3 z-10">
         <AlertCircle size={28} class="text-orange-400" />
-        <span class="text-white/70 text-xs">Camera Offline</span>
+        <span class="text-white/70 text-xs">{t('dashboard.cameraOffline')}</span>
         <button
           onclick={() => cm?.reconnect()}
           class="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white/10 text-white/80 text-xs hover:bg-white/20 transition-colors"

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -355,6 +355,7 @@
   "dashboard.apply": "Apply",
   "dashboard.backToGrid": "Back to grid",
   "dashboard.buffering": "Buffering",
+  "dashboard.cameraOffline": "Camera Offline",
   "dashboard.clickToLive": "Click for live view",
   "dashboard.configure": "Configure",
   "dashboard.errorState": "Error",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -355,6 +355,7 @@
   "dashboard.apply": "应用",
   "dashboard.backToGrid": "返回网格",
   "dashboard.buffering": "缓冲中",
+  "dashboard.cameraOffline": "摄像头离线",
   "dashboard.clickToLive": "点击查看实时画面",
   "dashboard.configure": "配置",
   "dashboard.errorState": "错误",


### PR DESCRIPTION
## Summary

三项独立的健壮性修复，源自 issue #165 拆分后可立即处理的部分 + 两个既有 tech-debt issue。

## 1. i18n: Camera Offline 离线提示中文化（#165 子问题4）

**问题**：摄像头离线时 UI 提示 \`Camera Offline\` 是硬编码英文，中文环境下未翻译。

**修复**：
- \`WasmPlayer.svelte\` 三处硬编码字符串接入现有 i18n 系统
- 新增 \`dashboard.cameraOffline\` key（en: "Camera Offline" / zh: "摄像头离线"）
- 顺带修复 \`'Disconnected'\` 硬编码 → \`live.webrtc.disconnected\`

**验证**：M5 部署的前端资源 grep 确认含中文 key。

## 2. autodiscover: 消除首扫双重 enrich（#161）

**问题**：首次启动扫描时，同一台 ONVIF 设备被执行两次 \`EnrichDevice\`（GetDeviceInformation SOAP 调用）。

**实测根因修正**：原 issue 的分析不完整。双重 enrich 有**两层**来源：
| 层 | 代码 | 说明 |
|----|------|------|
| 第1层 | \`onvif.Discover\` → \`enrichDevices\` (discovery.go) | Discover 内部自己 enrich，**绕过整个 Adder dedup** |
| 第2层 | Hello listener → \`HandleDiscovered\` → \`a.enrich\` | 原 issue 描述的 probe/Hello 竞态 |

最初仅加 \`reserveSeen\`（enrich 前预占 endpoint key）只解决第2层，对第1层无效——已在 M5 验证。

**最终修复**：
- 新增 \`onvif.DiscoverNoEnrich(ctx, timeout)\`（与 \`Discover\` 共享 \`discover(enrich bool)\` 核心，跳过内部 enrich）
- Scanner 改用 \`DiscoverNoEnrich\`（其 \`HandleDiscovered\` 本就会 enrich，Discover 内部那次是纯浪费）
- 保留 \`reserveSeen\` 解决第2层竞态
- API 手动扫描路径继续用 \`Discover\`（需立即返回 Manufacturer/Firmware 给 UI）

**M5 实测**：\`.212\`/\`.251\` 各从 enrich 2 次 → 1 次；90s 跨周期稳定；3 个回归测试。

## 3. auth: authCache 后台驱逐循环（#164）

**问题**：BasicAuth 的 \`authCache\`（sync.Map）无后台驱逐，从未被重新访问的缓存项（如一次性登录）会无限累积。相邻的 \`authFailures\` 限流器有 \`cleanupLoop\`，\`authCache\` 没有。

**修复**：
- \`sync.Once\` 惰性启动周期性驱逐 goroutine（首次 \`CheckPassword\` 触发），镜像 \`RateLimiter.cleanupLoop\`
- 抽出 \`evictExpiredAuthCache(now)\` 便于单测（无需等 ticker）
- 3 个测试（驱逐/边界/sync.Once 幂等），middleware 全包测试通过

## Test plan

- [x] middleware 全包 \`go test\` 通过（含 3 个新测试）
- [x] autodiscover/onvif/middleware Linux ARM64 交叉编译通过
- [x] gofmt 全部干净，prettier（JSON）通过
- [x] M5 实测：#161 双重 enrich 已消除（每个设备 enrich 1 次）
- [x] M5 实测：服务健康、无 panic、goroutine 无泄漏
- [x] M5 部署前端含中文 \`摄像头离线\` key
- [ ] CI 绿

## 关联

- Closes #161
- Closes #164
- #165 子问题4（i18n）在此 PR；子问题1+2（编码）→ #166；子问题3（TUTK）→ #167