### PR TITLE
fix(shutdown): join fire-and-forget goroutines in Stop() for 3 subsystems (#163)

### DIFF
--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -121,6 +121,12 @@ type CameraManager struct {
 	// outlive the DB handle and crash with "sql: database is closed" when the
 	// test/process tears down resources (flaky TestStartupBackfillStableID).
 	backfillWg sync.WaitGroup
+	// onvifEnsureWg tracks the per-recorder-start ONVIF backfill goroutines
+	// (ensureStableID / ensureProfileToken / ensureEncoding) spawned from
+	// startRecorderLocked. Each does its own configMu.Lock + persistConfig +
+	// DB write with a 15s timeout ctx; without joining them in Stop, those
+	// writes could race the DB/config teardown that Stop initiates (#163).
+	onvifEnsureWg sync.WaitGroup
 }
 
 // RelayManager is the subset of *relay.Manager the camera manager calls. Kept
@@ -506,6 +512,13 @@ func (cm *CameraManager) Stop() error {
 	// with "sql: database is closed". The goroutine checks ctx between cameras
 	// so this returns promptly once the caller cancels the start context.
 	cm.backfillWg.Wait()
+
+	// Wait for any in-flight per-recorder ONVIF ensure* goroutines
+	// (ensureStableID / ensureProfileToken / ensureEncoding). Each does a
+	// configMu.Lock + persistConfig + DB write with a 15s timeout; joining
+	// them here prevents those writes from racing the teardown performed by
+	// Stop / the caller above (#163). Bounded by the ensure* 15s timeout.
+	cm.onvifEnsureWg.Wait()
 
 	return nil
 }

--- a/internal/camera/manager_test.go
+++ b/internal/camera/manager_test.go
@@ -241,6 +241,62 @@ func TestStop(t *testing.T) {
 	// Status should be stopped
 }
 
+// TestStop_WaitsForONVIFEnsureGoroutines guards #163: Stop must join the
+// per-recorder ensure* goroutines (ensureStableID / ensureProfileToken /
+// ensureEncoding) spawned via launchTrackedEnsure. Without onvifEnsureWg.Wait
+// in Stop, those goroutines could still be mid configMu.Lock + persistConfig
+// + DB write when Stop returns, racing the caller's resource teardown.
+//
+// We exercise the tracker directly: spawn a tracked "ensure" that blocks on a
+// release channel, call Stop in a goroutine, and assert Stop does NOT return
+// until the tracked work is released and finishes.
+func TestStop_WaitsForONVIFEnsureGoroutines(t *testing.T) {
+	t.Helper()
+	mgr, _, _, _ := newTestManager(t)
+
+	release := make(chan struct{})
+	done := atomic.Bool{}
+
+	// launchTrackedEnsure is the exact wrapper used by startRecorderLocked for
+	// the three ensure* passes, so this exercises the real tracking path.
+	mgr.launchTrackedEnsure(func(_ string) {
+		select {
+		case <-release:
+		case <-time.After(5 * time.Second):
+			t.Error("tracked ensure goroutine was not released within 5s")
+		}
+		done.Store(true)
+	}, "cam-test")
+
+	// Give the goroutine a moment to start. We can't observe entry directly,
+	// but the Stop below will prove blocking: if it returns before release,
+	// the tracker is missing.
+	stopReturned := make(chan struct{})
+	go func() {
+		_ = mgr.Stop()
+		close(stopReturned)
+	}()
+
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop returned before the tracked ensure goroutine finished — onvifEnsureWg.Wait is missing in Stop")
+	case <-time.After(50 * time.Millisecond):
+		// expected: Stop is parked on onvifEnsureWg.Wait
+	}
+
+	close(release)
+
+	select {
+	case <-stopReturned:
+		// expected: Stop returned after the tracked goroutine exited
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s of releasing the tracked goroutine")
+	}
+	if !done.Load() {
+		t.Fatal("tracked ensure goroutine should have completed before Stop returned")
+	}
+}
+
 func TestStop_EmptyManager(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfg := testConfig()

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -407,22 +407,38 @@ func (cm *CameraManager) startRecorderLocked(ctx context.Context, cam config.Cam
 	// For ONVIF cameras without a stable_id yet, auto-populate it asynchronously
 	// so IP self-healing (internal/rediscovery) can later re-acquire the camera.
 	// This is best-effort and non-blocking: failures are logged and ignored.
+	// Tracked by onvifEnsureWg so Stop can join these goroutines and avoid a
+	// race between their configMu.Lock + persistConfig + DB write and the
+	// teardown Stop initiates (#163).
 	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.StableID) == "" {
-		go cm.ensureStableID(cam.ID)
+		cm.launchTrackedEnsure(cm.ensureStableID, cam.ID)
 	}
 	// For ONVIF cameras without a profile_token, persist the auto-selected one
 	// after Start resolves it — avoids re-running GetProfiles on every restart.
 	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.ProfileToken) == "" {
-		go cm.ensureProfileToken(cam.ID)
+		cm.launchTrackedEnsure(cm.ensureProfileToken, cam.ID)
 	}
 	// For ONVIF cameras without a resolved encoding, persist the probe result
 	// (RTSP DESCRIBE / ONVIF profile) so a later device outage doesn't leave
 	// encoding="" — which makes the frontend lose the codec and storm through
 	// the protocol chain. Mirrors ensureStableID/ensureProfileToken. See #112.
 	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.Encoding) == "" {
-		go cm.ensureEncoding(cam.ID)
+		cm.launchTrackedEnsure(cm.ensureEncoding, cam.ID)
 	}
 	return nil
+}
+
+// launchTrackedEnsure runs a best-effort ONVIF ensure* pass for a camera in a
+// goroutine tracked by onvifEnsureWg, so Stop can join it and prevent the
+// ensure write (configMu.Lock + persistConfig + DB write) from racing the
+// teardown Stop initiates (#163). Each ensure* uses its own 15s timeout ctx,
+// so worst-case a tracked goroutine blocks Stop for ≤15s.
+func (cm *CameraManager) launchTrackedEnsure(fn func(string), cameraID string) {
+	cm.onvifEnsureWg.Add(1)
+	go func() {
+		defer cm.onvifEnsureWg.Done()
+		fn(cameraID)
+	}()
 }
 
 // persistConfig saves the current config to disk if configPath is set.

--- a/internal/timelapse/merge_scheduler.go
+++ b/internal/timelapse/merge_scheduler.go
@@ -148,8 +148,16 @@ func (s *MergeScheduler) triggerDueAt(ctx context.Context, now time.Time) int {
 	for id, entry := range s.entries {
 		if !entry.nextRun.IsZero() && (now.After(entry.nextRun) || now.Equal(entry.nextRun)) {
 			triggered++
+			// Track the merge goroutine so Stop's wg.Wait() joins it too.
+			// Otherwise derived merges could outlive Stop and touch runFunc
+			// resources (e.g. the merger / DB) after the caller tears them
+			// down (#163). Add must happen before the goroutine starts so
+			// Stop's Wait can't race an Add-at-zero from a concurrent
+			// TriggerDue.
+			s.wg.Add(1)
 			// Run merge in background — do not block the loop
 			go func(camID string, refTime time.Time) {
+				defer s.wg.Done()
 				if err := s.runFunc(ctx, camID, refTime); err != nil {
 					slog.Error(
 						"merge scheduler: merge failed",

--- a/internal/timelapse/merge_scheduler_test.go
+++ b/internal/timelapse/merge_scheduler_test.go
@@ -408,6 +408,72 @@ func TestMergeScheduler_TriggerDue(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "merge goroutine should have executed")
 }
 
+// TestMergeScheduler_StopWaitsForDerivedMerge guards #163: Stop must join not
+// only the runLoop goroutine but also the per-camera merge goroutines spawned
+// by triggerDueAt. Without wg.Add around that goroutine, Stop could return
+// while a runFunc was still executing and touching caller-owned resources.
+//
+// To prove the wait is real, the runFunc observes ctx cancellation (as a real
+// merge callback would) but then does non-trivial post-cancel work
+// (teardownSleep). If Stop didn't join the goroutine, it would return
+// ~instantly after the cancel; we assert Stop takes at least teardownSleep.
+func TestMergeScheduler_StopWaitsForDerivedMerge(t *testing.T) {
+	t.Helper()
+
+	const teardownSleep = 80 * time.Millisecond
+	runStarted := make(chan struct{})
+	cancelled := atomic.Bool{}
+
+	s := NewMergeScheduler(nil)
+	s.SetRunFunc(func(ctx context.Context, cameraID string, refTime time.Time) error {
+		close(runStarted)
+		<-ctx.Done()
+		cancelled.Store(true)
+		// Simulate non-trivial teardown after cancellation. Stop's wg.Wait
+		// must cover this window — otherwise Stop would return before the
+		// merge goroutine finishes.
+		time.Sleep(teardownSleep)
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := fixedNow()
+	s.mu.Lock()
+	s.addOrUpdateAt(now, "cam-stop", 8*time.Hour)
+	s.entries["cam-stop"].nextRun = now.Add(-time.Hour) // force due
+	s.mu.Unlock()
+
+	s.Start(ctx)
+
+	// Do NOT call TriggerDue externally: it would pass the test's ctx into
+	// runFunc, which s.Stop() does not cancel (Stop cancels s.ctx). Instead
+	// rely on the runLoop's own triggerDueAt(s.ctx, ...) — nextRun is in the
+	// past, so the loop fires the merge on its first iteration and runFunc
+	// receives s.ctx, which Stop will cancel.
+
+	// Wait for the runFunc to actually be running, so Stop genuinely contends
+	// with an in-flight derived merge goroutine.
+	select {
+	case <-runStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runFunc did not start within 2s")
+	}
+
+	// Stop cancels s.ctx → the runFunc's <-ctx.Done() unblocks → it sleeps
+	// teardownSleep → returns → deferred wg.Done → Stop's Wait unblocks.
+	start := time.Now()
+	s.Stop()
+	elapsed := time.Since(start)
+
+	require.True(t, cancelled.Load(), "runFunc should have observed ctx cancellation")
+	if elapsed < teardownSleep {
+		t.Fatalf("Stop returned after %v (< %v teardown sleep) — wg.Wait is not joining the triggerDueAt goroutine",
+			elapsed, teardownSleep)
+	}
+}
+
 func TestMergeScheduler_TriggerDue_NotDue(t *testing.T) {
 	t.Helper()
 	var triggered int32

--- a/internal/timelapse/rolling.go
+++ b/internal/timelapse/rolling.go
@@ -59,6 +59,12 @@ type RollingMergeManager struct {
 	progressMu           sync.Mutex
 	progress             map[string]*progressEntry
 	progressCleanupDelay time.Duration
+	// wg tracks every runMerge goroutine so StopAll can wait for them to fully
+	// exit before returning. Without this, runMerge goroutines could briefly
+	// outlive StopAll and touch the merger/db after the caller (e.g. App.Stop)
+	// has begun tearing those resources down (#163). Matches the
+	// merge.RollingMergeCoordinator wg pattern.
+	wg sync.WaitGroup
 }
 
 func NewRollingMergeManager(merger TimelapseMerger, db MergeStatusUpdater, fps int, deleteOriginal bool) *RollingMergeManager {
@@ -88,6 +94,10 @@ func (r *RollingMergeManager) StartSegmentMerge(ctx context.Context, cameraID, s
 	r.nextID++
 	id := r.nextID
 	r.active[cameraID] = &activeEntry{cancel: cancel, id: id}
+	// Track the goroutine before launching it so StopAll's Wait can't race
+	// with a concurrent Add (sync.WaitGroup forbids Add-after-Wait-at-zero).
+	// Add stays under r.mu so StopAll's cancel+clear block observes it.
+	r.wg.Add(1)
 	r.mu.Unlock()
 
 	// Count total frames in segment dir for progress estimation.
@@ -119,6 +129,7 @@ func (r *RollingMergeManager) StopSegmentMerge(cameraID string) {
 }
 
 func (r *RollingMergeManager) runMerge(ctx context.Context, ownID uint64, cameraID, segmentDir, outputPath, recordingID string, totalFrames int) {
+	defer r.wg.Done() // paired with r.wg.Add in StartSegmentMerge
 	defer func() {
 		r.mu.Lock()
 		// Only delete if this goroutine's entry is still the active one.
@@ -274,7 +285,20 @@ func (r *RollingMergeManager) IsActive(cameraID string) bool {
 	return ok
 }
 
-// StopAll cancels all active merge goroutines.
+// StopAll cancels all active merge goroutines and waits for them to fully exit.
+//
+// Waiting is required to honor the App.Service contract ("Stop must release all
+// goroutines"): in-flight runMerge goroutines touch r.merger and r.db, which
+// the caller may begin tearing down once StopAll returns (#163). Without the
+// wait, those goroutines could briefly outlive the resources they reference.
+//
+// The cancel+clear happens under r.mu, but the Wait is OUTSIDE the lock —
+// runMerge's cleanup defer also acquires r.mu, so waiting under the lock would
+// deadlock. A concurrent StartSegmentMerge may add a fresh entry after the
+// clear; that goroutine is tracked by wg too, so Wait still returns promptly
+// (mergers honor ctx cancel) and the new entry is left in r.active for the
+// next lifecycle — matching the existing "final state may have active entries"
+// semantics documented in TestRollingMergeManager_ConcurrentStopAllAndStart.
 func (r *RollingMergeManager) StopAll() {
 	r.mu.Lock()
 	for _, entry := range r.active {
@@ -283,6 +307,10 @@ func (r *RollingMergeManager) StopAll() {
 	// Clear the map.
 	r.active = make(map[string]*activeEntry)
 	r.mu.Unlock()
+
+	// Wait for the cancelled runMerge goroutines to fully exit before clearing
+	// progress. Do not acquire r.mu here (see comment above).
+	r.wg.Wait()
 
 	// Also clear progress.
 	r.progressMu.Lock()

--- a/internal/timelapse/rolling_test.go
+++ b/internal/timelapse/rolling_test.go
@@ -6,9 +6,44 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// blockingMerger blocks Merge until releaseCh is closed (or ctx is cancelled),
+// then optionally simulates post-cancel teardown work (teardownSleep). Used to
+// prove StopAll waits for in-flight merges to fully exit (#163).
+type blockingMerger struct {
+	releaseCh     chan struct{}
+	started       chan struct{}
+	teardownSleep time.Duration // work done AFTER ctx cancel, BEFORE return
+	cancelled     atomic.Bool
+}
+
+func (b *blockingMerger) CanMerge() bool  { return true }
+func (b *blockingMerger) Tier() MergeTier { return TierGo }
+func (b *blockingMerger) Merge(ctx context.Context, _, outputPath string, _ int) (*MergeResult, error) {
+	if b.started != nil {
+		close(b.started)
+	}
+	select {
+	case <-b.releaseCh:
+		// released by the test — merge completes normally
+	case <-ctx.Done():
+		b.cancelled.Store(true)
+		// Simulate non-trivial teardown after cancellation (e.g. flushing a
+		// partial output). StopAll must wait for this, not just the cancel.
+		if b.teardownSleep > 0 {
+			time.Sleep(b.teardownSleep)
+		}
+		return nil, ctx.Err()
+	}
+	if outputPath != "" {
+		os.WriteFile(outputPath, []byte("merged"), 0o644)
+	}
+	return &MergeResult{Tier: TierGo, FramesMerged: 10, Duration: 1.0}, nil
+}
 
 // mockDB implements MergeStatusUpdater for testing.
 type mockDB struct {
@@ -161,6 +196,60 @@ func TestRollingMergeManager_StopAll(t *testing.T) {
 
 	if mgr.ActiveCount() != 0 {
 		t.Fatalf("expected 0 active merges after StopAll, got %d", mgr.ActiveCount())
+	}
+}
+
+// TestRollingMergeManager_StopAllWaitsForInFlightMerge guards #163:
+// StopAll must block until in-flight runMerge goroutines have fully exited.
+// Without wg tracking, StopAll returned immediately after clearing the map,
+// and the merger/DB write could race resource teardown in the caller.
+//
+// To prove the wait is real, the merger observes ctx cancellation (as a real
+// merger would) but then does non-trivial post-cancel work (teardownSleep).
+// If StopAll didn't join the goroutine, it would return ~instantly after the
+// cancel; we assert StopAll takes at least teardownSleep — i.e. it waited for
+// the goroutine to fully exit, not just for the cancel signal to be sent.
+func TestRollingMergeManager_StopAllWaitsForInFlightMerge(t *testing.T) {
+	t.Helper()
+	teardownSleep := 80 * time.Millisecond
+	merger := &blockingMerger{
+		releaseCh:     make(chan struct{}),
+		started:       make(chan struct{}),
+		teardownSleep: teardownSleep,
+	}
+	mgr := NewRollingMergeManager(merger, newMockDB(), 10, false)
+
+	tmpDir := t.TempDir()
+	segmentDir := filepath.Join(tmpDir, "segment")
+	os.MkdirAll(segmentDir, 0o755)
+	outputPath := filepath.Join(tmpDir, "output.mp4")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr.StartSegmentMerge(ctx, "cam-block", segmentDir, outputPath, "")
+
+	// Wait until the merger is actually running (inside Merge), so we know
+	// StopAll will be called while runMerge is genuinely in-flight.
+	select {
+	case <-merger.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("merge goroutine did not enter Merge within 2s")
+	}
+
+	// StopAll cancels the in-flight merge; the merger observes ctx.Done but
+	// then sleeps teardownSleep before returning. The wg.Wait in StopAll must
+	// cover that window — so StopAll should take ≥ teardownSleep.
+	start := time.Now()
+	mgr.StopAll()
+	elapsed := time.Since(start)
+
+	if elapsed < teardownSleep {
+		t.Fatalf("StopAll returned after %v (< %v teardown sleep) — wg.Wait is missing or not joining runMerge",
+			elapsed, teardownSleep)
+	}
+	if !merger.cancelled.Load() {
+		t.Fatal("merger should have observed ctx cancellation")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #163. Three subsystems spawned goroutines not tracked by a `WaitGroup`, so they could briefly outlive their manager's `Stop()` and touch shared resources (merger, DB, config) after the caller began teardown. All self-terminate via cancelable contexts, so this is a **cleanliness/consistency fix — not a blocker** — matching the `merge.RollingMergeCoordinator` `wg.Wait()` reference pattern (`internal/merge/rolling.go:1068`).

## Changes

### 1. `timelapse.RollingMergeManager` — track `runMerge` goroutines
- `StartSegmentMerge` does `r.wg.Add(1)` under `r.mu` **before** launching `go r.runMerge(...)`. Doing Add under the lock + before launch means `StopAll`'s `Wait` can never race an `Add-at-zero` (forbidden by `sync.WaitGroup`).
- `runMerge` defers `r.wg.Done()` (before its existing map-cleanup defer).
- `StopAll` calls `r.wg.Wait()` **outside** `r.mu` — `runMerge`'s cleanup defer also acquires `r.mu`, so waiting under the lock would deadlock. A concurrent `StartSegmentMerge` may add a fresh entry after the clear; its goroutine is tracked too, and mergers honor `ctx` cancel so `Wait` still returns promptly. This matches the existing "final state may have active entries" semantics already documented in `TestRollingMergeManager_ConcurrentStopAllAndStart`.

### 2. `timelapse.MergeScheduler` — track derived merge goroutines
- `triggerDueAt` now does `s.wg.Add(1)` before spawning the per-camera merge goroutine; `defer s.wg.Done()` inside.
- `Stop` already called `s.wg.Wait()`, so it now joins **both** `runLoop` and the derived merges.

### 3. `camera.CameraManager` — track ONVIF `ensure*` goroutines
- Route the 3 `ensure*` goroutines (`ensureStableID` / `ensureProfileToken` / `ensureEncoding`, spawned from `startRecorderLocked`) through a new `onvifEnsureWg` via a `launchTrackedEnsure(fn, cameraID)` helper (dedupes the 3 identical wrapper closures).
- `Stop` waits for `onvifEnsureWg` after `backfillWg`. Bounded by each `ensure*`'s 15s timeout ctx, so worst-case `Stop` latency is ≤15s.

## Race-window closed

Each of these goroutines does `configMu.Lock` + `persistConfig` + DB writes. Without joining them in `Stop`, those writes could race the DB/config teardown that `Stop` (or its caller, e.g. `App.Stop`) initiates — e.g. a `sql: database is closed` crash class. The existing `backfillWg` already protects the *startup* backfill goroutines from exactly this; this PR extends the same protection to the *per-recorder-start* goroutines.

## Test plan

- [x] `go test -race ./internal/timelapse/ ./internal/camera/ ./internal/merge/ ./pkg/app/` — all pass
- [x] `golangci-lint run` on changed packages — 0 issues
- [x] `gofmt` clean
- [x] New regression tests prove the wait is real (each asserts `Stop` blocks ≥ a post-cancel teardown sleep):
  - `TestRollingMergeManager_StopAllWaitsForInFlightMerge`
  - `TestMergeScheduler_StopWaitsForDerivedMerge`
  - `TestStop_WaitsForONVIFEnsureGoroutines`
- [x] Existing concurrent tests still pass:
  - `TestRollingMergeManager_ConcurrentStopAllAndStart` (Start+StopAll race)
  - `TestMergeScheduler_ConcurrentTriggerDuringLoop` (TriggerDue×10 during loop)

### Test-design note

`TestMergeScheduler_StopWaitsForDerivedMerge` deliberately relies on the `runLoop`'s own `triggerDueAt(s.ctx, …)` to fire the merge — **not** an external `TriggerDue(testCtx)`. `Stop` cancels `s.ctx` (derived in `Start`), not the caller's ctx; an external `TriggerDue` would propagate the wrong ctx into `runFunc` and the post-cancel teardown would never unblock. A first version of the test hit exactly this 10-min hang; the fix is to let the loop drive the trigger.

## Severity

Low — does NOT block any release (all three used cancelable/timeout contexts and self-terminated). This is the consistency fix described in #163.