### PR TITLE
fix(camera): unify encoding read-paths so list/get agree with LiveView (#166)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -102,23 +102,23 @@ func (h *Handler) handleListCameras(w http.ResponseWriter, r *http.Request) {
 		cameraRowForAPI(&cameras[i])
 	}
 	// Backfill encoding for cameras whose stored encoding is empty (e.g. ONVIF
-	// auto-detect cameras like the ESP32 MiBeeCam, where encoding is resolved at
-	// runtime by the recorder). Without this, the camera list reports encoding=""
-	// and frontend pages that select a player from the list (Surveillance grid)
-	// cannot tell a JPEG camera from an unknown one → they fall back to HLS and
-	// render black (the per-camera LiveView page works because it queries /protocols
-	// which already probes the live recorder). Probe the running recorder here so
-	// every list consumer sees the same resolved encoding.
+	// Resolve each camera's displayed encoding from the LIVE recorder probe so
+	// the list agrees with /protocols and LiveView (single source of truth). The
+	// probe is authoritative: some cameras physically stream a different codec
+	// than their stored config (e.g. Xiaomi H.265 cameras whose DB still says
+	// h264, or ONVIF auto-detect devices). When the probe is empty (camera
+	// offline / recorder not started / codec not yet detected) we keep the
+	// stored value as a fallback so the UI still has something to render and
+	// doesn't regress to the #112 black-screen-on-empty-encoding failure.
+	//
+	// For protocol-configured cameras (rtsp/http/srt/rtmp) the recorder is
+	// constructed from the stored encoding, so the probe returns the SAME codec
+	// — the displayed value is unchanged. For auto-detect cameras (onvif/xiaomi)
+	// the probe is the real codec and the stored value may be stale or empty;
+	// showing the probe here makes list/get/protocols consistent (#166).
 	if h.camMgr != nil {
 		for i := range cameras {
-			if cameras[i].Encoding != "" {
-				continue
-			}
-			if rec := h.camMgr.GetRecorder(cameras[i].ID); rec != nil {
-				if codec, _, _, _ := getCodecParams(rec); codec != "" {
-					cameras[i].Encoding = string(codec)
-				}
-			}
+			cameras[i].Encoding = resolveEncoding(cameras[i].Encoding, probeCodec(h.camMgr, cameras[i].ID))
 		}
 	}
 	// Summary view: return only the fields needed for grid/dashboard display.
@@ -437,16 +437,42 @@ func (h *Handler) handleGetCamera(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	cameraRowForAPI(row)
-	// Backfill encoding from the live recorder when the stored value is empty
-	// (ONVIF auto-detect cameras). See handleListCameras for the rationale.
-	if row.Encoding == "" && h.camMgr != nil {
-		if rec := h.camMgr.GetRecorder(id); rec != nil {
-			if codec, _, _, _ := getCodecParams(rec); codec != "" {
-				row.Encoding = string(codec)
-			}
-		}
+	// Resolve displayed encoding from the live recorder probe (authoritative),
+	// falling back to the stored value when the probe is empty. Matches
+	// handleListCameras and /protocols so all three paths agree. See
+	// handleListCameras for the full rationale (#166).
+	if h.camMgr != nil {
+		row.Encoding = resolveEncoding(row.Encoding, probeCodec(h.camMgr, id))
 	}
 	writeJSON(w, http.StatusOK, row)
+}
+
+// probeCodec returns the live recorder's runtime-detected codec for a camera,
+// or "" when there is no running recorder or its codec hasn't been detected
+// yet. It is a thin wrapper over GetRecorder + getCodecParams so callers don't
+// repeat the nil-recorder / empty-codec dance.
+func probeCodec(camMgr *camera.CameraManager, id string) model.Format {
+	if camMgr == nil {
+		return ""
+	}
+	rec := camMgr.GetRecorder(id)
+	if rec == nil {
+		return ""
+	}
+	codec, _, _, _ := getCodecParams(rec)
+	return codec
+}
+
+// resolveEncoding picks the displayed encoding for a camera: the recorder's
+// runtime-probed codec when it is non-empty (authoritative — the recorder reads
+// the actual stream), otherwise the stored value as a fallback (covers offline
+// cameras / codec-not-yet-detected). Centralizing this keeps the list, get, and
+// /protocols read-paths consistent (#166) and gives a single seam to test.
+func resolveEncoding(stored string, probe model.Format) string {
+	if probe != "" {
+		return string(probe)
+	}
+	return stored
 }
 
 // handleCameraPushStatus returns the runtime status of a camera's push-out relay

--- a/internal/api/handlers_camera_test.go
+++ b/internal/api/handlers_camera_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -359,6 +360,48 @@ func TestIsImageFile_MP4(t *testing.T) {
 func TestIsImageFile_NoExtension(t *testing.T) {
 	t.Parallel()
 	require.False(t, isImageFile("frame"))
+}
+
+// --- resolveEncoding / probeCodec tests (encoding read-path unification, #166) ---
+
+// TestResolveEncoding_ProbeWinsOverStored proves the live recorder probe is
+// authoritative: a camera stored as h264 but physically streaming h265 (e.g.
+// Xiaomi) must display h265. This is the core of the #165 fix.
+func TestResolveEncoding_ProbeWinsOverStored(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	got := resolveEncoding("h264", model.FormatH265)
+	require.Equal(t, "h265", got, "probe (h265) must override stored h264")
+}
+
+// TestResolveEncoding_StoredFallbackOnEmptyProbe proves an empty probe (camera
+// offline / codec not yet detected) keeps the stored value. This guards against
+// re-introducing #112 (black screen when encoding="" reached the frontend).
+func TestResolveEncoding_StoredFallbackOnEmptyProbe(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	require.Equal(t, "h264", resolveEncoding("h264", ""),
+		"empty probe must fall back to stored value")
+	require.Equal(t, "", resolveEncoding("", ""),
+		"empty probe + empty stored stays empty")
+}
+
+// TestResolveEncoding_ProbeFillsEmptyStored proves the probe fills in an empty
+// stored value (ONVIF auto-detect devices — the original backfill case).
+func TestResolveEncoding_ProbeFillsEmptyStored(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	require.Equal(t, "jpeg", resolveEncoding("", model.EncJPEG),
+		"probe must fill an empty stored encoding")
+}
+
+// TestProbeCodec_NilManager proves probeCodec is nil-safe so handlers can call
+// it unconditionally even when camMgr is unset (e.g. setup-required state).
+func TestProbeCodec_NilManager(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	require.Equal(t, model.Format(""), probeCodec(nil, "any-cam"),
+		"probeCodec(nil, ...) must return empty, not panic")
 }
 
 // --- handleListCameras tests ---

--- a/web/src/__tests__/CameraForm.test.ts
+++ b/web/src/__tests__/CameraForm.test.ts
@@ -185,6 +185,72 @@ describe('CameraForm - push target platform selector', () => {
   });
 });
 
+describe('CameraForm - encoding field visibility (#166)', () => {
+  afterEach(() => {
+    cleanup();
+    mockApiRequest.mockReset();
+  });
+
+  // Xiaomi recorders detect codec from the live stream and ignore any stored
+  // encoding, so the field must be read-only "auto-detect" (like ONVIF).
+  it('renders encoding as disabled auto-detect for xiaomi cameras', async () => {
+    mockApiRequest.mockImplementation((path: string) => {
+      if (path === '/relay-presets') return Promise.resolve(mockPresets);
+      return Promise.resolve(null);
+    });
+
+    const xiaomiCam = {
+      id: 'xiaomi-test',
+      name: 'Xiaomi Cam',
+      protocol: 'xiaomi',
+      encoding: 'h264', // stale value — must NOT be editable
+      url: 'xiaomi://abc',
+      enabled: true,
+    };
+    const { container } = render(CameraForm, {
+      props: defaultProps({ editingCamera: xiaomiCam as any }),
+    });
+
+    await vi.waitFor(() => {
+      const encSelect = container.querySelector('#cam-encoding') as HTMLSelectElement | null;
+      expect(encSelect, 'encoding <select> should exist').toBeTruthy();
+      expect(encSelect!.disabled, 'encoding field must be disabled for xiaomi').toBe(true);
+      // The only option is auto-detect
+      const opts = Array.from(encSelect!.options);
+      expect(opts.length).toBe(1);
+      expect(opts[0].value).toBe('');
+    });
+  });
+
+  // rtsp/http/srt/rtmp keep encoding editable — it drives recorder selection.
+  it('renders encoding as editable for rtsp cameras', async () => {
+    mockApiRequest.mockImplementation((path: string) => {
+      if (path === '/relay-presets') return Promise.resolve(mockPresets);
+      return Promise.resolve(null);
+    });
+
+    const rtspCam = {
+      id: 'rtsp-test',
+      name: 'RTSP Cam',
+      protocol: 'rtsp',
+      encoding: 'h264',
+      url: 'rtsp://example/stream',
+      enabled: true,
+    };
+    const { container } = render(CameraForm, {
+      props: defaultProps({ editingCamera: rtspCam as any }),
+    });
+
+    await vi.waitFor(() => {
+      const encSelect = container.querySelector('#cam-encoding') as HTMLSelectElement | null;
+      expect(encSelect, 'encoding <select> should exist').toBeTruthy();
+      expect(encSelect!.disabled, 'encoding field must be editable for rtsp').toBe(false);
+      // Multiple codec options available (h264/h265/mjpeg)
+      expect(encSelect!.options.length).toBeGreaterThan(1);
+    });
+  });
+});
+
 describe('CameraForm - transcode policy', () => {
   afterEach(() => {
     cleanup();

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -140,7 +140,8 @@ let validationErrors = $state<Record<string, string>>({});
     if (!proto) return;
     const encodings = proto.encodings;
     if (!encodings.includes(formEncoding)) {
-      if (formProtocol === 'onvif') {
+      if (formProtocol === 'onvif' || formProtocol === 'xiaomi') {
+        // Auto-detect protocols: codec comes from the live stream, not config.
         formEncoding = '';
       } else if (formProtocol === 'http') {
         formEncoding = 'jpeg';
@@ -511,7 +512,10 @@ async function performCameraSave() {
             serial_number: formSerialNumber || undefined,
             retention_days: formRetentionDays,
             stream_encoding: formProtocol === 'onvif' ? (formStreamEncoding || undefined) : undefined,
-            encoding: formEncoding,
+            // onvif/xiaomi auto-detect codec from the live stream and ignore the
+            // stored value, so don't send one (avoids writing a stale label).
+            // rtsp/http/srt/rtmp send formEncoding — it drives recorder selection.
+            encoding: formProtocol === 'onvif' || formProtocol === 'xiaomi' ? undefined : formEncoding,
             transcoding: {
                 enabled: formTranscodingEnabled,
                 target_codec: formTranscodingCodec,
@@ -565,7 +569,10 @@ async function performCameraSave() {
             serial_number: formSerialNumber || undefined,
             retention_days: formRetentionDays,
             stream_encoding: formProtocol === 'onvif' ? (formStreamEncoding || undefined) : undefined,
-            encoding: formEncoding,
+            // onvif/xiaomi auto-detect codec from the live stream and ignore the
+            // stored value, so don't send one (avoids writing a stale label).
+            // rtsp/http/srt/rtmp send formEncoding — it drives recorder selection.
+            encoding: formProtocol === 'onvif' || formProtocol === 'xiaomi' ? undefined : formEncoding,
             transcoding: {
                 enabled: formTranscodingEnabled,
                 target_codec: formTranscodingCodec,
@@ -629,14 +636,21 @@ async function performCameraSave() {
     <!-- Encoding -->
     <div>
       <label for="cam-encoding" class="input-label">{t('cameras.tableEncoding')}</label>
-      <select id="cam-encoding" class="input" bind:value={formEncoding}>
-        {#if formProtocol === 'onvif'}
+      <!-- onvif + xiaomi auto-detect their codec from the live stream and ignore
+           any stored value, so the field is read-only "auto-detect" for them.
+           rtsp/http/srt/rtmp keep it editable — it drives recorder selection
+           (H264Recorder vs H265Recorder). See #166. -->
+      {#if formProtocol === 'onvif' || formProtocol === 'xiaomi'}
+        <select id="cam-encoding" class="input" disabled>
           <option value="">{t('cameras.autoDetect')}</option>
-        {/if}
-        {#each (protocolsMap.get(formProtocol)?.encodings || [formEncoding]) as enc}
-          <option value={enc}>{t('cameras.encoding.' + enc) || enc.toUpperCase()}</option>
-        {/each}
-      </select>
+        </select>
+      {:else}
+        <select id="cam-encoding" class="input" bind:value={formEncoding}>
+          {#each (protocolsMap.get(formProtocol)?.encodings || [formEncoding]) as enc}
+            <option value={enc}>{t('cameras.encoding.' + enc) || enc.toUpperCase()}</option>
+          {/each}
+        </select>
+      {/if}
     </div>
 
     {#if formProtocol === 'xiaomi'}

--- a/web/src/lib/components/DiscoveryPanel.svelte
+++ b/web/src/lib/components/DiscoveryPanel.svelte
@@ -311,7 +311,10 @@
       await createCamera({
         name: device.name,
         protocol: 'xiaomi',
-        encoding: 'h264',
+        // encoding intentionally omitted: Xiaomi recorders detect the codec
+        // from the live stream (H.264 vs H.265) and ignore any stored value,
+        // so sending 'h264' here was misleading. The backend resolves and
+        // surfaces the real codec via the /protocols probe (#166).
         url: `xiaomi://${device.did}`,
         enabled: true,
       });


### PR DESCRIPTION
Closes #166. Fixes the user-visible bug from #165 (\"无法切换编码\" / can't switch encoding back to h264).

## Root cause

The bug was a **read-path inconsistency**, not a write bug. Three API paths returned `encoding` with different trust semantics:

| Path | Used by | Behavior |
|---|---|---|
| `GET /api/cameras/{id}/protocols` | LiveView | **Probe wins** (unconditional) |
| `GET /api/cameras` (list) | Cameras list, Dashboard, Surveillance grid | **DB wins** (probe only when DB empty) |
| `GET /api/cameras/{id}` (get) | Camera detail | **DB wins** (probe only when DB empty) |

Xiaomi cameras physically stream H.265, so `/protocols` always reported `h265` while the list/get showed the DB's stale/edited `h264`. From the user's perspective the \"switch back to h264\" save succeeded but LiveView kept showing h265 — looking broken.

## Fix

**Unify all three read-paths** so list/get match `/protocols`. Extracted two helpers:
- `probeCodec(camMgr, id) model.Format` — nil-safe recorder codec probe
- `resolveEncoding(stored, probe) string` — **probe wins when non-empty, stored value is the fallback**

All three paths now resolve encoding identically: the recorder's runtime probe is authoritative (it reads the actual stream); when the probe is empty (camera offline / codec not yet detected) the stored value is kept as a fallback — avoiding the **#112 black-screen regression** where `encoding=\"\"` reached the frontend.

### Why this is safe for configured protocols
`rtsp`/`http`/`srt`/`rtmp` recorders are constructed *from* the stored encoding, so `getCodecParams` returns the **same** codec — the displayed value is unchanged. Only auto-detect cameras (`onvif`/`xiaomi`) are affected, and there the probe *is* the correct answer.

## Frontend

- **`DiscoveryPanel.svelte`**: drop the hardcoded `encoding: 'h264'` for Xiaomi. The recorder ignores it and detects codec from the live stream, so sending it was misleading.
- **`CameraForm.svelte`**: render the encoding `<select>` as **read-only \"auto-detect\"** for `xiaomi` (same UX as the existing `onvif` auto-detect), and omit `encoding` from the `xiaomi`/`onvif` save payloads so a stale label can't be written. `rtsp`/`http`/`srt`/`rtmp` stay editable — encoding drives recorder selection there (`H264Recorder` vs `H265Recorder`) and must remain a user input.

## Why this is narrower than the full #166 proposal

The issue proposed making encoding **fully read-only for all protocols**. My investigation (in the plan) found that's **unsafe**: `encoding` is load-bearing for recorder selection (`internal/camera/recorder_factory.go` switches on `cam.Encoding` to pick the recorder type for rtsp/http/srt/rtmp). Making it read-only everywhere would require a pre-construction RTSP probe and risks re-introducing #112. This targeted fix resolves the actual user-visible inconsistency without that risk.

The DB schema and `ensureEncoding` machinery are deliberately **unchanged** — the read-time probe makes them consistent without new write paths.

## Test plan

- [x] `go test -race ./internal/api/ ./internal/camera/` — 652 pass
- [x] `golangci-lint run` on changed packages — 0 issues; `gofmt` clean
- [x] `cd web && npx vitest run` — 491 pass
- [x] New unit tests:
  - `resolveEncoding`: probe-wins-over-stored, stored-fallback-on-empty-probe, probe-fills-empty-stored
  - `probeCodec`: nil-manager safety
  - `CameraForm`: xiaomi renders disabled auto-detect; rtsp stays editable with multiple codec options
- [ ] M5 (`192.168.63.30`): verify a Xiaomi camera shows the same encoding on Cameras list, detail, LiveView, and Surveillance grid (all h265); an RTSP H.264 camera still shows h264 and is still editable; an offline camera still shows its last-known encoding.