### PR TITLE
fix(i18n): localize Dashboard health statuses + AVI play tooltip (#170)

### DIFF
--- a/web/src/components/library/CompactList.svelte
+++ b/web/src/components/library/CompactList.svelte
@@ -418,7 +418,7 @@
                   <button
                     onclick={(e) => handlePlayClick(e, recording.id)}
                     class="btn btn-ghost action-btn action-btn--play"
-                    title="Play AVI"
+                    title={t('recordings.view')}
                   >
                     <Play size={16} />
                   </button>

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -137,6 +137,13 @@
     if (s === 'reconnecting') return t('health.status.reconnecting');
     if (s === 'error' || s === 'failed') return t('cameras.statusError');
     if (s === 'stopped') return t('cameras.statusStopped');
+    // Camera-health statuses from /api/cameras/{id}/health (model.HealthStatus):
+    // healthy / warning / unknown. Without these branches the raw English enum
+    // value leaked into the UI (#170). statusColor() above already mapped these
+    // to colors, so this also fixes the "right color, wrong text" inconsistency.
+    if (s === 'healthy') return t('health.statusHealthy');
+    if (s === 'warning' || s === 'degraded') return t('health.statusWarning');
+    if (s === 'unknown') return t('health.statusUnknown');
     return s;
   }
 


### PR DESCRIPTION
Closes #170. Two hardcoded-English leftovers found during M5 testing (same class as the #165 / #100 i18n gaps).

## Changes

### 1. Dashboard camera-health list — `statusLabel()` (`web/src/routes/Dashboard.svelte:131`)
`statusLabel()` handled `recording`/`active`/`reconnecting`/`error`/`stopped` but fell through to the raw enum string for `healthy` / `warning` / `unknown`. So Chinese locales showed bare `healthy` / `warning` while `statusColor()` (same file, line 124) already painted the correct colors — the \"right color, wrong text\" inconsistency described in the issue.

Added three branches mapping to the **existing** health-status keys:
- `healthy` → `health.statusHealthy` (健康 / Healthy)
- `warning` / `degraded` → `health.statusWarning` (警告 / Warning)
- `unknown` → `health.statusUnknown` (未知 / Unknown)

### 2. Recordings AVI play tooltip — `web/src/components/library/CompactList.svelte:421`
`title=\"Play AVI\"` was the only hardcoded tooltip in the action cluster (the transcode button uses `transcoding.recordings.transcodeBtn`, the download button uses `transcoding.download_transcoded`). Switched to the **existing** `recordings.view` key (\"查看\" / \"View\") — also aligns the UX with the text-based \"view\" entry other formats use, per the issue's suggestion.

## Notes
- **Reused existing i18n keys only** — no `zh.json` / `en.json` changes (`health.statusHealthy`, `health.statusWarning`, `health.statusUnknown`, `recordings.view` all already exist in both locales).
- No new tests: there's no existing Dashboard/CompactList test harness, and these are pure string mappings. Verified via the issue's M5 reproduction (中文 locale).

## Test plan
- [x] `cd web && npx vitest run` — 491 pass
- [x] `rtk go build ./...` — clean
- [x] prettier clean on changed files
- [ ] M5 (`192.168.63.30`): re-verify the Dashboard health list shows 健康/警告/未知 instead of bare English; AVI recording tooltip shows 查看.