### PR TITLE
feat(monitoring): codec probe Prometheus metrics (#140)

### DIFF
--- a/docs/en/metrics.md
+++ b/docs/en/metrics.md
@@ -341,7 +341,43 @@ rate(nvr_remote_log_dropped_total[5m]) > 0
 
 ---
 
-## 13. Built-in Runtime Metrics
+## 13. Codec Probe Metrics
+
+Observe the codec-detection pipeline (recorder probe → DB persist → `/protocols` → orchestrator → player). The H.265 chain is the project's largest complexity and defect source — issue #112 (H.265 black screen) was a **silent probe failure**. These metrics make probe outcome and latency visible so stale-encoding problems surface before users see black video.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nvr_codec_probe_total` | Counter | `camera_id`, `encoding`, `result` | Codec probes by resolved encoding and outcome |
+| `nvr_codec_probe_duration_seconds` | Histogram | `camera_id` | Latency of the RTSP DESCRIBE codec probe |
+| `nvr_resolved_encoding` | Gauge | `camera_id`, `encoding` | Last codec resolved and persisted (value always `1`; the `encoding` label is the signal) |
+
+**`result` label values for `nvr_codec_probe_total`:**
+- `ok` — the live RTSP DESCRIBE resolved the codec (authoritative)
+- `unsupported` — the probe returned empty; fell back to a claimed/default encoding (the device works but its codec wasn't verified from the live stream)
+- `fail` — probe empty **and** no claim; defaulted to H264. Highest stale-encoding risk (see #112).
+
+**`encoding` label values:** `h264`, `h265`, `mjpeg`, `jpeg` (lowercase, normalized — `MJPEG`→`jpeg`).
+
+**Usage / alerts:**
+
+```promql
+# Stale-encoding suspect: a single camera's probe fails >50% over 5 min
+sum(rate(nvr_codec_probe_total{result="fail"}[5m]))
+  by (camera_id)
+  / sum(rate(nvr_codec_probe_total[5m])) by (camera_id) > 0.5
+
+# Slow/unreachable devices: high probe latency p99
+histogram_quantile(0.99, sum(rate(nvr_codec_probe_duration_seconds_bucket[5m])) by (le, camera_id)) > 2.5
+
+# Persisted encoding drift: nvr_resolved_encoding disagrees with the live codec
+# reported by other labels/paths — investigate as a persistence bug.
+```
+
+**Notes:** Emitted from `ONVIFRecorder.detectEncoding()` (counter + duration) and `ensureEncoding` (resolved gauge). Probe duration is the RTSP DESCRIBE round-trip only — it excludes ONVIF profile fallback. Histogram buckets: `0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10` seconds.
+
+---
+
+## 14. Built-in Runtime Metrics
 
 In addition to custom NVR metrics, these standard collectors are registered:
 

--- a/docs/zh/metrics.md
+++ b/docs/zh/metrics.md
@@ -341,7 +341,43 @@ rate(nvr_remote_log_dropped_total[5m]) > 0
 
 ---
 
-## 13. 内置运行时指标
+## 13. 编码探测指标
+
+观测编码检测链路（recorder 探测 → DB 持久化 → `/protocols` → orchestrator → 播放器）。H.265 链路是本项目最大的复杂度与缺陷来源——#112（H.265 黑屏）就是一次**静默的探测失败**。这些指标让探测结果与延迟可观测，使编码陈旧问题在用户看到黑屏之前就能被发现。
+
+| 指标 | 类型 | 标签 | 说明 |
+|--------|------|--------|-------------|
+| `nvr_codec_probe_total` | Counter | `camera_id`, `encoding`, `result` | 按解析出的编码与结果统计的探测次数 |
+| `nvr_codec_probe_duration_seconds` | Histogram | `camera_id` | RTSP DESCRIBE 编码探测耗时 |
+| `nvr_resolved_encoding` | Gauge | `camera_id`, `encoding` | 最近解析并持久化的编码（值恒为 `1`，`encoding` 标签才是信号） |
+
+**`nvr_codec_probe_total` 的 `result` 标签取值：**
+- `ok` — 实时 RTSP DESCRIBE 成功解析编码（权威结果）
+- `unsupported` — 探测返回空，回退到声明/默认编码（设备可用，但未从实时流验证）
+- `fail` — 探测返回空**且**无声明值，默认为 H264。陈旧编码风险最高（见 #112）。
+
+**`encoding` 标签取值：** `h264`、`h265`、`mjpeg`、`jpeg`（小写，`MJPEG`→`jpeg` 归一化）。
+
+**用法 / 告警：**
+
+```promql
+# 陈旧编码嫌疑：单相机 5 分钟内探测失败率 > 50%
+sum(rate(nvr_codec_probe_total{result="fail"}[5m]))
+  by (camera_id)
+  / sum(rate(nvr_codec_probe_total[5m])) by (camera_id) > 0.5
+
+# 慢/不可达设备：探测延迟 p99 偏高
+histogram_quantile(0.99, sum(rate(nvr_codec_probe_duration_seconds_bucket[5m])) by (le, camera_id)) > 2.5
+
+# 持久化编码漂移：nvr_resolved_encoding 与其他路径上报的实时编码不符
+# —— 应作为持久化 bug 排查。
+```
+
+**说明：** 由 `ONVIFRecorder.detectEncoding()`（计数器 + 耗时）和 `ensureEncoding`（resolved gauge）发出。探测耗时仅含 RTSP DESCRIBE 往返，不含 ONVIF profile 回退。直方图桶：`0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10` 秒。
+
+---
+
+## 14. 内置运行时指标
 
 除了自定义的 NVR 指标外，还注册了以下标准收集器：
 

--- a/internal/camera/rediscovery.go
+++ b/internal/camera/rediscovery.go
@@ -377,6 +377,15 @@ func (cm *CameraManager) ensureEncoding(cameraID string) {
 			}
 			logger.Info("auto-persisted encoding for camera", logArgs...)
 		}
+		// Surface the resolved encoding as a gauge for stale-encoding alerts
+		// (#140): compare this label against the recorder's live codec — a
+		// persistent mismatch signals a persistence bug. Value is always 1; the
+		// encoding label is the signal. Emitted on every resolution (including
+		// the idempotent alreadySet early-return above is skipped on purpose,
+		// since nothing changed).
+		if cm.metrics != nil {
+			cm.metrics.ResolvedEncoding.WithLabelValues(cameraID, encLower).Set(1)
+		}
 		// Best-effort DB persist. Single-column UPDATEs (not full-row upsert) so
 		// they can't be clobbered by a concurrent UpsertCamera rebuilding the row.
 		if cm.db != nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -99,6 +99,15 @@ type Metrics struct {
 	SQLiteReadInUseConnections prometheus.Gauge   // read pool
 	SQLiteReadWaitCount        prometheus.Counter // read pool: times a conn was unavailable
 	SQLiteReadWaitDuration     prometheus.Gauge   // read pool: cumulative seconds waited for a conn
+
+	// Codec probe metrics — observability for the H.265 codec-probe pipeline
+	// (recorder probe → DB persist → /protocols → orchestrator → player). The
+	// chain is the project's largest complexity/defect source (#112 black-screen
+	// was a silent probe failure). These make probe outcome + latency visible to
+	// Prometheus so stale-encoding issues surface before users see black video.
+	CodecProbeTotal           *prometheus.CounterVec   // labels: camera_id, encoding, result (ok|fail|unsupported)
+	CodecProbeDurationSeconds *prometheus.HistogramVec // labels: camera_id — RTSP DESCRIBE probe latency
+	ResolvedEncoding          *prometheus.GaugeVec     // labels: camera_id, encoding — last persisted encoding (alert on drift)
 }
 
 // NewMetrics creates a new Metrics instance with a custom registry,
@@ -467,6 +476,21 @@ func NewMetrics() *Metrics {
 		Help: "Total seconds callers waited for a read-pool connection (cumulative since start).",
 	})
 
+	// Codec probe metrics — see the Metrics struct comment for rationale (#140).
+	codecProbeTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "nvr_codec_probe_total",
+		Help: "Total codec probes by camera, resolved encoding, and result. result=ok: live RTSP DESCRIBE resolved the codec; unsupported: probe empty, fell back to a claimed/default encoding; fail: probe empty AND no fallback (defaulted to H264 — highest stale-encoding risk, see #112).",
+	}, []string{"camera_id", "encoding", "result"})
+	codecProbeDurationSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "nvr_codec_probe_duration_seconds",
+		Help:    "Latency of the RTSP DESCRIBE codec probe in seconds, partitioned by camera. High p99 indicates slow/unreachable devices.",
+		Buckets: []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{"camera_id"})
+	resolvedEncoding := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "nvr_resolved_encoding",
+		Help: "Last codec resolved for a camera and persisted to DB (value is always 1; the encoding label is the signal). Compare against the recorder's live codec to detect stale persisted encoding — a persistent mismatch indicates a persistence bug.",
+	}, []string{"camera_id", "encoding"})
+
 	reg.MustRegister(
 		recordingBytesTotal,
 		activeCameras,
@@ -543,6 +567,9 @@ func NewMetrics() *Metrics {
 		sqliteReadInUseConnections,
 		sqliteReadWaitCount,
 		sqliteReadWaitDuration,
+		codecProbeTotal,
+		codecProbeDurationSeconds,
+		resolvedEncoding,
 	)
 
 	return &Metrics{
@@ -622,6 +649,9 @@ func NewMetrics() *Metrics {
 		SQLiteReadInUseConnections:     sqliteReadInUseConnections,
 		SQLiteReadWaitCount:            sqliteReadWaitCount,
 		SQLiteReadWaitDuration:         sqliteReadWaitDuration,
+		CodecProbeTotal:                codecProbeTotal,
+		CodecProbeDurationSeconds:      codecProbeDurationSeconds,
+		ResolvedEncoding:               resolvedEncoding,
 	}
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,6 +168,81 @@ func TestHLSFramesDroppedCounter(t *testing.T) {
 		}
 	}
 	t.Fatal("expected nvr_hls_frames_dropped_total metric family")
+}
+
+// TestCodecProbeMetrics covers the H.265 codec-probe observability metrics (#140):
+// the probe counter must be partitioned by result (ok/unsupported/fail), the
+// duration histogram must record observations, and the resolved-encoding gauge
+// must carry the encoding label that stale-encoding alerts compare against.
+func TestCodecProbeMetrics(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	m := NewMetrics()
+	require.NotNil(t, m.CodecProbeTotal)
+	require.NotNil(t, m.CodecProbeDurationSeconds)
+	require.NotNil(t, m.ResolvedEncoding)
+
+	// Simulate the three probe outcomes detectEncoding records.
+	m.CodecProbeTotal.WithLabelValues("cam-onvif", "h265", "ok").Inc()
+	m.CodecProbeTotal.WithLabelValues("cam-onvif", "h265", "ok").Inc()
+	m.CodecProbeTotal.WithLabelValues("cam-onvif", "h264", "unsupported").Inc()
+	m.CodecProbeTotal.WithLabelValues("cam-flaky", "h264", "fail").Inc()
+
+	// Duration observations.
+	m.CodecProbeDurationSeconds.WithLabelValues("cam-onvif").Observe(0.12)
+	m.CodecProbeDurationSeconds.WithLabelValues("cam-onvif").Observe(2.1)
+
+	// Resolved encoding — value is always 1; the label is the signal.
+	m.ResolvedEncoding.WithLabelValues("cam-onvif", "h265").Set(1)
+
+	families, err := m.Registry.Gather()
+	require.NoError(t, err)
+
+	byName := make(map[string]*dto.MetricFamily, len(families))
+	for _, f := range families {
+		byName[f.GetName()] = f
+	}
+
+	// Counter: 3 distinct (camera,encoding,result) combos
+	// (cam-onvif/h265/ok, cam-onvif/h264/unsupported, cam-flaky/h264/fail).
+	probeFam, ok := byName["nvr_codec_probe_total"]
+	require.True(t, ok, "expected nvr_codec_probe_total metric family")
+	require.Len(t, probeFam.GetMetric(), 3, "3 distinct label combinations")
+
+	// ok/h265 incremented twice → counter value 2.
+	var okCount float64
+	for _, met := range probeFam.GetMetric() {
+		labels := labelMap(met)
+		if labels["camera_id"] == "cam-onvif" && labels["encoding"] == "h265" && labels["result"] == "ok" {
+			okCount = met.GetCounter().GetValue()
+		}
+	}
+	require.Equal(t, float64(2), okCount, "ok/h265 should have count 2")
+
+	// Duration histogram: 2 observations for cam-onvif.
+	durFam, ok := byName["nvr_codec_probe_duration_seconds"]
+	require.True(t, ok, "expected nvr_codec_probe_duration_seconds metric family")
+	require.NotEmpty(t, durFam.GetMetric(), "duration histogram should have samples")
+	require.Equal(t, uint64(2), durFam.GetMetric()[0].GetHistogram().GetSampleCount(),
+		"cam-onvif duration histogram should have 2 observations")
+
+	// Resolved encoding gauge: value 1, encoding label h265.
+	encFam, ok := byName["nvr_resolved_encoding"]
+	require.True(t, ok, "expected nvr_resolved_encoding metric family")
+	require.NotEmpty(t, encFam.GetMetric())
+	require.Equal(t, float64(1), encFam.GetMetric()[0].GetGauge().GetValue(),
+		"resolved_encoding gauge value should always be 1")
+	require.Equal(t, "h265", labelMap(encFam.GetMetric()[0])["encoding"],
+		"resolved_encoding gauge should carry the encoding label")
+}
+
+// labelMap converts a metric's labels to a string map for assertion.
+func labelMap(m *dto.Metric) map[string]string {
+	out := make(map[string]string, len(m.GetLabel()))
+	for _, l := range m.GetLabel() {
+		out[l.GetName()] = l.GetValue()
+	}
+	return out
 }
 
 func TestNewStreamingMetrics(t *testing.T) {

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -304,27 +304,46 @@ func (r *ONVIFRecorder) detectEncoding(ctx context.Context) string {
 	// fall back to it and log a warning when it disagrees with reality.
 	claimed := r.claimedEncoding(ctx)
 
+	// recordProbe emits a codec-probe metric event (#140). result is one of:
+	//   ok          — live RTSP DESCRIBE resolved the codec (authoritative)
+	//   unsupported — probe empty; fell back to a claimed/default encoding (device works but wasn't verified live)
+	//   fail        — probe empty AND no claim; defaulted to H264 (highest stale-encoding risk, see #112)
+	recordProbe := func(encoding, result string) {
+		if r.metrics == nil {
+			return
+		}
+		r.metrics.CodecProbeTotal.WithLabelValues(r.cfg.CameraID, strings.ToLower(encoding), result).Inc()
+	}
+
 	// 1. RTSP DESCRIBE is authoritative. Some ONVIF cameras lie about their codec.
 	if r.rtspURL != "" {
-		if enc := r.probeEncodingFn(); enc != "" {
-			if claimed != "" && !strings.EqualFold(enc, claimed) {
+		probeStart := time.Now()
+		probed := r.probeEncodingFn()
+		if r.metrics != nil {
+			r.metrics.CodecProbeDurationSeconds.WithLabelValues(r.cfg.CameraID).Observe(time.Since(probeStart).Seconds())
+		}
+		if probed != "" {
+			if claimed != "" && !strings.EqualFold(probed, claimed) {
 				onvifRecLogger.Warn("ONVIF-declared encoding disagrees with actual RTSP stream; trusting the stream",
-					"camera_id", r.cfg.CameraID, "declared", claimed, "actual", enc)
+					"camera_id", r.cfg.CameraID, "declared", claimed, "actual", probed)
 			} else {
-				onvifRecLogger.Info("detected encoding via RTSP DESCRIBE", "camera_id", r.cfg.CameraID, "encoding", enc)
+				onvifRecLogger.Info("detected encoding via RTSP DESCRIBE", "camera_id", r.cfg.CameraID, "encoding", probed)
 			}
-			return enc
+			recordProbe(probed, "ok")
+			return probed
 		}
 	}
 
 	// 2/3. Fall back to the claimed encoding (config or ONVIF).
 	if claimed != "" {
 		onvifRecLogger.Info("RTSP DESCRIBE unavailable, using claimed encoding", "camera_id", r.cfg.CameraID, "encoding", claimed)
+		recordProbe(claimed, "unsupported")
 		return claimed
 	}
 
 	// 4. Default to H264
 	onvifRecLogger.Warn("could not detect encoding, defaulting to H264", "camera_id", r.cfg.CameraID)
+	recordProbe("H264", "fail")
 	return "H264"
 }
 


### PR DESCRIPTION
Closes #140. Adds observability for the H.265 codec-probe pipeline so stale-encoding issues surface before users see black video (#112 was a silent probe failure).

## Metrics (3 new, exposed at `/metrics`)

| Metric | Type | Labels | Description |
|---|---|---|---|
| `nvr_codec_probe_total` | Counter | `camera_id`, `encoding`, `result` | Codec probes by resolved encoding + outcome |
| `nvr_codec_probe_duration_seconds` | Histogram | `camera_id` | RTSP DESCRIBE probe latency (buckets 0.05–10s) |
| `nvr_resolved_encoding` | Gauge | `camera_id`, `encoding` | Last persisted encoding (value always 1; the `encoding` label is the signal) |

**`result` values:** `ok` (live RTSP DESCRIBE resolved the codec), `unsupported` (probe empty, fell back to a claimed/default encoding), `fail` (probe empty **and** no claim → defaulted H264 — highest stale-encoding risk).

## Instrumentation

- **`ONVIFRecorder.detectEncoding()`** (`internal/recorder/onvif.go`): wraps `probeEncodingFn()` for duration and records the result/encoding at every return path (`ok`/`unsupported`/`fail`). This is the natural probe seam — recorders already hold a `*metrics.Metrics`.
- **`CameraManager.ensureEncoding`** (`internal/camera/rediscovery.go`): emits `nvr_resolved_encoding` after a successful persist (deliberately skipped on the idempotent `alreadySet` early-return, since nothing changed).

### Scope decision (deviation from the issue, called out)
The issue suggested a 3rd instrumentation point in the `/protocols` handler. I **did not** add that — it would require threading `*metrics.Metrics` into the `api` package (currently metrics-free), and `ensureEncoding` + `detectEncoding` already cover the two natural seams (persisted value + probe outcome). Adding the api-handler point would duplicate `resolved_encoding` without new signal. Happy to add it if you want the live `/protocols` response specifically tracked.

## Docs
Added a **\"Codec Probe Metrics\"** section (section 13) to `docs/en/metrics.md` and `docs/zh/metrics.md` with the metric table + PromQL alert examples:
- Stale-encoding suspect: probe fail rate > 50% over 5 min per camera
- Slow/unreachable devices: probe latency p99 > 2.5s
- Persisted-encoding drift: `nvr_resolved_encoding` disagrees with live codec

## Test plan
- [x] `TestCodecProbeMetrics` — counter partitioning by `result`, histogram sample count, gauge label/value contract
- [x] `go test ./internal/metrics/ ./internal/recorder/ ./internal/camera/ ./internal/api/` — 824 pass
- [x] `golangci-lint run` on changed packages — 0 issues; `gofmt` clean
- [x] `go build ./...` — clean
- [ ] M5 (`192.168.63.30`): `curl localhost:9090/metrics | grep nvr_codec_probe` after a camera reconnect — confirm the counter/histogram/gauge appear with the expected labels.
- [ ] RPi 3B: confirm scrape overhead is negligible (metrics are event-driven, not per-frame).