### PR TITLE
fix(ai): ObjectDetector passed output dims as input — AI detection silently failed every frame (#173)

### DIFF
--- a/web/src/lib/ai-detection/inference.test.ts
+++ b/web/src/lib/ai-detection/inference.test.ts
@@ -328,7 +328,27 @@ describe('ObjectDetector', () => {
 
       await detector.detect(mockFrame);
 
-      expect(mockRuntime.run).toHaveBeenCalledWith(expect.any(Float32Array), [1, 84, 8400]);
+      // Input dims are [1, 3, inputSize, inputSize] (NCHW RGB image), NOT the
+      // output shape [1, 84, 8400]. Regression guard for #173.
+      expect(mockRuntime.run).toHaveBeenCalledWith(expect.any(Float32Array), [1, 3, 640, 640]);
+    });
+
+    it('passes input dims whose product matches the preprocessed tensor length (#173 regression)', async () => {
+      // The dims passed to runtime.run must describe the SAME element count as
+      // the Float32Array produced by preprocessFrame. Previously the output
+      // shape [1,84,8400]=705600 was passed while the input tensor had
+      // [1,3,640,640]=1228800 elements → ORT threw on every frame (#173).
+      const runSpy = vi.mocked(mockRuntime.run);
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 1 });
+      const mockFrame = createMockVideoFrame();
+
+      await detector.detect(mockFrame);
+
+      expect(runSpy).toHaveBeenCalledTimes(1);
+      const [tensorArg, dimsArg] = runSpy.mock.calls[0];
+      const tensorLen = (tensorArg as Float32Array).length;
+      const dimsProduct = (dimsArg as number[]).reduce((a, b) => a * b, 1);
+      expect(dimsProduct).toBe(tensorLen);
     });
 
     it('filters by confidence threshold', async () => {

--- a/web/src/lib/ai-detection/inference.ts
+++ b/web/src/lib/ai-detection/inference.ts
@@ -449,7 +449,11 @@ export class ObjectDetector {
       );
 
       // 2. Run inference
-      const dims = [1, 4 + this._numClasses, this._numBoxes];
+      // Input tensor shape is [1, 3, inputSize, inputSize] — the preprocessed
+      // RGB Float32 image (NCHW). Do NOT use the *output* shape [1, 4+numClasses,
+      // numBoxes] here; that produces a tensor of the wrong size and every
+      // inference throws "Tensor's size does not match data length" (#173).
+      const dims = [1, 3, this._inputSize, this._inputSize];
       const results = await this._runtime.run(tensor, dims);
 
       // 3. Parse output — get first output tensor


### PR DESCRIPTION
## Summary

Fixes #173. AI object detection has been **completely non-functional since #16 introduced it** — every inference frame threw `Tensor's size(705600) does not match data length(1228800)` and was silently swallowed, so no detection box ever rendered.

## Root cause

`web/src/lib/ai-detection/inference.ts:452` passed the **output** tensor shape as the **input** dims:

```ts
const dims = [1, 4 + this._numClasses, this._numBoxes];   // [1, 84, 8400] = 705600 — OUTPUT shape
const results = await this._runtime.run(tensor, dims);
```

`preprocessFrame` produces a `[1, 3, 640, 640]` Float32Array (1,228,800 elements). ORT built a tensor of size 705,600 from the dims but received 1,228,800 data elements → mismatch → throw. The `catch` in `detect()` logged a warning and returned empty detections, so the failure was invisible apart from console spam.

## Fix

```diff
- const dims = [1, 4 + this._numClasses, this._numBoxes];
+ const dims = [1, 3, this._inputSize, this._inputSize];
```

## Why CI didn't catch it

The existing test `'passes correct tensor dims to runtime'` asserted `toHaveBeenCalledWith(..., [1, 84, 8400])` — it **encoded the bug**, so the test passed while production was broken. This PR corrects that assertion to `[1, 3, 640, 640]` and adds a regression test that checks the dims product equals the preprocessed tensor length (1·3·640·640 = 1,228,800), so this class of input/output confusion cannot recur silently.

## Verification

- `cd web && npm test` — 492 tests pass (incl. 36 in inference.test.ts, +2 new)
- `cd web && npm run build` — clean
- ONNX model verified independently: input `images` = `[1,3,640,640]`, output `output0` = `[1,84,8400]` (parsed from `/mnt/data/nvr/models/yolo11n.onnx` protobuf)

## Test plan

- [x] Unit tests pass
- [ ] Deploy to M5, open a camera with AI enabled, confirm detection boxes render (was: never rendered) and console is free of `Tensor's size` errors

cc @Mi-Bee-Studio/nvr
