### PR TITLE
fix(autodiscover): normalize endpoint dedup queries — prevent duplicate cameras on auth-required devices (#175)

### DIFF
--- a/cmd/mibee-nvr/repair.go
+++ b/cmd/mibee-nvr/repair.go
@@ -52,6 +52,8 @@ func runRepair() int {
 		return runRepairPruneIntermediateMP4()
 	case "reclaim-orphan-merges":
 		return runRepairReclaimOrphanMerges()
+	case "normalize-endpoints":
+		return runRepairNormalizeEndpoints()
 	case "--help", "-h":
 		printRepairUsage()
 		return 0
@@ -1246,6 +1248,9 @@ Subcommands:
   reclaim-orphan-merges Remove merged-output .mp4 files left on disk after their recording
                          row was deleted via the web UI (pre-#117 fix leak). Only touches
                          unreferenced .mp4 files; never source segments or frame dirs.
+  normalize-endpoints   Canonicalize every camera's onvif_endpoint (elide default :80/:443,
+                         lowercase scheme/host, strip trailing slash) so dedup queries match
+                         across discovery paths. Fixes legacy rows written before #175.
 
 Common options:
   --dry-run      Report what would change without modifying (default)

--- a/cmd/mibee-nvr/repair_endpoints.go
+++ b/cmd/mibee-nvr/repair_endpoints.go
@@ -1,0 +1,102 @@
+package main
+
+// repair normalize-endpoints: canonicalize every camera's onvif_endpoint column
+// so that dedup queries (CameraIDByOnvifEndpoint / CameraExistsByOnvifEndpoint)
+// match across discovery paths. Fixes legacy rows written before #175, where a
+// row stored as "http://1.2.3.4:80/onvif/..." failed to match a later discovery
+// of "http://1.2.3.4/onvif/..." (no default port) and got re-enrolled as a
+// duplicate camera.
+//
+// Safe to run while the server is stopped (preferred) or running (WAL mode).
+// Default is --dry-run; pass --execute to apply.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+)
+
+func runRepairNormalizeEndpoints() int {
+	opts := parseRepairFlags(3) // subcommand is os.Args[2]; flags start at 3
+
+	// Help flag short-circuit (parseRepairFlags does not handle --help).
+	for _, a := range os.Args[3:] {
+		if a == "--help" || a == "-h" {
+			printRepairNormalizeEndpointsUsage()
+			return 0
+		}
+	}
+
+	db, _, err := openDBFromConfig(opts.configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+
+	ctx, cancel := setupSignalHandler()
+	defer cancel()
+
+	rows, err := db.ListCameraEndpointsForRepair(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: query cameras: %v\n", err)
+		return 1
+	}
+
+	fmt.Println("REPAIR NORMALIZE-ENDPOINTS")
+	fmt.Println("===========================")
+	if opts.dryRun {
+		fmt.Println("DRY RUN — no changes made. Run with --execute to apply.")
+	}
+	fmt.Println()
+
+	changed := 0
+	unchanged := 0
+	for _, r := range rows {
+		normalized := storage.NormalizeOnvifEndpoint(r.Endpoint)
+		if normalized == r.Endpoint {
+			unchanged++
+			continue
+		}
+		changed++
+		fmt.Printf("  %s\n    %q\n →  %q\n", r.Name, r.Endpoint, normalized)
+		if !opts.dryRun {
+			if err := db.UpdateCameraOnvifEndpointRaw(ctx, r.ID, normalized); err != nil {
+				fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", r.ID, err)
+				return 1
+			}
+		}
+	}
+
+	fmt.Println()
+	if changed == 0 {
+		fmt.Printf("All %d camera endpoint(s) already canonical. Nothing to do.\n", unchanged)
+	} else {
+		action := "would be updated"
+		if !opts.dryRun {
+			action = "updated"
+		}
+		fmt.Printf("%d endpoint(s) %s, %d already canonical.\n", changed, action, unchanged)
+	}
+	return 0
+}
+
+func printRepairNormalizeEndpointsUsage() {
+	fmt.Print(`Usage: mibee-nvr repair normalize-endpoints [--execute] [--config <path>]
+
+Canonicalize every camera's onvif_endpoint column so that dedup queries match
+across discovery paths (elides default :80/:443, lowercases scheme/host, strips
+trailing slash). Fixes legacy rows written before issue #175, where a device
+stored as "http://1.2.3.4:80/..." failed to match a later discovery of
+"http://1.2.3.4/..." and got re-enrolled as a duplicate.
+
+Safe to run while the server is stopped (preferred) or running (WAL mode).
+
+Options:
+  --dry-run       Report what would change without modifying (default)
+  --execute       Actually apply the normalization
+  --config <path> Config file path (default: mibee-nvr.yaml)
+  --help, -h      Show this help
+`)
+}

--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -22,7 +22,6 @@ package autodiscover
 import (
 	"context"
 	"log/slog"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -217,40 +216,13 @@ func canonicalEndpoint(endpoint string, xaddrs []string) string {
 	return ""
 }
 
-// normalizeEndpoint canonicalizes an ONVIF device-service URL so that
-// semantically-identical endpoints compare equal. It:
-//   - lowercases the scheme and host (case-insensitive per RFC 3986)
-//   - elides the default port (:80 for http, :443 for https)
-//   - strips trailing slashes
-//
-// If the input is not a valid URL (unexpected for ONVIF XAddrs, but possible
-// from malformed firmware), it falls back to a best-effort strings.TrimRight
-// so the comparison never panics.
+// normalizeEndpoint canonicalizes an ONVIF device-service URL. It is a thin
+// wrapper around storage.NormalizeOnvifEndpoint so that the canonical form is
+// identical between the autodiscover discovery path and the storage write/dedup
+// paths — preventing :80-vs-no-port mismatches from defeating dedup (#175).
+// Kept as an unexported alias for the existing call sites in this package.
 func normalizeEndpoint(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-	u, err := url.Parse(raw)
-	if err != nil || u.Scheme == "" || u.Host == "" {
-		// Fallback: at least strip trailing slashes (legacy behavior).
-		return strings.TrimRight(raw, "/")
-	}
-	scheme := strings.ToLower(u.Scheme)
-	host := strings.ToLower(u.Hostname())
-	port := u.Port()
-	// Elide default ports.
-	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
-		port = ""
-	}
-	// Reconstruct the canonical form.
-	result := scheme + "://" + host
-	if port != "" {
-		result += ":" + port
-	}
-	path := strings.TrimRight(u.Path, "/")
-	result += path
-	return result
+	return storage.NormalizeOnvifEndpoint(raw)
 }
 
 // matchesIgnoreScope reports whether any of the device's scopes contains any

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
@@ -51,10 +52,12 @@ func (cm *CameraManager) AddCamera(ctx context.Context, cam config.CameraConfig)
 			break
 		}
 		// ONVIF endpoint dedup: both must be onvif protocol with a non-empty,
-		// equal endpoint. Stripped of trailing slash for tolerance.
+		// equal endpoint. Compared via NormalizeOnvifEndpoint (lowercases
+		// scheme/host, elides default port :80/:443, strips trailing slash) so
+		// that "http://1.2.3.4/..." and "http://1.2.3.4:80/..." match (#175).
 		if cam.Protocol == string(model.ProtoONVIF) && existing.Protocol == string(model.ProtoONVIF) {
-			if ep := strings.TrimRight(cam.ONVIFEndpoint, "/"); ep != "" {
-				if strings.TrimRight(existing.ONVIFEndpoint, "/") == ep {
+			if ep := storage.NormalizeOnvifEndpoint(cam.ONVIFEndpoint); ep != "" {
+				if storage.NormalizeOnvifEndpoint(existing.ONVIFEndpoint) == ep {
 					dup = true
 					dupID = existing.ID
 					break

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -165,13 +165,18 @@ func (d *DB) ListArchivedCameras(ctx context.Context) ([]CameraRow, error) {
 	return res, nil
 }
 
-// UpsertCamera inserts or updates a camera record in the database
+// UpsertCamera inserts or updates a camera record in the database.
+//
+// The onvifEndpoint is normalized to its canonical form (default port :80/:443
+// elided, scheme/host lowercased) before storage so that dedup queries can use
+// a normalized comparison and a device discovered as "http://1.2.3.4/..." still
+// matches a later write of "http://1.2.3.4:80/..." (#175).
 func (d *DB) UpsertCamera(ctx context.Context, id, name, protocol, encoding, url, username, password string, onvifEndpoint, profileToken, streamEncoding, stableID string) error {
 	q := `INSERT INTO cameras(id, name, protocol, encoding, url, username, password, onvif_endpoint, profile_token, stream_encoding, stable_id) VALUES(?,?,?,?,?,?,?,?,?,?,?)
 
 		 ON CONFLICT(id) DO UPDATE SET name=excluded.name, protocol=excluded.protocol, encoding=excluded.encoding, url=excluded.url, username=excluded.username, password=excluded.password, onvif_endpoint=excluded.onvif_endpoint, profile_token=excluded.profile_token, stream_encoding=excluded.stream_encoding, stable_id=excluded.stable_id;`
 
-	_, err := d.db.ExecContext(ctx, q, id, name, protocol, encoding, url, username, password, onvifEndpoint, profileToken, streamEncoding, stableID)
+	_, err := d.db.ExecContext(ctx, q, id, name, protocol, encoding, url, username, password, NormalizeOnvifEndpoint(onvifEndpoint), profileToken, streamEncoding, stableID)
 
 	return err
 }
@@ -212,11 +217,11 @@ func (d *DB) CameraExistsByOnvifEndpoint(ctx context.Context, onvifEndpoint, ser
 		return false, nil
 	}
 	if onvifEndpoint != "" {
-		var c int
-		if err := d.readConn().QueryRowContext(ctx, `SELECT COUNT(*) FROM cameras WHERE onvif_endpoint=? LIMIT 1`, onvifEndpoint).Scan(&c); err != nil {
+		found, err := d.endpointExists(ctx, onvifEndpoint)
+		if err != nil {
 			return false, err
 		}
-		if c > 0 {
+		if found {
 			return true, nil
 		}
 	}
@@ -437,12 +442,11 @@ func (d *DB) CameraIDByOnvifEndpoint(ctx context.Context, onvifEndpoint, serial 
 		return "", "", nil
 	}
 	if onvifEndpoint != "" {
-		var id string
-		if err := d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE onvif_endpoint=? LIMIT 1`, onvifEndpoint).Scan(&id); err != nil {
-			if err != sql.ErrNoRows {
-				return "", "", err
-			}
-		} else {
+		id, found, err := d.cameraIDByEndpoint(ctx, onvifEndpoint)
+		if err != nil {
+			return "", "", err
+		}
+		if found {
 			return id, "endpoint", nil
 		}
 	}

--- a/internal/storage/db_camera_test.go
+++ b/internal/storage/db_camera_test.go
@@ -170,3 +170,62 @@ func TestCameraIDByOnvifEndpoint(t *testing.T) {
 	require.Equal(t, camID2, id)
 	require.Equal(t, "endpoint", kind, "endpoint match must be reported when both endpoint and serial match")
 }
+
+// TestCameraIDByOnvifEndpoint_DefaultPortMismatch is the regression test for
+// issue #175: a row stored with an explicit default port (:80) must still be
+// matched by a query without it (and vice versa). Before the fix,
+// CameraIDByOnvifEndpoint did a raw WHERE onvif_endpoint=? exact match, so
+// autodiscover (which discovers endpoints WITHOUT :80 from WS-Discovery
+// XAddrs) would miss a camera stored WITH :80 and create a duplicate.
+func TestCameraIDByOnvifEndpoint_DefaultPortMismatch(t *testing.T) {
+	db := newCameraDB(t)
+	ctx := context.Background()
+	const camID = "cam-port"
+
+	// Store WITH explicit :80. UpsertCamera now normalizes on write, so the
+	// stored value is actually "http://192.168.1.50/onvif/device_service"; we
+	// also directly exercise the un-normalized stored case below.
+	require.NoError(t, db.UpsertCamera(ctx, camID, "Port Cam", "onvif", "", "", "", "",
+		"http://192.168.1.50:80/onvif/device_service", "", "", ""))
+
+	// Query WITHOUT :80 → must match (this is the autodiscover discovery form).
+	id, kind, err := db.CameraIDByOnvifEndpoint(ctx, "http://192.168.1.50/onvif/device_service", "")
+	require.NoError(t, err)
+	require.Equal(t, camID, id)
+	require.Equal(t, "endpoint", kind)
+
+	// Query WITH :80 → must still match (normalized comparison).
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "http://192.168.1.50:80/onvif/device_service", "")
+	require.NoError(t, err)
+	require.Equal(t, camID, id)
+	require.Equal(t, "endpoint", kind)
+
+	// Simulate a LEGACY un-normalized row (written before UpsertCamera
+	// normalized on write) by directly poking the column to contain :80.
+	_, err = db.db.ExecContext(ctx, `UPDATE cameras SET onvif_endpoint=? WHERE id=?`,
+		"http://192.168.1.50:80/onvif/device_service", camID)
+	require.NoError(t, err)
+	// Now a query WITHOUT :80 must STILL match via the normalize-and-compare
+	// fallback scan — this is the exact scenario from #175.
+	id, kind, err = db.CameraIDByOnvifEndpoint(ctx, "http://192.168.1.50/onvif/device_service", "")
+	require.NoError(t, err)
+	require.Equal(t, camID, id, "legacy row stored with :80 must match a query without :80 (#175)")
+	require.Equal(t, "endpoint", kind)
+}
+
+// TestCameraExistsByOnvifEndpoint_DefaultPortMismatch mirrors the above for the
+// sibling Exists query, which had the same exact-match bug.
+func TestCameraExistsByOnvifEndpoint_DefaultPortMismatch(t *testing.T) {
+	db := newCameraDB(t)
+	ctx := context.Background()
+	// Legacy row stored with explicit :80 via direct column poke.
+	require.NoError(t, db.UpsertCamera(ctx, "cam-ex", "Exists Cam", "onvif", "", "", "", "",
+		"http://192.168.1.70/onvif/device_service", "", "", ""))
+	_, err := db.db.ExecContext(ctx, `UPDATE cameras SET onvif_endpoint=? WHERE id=?`,
+		"http://192.168.1.70:80/onvif/device_service", "cam-ex")
+	require.NoError(t, err)
+
+	found, err := db.CameraExistsByOnvifEndpoint(ctx, "http://192.168.1.70/onvif/device_service", "")
+	require.NoError(t, err)
+	require.True(t, found, "query without :80 must match legacy row stored with :80 (#175)")
+}

--- a/internal/storage/endpoint.go
+++ b/internal/storage/endpoint.go
@@ -67,9 +67,12 @@ func (d *DB) endpointExists(ctx context.Context, query string) (bool, error) {
 		return true, nil
 	}
 	// Fallback: normalize every stored endpoint and compare to the normalized query.
+	// This catches legacy rows stored before UpsertCamera normalized on write
+	// (e.g. a row with explicit :80 while the query omits it). Note we MUST scan
+	// even when the query is already canonical, because the STORED value may not be.
 	normQuery := NormalizeOnvifEndpoint(query)
-	if normQuery == "" || normQuery == query {
-		return false, nil // already tried exact; nothing more to do
+	if normQuery == "" {
+		return false, nil
 	}
 	rows, err := d.readConn().QueryContext(ctx, `SELECT onvif_endpoint FROM cameras`)
 	if err != nil {
@@ -99,9 +102,10 @@ func (d *DB) cameraIDByEndpoint(ctx context.Context, query string) (string, bool
 	} else if err != sql.ErrNoRows {
 		return "", false, err
 	}
-	// Fallback: normalize-and-compare scan.
+	// Fallback: normalize-and-compare scan. Catches legacy un-normalized rows
+	// even when the query is already canonical (the stored value may carry :80).
 	normQuery := NormalizeOnvifEndpoint(query)
-	if normQuery == "" || normQuery == query {
+	if normQuery == "" {
 		return "", false, nil
 	}
 	rows, err := d.readConn().QueryContext(ctx, `SELECT id, onvif_endpoint FROM cameras`)

--- a/internal/storage/endpoint.go
+++ b/internal/storage/endpoint.go
@@ -1,0 +1,158 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"strings"
+)
+
+// NormalizeOnvifEndpoint canonicalizes an ONVIF device-service URL so that
+// semantically-identical endpoints compare equal. It:
+//   - lowercases the scheme and host (case-insensitive per RFC 3986)
+//   - elides the default port (:80 for http, :443 for https)
+//   - strips trailing slashes
+//
+// This is the single source of truth for endpoint canonicalization across the
+// codebase. The autodiscover package re-exports it (it previously had its own
+// private copy); the storage layer uses it for both write-side normalization
+// (UpsertCamera stores the canonical form) and read-side dedup matching
+// (CameraIDByOnvifEndpoint / CameraExistsByOnvifEndpoint normalize before
+// comparing), so that a device discovered as "http://1.2.3.4/onvif/..." matches
+// a row stored as "http://1.2.3.4:80/onvif/..." (#175).
+//
+// If the input is not a valid URL (unexpected for ONVIF XAddrs, but possible
+// from malformed firmware), it falls back to a best-effort strings.TrimRight
+// so the comparison never panics.
+func NormalizeOnvifEndpoint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		// Fallback: at least strip trailing slashes (legacy behavior).
+		return strings.TrimRight(raw, "/")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	port := u.Port()
+	// Elide default ports.
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+	// Reconstruct the canonical form.
+	result := scheme + "://" + host
+	if port != "" {
+		result += ":" + port
+	}
+	path := strings.TrimRight(u.Path, "/")
+	result += path
+	return result
+}
+
+// endpointExists reports whether any camera row's onvif_endpoint is
+// semantically equal to query after canonicalization. It first tries an exact
+// SQL match (the common, already-normalized case), then falls back to a
+// normalize-and-compare scan of all rows so that legacy rows stored with a
+// default port (:80) still match a query without it (#175). The camera count
+// is small (tens), so the fallback scan is cheap.
+func (d *DB) endpointExists(ctx context.Context, query string) (bool, error) {
+	// Fast path: exact match on the (now normalized-on-write) column.
+	var c int
+	if err := d.readConn().QueryRowContext(ctx, `SELECT COUNT(*) FROM cameras WHERE onvif_endpoint=? LIMIT 1`, query).Scan(&c); err != nil {
+		return false, err
+	}
+	if c > 0 {
+		return true, nil
+	}
+	// Fallback: normalize every stored endpoint and compare to the normalized query.
+	normQuery := NormalizeOnvifEndpoint(query)
+	if normQuery == "" || normQuery == query {
+		return false, nil // already tried exact; nothing more to do
+	}
+	rows, err := d.readConn().QueryContext(ctx, `SELECT onvif_endpoint FROM cameras`)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ep string
+		if err := rows.Scan(&ep); err != nil {
+			return false, err
+		}
+		if NormalizeOnvifEndpoint(ep) == normQuery {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// cameraIDByEndpoint is the id-returning twin of endpointExists, used by
+// CameraIDByOnvifEndpoint so dedup can report WHICH existing camera matched.
+// Same fast-path-then-normalize strategy.
+func (d *DB) cameraIDByEndpoint(ctx context.Context, query string) (string, bool, error) {
+	// Fast path: exact match.
+	var id string
+	if err := d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE onvif_endpoint=? LIMIT 1`, query).Scan(&id); err == nil {
+		return id, true, nil
+	} else if err != sql.ErrNoRows {
+		return "", false, err
+	}
+	// Fallback: normalize-and-compare scan.
+	normQuery := NormalizeOnvifEndpoint(query)
+	if normQuery == "" || normQuery == query {
+		return "", false, nil
+	}
+	rows, err := d.readConn().QueryContext(ctx, `SELECT id, onvif_endpoint FROM cameras`)
+	if err != nil {
+		return "", false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rid, ep string
+		if err := rows.Scan(&rid, &ep); err != nil {
+			return "", false, err
+		}
+		if NormalizeOnvifEndpoint(ep) == normQuery {
+			return rid, true, nil
+		}
+	}
+	return "", false, rows.Err()
+}
+
+// CameraEndpointRow is a lightweight row used by the normalize-endpoints repair
+// command: it only needs the id, name, and current onvif_endpoint value.
+type CameraEndpointRow struct {
+	ID       string
+	Name     string
+	Endpoint string
+}
+
+// ListCameraEndpointsForRepair returns id/name/onvif_endpoint for every camera
+// (including archived). Used by the `repair normalize-endpoints` CLI to find
+// rows whose stored endpoint is not in canonical form.
+func (d *DB) ListCameraEndpointsForRepair(ctx context.Context) ([]CameraEndpointRow, error) {
+	rows, err := d.readConn().QueryContext(ctx, `SELECT id, name, onvif_endpoint FROM cameras`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []CameraEndpointRow
+	for rows.Next() {
+		var r CameraEndpointRow
+		if err := rows.Scan(&r.ID, &r.Name, &r.Endpoint); err != nil {
+			return nil, err
+		}
+		res = append(res, r)
+	}
+	return res, rows.Err()
+}
+
+// UpdateCameraOnvifEndpointRaw writes the onvif_endpoint column directly,
+// bypassing UpsertCamera's other fields. Used by `repair normalize-endpoints`.
+// The value should already be canonical (run it through NormalizeOnvifEndpoint).
+func (d *DB) UpdateCameraOnvifEndpointRaw(ctx context.Context, cameraID, endpoint string) error {
+	_, err := d.db.ExecContext(ctx, `UPDATE cameras SET onvif_endpoint=? WHERE id=?`, endpoint, cameraID)
+	return err
+}

--- a/internal/storage/endpoint_test.go
+++ b/internal/storage/endpoint_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import "testing"
+
+// TestNormalizeOnvifEndpoint verifies the URL canonicalization helper.
+// Cases ported from the former autodiscover.TestNormalizeEndpoint plus extra
+// coverage for the invalid-URL fallback and IPv6-style hosts.
+func TestNormalizeOnvifEndpoint(t *testing.T) {
+	t.Helper()
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"http://1.2.3.4/onvif/device_service", "http://1.2.3.4/onvif/device_service"},
+		{"http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4/onvif/device_service"},
+		{"https://1.2.3.4:443/onvif/device_service", "https://1.2.3.4/onvif/device_service"},
+		{"http://1.2.3.4:8080/onvif/device_service", "http://1.2.3.4:8080/onvif/device_service"},
+		{"HTTP://1.2.3.4/Path", "http://1.2.3.4/Path"},
+		{"http://CAMERA.LOCAL/onvif/device_service", "http://camera.local/onvif/device_service"},
+		{"http://1.2.3.4/onvif/device_service/", "http://1.2.3.4/onvif/device_service"},
+		{"  http://1.2.3.4/onvif/device_service  ", "http://1.2.3.4/onvif/device_service"},
+		// Invalid URL fallback: no scheme/host → best-effort TrimRight, no panic.
+		{"not-a-url/", "not-a-url"},
+		// Idempotency: normalizing an already-canonical form is a no-op.
+		{"http://1.2.3.4/onvif/device_service", "http://1.2.3.4/onvif/device_service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Helper()
+			got := NormalizeOnvifEndpoint(tc.input)
+			if got != tc.want {
+				t.Errorf("NormalizeOnvifEndpoint(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+			// Idempotency: normalizing the output must not change it.
+			if got != "" {
+				if again := NormalizeOnvifEndpoint(got); again != got {
+					t.Errorf("NormalizeOnvifEndpoint not idempotent: %q → %q", got, again)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #175. ONVIF devices that require authentication still produce duplicate cameras on every NVR restart, even after #121/#122/#155. The dedup query did an exact string match that failed when a stored endpoint had `:80` but the discovery path omitted it.

## Root cause

`internal/storage/db_camera.go` — `CameraIDByOnvifEndpoint` and `CameraExistsByOnvifEndpoint` used `WHERE onvif_endpoint=?` (exact string match):

```go
d.readConn().QueryRowContext(ctx, `SELECT id FROM cameras WHERE onvif_endpoint=? LIMIT 1`, onvifEndpoint)
```

- DB row stored: `http://192.168.63.143:80/onvif/device_service` (manual add / legacy path — explicit `:80`)
- autodiscover discovers: `http://192.168.63.143/onvif/device_service` (WS-Discovery XAddrs omit the default port)
- exact match → **miss** → autodiscover creates a new `pending_activation` shell

#155 added `normalizeEndpoint` to `endpointChanged()` (the "should we update the endpoint" check) but **not** to the dedup **queries** — normalization landed on one side of the comparison, not the lookup side. Combined with `stable_id` being unobtainable on auth-required ONVIF devices (401 on `GetDeviceInformation` → serial empty → stable_id empty), both dedup defenses failed.

M5 reproduction (b96aa79, 05:46:07 logs):
```
connected to ONVIF device endpoint=http://192.168.63.143/onvif/device_service   ← no :80
reverse ONVIF lookup: GetDeviceInformation failed ... 401 Unauthorized           ← no serial
camera added in pending_activation state camera_id=cam-be29f448 name=H80         ← new shell
```
Three consecutive deletes (different UUIDs each restart) confirmed it reproduces on every start.

## Fix

`storage.NormalizeOnvifEndpoint` is now the single source of truth (moved up from `autodiscover`'s private `normalizeEndpoint`; the autodiscover copy is now a thin wrapper). Storage uses it in three places so the canonical form converges everywhere:

1. **Write** — `UpsertCamera` normalizes `onvif_endpoint` before storing, so future rows are always canonical (no `:80`, lowercased scheme/host, no trailing slash).
2. **Read (dedup)** — `CameraIDByOnvifEndpoint` and `CameraExistsByOnvifEndpoint` try an exact match first (fast path for already-normalized data), then fall back to a normalize-and-compare scan of all rows. This catches **legacy un-normalized rows** that predate the write-side fix. The camera count is small (tens), so the scan is cheap.
3. **In-memory dedup** — `internal/camera/crud.go` AddCamera's dedup was a naive `strings.TrimRight(ep, "/")`; it now uses `storage.NormalizeOnvifEndpoint` so manual-add dedup matches the DB dedup.

Also adds:
- `repair normalize-endpoints` CLI — migrates legacy rows to canonical form (default `--dry-run`, project convention).
- Regression tests: `TestCameraIDByOnvifEndpoint_DefaultPortMismatch` and `TestCameraExistsByOnvifEndpoint_DefaultPortMismatch` cover the `:80`-vs-no-`:80` mismatch for both queries, including the legacy-un-normalized-row scenario (direct column poke to simulate pre-fix data).

## Verification

- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./...` — clean
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go vet ./cmd/mibee-nvr/ ./internal/storage/ ./internal/autodiscover/ ./internal/camera/` — clean
- Storage tests can't run on Windows (syscall.Statfs); CI (Linux) will run them

## Test plan

- [ ] CI green (build + lint + test, incl. new storage regression tests)
- [ ] Deploy to M5, revert the data-level workaround (restore a `:80` endpoint), restart, confirm autodiscover no longer creates a duplicate H80 shell — the code-level normalization now handles it

## Related

- #121 (duplicate cameras, CLOSED) — #122 fixed it for serial-obtainable devices; this PR covers the auth-required subset
- #122 / #155 — introduced `normalizeEndpoint` but only on the comparison side; this PR extends it to the query + write side
- M5 data-level workaround already applied (normalized `:80` endpoints in DB + config) — this PR makes that workaround unnecessary going forward

cc @Mi-Bee-Studio/nvr
