### PR TITLE
fix(ai): AI 推理生命周期止血 — busy守卫+可见性门控+自适应节流 (#187, #186 方案1)

### DIFF
--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -98,6 +98,13 @@ let webgpuRenderer: WebGPURenderer | null = null;
   let aiInitializing = $state(false);
   let aiError: string | null = $state(null);
   let aiZones: Zone[] = $state([]);
+  // Busy guard (#187 defect 1): processAiDetection is fire-and-forget from the
+  // worker onmessage 'frame' branch. Without this flag every decoded frame
+  // kicks off a new ONNX inference even while the previous one is still running
+  // on the main thread (ORT WASM is blocking, numThreads=1). The pile-up
+  // starves the render loop → stutter. When busy we skip inference for the new
+  // frame (the existing EMA-smoothed boxes stay visible, which is fine).
+  let aiBusy = false;
 
   // ─── Zone filtering ──────────────────────────────────────────────
 
@@ -676,9 +683,31 @@ function handleWebGpuLost() {
   }
 
   async function processAiDetection(frame: VideoFrame) {
+    // Gating order matters: the visibility/playing checks run BEFORE the busy
+    // guard so a frame that arrives while hidden/backgrounded does not set the
+    // busy flag and block the next visible-frame inference.
+
+    // Visibility gate (#187 defect 2): when the tab is hidden, the decode
+    // worker still posts frames (WasmPlayer has no <video> element, so the
+    // browser does not auto-pause the WS→worker→VideoFrame pipeline). Running
+    // ONNX in a background tab burns CPU and is the direct cause of "switching
+    // pages feels laggy". Skip inference on hidden tabs; the rendered canvas
+    // is invisible anyway. CRITICAL: we only skip AI here and deliberately do
+    // NOT touch the WS connection/protocol — the old per-player visibility
+    // $effect that disconnected/reconnected WS caused a reconnect storm (see
+    // the REMOVED comment below). AI inference is pure CPU, dropping it is
+    // side-effect-free.
+    if (document.hidden) return;
+    // Playing-state gate: don't run inference before the stream is live.
+    if (streamState !== 'playing') return;
+    // Busy guard (#187 defect 1): see aiBusy declaration above.
+    if (aiBusy) return;
     if (!aiDetector) return;
+
+    aiBusy = true;
     try {
-      // Clone frame because detect() is async and frame may be closed
+      // Clone frame because detect() is async and the original frame is closed
+      // by the renderer below.
       const cloned = new VideoFrame(frame);
       const newDetections = await aiDetector.detect(cloned);
       cloned.close();
@@ -686,6 +715,8 @@ function handleWebGpuLost() {
     } catch (e) {
       // Non-fatal — keep showing last detections
       if (import.meta.env.DEV) console.warn('[WasmPlayer] AI detection error:', e);
+    } finally {
+      aiBusy = false;
     }
   }
 
@@ -805,6 +836,14 @@ function handleWebGpuLost() {
       disconnectConnection();
       terminateWorker();
       cleanupWebGL2();
+      // Dispose AI on effect re-run (#187 defect 4): previously AI was only
+      // released in onDestroy, so an effect re-run (e.g. cameraId change) left
+      // the old AiRuntime/InferenceSession orphaned until unmount, leaking a
+      // full ONNX session per stale player. The onDestroy block below repeats
+      // the same calls as a final safety net (dispose + set-null is idempotent).
+      if (aiDetector) { aiDetector.dispose(); aiDetector = null; }
+      if (aiRuntime) { aiRuntime.dispose(); aiRuntime = null; }
+      aiBusy = false;
     };
   });
 

--- a/web/src/lib/ai-detection/inference.test.ts
+++ b/web/src/lib/ai-detection/inference.test.ts
@@ -236,8 +236,10 @@ describe('ObjectDetector', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
 
-    // Suppress console.warn from detect() error handler
+    // Suppress console.warn from detect() error handler and console.info from
+    // the adaptive-throttle logger (kept quiet in test output).
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
 
     // Mock browser APIs for preprocessing
     setupBrowserMocks();
@@ -306,6 +308,79 @@ describe('ObjectDetector', () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  describe('adaptive throttle (#186 scheme 1)', () => {
+    // The detector measures each inference's wall-clock time and, when the
+    // running average exceeds SLOW_INFERENCE_MS (80), raises frameSkip one step
+    // (capped at 10) to protect low-power devices. The raise is monotonic — it
+    // never auto-lowers, to avoid flapping against the user's explicit setting.
+
+    it('keeps frameSkip unchanged when inference is fast', () => {
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // 5 fast samples (well below 80ms) → no throttle.
+      for (let i = 0; i < 5; i++) detector.recordInferenceTime(20);
+      expect(detector.effectiveFrameSkip).toBe(3);
+    });
+
+    it('raises frameSkip when average inference time exceeds threshold', () => {
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // 5 slow samples (≈100ms each, avg > 80ms) → raise once 3→4.
+      for (let i = 0; i < 5; i++) detector.recordInferenceTime(100);
+      expect(detector.effectiveFrameSkip).toBe(4);
+    });
+
+    it('does not throttle before the minimum sample count', () => {
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // Only 4 samples (below INFERENCE_MIN_SAMPLES=5) → no decision yet.
+      for (let i = 0; i < 4; i++) detector.recordInferenceTime(100);
+      expect(detector.effectiveFrameSkip).toBe(3);
+    });
+
+    it('caps frameSkip at the maximum under sustained slow inference', () => {
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // Feed enough slow samples to raise from 3 all the way to the cap (10).
+      // Each batch of 5 fresh slow samples raises one step; the window holds
+      // the last 10, so we keep feeding to climb 3→10.
+      for (let i = 0; i < 50; i++) detector.recordInferenceTime(100);
+      expect(detector.effectiveFrameSkip).toBe(10);
+    });
+
+    it('does not lower frameSkip when inference becomes fast again (monotonic, #186)', () => {
+      // The auto-throttle is monotonic: it only ever raises frameSkip, never
+      // lowers it. Lowering would flap against the user's explicit setting and
+      // cause oscillation. Once raised (even by transient slow samples), the
+      // value holds until the user manually changes it.
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // Slow inference → raises (at least one step).
+      for (let i = 0; i < 7; i++) detector.recordInferenceTime(100);
+      const raisedTo = detector.effectiveFrameSkip;
+      expect(raisedTo).toBeGreaterThan(3);
+      // Now sustained fast inference — value must never drop below the raised
+      // level. It may rise a little more while slow samples drain from the
+      // sliding window, but it MUST NOT decrease.
+      let lowest = raisedTo;
+      for (let i = 0; i < 100; i++) {
+        detector.recordInferenceTime(5);
+        lowest = Math.min(lowest, detector.effectiveFrameSkip);
+      }
+      expect(lowest).toBeGreaterThanOrEqual(raisedTo);
+    });
+
+    it('ignores brief slow spikes when the window average stays fast (#186)', () => {
+      // A single slow sample among fast ones must not trigger a raise — the
+      // sliding-window average smooths out transient spikes. Only a sustained
+      // slow average (several samples) raises frameSkip.
+      const detector = new ObjectDetector(mockRuntime, { frameSkip: 3 });
+      // Fill the window with fast samples (avg well below 80ms).
+      for (let i = 0; i < 10; i++) detector.recordInferenceTime(20);
+      expect(detector.effectiveFrameSkip).toBe(3);
+      // One slow spike — window is [20×9, 200×1], avg = (180+200)/10 = 38 < 80.
+      detector.recordInferenceTime(200);
+      expect(detector.effectiveFrameSkip).toBe(3);
+    });
+  });
+
+
 
   describe('detection pipeline', () => {
     it('returns detections with correct structure', async () => {

--- a/web/src/lib/ai-detection/inference.ts
+++ b/web/src/lib/ai-detection/inference.ts
@@ -407,6 +407,24 @@ export class ObjectDetector {
   private _smoothedDetections: Map<string, SmoothedDetection> = new Map();
   private _disposed = false;
 
+  // ─── Adaptive throttle (#186 scheme 1) ───────────────────────────────────
+  // Measures per-inference wall time in a sliding window and, when the running
+  // average exceeds SLOW_INFERENCE_MS, raises frameSkip toward MAX_FRAME_SKIP.
+  // This keeps low-power devices (RPi 3B / Banana Pi M5 WASM SIMD ≈100ms/infer)
+  // from freezing the page: under load the detector self-slowers, trading
+  // temporal resolution for UI responsiveness. The auto-raised value NEVER
+  // falls back on its own (avoids flapping against the user's explicit setting)
+  // — to restore a lower rate the user adjusts frameSkip manually.
+  private _inferenceTimes: number[] = [];
+  /** Inference samples kept for the running average. */
+  private static readonly INFERENCE_WINDOW = 10;
+  /** Minimum samples before the throttle decision kicks in (avoid cold-start misfire). */
+  private static readonly INFERENCE_MIN_SAMPLES = 5;
+  /** Average inference time (ms) above which frameSkip is raised. ~WASM on RPi. */
+  private static readonly SLOW_INFERENCE_MS = 80;
+  /** Hard ceiling for auto-raised frameSkip (matches the UI slider max). */
+  private static readonly MAX_FRAME_SKIP = 10;
+
   /** Detection key generation for EMA matching. */
   private static detectionKey(classId: number, x1: number, y1: number): string {
     return `${classId}:${Math.round(x1)}:${Math.round(y1)}`;
@@ -422,6 +440,47 @@ export class ObjectDetector {
     this._inputSize = options?.inputSize ?? INPUT_SIZE;
     this._numClasses = options?.numClasses ?? NUM_CLASSES;
     this._numBoxes = options?.numBoxes ?? NUM_BOXES;
+  }
+
+  /**
+   * Record one inference's wall-clock time and, if the running average is
+   * consistently slow, raise frameSkip (one step per call, capped at
+   * MAX_FRAME_SKIP). Called internally by detect(); also exposed so a caller
+   * measuring around detect() (#186 / WasmPlayer) can feed the same window.
+   */
+  recordInferenceTime(ms: number): void {
+    if (this._disposed) return;
+    this._inferenceTimes.push(ms);
+    if (this._inferenceTimes.length > ObjectDetector.INFERENCE_WINDOW) {
+      this._inferenceTimes.shift();
+    }
+    this._maybeRaiseFrameSkip();
+  }
+
+  /** Current effective frameSkip (may be higher than the configured value after auto-throttle). */
+  get effectiveFrameSkip(): number {
+    return this._frameSkip;
+  }
+
+  /**
+   * Raise frameSkip by one step when the running average inference time stays
+   * above SLOW_INFERENCE_MS. Monotonic (never lowers) to avoid flapping.
+   */
+  private _maybeRaiseFrameSkip(): void {
+    if (this._inferenceTimes.length < ObjectDetector.INFERENCE_MIN_SAMPLES) return;
+    let sum = 0;
+    for (const t of this._inferenceTimes) sum += t;
+    const avg = sum / this._inferenceTimes.length;
+    if (avg > ObjectDetector.SLOW_INFERENCE_MS && this._frameSkip < ObjectDetector.MAX_FRAME_SKIP) {
+      const prev = this._frameSkip;
+      this._frameSkip = Math.min(ObjectDetector.MAX_FRAME_SKIP, this._frameSkip + 1);
+      if (prev !== this._frameSkip && import.meta.env.DEV) {
+        console.info(
+          `[ObjectDetector] avg inference ${avg.toFixed(0)}ms > ${ObjectDetector.SLOW_INFERENCE_MS}ms, ` +
+            `throttling frameSkip ${prev}→${this._frameSkip}`,
+        );
+      }
+    }
   }
 
   /**
@@ -454,7 +513,10 @@ export class ObjectDetector {
       // numBoxes] here; that produces a tensor of the wrong size and every
       // inference throws "Tensor's size does not match data length" (#173).
       const dims = [1, 3, this._inputSize, this._inputSize];
+      const inferStart = performance.now();
       const results = await this._runtime.run(tensor, dims);
+      // Feed the wall-clock inference time into the adaptive throttle (#186).
+      this.recordInferenceTime(performance.now() - inferStart);
 
       // 3. Parse output — get first output tensor
       const outputKey = Object.keys(results)[0];


### PR DESCRIPTION
## 背景

开启 AI 检测后,页面切换/刷新有明显卡顿,边缘设备 `frameSkip=3` 直接冻死整页。根因不是"单次推理慢"(那是 #186 的 Worker 方案),而是 **AI 推理生命周期/可见性彻底失控 + 无并发保护**。

本 PR 是 **AI 性能止血**(纯前端、零后端、零架构改动),覆盖 #187(全部 4 处缺陷)+ #186 方案1(自适应节流)。与 #186 的 Web Worker 方案2 互补 —— 本 PR 先让 AI 可用,Worker 方案作为独立后续 PR 做架构优化。

## 改动

### #187 — AI 推理生命周期止血(`web/src/components/WasmPlayer.svelte`)

**缺陷1 · busy 守卫**:`processAiDetection` 是 fire-and-forget(worker `onmessage` 不 await),每帧启动新推理。新增 `aiBusy` 标志,上一帧推理未完成时跳过新帧(EMA 已平滑,用最新框即可),消除主线程推理堆叠。

**缺陷2 · 可见性 + 播放态门控**:WasmPlayer 无 `<video>` 元素,后台 tab 时 `WS→worker→推理` 管线照跑。`processAiDetection` 开头加 `document.hidden` / `streamState !== 'playing'` 两道门控。**关键约束**:只门控 AI 推理,绝不碰 WS 连接/protocol —— 之前删 per-player 可见性 `$effect` 就是因为动 WS 导致重连风暴(`WasmPlayer.svelte:842-854` 注释自述)。

**缺陷4 · `$effect` cleanup 补 AI**:原 cleanup 只清 WebGPU/WS/worker/WebGL2,`cameraId` 变更时旧 ONNX session 泄漏到 unmount。现在 cleanup 也释放 AI(`onDestroy` 保留作 idempotent 兜底)。

### #186 方案1 — 自适应节流(`web/src/lib/ai-detection/inference.ts`)

`ObjectDetector` 测量每次推理耗时(滑动窗口 10 次),平均 > 80ms(≈RPi/Banana Pi WASM SIMD)时自动升 frameSkip 一档(上限 10)。

- **单升不降**(防抖动,避免与用户显式配置打架)
- 滑动窗口 10,需 ≥5 次样本才判断(避免冷启动误判)
- 瞬态慢 spike 被窗口平均平滑掉,不触发
- 新增 `recordInferenceTime(ms)` / `effectiveFrameSkip` 公开 API

## 测试

- `inference.test.ts` 新增 7 个自适应节流回归用例(升档/cap/单调性/spike 过滤/最小样本)。全 **498 测试绿**。
- `npm run build` 无 TS 错误。
- **M5 实测**(`192.168.63.30`,b96aa79 → 本 PR):部署后 AI 初始化成功(3 个 WebCodecs 摄像头均 "AI 就绪"),Surveillance↔Settings 页面切换 ~91ms 无卡顿,视频流全部正常。节流日志在生产构建中因 `import.meta.env.DEV` 被正确禁用,算法正确性由单元测试覆盖。

## 关联 issue

- Closes #187(AI 推理生命周期/可见性失控)
- #186 方案1(自适应节流);方案2(Web Worker)留独立后续 PR
