### PR TITLE
fix(ai): 配置单一真相源+per-camera 接入+UI 补全 (#182, #179, #180, #181)

### DIFF
--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -14,7 +14,7 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
   import AiOverlay from './AiOverlay.svelte';
   import { AiRuntime } from '$lib/ai-detection/runtime';
   import { ObjectDetector, type Detection } from '$lib/ai-detection/inference';
-  import { getAiSettings, getAIZones, getAiStatus, type AiDetectionSettings, type Zone } from '$lib/api/ai';
+  import { getAIZones, getAiStatus, resolveAiSettings, getPerCameraAiSettings, type AiDetectionSettings, type Zone } from '$lib/api/ai';
 
   let {
     cameraId,
@@ -620,8 +620,24 @@ function handleWebGpuLost() {
     aiInitializing = true;
     aiError = null;
     try {
-      const settings = getAiSettings();
+      // Single source of truth (#182): the backend YAML config is authoritative.
+      // resolveAiSettings() pulls /api/ai/status, clamps, and caches to localStorage
+      // for offline fallback. Editing mibee-nvr.yaml + restart now takes effect on
+      // the next player init (previously the stale localStorage value won and a
+      // manual UI save was required to "discover" the new value).
+      const settings = await resolveAiSettings();
       if (!settings.enabled) return;
+
+      // Per-camera override (#179): if this camera has explicit per-camera settings,
+      // they win over the global defaults. This lets the user tune sensitivity per
+      // camera (e.g. high recall at an entrance, high precision indoors) — the
+      // prerequisite for the scenario-based tuning guide (docs/{zh,en}/ai-detection-tuning.md).
+      // Per-camera enabled flag: when present and false, this camera skips AI even
+      // if the global toggle is on. (Global-off always wins — handled by the check above.)
+      const perCam = getPerCameraAiSettings()[cameraId];
+      if (perCam && perCam.enabled === false) {
+        return;
+      }
 
       aiRuntime = new AiRuntime();
       // Fetch the backend-configured model_url (from /api/ai/status) instead of
@@ -645,8 +661,9 @@ function handleWebGpuLost() {
       });
 
       aiDetector = new ObjectDetector(aiRuntime, {
-        confidenceThreshold: settings.confidenceThreshold,
-        frameSkip: settings.frameSkip,
+        // Per-camera value (if set) overrides the global default (#179).
+        confidenceThreshold: perCam?.confidenceThreshold ?? settings.confidenceThreshold,
+        frameSkip: perCam?.frameSkip ?? settings.frameSkip,
       });
     } catch (e) {
       // AI is a non-fatal overlay — never abort the video. The most common

--- a/web/src/lib/api/ai.ts
+++ b/web/src/lib/api/ai.ts
@@ -67,6 +67,39 @@ export function saveAiSettings(settings: AiDetectionSettings): void {
   }
 }
 
+// ─── Single source of truth (#182) ───────────────────────────────────────────
+
+/**
+ * Resolve the authoritative AI detection settings.
+ *
+ * The backend YAML config (`GET /api/ai/status`) is the single source of truth.
+ * localStorage is only an offline cache used when the API is unreachable (NVR
+ * restarting, network down) so the player can still show *something* rather
+ * than nothing. This fixes #182: previously the player read localStorage only
+ * (`getAiSettings`), so editing mibee-nvr.yaml and restarting had no effect on
+ * an already-open browser (its localStorage was stale), and different browsers
+ * saw different AI behavior for the same NVR.
+ *
+ * On success the backend value is written back to localStorage so the next
+ * offline fallback is fresh.
+ */
+export async function resolveAiSettings(): Promise<AiDetectionSettings> {
+  try {
+    const status = await getAiStatus();
+    const settings: AiDetectionSettings = {
+      enabled: status.enabled,
+      confidenceThreshold: clampConfidence(status.confidence_threshold),
+      frameSkip: clampFrameSkip(status.frame_skip_rate),
+    };
+    // Mirror into localStorage so a later offline path falls back to fresh data.
+    saveAiSettings(settings);
+    return settings;
+  } catch {
+    // API unreachable (offline / NVR mid-restart): fall back to the cached copy.
+    return getAiSettings();
+  }
+}
+
 // ─── Validation helpers ───────────────────────────────────────────────────────
 
 function clampConfidence(value: number): number {

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -905,6 +905,7 @@
   "settings.ai.noCameras": "No cameras configured",
   "settings.ai.perCameraConfidence": "Confidence Threshold (override)",
   "settings.ai.perCameraDesc": "Configure AI detection individually for each camera.",
+  "settings.ai.perCameraHint": "Tune this camera’s detection parameters. Leave unset to use the global values above.",
   "settings.ai.perCameraFrameSkip": "Frame Skip (override)",
   "settings.ai.perCameraSaved": "Per-camera AI settings saved",
   "settings.ai.perCameraTitle": "Per-Camera AI Settings",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -905,6 +905,7 @@
   "settings.ai.noCameras": "未配置摄像头",
   "settings.ai.perCameraConfidence": "置信度阈值（覆盖全局）",
   "settings.ai.perCameraDesc": "为每个摄像头单独配置 AI 检测。",
+  "settings.ai.perCameraHint": "调整此摄像头的检测参数。留空则使用上方全局值。",
   "settings.ai.perCameraFrameSkip": "帧跳过（覆盖全局）",
   "settings.ai.perCameraSaved": "单摄像头 AI 设置已保存",
   "settings.ai.perCameraTitle": "单摄像头 AI 设置",

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -18,6 +18,7 @@
   let aiConfidenceThreshold = $state(0.5);
   let originalConfidence = $state(0.5);
   let aiFrameSkip = $state(3);
+  let originalFrameSkip = $state(3);
   let aiDetectedBackend = $state('');
   let loading = $state(true);
 
@@ -48,7 +49,8 @@
   let isDirty = $derived(
     !loading && (
       aiEnabled !== originalAiEnabled ||
-      aiConfidenceThreshold !== originalConfidence
+      aiConfidenceThreshold !== originalConfidence ||
+      aiFrameSkip !== originalFrameSkip
     )
   );
 
@@ -62,6 +64,7 @@
       aiConfidenceThreshold = status.confidence_threshold;
       originalConfidence = status.confidence_threshold;
       aiFrameSkip = status.frame_skip_rate;
+      originalFrameSkip = status.frame_skip_rate;
     } catch (e) {
       console.warn('Failed to load AI status from backend, falling back to localStorage:', e);
       const settings = getAiSettings();
@@ -70,6 +73,7 @@
       aiConfidenceThreshold = settings.confidenceThreshold;
       originalConfidence = settings.confidenceThreshold;
       aiFrameSkip = settings.frameSkip;
+      originalFrameSkip = settings.frameSkip;
     }
     aiDetectedBackend = detectAiBackend();
   }
@@ -87,12 +91,14 @@
     });
     originalAiEnabled = aiEnabled;
     originalConfidence = aiConfidenceThreshold;
+    originalFrameSkip = aiFrameSkip;
     showToast(t('settings.saved'), 'success');
   }
 
   function resetForm() {
     aiEnabled = originalAiEnabled;
     aiConfidenceThreshold = originalConfidence;
+    aiFrameSkip = originalFrameSkip;
   }
 
   // MiBeeVision key management
@@ -207,21 +213,52 @@
   }
 
   function getCameraConfig(cameraId: string) {
-    return perCameraAIConfig[cameraId] || { enabled: false, confidence: 0.5 };
+    // Field names MUST match PerCameraAiState ({ enabled, confidenceThreshold,
+    // frameSkip }). Previously this returned { enabled, confidence } (wrong key),
+    // which is why the per-camera values never reached the player (#180).
+    return (
+      perCameraAIConfig[cameraId] || { enabled: false, confidenceThreshold: 0.5, frameSkip: 3 }
+    );
   }
 
   function togglePerCameraAi(cameraId: string) {
     if (!perCameraAIConfig[cameraId]) {
-      perCameraAIConfig[cameraId] = { enabled: false, confidence: 0.5 };
+      perCameraAIConfig[cameraId] = { enabled: false, confidenceThreshold: 0.5, frameSkip: 3 };
     }
     perCameraAIConfig[cameraId].enabled = !perCameraAIConfig[cameraId].enabled;
     perCameraAIConfig = perCameraAIConfig;
     savePerCameraAiSettings(perCameraAIConfig);
   }
 
+  /** Patch per-camera confidence/frameSkip and persist immediately (#180). */
+  function updatePerCamera(
+    cameraId: string,
+    patch: Partial<{ confidenceThreshold: number; frameSkip: number }>,
+  ) {
+    if (!perCameraAIConfig[cameraId]) {
+      perCameraAIConfig[cameraId] = { enabled: true, confidenceThreshold: 0.5, frameSkip: 3 };
+    }
+    if (patch.confidenceThreshold !== undefined) {
+      perCameraAIConfig[cameraId].confidenceThreshold = patch.confidenceThreshold;
+    }
+    if (patch.frameSkip !== undefined) {
+      perCameraAIConfig[cameraId].frameSkip = patch.frameSkip;
+    }
+    perCameraAIConfig = perCameraAIConfig;
+    savePerCameraAiSettings(perCameraAIConfig);
+  }
+
   onMount(() => {
-    Promise.all([loadAiSettings(), loadMiBeeVisionKeys(), loadZones()]).then(() => {
-      allCameras = listCameras().catch(() => []) as any;
+    Promise.all([
+      loadAiSettings(),
+      loadMiBeeVisionKeys(),
+      loadZones(),
+      // listCameras is async (returns Promise<Camera[]>); it MUST be awaited,
+      // not assigned directly — otherwise allCameras holds a Promise (truthy but
+      // .length === undefined) and the per-camera list renders nothing (#180).
+      listCameras().catch(() => []),
+    ]).then(([, , , cams]) => {
+      allCameras = cams;
       perCameraAIConfig = getPerCameraAiSettings();
       loading = false;
     });
@@ -279,6 +316,24 @@
             step="0.1"
           />
           <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.confidenceHint')}</p>
+        </div>
+
+        <!-- Frame Skip (#181) -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <label class="input-label" for="ai-frame-skip">{t('settings.ai.frameSkip')}</label>
+            <span class="text-sm font-medium th-text-primary">{aiFrameSkip}</span>
+          </div>
+          <input
+            id="ai-frame-skip"
+            type="range"
+            class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
+            bind:value={aiFrameSkip}
+            min="1"
+            max="10"
+            step="1"
+          />
+          <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.frameSkipHint')}</p>
         </div>
 
         <!-- Model & Backend Info -->
@@ -377,6 +432,46 @@
               </div>
               <ChevronDown size={16} class="th-text-tertiary transition-transform {expandedCameras[cam.id] ? 'rotate-180' : ''}" />
             </button>
+
+            {#if expandedCameras[cam.id]}
+              <div class="p-3 border-t th-border space-y-4 th-bg-hover">
+                <p class="text-xs th-text-tertiary">{t('settings.ai.perCameraHint')}</p>
+                <!-- Per-camera confidence -->
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <label class="input-label text-sm" for="percam-conf-{cam.id}">{t('settings.ai.confidenceThreshold')}</label>
+                    <span class="text-sm th-text-secondary">{Math.round((getCameraConfig(cam.id).confidenceThreshold ?? 0.5) * 100)}%</span>
+                  </div>
+                  <input
+                    id="percam-conf-{cam.id}"
+                    type="range"
+                    class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
+                    min="0.1"
+                    max="0.9"
+                    step="0.1"
+                    value={getCameraConfig(cam.id).confidenceThreshold ?? 0.5}
+                    oninput={(e) => updatePerCamera(cam.id, { confidenceThreshold: parseFloat(e.currentTarget.value) })}
+                  />
+                </div>
+                <!-- Per-camera frame skip -->
+                <div>
+                  <div class="flex items-center justify-between mb-2">
+                    <label class="input-label text-sm" for="percam-skip-{cam.id}">{t('settings.ai.frameSkip')}</label>
+                    <span class="text-sm th-text-secondary">{getCameraConfig(cam.id).frameSkip ?? 3}</span>
+                  </div>
+                  <input
+                    id="percam-skip-{cam.id}"
+                    type="range"
+                    class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
+                    min="1"
+                    max="10"
+                    step="1"
+                    value={getCameraConfig(cam.id).frameSkip ?? 3}
+                    oninput={(e) => updatePerCamera(cam.id, { frameSkip: parseInt(e.currentTarget.value) })}
+                  />
+                </div>
+              </div>
+            {/if}
           </div>
         {/each}
       </div>


### PR DESCRIPTION
## 背景

AI 配置存在多个断裂:① 两个真相源(后端 YAML vs 浏览器 localStorage)不同步,改 YAML 重启后前端仍用旧值(#182);② per-camera 配置数据层已实现但播放器完全不读,是死代码(#179);③ per-camera UI 展开是空操作(#180);④ frameSkip 无 UI 滑块(#181)。

本 PR 打通整个配置链路:后端为准 → 前端读取 → per-camera 覆盖 → UI 暴露。

## 改动

### #182 单一真相源(`ai.ts` + `WasmPlayer.svelte`)
- 新增 `resolveAiSettings()`:后端 `/api/ai/status` 为权威源,localStorage 仅作离线缓存。成功时写回 localStorage 保持缓存新鲜。
- `WasmPlayer.initAiDetection` 用 `resolveAiSettings()` 替代 `getAiSettings()`。

### #179 WasmPlayer 接入 per-camera 配置(`WasmPlayer.svelte`)
- `initAiDetection` 读 `getPerCameraAiSettings()[cameraId]`,per-camera 的 confidenceThreshold/frameSkip 覆盖全局默认(`cameraId` 已是 prop)。优先级:per-camera 值(若设置)> 全局值。
- per-camera `enabled=false` 时该摄像头跳过 AI(全局 off 仍优先)。

### #180 per-camera UI 展开块(`AIPanel.svelte`)
- 展开按钮原来是空操作。现在展开后显示置信度 + frameSkip 滑块,改动即时持久化到 localStorage。
- 修正 `getCameraConfig` 字段名(原来返回 `{enabled, confidence}` 错误键,对齐 `PerCameraAiState`)。
- 新增 `updatePerCamera` 辅助函数。
- **附带修复**:`onMount` 里 `allCameras = listCameras().catch(() => [])` 未 await,把 Promise 赋给了 `$state`,导致 per-camera 摄像头列表一直不渲染。改为 `await` 后正确加载。

### #181 frameSkip 全局滑块(`AIPanel.svelte`)
- 全局 AI 卡片新增 frameSkip 滑块(1-10)。
- `isDirty`/`loadAiSettings`/`performSave`/`resetForm` 同步 `originalFrameSkip`。

### i18n
- 新增 `settings.ai.perCameraHint`(zh/en)。

## 测试
- 全 **498 测试绿**,build 无 TS 错误。
- **M5 实测**:① 全局 frameSkip 滑块显示"10"(来自后端 `frame_skip_rate=10`),置信度"90%"(后端 0.9)→ 单一真相源生效;② per-camera 卡片展开后显示 11 个摄像头;③ "7-8楼转角"展开后显示置信度 50% + frameSkip 3 滑块。需清 service worker 缓存看新 bundle。

## 关联 issue
- Closes #182, Closes #179, Closes #180, Closes #181
