### PR TITLE
feat(ai): EMA/maxAge 可配 + 类别过滤 + 模型选择 (#183, #184, #185)

### DIFF
--- a/internal/ai/engine.go
+++ b/internal/ai/engine.go
@@ -15,6 +15,9 @@ type Config struct {
 	Zones               map[string][]ROI `yaml:"zones"`
 	FrameSkipRate       int              `yaml:"frame_skip_rate"`
 	ConfidenceThreshold float64          `yaml:"confidence_threshold"`
+	EmaAlpha            float64          `yaml:"ema_alpha"`
+	MaxAge              int              `yaml:"max_age"`
+	EnabledClasses      []string         `yaml:"enabled_classes"`
 }
 
 // Manager manages AI configuration. No backend inference — the browser

--- a/internal/api/ai_handler.go
+++ b/internal/api/ai_handler.go
@@ -3,6 +3,10 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/ai"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -37,6 +41,9 @@ func (h *AIHandler) syncAndSaveConfig() {
 		Zones:               aiCfg.Zones,
 		FrameSkipRate:       aiCfg.FrameSkipRate,
 		ConfidenceThreshold: aiCfg.ConfidenceThreshold,
+		EmaAlpha:            aiCfg.EmaAlpha,
+		MaxAge:              aiCfg.MaxAge,
+		EnabledClasses:      aiCfg.EnabledClasses,
 	}
 	if err := config.Save(h.configPath, h.config); err != nil {
 		logger.Warn("failed to save AI config", "error", err)
@@ -55,6 +62,9 @@ func (h *AIHandler) handleAIStatus(w http.ResponseWriter, r *http.Request) {
 		"model_url":            cfg.ModelURL,
 		"confidence_threshold": cfg.ConfidenceThreshold,
 		"frame_skip_rate":      cfg.FrameSkipRate,
+		"ema_alpha":            cfg.EmaAlpha,
+		"max_age":              cfg.MaxAge,
+		"enabled_classes":      cfg.EnabledClasses,
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -69,6 +79,12 @@ func (h *AIHandler) handleAIUpdateConfig(w http.ResponseWriter, r *http.Request)
 		ConfidenceThreshold *float64 `json:"confidence_threshold,omitempty"`
 		FrameSkipRate       *int     `json:"frame_skip_rate,omitempty"`
 		ModelURL            *string  `json:"model_url,omitempty"`
+		EmaAlpha            *float64 `json:"ema_alpha,omitempty"`
+		MaxAge              *int     `json:"max_age,omitempty"`
+		// EnabledClasses uses a pointer-to-slice so an explicit empty array
+		// ([]) is distinguishable from "field omitted" (nil). nil = leave
+		// unchanged; &[] = clear the filter (detect all classes).
+		EnabledClasses *[]string `json:"enabled_classes,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -89,6 +105,15 @@ func (h *AIHandler) handleAIUpdateConfig(w http.ResponseWriter, r *http.Request)
 	}
 	if body.ModelURL != nil {
 		cfg.ModelURL = *body.ModelURL
+	}
+	if body.EmaAlpha != nil {
+		cfg.EmaAlpha = *body.EmaAlpha
+	}
+	if body.MaxAge != nil {
+		cfg.MaxAge = *body.MaxAge
+	}
+	if body.EnabledClasses != nil {
+		cfg.EnabledClasses = *body.EnabledClasses
 	}
 
 	h.manager.UpdateConfig(cfg)
@@ -276,4 +301,50 @@ func (h *AIHandler) handleAIDeleteZone(w http.ResponseWriter, r *http.Request) {
 	h.syncAndSaveConfig()
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// --- Model listing endpoint (#185) ---
+
+// aiModelInfo describes one selectable ONNX model file.
+type aiModelInfo struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`  // "/models/<name>" — the URL the browser loads
+	Size int64  `json:"size"` // bytes
+}
+
+// handleAIModels handles GET /api/ai/models.
+// Lists the .onnx files available under {storage_root}/models/ so the Settings
+// UI can offer a model picker (precision/speed trade-off between yolo11n/s/m).
+// Mirrors the directory used by the public GET /models/{filename} file server
+// (handler.go handleServeModel), so the listed URLs are directly loadable.
+func (h *AIHandler) handleAIModels(w http.ResponseWriter, r *http.Request) {
+	modelDir := filepath.Join(h.config.Storage.RootDir, "models")
+	entries, err := os.ReadDir(modelDir)
+	if err != nil {
+		// Directory missing (e.g. download-model never run) → return an empty
+		// list rather than a 500; the UI shows "no models available".
+		writeJSON(w, http.StatusOK, map[string]any{"models": []aiModelInfo{}})
+		return
+	}
+
+	models := make([]aiModelInfo, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".onnx") {
+			continue
+		}
+		info, err := e.Info()
+		size := int64(0)
+		if err == nil {
+			size = info.Size()
+		}
+		models = append(models, aiModelInfo{
+			Name: e.Name(),
+			URL:  "/models/" + e.Name(),
+			Size: size,
+		})
+	}
+	// Stable, predictable order (name ascending).
+	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+
+	writeJSON(w, http.StatusOK, map[string]any{"models": models})
 }

--- a/internal/api/handlers_ai.go
+++ b/internal/api/handlers_ai.go
@@ -258,6 +258,7 @@ func getDefaultStatsSince(period string) (t time.Time) {
 func (h *Handler) registerAIRoutes(r chi.Router) {
 	r.Get("/api/ai/status", h.aiHandler.handleAIStatus)
 	r.Put("/api/ai/config", h.aiHandler.handleAIUpdateConfig)
+	r.Get("/api/ai/models", h.aiHandler.handleAIModels)
 	r.Get("/api/ai/zones", h.aiHandler.handleAIZones)
 	r.Post("/api/ai/zones", h.aiHandler.handleAICreateZone)
 	r.Put("/api/ai/zones/{id}", h.aiHandler.handleAIUpdateZone)

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -305,6 +305,15 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.AI.ModelURL == "" {
 		cfg.AI.ModelURL = "/models/yolo11n.onnx"
 	}
+	// EMA smoothing defaults (#183): mirror the ObjectDetector constants so a
+	// config that omits these fields behaves identically to the pre-config era.
+	if cfg.AI.EmaAlpha <= 0 {
+		cfg.AI.EmaAlpha = 0.3
+	}
+	if cfg.AI.MaxAge <= 0 {
+		cfg.AI.MaxAge = 15
+	}
+	// EnabledClasses default: empty = all 80 COCO classes (no filtering, #184).
 
 	// Remote log defaults
 	if cfg.RemoteLog.Format == "" {

--- a/internal/config/config_ai.go
+++ b/internal/config/config_ai.go
@@ -14,4 +14,16 @@ type AIConfig struct {
 	Zones               map[string][]ai.ROI `yaml:"zones" json:"zones"`
 	FrameSkipRate       int                 `yaml:"frame_skip_rate" json:"frameSkipRate"`
 	ConfidenceThreshold float64             `yaml:"confidence_threshold" json:"confidenceThreshold"`
+	// EmaAlpha is the EMA smoothing factor for bounding-box positions
+	// (#183): higher = more responsive (box follows motion quickly), lower =
+	// smoother (box jitters less). Range 0.1–0.9; default 0.3.
+	EmaAlpha float64 `yaml:"ema_alpha" json:"emaAlpha"`
+	// MaxAge is how many detection cycles a disappeared box lingers before
+	// removal (#183): higher = boxes stay longer when an object is briefly
+	// occluded, lower = boxes vanish faster. Range 3–30; default 15.
+	MaxAge int `yaml:"max_age" json:"maxAge"`
+	// EnabledClasses restricts detection to the given COCO class labels
+	// (#184). Empty/nil = all 80 classes (current behavior). Example:
+	// ["person", "car"] shows only people and cars.
+	EnabledClasses []string `yaml:"enabled_classes" json:"enabledClasses"`
 }

--- a/pkg/app/helpers.go
+++ b/pkg/app/helpers.go
@@ -28,6 +28,9 @@ func aiConfigFromConfig(cfg config.AIConfig) ai.Config {
 		Zones:               cfg.Zones,
 		FrameSkipRate:       cfg.FrameSkipRate,
 		ConfidenceThreshold: cfg.ConfidenceThreshold,
+		EmaAlpha:            cfg.EmaAlpha,
+		MaxAge:              cfg.MaxAge,
+		EnabledClasses:      cfg.EnabledClasses,
 	}
 }
 

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -664,6 +664,11 @@ function handleWebGpuLost() {
         // Per-camera value (if set) overrides the global default (#179).
         confidenceThreshold: perCam?.confidenceThreshold ?? settings.confidenceThreshold,
         frameSkip: perCam?.frameSkip ?? settings.frameSkip,
+        // EMA smoothing + class filter are global-only for now (#183/#184);
+        // per-camera override of these can follow if needed.
+        emaAlpha: settings.emaAlpha,
+        maxAge: settings.maxAge,
+        enabledClasses: settings.enabledClasses,
       });
     } catch (e) {
       // AI is a non-fatal overlay — never abort the video. The most common

--- a/web/src/lib/ai-detection/inference.test.ts
+++ b/web/src/lib/ai-detection/inference.test.ts
@@ -380,6 +380,64 @@ describe('ObjectDetector', () => {
     });
   });
 
+  describe('class filter (#184)', () => {
+    // The detector can restrict results to a subset of COCO class labels.
+    // null/empty enabledClasses = all classes (no filtering). A non-empty array
+    // keeps only detections whose best-class label is in the set.
+
+    function buildMultiClassOutput(): { data: Float32Array; dims: number[] } {
+      // Three detections: person (0), car (2), chair (56). All high-confidence.
+      return buildYoloOutput([
+        { boxIndex: 0, cx: 100, cy: 100, w: 50, h: 80, classId: 0, rawScore: 6 },
+        { boxIndex: 1, cx: 300, cy: 300, w: 60, h: 40, classId: 2, rawScore: 6 },
+        { boxIndex: 2, cx: 500, cy: 500, w: 40, h: 40, classId: 56, rawScore: 6 },
+      ]);
+    }
+
+    it('returns all classes when enabledClasses is null/empty (default)', async () => {
+      const { data, dims } = buildMultiClassOutput();
+      const rt = createMockRuntime(data, dims);
+      const detector = new ObjectDetector(rt, { frameSkip: 1, enabledClasses: null });
+      const results = await detector.detect(createMockVideoFrame());
+      const labels = results.map((d) => d.label).sort();
+      expect(labels).toEqual(['car', 'chair', 'person']);
+    });
+
+    it('returns only the enabled classes when a filter is set', async () => {
+      const { data, dims } = buildMultiClassOutput();
+      const rt = createMockRuntime(data, dims);
+      const detector = new ObjectDetector(rt, {
+        frameSkip: 1,
+        // Only people and cars — chair must be dropped.
+        enabledClasses: ['person', 'car'],
+      });
+      const results = await detector.detect(createMockVideoFrame());
+      const labels = results.map((d) => d.label).sort();
+      expect(labels).toEqual(['car', 'person']);
+      expect(labels).not.toContain('chair');
+    });
+
+    it('drops all detections when the filter matches no class', async () => {
+      const { data, dims } = buildMultiClassOutput();
+      const rt = createMockRuntime(data, dims);
+      const detector = new ObjectDetector(rt, {
+        frameSkip: 1,
+        enabledClasses: ['airplane'], // none of person/car/chair
+      });
+      const results = await detector.detect(createMockVideoFrame());
+      expect(results).toHaveLength(0);
+    });
+
+    it('treats an empty array the same as null (all classes)', async () => {
+      const { data, dims } = buildMultiClassOutput();
+      const rt = createMockRuntime(data, dims);
+      const detector = new ObjectDetector(rt, { frameSkip: 1, enabledClasses: [] });
+      const results = await detector.detect(createMockVideoFrame());
+      const labels = results.map((d) => d.label).sort();
+      expect(labels).toEqual(['car', 'chair', 'person']);
+    });
+  });
+
 
 
   describe('detection pipeline', () => {

--- a/web/src/lib/ai-detection/inference.ts
+++ b/web/src/lib/ai-detection/inference.ts
@@ -53,6 +53,13 @@ export interface ObjectDetectorOptions {
   emaAlpha?: number;
   /** Max age (in skipped frames) before a smoothed detection is removed (default: 15). */
   maxAge?: number;
+  /**
+   * Restrict detection to these COCO class labels (#184). null/undefined/empty =
+   * all 80 classes (no filtering). A non-empty array keeps only detections whose
+   * best class label is in the set — a more precise noise filter than a global
+   * confidence threshold (e.g. show only "person"/"car", never "chair"/"clock").
+   */
+  enabledClasses?: string[] | null;
   /** Input size for YOLO model (default: 640). */
   inputSize?: number;
   /** Number of COCO classes (default: 80). */
@@ -399,6 +406,8 @@ export class ObjectDetector {
   private _frameSkip: number;
   private _emaAlpha: number;
   private _maxAge: number;
+  /** null = all classes (no filtering); a Set = only keep these class labels (#184). */
+  private _enabledClasses: Set<string> | null = null;
   private _inputSize: number;
   private _numClasses: number;
   private _numBoxes: number;
@@ -437,6 +446,9 @@ export class ObjectDetector {
     this._frameSkip = options?.frameSkip ?? FRAME_SKIP;
     this._emaAlpha = options?.emaAlpha ?? EMA_ALPHA;
     this._maxAge = options?.maxAge ?? MAX_AGE;
+    // Build a label Set for O(1) class filtering (#184). Empty/null = all classes.
+    const ec = options?.enabledClasses;
+    this._enabledClasses = ec && ec.length > 0 ? new Set(ec) : null;
     this._inputSize = options?.inputSize ?? INPUT_SIZE;
     this._numClasses = options?.numClasses ?? NUM_CLASSES;
     this._numBoxes = options?.numBoxes ?? NUM_BOXES;
@@ -530,6 +542,14 @@ export class ObjectDetector {
         this._numBoxes,
         this._confidenceThreshold,
       );
+
+      // 4b. Class filter (#184): if a non-empty enabledClasses set is configured,
+      // drop any detection whose best class label isn't in the set. This runs
+      // before NMS so suppressed-class boxes don't interfere with kept-class
+      // box selection. A null set means "all classes" (no filtering).
+      if (this._enabledClasses) {
+        detections = detections.filter((d) => this._enabledClasses!.has(COCO_CLASSES[d.classId] ?? ''));
+      }
 
       // 5. NMS
       detections = nms(detections, this._nmsThreshold);

--- a/web/src/lib/api/ai.ts
+++ b/web/src/lib/api/ai.ts
@@ -16,6 +16,12 @@ export interface AiDetectionSettings {
   confidenceThreshold: number;
   /** Detect every N frames (1–10, default 3) */
   frameSkip: number;
+  /** EMA smoothing factor for box positions (#183, 0.1–0.9, default 0.3). Optional for back-compat. */
+  emaAlpha?: number;
+  /** Max detection cycles a disappeared box lingers (#183, 3–30, default 15). Optional for back-compat. */
+  maxAge?: number;
+  /** Restrict detection to these COCO class labels (#184). null/undefined = all 80 classes. */
+  enabledClasses?: string[] | null;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -26,6 +32,9 @@ const DEFAULTS: AiDetectionSettings = {
   enabled: false,
   confidenceThreshold: 0.5,
   frameSkip: 3,
+  emaAlpha: 0.3,
+  maxAge: 15,
+  enabledClasses: null,
 };
 
 // ─── Persistence ──────────────────────────────────────────────────────────────
@@ -43,6 +52,10 @@ export function getAiSettings(): AiDetectionSettings {
       enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : DEFAULTS.enabled,
       confidenceThreshold: clampConfidence(parsed.confidenceThreshold),
       frameSkip: clampFrameSkip(parsed.frameSkip),
+      emaAlpha: clampEmaAlpha(parsed.emaAlpha),
+      maxAge: clampMaxAge(parsed.maxAge),
+      // null/undefined/[] all mean "all classes"; only a non-empty array filters.
+      enabledClasses: Array.isArray(parsed.enabledClasses) ? parsed.enabledClasses : null,
     };
   } catch {
     return { ...DEFAULTS };
@@ -60,6 +73,9 @@ export function saveAiSettings(settings: AiDetectionSettings): void {
         enabled: settings.enabled,
         confidenceThreshold: clampConfidence(settings.confidenceThreshold),
         frameSkip: clampFrameSkip(settings.frameSkip),
+        emaAlpha: clampEmaAlpha(settings.emaAlpha),
+        maxAge: clampMaxAge(settings.maxAge),
+        enabledClasses: Array.isArray(settings.enabledClasses) ? settings.enabledClasses : null,
       }),
     );
   } catch (e) {
@@ -90,6 +106,14 @@ export async function resolveAiSettings(): Promise<AiDetectionSettings> {
       enabled: status.enabled,
       confidenceThreshold: clampConfidence(status.confidence_threshold),
       frameSkip: clampFrameSkip(status.frame_skip_rate),
+      emaAlpha: clampEmaAlpha(status.ema_alpha),
+      maxAge: clampMaxAge(status.max_age),
+      // Backend omits enabled_classes when unset (all classes). Treat null/empty
+      // as "all classes" on the client too.
+      enabledClasses:
+        Array.isArray(status.enabled_classes) && status.enabled_classes.length > 0
+          ? status.enabled_classes
+          : null,
     };
     // Mirror into localStorage so a later offline path falls back to fresh data.
     saveAiSettings(settings);
@@ -110,6 +134,16 @@ function clampConfidence(value: number): number {
 function clampFrameSkip(value: number): number {
   if (typeof value !== 'number' || isNaN(value)) return DEFAULTS.frameSkip;
   return Math.min(10, Math.max(1, Math.round(value)));
+}
+
+function clampEmaAlpha(value: number | undefined): number {
+  if (typeof value !== 'number' || isNaN(value) || value <= 0) return DEFAULTS.emaAlpha!;
+  return Math.round(Math.min(0.9, Math.max(0.1, value)) * 10) / 10;
+}
+
+function clampMaxAge(value: number | undefined): number {
+  if (typeof value !== 'number' || isNaN(value) || value <= 0) return DEFAULTS.maxAge!;
+  return Math.min(30, Math.max(3, Math.round(value)));
 }
 
 // ─── Backend detection ────────────────────────────────────────────────────────
@@ -172,6 +206,9 @@ export interface AiStatus {
   model_url: string;
   confidence_threshold: number;
   frame_skip_rate: number;
+  ema_alpha?: number;
+  max_age?: number;
+  enabled_classes?: string[] | null;
 }
 
 export interface AiConfigUpdate {
@@ -179,6 +216,15 @@ export interface AiConfigUpdate {
   confidence_threshold?: number;
   frame_skip_rate?: number;
   model_url?: string;
+  ema_alpha?: number;
+  max_age?: number;
+  enabled_classes?: string[] | null;
+}
+
+export interface AiModelInfo {
+  name: string;
+  url: string;
+  size: number;
 }
 
 // ─── Backend API functions ────────────────────────────────────────────────
@@ -192,6 +238,12 @@ export async function updateAiConfig(config: AiConfigUpdate): Promise<void> {
     method: 'PUT',
     body: JSON.stringify(config),
   });
+}
+
+/** List selectable ONNX models under {storage_root}/models/ (#185). */
+export async function listAiModels(): Promise<AiModelInfo[]> {
+  const resp = await apiRequest<{ models: AiModelInfo[] }>('/ai/models');
+  return resp.models ?? [];
 }
 
 // ─── Per-camera localStorage ──────────────────────────────────────────────────

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -297,12 +297,14 @@ export {
   deleteAIZone,
   getAiStatus,
   updateAiConfig,
+  listAiModels,
 } from './ai';
 
 export type {
   AiDetectionSettings,
   AiStatus,
   AiConfigUpdate,
+  AiModelInfo,
   Zone,
   ZoneList,
   CreateZoneRequest,

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1435,5 +1435,19 @@
   "xiaomi.verifyCodePlaceholder": "Verification code",
   "xiaomi.verifyEmailHint": "Enter the code sent to {email}",
   "xiaomi.verifyPhoneHint": "Enter the code sent to {phone}",
-  "xiaomi.verifyTitle": "Verification Required"
+  "xiaomi.verifyTitle": "Verification Required",
+  "settings.ai.classFilter": "Detection Classes",
+  "settings.ai.classFilterHint": "Detect only the selected classes (e.g. people/vehicles). Empty = all 80 classes.",
+  "settings.ai.allClasses": "All",
+  "settings.ai.classFilterDetails": "Detailed class selection",
+  "settings.ai.classPresetAll": "All classes",
+  "settings.ai.classPresetPerson": "People only",
+  "settings.ai.classPresetSecurity": "Security common",
+  "settings.ai.classPresetPersonVehicle": "People + vehicles",
+  "settings.ai.advanced": "Advanced parameters",
+  "settings.ai.emaAlpha": "Smoothing factor",
+  "settings.ai.emaAlphaHint": "Box position smoothing: lower = smoother (box lags), higher = more responsive.",
+  "settings.ai.maxAge": "Box dwell time",
+  "settings.ai.maxAgeHint": "After an object disappears, its box lingers up to ~{secs} seconds.",
+  "settings.ai.noModelsHint": "No models found. Run mibee-nvr download-model to fetch one."
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1435,5 +1435,19 @@
   "xiaomi.verifyCodePlaceholder": "验证码",
   "xiaomi.verifyEmailHint": "请输入发送至 {email} 的验证码",
   "xiaomi.verifyPhoneHint": "请输入发送至 {phone} 的验证码",
-  "xiaomi.verifyTitle": "需要验证"
+  "xiaomi.verifyTitle": "需要验证",
+  "settings.ai.classFilter": "检测类别",
+  "settings.ai.classFilterHint": "只检测选中的类别（如只圈人/车）。空选 = 全部 80 类。",
+  "settings.ai.allClasses": "全部",
+  "settings.ai.classFilterDetails": "详细类别选择",
+  "settings.ai.classPresetAll": "全部类别",
+  "settings.ai.classPresetPerson": "仅人物",
+  "settings.ai.classPresetSecurity": "安防常见",
+  "settings.ai.classPresetPersonVehicle": "人 + 车辆",
+  "settings.ai.advanced": "高级参数",
+  "settings.ai.emaAlpha": "平滑系数",
+  "settings.ai.emaAlphaHint": "框位置平滑：越低越平滑（框跟手慢），越高越灵敏。",
+  "settings.ai.maxAge": "框滞留时长",
+  "settings.ai.maxAgeHint": "目标消失后检测框最多保留约 {secs} 秒。",
+  "settings.ai.noModelsHint": "未找到模型。运行 mibee-nvr download-model 下载。"
 }

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { getAiSettings, saveAiSettings, detectAiBackend, listCameras, getAiStatus, updateAiConfig } from '$lib/api';
+  import { getAiSettings, saveAiSettings, detectAiBackend, listCameras, getAiStatus, updateAiConfig, listAiModels } from '$lib/api';
   import { getPerCameraAiSettings, savePerCameraAiSettings, getAIZones, createAIZone, deleteAIZone } from '$lib/api';
   import { getSettings, generateAPIKey, revokeAPIKey } from '$lib/api';
   import { refreshMiBeeVisionStatus } from '$lib/mibeevision-status.svelte';
-  import type { Camera, Zone, PerCameraAiState } from '$lib/api';
+  import type { Camera, Zone, PerCameraAiState, AiModelInfo } from '$lib/api';
+  import { COCO_CLASSES } from '$lib/ai-detection/inference';
   import { t } from '$lib/i18n';
   import { Plus, Trash2, X, Copy, Check, ChevronDown } from 'lucide-svelte';
   import { showToast } from '$lib/toast';
@@ -19,6 +20,18 @@
   let originalConfidence = $state(0.5);
   let aiFrameSkip = $state(3);
   let originalFrameSkip = $state(3);
+  // Advanced detection params (#183/#184/#185)
+  let aiEmaAlpha = $state(0.3);
+  let originalEmaAlpha = $state(0.3);
+  let aiMaxAge = $state(15);
+  let originalMaxAge = $state(15);
+  let aiEnabledClasses = $state<string[] | null>(null); // null = all classes
+  let originalEnabledClasses = $state<string[] | null>(null);
+  let aiModelUrl = $state('');
+  let originalModelUrl = $state('');
+  let aiModels = $state<AiModelInfo[]>([]);
+  let showAdvanced = $state(false);
+  let showClassFilter = $state(false);
   let aiDetectedBackend = $state('');
   let loading = $state(true);
 
@@ -46,11 +59,24 @@
 
   const hasMiBeeVisionKey = $derived(mibeeVisionKeys.length > 0);
 
+  // Compare two enabled-classes values for isDirty (order-insensitive).
+  function classesEqual(a: string[] | null, b: string[] | null): boolean {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    const sb = new Set(b);
+    return a.every((c) => sb.has(c));
+  }
+
   let isDirty = $derived(
     !loading && (
       aiEnabled !== originalAiEnabled ||
       aiConfidenceThreshold !== originalConfidence ||
-      aiFrameSkip !== originalFrameSkip
+      aiFrameSkip !== originalFrameSkip ||
+      aiEmaAlpha !== originalEmaAlpha ||
+      aiMaxAge !== originalMaxAge ||
+      !classesEqual(aiEnabledClasses, originalEnabledClasses) ||
+      aiModelUrl !== originalModelUrl
     )
   );
 
@@ -65,6 +91,17 @@
       originalConfidence = status.confidence_threshold;
       aiFrameSkip = status.frame_skip_rate;
       originalFrameSkip = status.frame_skip_rate;
+      aiEmaAlpha = status.ema_alpha ?? 0.3;
+      originalEmaAlpha = aiEmaAlpha;
+      aiMaxAge = status.max_age ?? 15;
+      originalMaxAge = aiMaxAge;
+      aiEnabledClasses =
+        Array.isArray(status.enabled_classes) && status.enabled_classes.length > 0
+          ? [...status.enabled_classes]
+          : null;
+      originalEnabledClasses = aiEnabledClasses ? [...aiEnabledClasses] : null;
+      aiModelUrl = status.model_url ?? '';
+      originalModelUrl = aiModelUrl;
     } catch (e) {
       console.warn('Failed to load AI status from backend, falling back to localStorage:', e);
       const settings = getAiSettings();
@@ -74,6 +111,14 @@
       originalConfidence = settings.confidenceThreshold;
       aiFrameSkip = settings.frameSkip;
       originalFrameSkip = settings.frameSkip;
+      aiEmaAlpha = settings.emaAlpha ?? 0.3;
+      originalEmaAlpha = aiEmaAlpha;
+      aiMaxAge = settings.maxAge ?? 15;
+      originalMaxAge = aiMaxAge;
+      aiEnabledClasses = settings.enabledClasses ? [...settings.enabledClasses] : null;
+      originalEnabledClasses = aiEnabledClasses ? [...aiEnabledClasses] : null;
+      aiModelUrl = '';
+      originalModelUrl = '';
     }
     aiDetectedBackend = detectAiBackend();
   }
@@ -83,15 +128,27 @@
       enabled: aiEnabled,
       confidence_threshold: aiConfidenceThreshold,
       frame_skip_rate: aiFrameSkip,
+      ema_alpha: aiEmaAlpha,
+      max_age: aiMaxAge,
+      // Send the array as-is; null/empty means "all classes".
+      enabled_classes: aiEnabledClasses && aiEnabledClasses.length > 0 ? aiEnabledClasses : [],
+      model_url: aiModelUrl || undefined,
     });
     saveAiSettings({
       enabled: aiEnabled,
       confidenceThreshold: aiConfidenceThreshold,
       frameSkip: aiFrameSkip,
+      emaAlpha: aiEmaAlpha,
+      maxAge: aiMaxAge,
+      enabledClasses: aiEnabledClasses && aiEnabledClasses.length > 0 ? aiEnabledClasses : null,
     });
     originalAiEnabled = aiEnabled;
     originalConfidence = aiConfidenceThreshold;
     originalFrameSkip = aiFrameSkip;
+    originalEmaAlpha = aiEmaAlpha;
+    originalMaxAge = aiMaxAge;
+    originalEnabledClasses = aiEnabledClasses ? [...aiEnabledClasses] : null;
+    originalModelUrl = aiModelUrl;
     showToast(t('settings.saved'), 'success');
   }
 
@@ -99,6 +156,10 @@
     aiEnabled = originalAiEnabled;
     aiConfidenceThreshold = originalConfidence;
     aiFrameSkip = originalFrameSkip;
+    aiEmaAlpha = originalEmaAlpha;
+    aiMaxAge = originalMaxAge;
+    aiEnabledClasses = originalEnabledClasses ? [...originalEnabledClasses] : null;
+    aiModelUrl = originalModelUrl;
   }
 
   // MiBeeVision key management
@@ -248,16 +309,68 @@
     savePerCameraAiSettings(perCameraAIConfig);
   }
 
+  // ─── Class filter (#184) ────────────────────────────────────────────────
+  // Curated subset of COCO classes offered as checkboxes (the full 80 are too
+  // many to scan; common surveillance targets cover most use cases). The full
+  // label set remains the source of truth via COCO_CLASSES.
+  const COMMON_CLASSES = [
+    'person', 'bicycle', 'car', 'motorcycle', 'bus', 'truck',
+    'cat', 'dog', 'bird', 'horse',
+    'backpack', 'handbag', 'suitcase',
+    'chair', 'clock',
+  ];
+  const CLASS_PRESETS: { label: string; classes: string[] | null }[] = [
+    { label: 'settings.ai.classPresetAll', classes: null },
+    { label: 'settings.ai.classPresetPerson', classes: ['person'] },
+    { label: 'settings.ai.classPresetSecurity', classes: ['person', 'bicycle', 'car', 'motorcycle', 'bus', 'truck', 'dog', 'cat'] },
+    { label: 'settings.ai.classPresetPersonVehicle', classes: ['person', 'bicycle', 'car', 'motorcycle', 'bus', 'truck'] },
+  ];
+
+  function applyClassPreset(classes: string[] | null) {
+    aiEnabledClasses = classes ? [...classes] : null;
+  }
+
+  function toggleClass(label: string) {
+    const set = new Set(aiEnabledClasses ?? []);
+    if (set.has(label)) set.delete(label);
+    else set.add(label);
+    // Empty selection = all classes (more intuitive than "detect nothing").
+    aiEnabledClasses = set.size > 0 ? [...set] : null;
+  }
+
+  function isClassEnabled(label: string): boolean {
+    // null = all enabled; otherwise check membership.
+    return aiEnabledClasses === null || aiEnabledClasses.includes(label);
+  }
+
+  // ─── Models (#185) ──────────────────────────────────────────────────────
+  async function loadAiModels() {
+    try {
+      aiModels = await listAiModels();
+    } catch {
+      aiModels = [];
+    }
+  }
+
+  // Human-readable model size for the dropdown.
+  function formatBytes(bytes: number): string {
+    if (!bytes) return '';
+    if (bytes >= 1_000_000) return (bytes / 1_000_000).toFixed(1) + ' MB';
+    if (bytes >= 1000) return (bytes / 1000).toFixed(0) + ' KB';
+    return bytes + ' B';
+  }
+
   onMount(() => {
     Promise.all([
       loadAiSettings(),
       loadMiBeeVisionKeys(),
       loadZones(),
+      loadAiModels(),
       // listCameras is async (returns Promise<Camera[]>); it MUST be awaited,
       // not assigned directly — otherwise allCameras holds a Promise (truthy but
       // .length === undefined) and the per-camera list renders nothing (#180).
       listCameras().catch(() => []),
-    ]).then(([, , , cams]) => {
+    ]).then(([, , , , cams]) => {
       allCameras = cams;
       perCameraAIConfig = getPerCameraAiSettings();
       loading = false;
@@ -336,11 +449,121 @@
           <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.frameSkipHint')}</p>
         </div>
 
-        <!-- Model & Backend Info -->
+        <!-- Class Filter (#184) -->
+        <div>
+          <div class="flex items-center justify-between mb-2">
+            <label class="input-label">{t('settings.ai.classFilter')}</label>
+            <span class="text-sm font-medium th-text-primary">
+              {aiEnabledClasses === null ? t('settings.ai.allClasses') : `${aiEnabledClasses.length}`}
+            </span>
+          </div>
+          <p class="text-xs th-text-tertiary mb-2">{t('settings.ai.classFilterHint')}</p>
+          <!-- Presets -->
+          <div class="flex flex-wrap gap-2 mb-2">
+            {#each CLASS_PRESETS as preset}
+              <button
+                type="button"
+                class="px-2 py-1 text-xs rounded-md border th-border th-bg-hover hover:th-bg-hover transition-colors {classesEqual(aiEnabledClasses, preset.classes) ? 'ring-1 ring-blue-500' : ''}"
+                onclick={() => applyClassPreset(preset.classes)}
+              >
+                {t(preset.label)}
+              </button>
+            {/each}
+          </div>
+          <!-- Expandable detailed selection -->
+          <button
+            type="button"
+            class="text-xs th-text-secondary hover:th-text-primary flex items-center gap-1"
+            onclick={() => (showClassFilter = !showClassFilter)}
+          >
+            <ChevronDown size={12} class="transition-transform {showClassFilter ? 'rotate-180' : ''}" />
+            {t('settings.ai.classFilterDetails')}
+          </button>
+          {#if showClassFilter}
+            <div class="mt-2 p-3 rounded-md border th-border grid grid-cols-2 sm:grid-cols-3 gap-2 th-bg-hover">
+              {#each COMMON_CLASSES as cls}
+                <label class="flex items-center gap-2 text-xs th-text-secondary cursor-pointer">
+                  <input
+                    type="checkbox"
+                    class="accent-blue-600"
+                    checked={isClassEnabled(cls)}
+                    onchange={() => toggleClass(cls)}
+                  />
+                  {cls}
+                </label>
+              {/each}
+            </div>
+          {/if}
+        </div>
+
+        <!-- Advanced (#183): EMA + MaxAge -->
+        <div>
+          <button
+            type="button"
+            class="text-xs th-text-secondary hover:th-text-primary flex items-center gap-1"
+            onclick={() => (showAdvanced = !showAdvanced)}
+          >
+            <ChevronDown size={12} class="transition-transform {showAdvanced ? 'rotate-180' : ''}" />
+            {t('settings.ai.advanced')}
+          </button>
+          {#if showAdvanced}
+            <div class="mt-2 p-3 rounded-md border th-border space-y-4 th-bg-hover">
+              <!-- EMA alpha -->
+              <div>
+                <div class="flex items-center justify-between mb-2">
+                  <label class="input-label text-sm" for="ai-ema-alpha">{t('settings.ai.emaAlpha')}</label>
+                  <span class="text-sm th-text-secondary">{aiEmaAlpha.toFixed(1)}</span>
+                </div>
+                <input
+                  id="ai-ema-alpha"
+                  type="range"
+                  class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
+                  bind:value={aiEmaAlpha}
+                  min="0.1"
+                  max="0.9"
+                  step="0.1"
+                />
+                <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.emaAlphaHint')}</p>
+              </div>
+              <!-- Max age -->
+              <div>
+                <div class="flex items-center justify-between mb-2">
+                  <label class="input-label text-sm" for="ai-max-age">{t('settings.ai.maxAge')}</label>
+                  <span class="text-sm th-text-secondary">{aiMaxAge}</span>
+                </div>
+                <input
+                  id="ai-max-age"
+                  type="range"
+                  class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
+                  bind:value={aiMaxAge}
+                  min="3"
+                  max="30"
+                  step="1"
+                />
+                <!-- Show the equivalent dwell time so users understand maxAge in
+                     real seconds rather than abstract "detection cycles" (#183). -->
+                <p class="text-xs th-text-tertiary mt-1">
+                  {t('settings.ai.maxAgeHint', { values: { secs: (aiMaxAge / (30 / aiFrameSkip)).toFixed(1) } })}
+                </p>
+              </div>
+            </div>
+          {/if}
+        </div>
+
+        <!-- Model selection (#185) + Backend Info -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div class="p-3 rounded-md th-bg-hover border th-border">
             <div class="text-xs th-text-tertiary mb-1">{t('settings.ai.modelInfo')}</div>
-            <div class="text-sm font-medium th-text-primary">{t('settings.ai.modelName')}</div>
+            {#if aiModels.length > 0}
+              <select class="input mt-1 text-sm" bind:value={aiModelUrl}>
+                {#each aiModels as m (m.url)}
+                  <option value={m.url}>{m.name} ({formatBytes(m.size)})</option>
+                {/each}
+              </select>
+            {:else}
+              <div class="text-sm font-medium th-text-primary">{t('settings.ai.modelName')}</div>
+              <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.noModelsHint')}</p>
+            {/if}
           </div>
           <div class="p-3 rounded-md th-bg-hover border th-border">
             <div class="text-xs th-text-tertiary mb-1">{t('settings.ai.backendInfo')}</div>


### PR DESCRIPTION
## 背景

AI 检测的三个增强能力:① EMA 平滑参数(emaAlpha/maxAge)硬编码,误检滞留时长不可调(#183);② 80 类全显示,"什么都圈"主因之一,无法只圈人/车(#184);③ 模型无 UI 选择,无法在精度/速度间切换(#185)。

本 PR 给 AI 检测补齐"按需调参 + 定向降噪 + 模型管理"三项能力。

## 改动

### #183 EMA 平滑参数可配(后端 + 前端)
- 后端 `AIConfig`/`ai.Config` 加 `EmaAlpha`/`MaxAge`(yaml+json),`apply_defaults` 默认 0.3/15,converter 映射,handler status/update 支持。
- 前端 `AiDetectionSettings` 加可选字段,`resolveAiSettings` 从后端读取,clamp 辅助函数。
- `AIPanel` 高级折叠区:emaAlpha(0.1–0.9)/maxAge(3–30) 滑块,maxAge 旁显示折算秒数 `≈ {maxAge/(30/frameSkip)} 秒`。

### #184 类别过滤(inference.ts + AIPanel)
- `ObjectDetector` 加 `enabledClasses` 选项,`parseYoloOutput` 后按类别标签过滤(null/空=全部 80 类,非空=只保留集合内)。NMS 前过滤,避免被抑制类干扰。
- `AIPanel`:预设按钮(全部/仅人物/安防常见/人+车) + 可展开常用类别复选框(15 个 surveillance 常见类)。
- `inference.test.ts` 新增 4 个类别过滤回归用例(全部/过滤/无匹配/空数组)。

### #185 模型选择(后端 + 前端)
- 后端新增 `GET /api/ai/models`,列出 `{storage_root}/models/` 下 `.onnx`(名称+URL+大小,按名排序)。空目录返回空列表。
- 前端 `listAiModels()`,`AIPanel` 模型信息区从写死文本改为 `<select>` 下拉(绑定 `model_url`),无模型时显示提示。

## 测试
- 全 **502 测试绿**(新增 4 类别过滤),build 无 TS 错误,后端交叉编译 ARM64 通过。
- **M5 实测**:① `/api/ai/status` 返回 `ema_alpha:0.3, max_age:15, enabled_classes:null`;② `/api/ai/models` 返回 `yolo11n.onnx (10.7MB)`;③ 设置页显示类别过滤(预设"仅人物"→指示器变"1")、高级参数(平滑系数/框滞留时长滑块)、模型下拉(yolo11n.onnx)。需清 service worker 缓存看新 bundle。

## 关联 issue
- Closes #183, Closes #184, Closes #185
