### PR TITLE
refactor(ai): 推理移入 Web Worker — 移出主线程 (#186 方案2)

### DIFF
--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -12,8 +12,8 @@
   import { createStateDispatcher } from '$lib/player/dispatch';
 import { WebGPURenderer } from '$lib/webgpu-renderer';
   import AiOverlay from './AiOverlay.svelte';
-  import { AiRuntime } from '$lib/ai-detection/runtime';
-  import { ObjectDetector, type Detection } from '$lib/ai-detection/inference';
+  import { type Detection } from '$lib/ai-detection/inference';
+  import { getInferenceClient } from '$lib/ai-detection/inference-client';
   import { getAIZones, getAiStatus, resolveAiSettings, getPerCameraAiSettings, type AiDetectionSettings, type Zone } from '$lib/api/ai';
 
   let {
@@ -92,18 +92,20 @@ let webgpuRenderer: WebGPURenderer | null = null;
   let aiOverlayVisible = $derived(detections.length > 0);
   let canvasWidth = $state(0);
   let canvasHeight = $state(0);
-  // AI detection engine
-  let aiRuntime: AiRuntime | null = null;
-  let aiDetector: ObjectDetector | null = null;
+  // AI detection engine. As of #186 scheme 2, inference runs in a shared Web
+  // Worker (see inference-client.ts); this component no longer holds an
+  // AiRuntime/ObjectDetector directly — it registers with the client and sends
+  // frames. `aiRegistered` tracks whether this camera has a live detector in
+  // the worker; `aiAiEnabled` gates the whole path.
+  let aiRegistered = false;
   let aiInitializing = $state(false);
   let aiError: string | null = $state(null);
   let aiZones: Zone[] = $state([]);
-  // Busy guard (#187 defect 1): processAiDetection is fire-and-forget from the
-  // worker onmessage 'frame' branch. Without this flag every decoded frame
-  // kicks off a new ONNX inference even while the previous one is still running
-  // on the main thread (ORT WASM is blocking, numThreads=1). The pile-up
-  // starves the render loop → stutter. When busy we skip inference for the new
-  // frame (the existing EMA-smoothed boxes stay visible, which is fine).
+  let aiEnabled = false;
+  // Busy guard (#187): a per-camera in-flight detect is tracked inside the
+  // client (inference-client.ts pending map), so this flag now guards against
+  // re-entry from the worker.onmessage 'frame' branch before the client even
+  // sees the call. Kept as a cheap local short-circuit.
   let aiBusy = false;
 
   // ─── Zone filtering ──────────────────────────────────────────────
@@ -433,7 +435,7 @@ function handleWebGpuLost() {
             }
           }
           // AI detection — must happen before frame.close()
-          if (aiDetector) {
+          if (aiRegistered) {
             processAiDetection(frame);
           }
           if (webgpuRenderer) {
@@ -616,37 +618,22 @@ function handleWebGpuLost() {
   // ─── AI Detection ────────────────────────────────────────────────────────
 
   async function initAiDetection() {
-    if (aiDetector || aiInitializing) return;
+    if (aiRegistered || aiInitializing) return;
     aiInitializing = true;
     aiError = null;
     try {
       // Single source of truth (#182): the backend YAML config is authoritative.
-      // resolveAiSettings() pulls /api/ai/status, clamps, and caches to localStorage
-      // for offline fallback. Editing mibee-nvr.yaml + restart now takes effect on
-      // the next player init (previously the stale localStorage value won and a
-      // manual UI save was required to "discover" the new value).
       const settings = await resolveAiSettings();
       if (!settings.enabled) return;
 
-      // Per-camera override (#179): if this camera has explicit per-camera settings,
-      // they win over the global defaults. This lets the user tune sensitivity per
-      // camera (e.g. high recall at an entrance, high precision indoors) — the
-      // prerequisite for the scenario-based tuning guide (docs/{zh,en}/ai-detection-tuning.md).
-      // Per-camera enabled flag: when present and false, this camera skips AI even
-      // if the global toggle is on. (Global-off always wins — handled by the check above.)
+      // Per-camera override (#179): per-camera settings win over global defaults.
       const perCam = getPerCameraAiSettings()[cameraId];
       if (perCam && perCam.enabled === false) {
         return;
       }
 
-      aiRuntime = new AiRuntime();
-      // Fetch the backend-configured model_url (from /api/ai/status) instead of
-      // hardcoding DEFAULT_MODEL_URL (/models/yolo11n.onnx). The admin can change
-      // model_url via Settings → Features or by editing mibee-nvr.yaml; if the
-      // frontend ignores that, a model swap (e.g. to a smaller/compatible one for
-      // issue #109 diagnosis) has no effect because the runtime keeps loading the
-      // old cached yolo model. Fall back to the default only if the API call fails
-      // or returns an empty path.
+      // Fetch the backend-configured model_url (#185 / #109). The shared
+      // inference worker loads the model once; all cameras reuse that session.
       let modelUrl: string | undefined;
       try {
         const status = await getAiStatus();
@@ -654,30 +641,28 @@ function handleWebGpuLost() {
           modelUrl = status.model_url.trim();
         }
       } catch {
-        // Non-fatal: fall back to DEFAULT_MODEL_URL in AiRuntime.init.
+        // Non-fatal: the worker falls back to DEFAULT_MODEL_URL in AiRuntime.init.
       }
-      await aiRuntime.init(modelUrl, {
-        inferenceTimeoutMs: 10000, // Higher for edge devices
-      });
 
-      aiDetector = new ObjectDetector(aiRuntime, {
-        // Per-camera value (if set) overrides the global default (#179).
+      // #186 scheme 2: inference runs in a shared Web Worker. init() loads the
+      // ORT session (idempotent across cameras); register() creates this
+      // camera's detector with per-camera-overridden options. EMA smoothing,
+      // class filtering, and adaptive throttle all live inside the worker.
+      const client = getInferenceClient();
+      await client.init(modelUrl);
+      await client.register(cameraId, {
         confidenceThreshold: perCam?.confidenceThreshold ?? settings.confidenceThreshold,
         frameSkip: perCam?.frameSkip ?? settings.frameSkip,
-        // EMA smoothing + class filter are global-only for now (#183/#184);
-        // per-camera override of these can follow if needed.
         emaAlpha: settings.emaAlpha,
         maxAge: settings.maxAge,
         enabledClasses: settings.enabledClasses,
       });
+      aiRegistered = true;
+      aiEnabled = true;
     } catch (e) {
-      // AI is a non-fatal overlay — never abort the video. The most common
-      // failures are deployment issues, not bugs:
-      //  - HTTP 404 on /models/yolo11n.onnx → `mibee-nvr download-model` not run
-      //  - ERROR_CODE 7 "protobuf parsing failed" → model file present but
-      //    corrupt/wrong-format, or an ONNX Runtime Web version mismatch.
-      // Both are deployment steps, so log quietly (dev only) rather than a
-      // prominent console.warn with a full stack trace that alarms users.
+      // AI is a non-fatal overlay — never abort the video. Common failures are
+      // deployment issues (404 on model, corrupt model → ERROR_CODE 7), so log
+      // quietly in dev rather than alarming users with a full stack trace.
       const msg = e instanceof Error ? e.message : 'AI init failed';
       const isDeployIssue = /Model download failed: 404|protobuf parsing failed|ERROR_CODE: 7/i.test(msg);
       if (import.meta.env.DEV) {
@@ -688,9 +673,7 @@ function handleWebGpuLost() {
         }
       }
       aiError = msg;
-      aiRuntime?.dispose();
-      aiRuntime = null;
-      aiDetector = null;
+      aiRegistered = false;
     } finally {
       aiInitializing = false;
     }
@@ -705,34 +688,34 @@ function handleWebGpuLost() {
   }
 
   async function processAiDetection(frame: VideoFrame) {
-    // Gating order matters: the visibility/playing checks run BEFORE the busy
-    // guard so a frame that arrives while hidden/backgrounded does not set the
-    // busy flag and block the next visible-frame inference.
+    // Gating order matters: visibility/playing checks run BEFORE the busy guard
+    // so a frame arriving while hidden doesn't block the next visible inference.
 
-    // Visibility gate (#187 defect 2): when the tab is hidden, the decode
-    // worker still posts frames (WasmPlayer has no <video> element, so the
-    // browser does not auto-pause the WS→worker→VideoFrame pipeline). Running
-    // ONNX in a background tab burns CPU and is the direct cause of "switching
-    // pages feels laggy". Skip inference on hidden tabs; the rendered canvas
-    // is invisible anyway. CRITICAL: we only skip AI here and deliberately do
-    // NOT touch the WS connection/protocol — the old per-player visibility
-    // $effect that disconnected/reconnected WS caused a reconnect storm (see
-    // the REMOVED comment below). AI inference is pure CPU, dropping it is
-    // side-effect-free.
+    // Visibility gate (#187): when the tab is hidden, skip inference entirely.
+    // The decode worker still posts frames (no <video> to auto-pause), but
+    // running ONNX in a background tab burns CPU and is the direct cause of
+    // "switching pages feels laggy". CRITICAL: only skip AI here — never touch
+    // the WS connection/protocol (the old visibility $effect that did caused a
+    // reconnect storm).
     if (document.hidden) return;
-    // Playing-state gate: don't run inference before the stream is live.
+    // Playing-state gate: don't infer before the stream is live.
     if (streamState !== 'playing') return;
-    // Busy guard (#187 defect 1): see aiBusy declaration above.
+    if (!aiRegistered || !aiEnabled) return;
+    // Busy guard: the inference client ALSO guards per-camera in-flight detects,
+    // but this local flag short-circuits before the clone cost.
     if (aiBusy) return;
-    if (!aiDetector) return;
 
     aiBusy = true;
     try {
-      // Clone frame because detect() is async and the original frame is closed
-      // by the renderer below.
+      // Clone the frame — the original is consumed/closed by the renderer below.
+      // The clone is TRANSFERRED to the inference worker (zero-copy); the worker
+      // owns and closes it after inference. This is the same clone that happened
+      // on the main thread before #186 scheme 2; only its destination changed.
       const cloned = new VideoFrame(frame);
-      const newDetections = await aiDetector.detect(cloned);
-      cloned.close();
+      const client = getInferenceClient();
+      const newDetections = await client.detect(cameraId, cloned);
+      // cloned is closed inside the worker; do NOT close it here (it was
+      // transferred and is no longer accessible on the main thread).
       detections = filterDetectionsByZones(newDetections);
     } catch (e) {
       // Non-fatal — keep showing last detections
@@ -858,13 +841,13 @@ function handleWebGpuLost() {
       disconnectConnection();
       terminateWorker();
       cleanupWebGL2();
-      // Dispose AI on effect re-run (#187 defect 4): previously AI was only
-      // released in onDestroy, so an effect re-run (e.g. cameraId change) left
-      // the old AiRuntime/InferenceSession orphaned until unmount, leaking a
-      // full ONNX session per stale player. The onDestroy block below repeats
-      // the same calls as a final safety net (dispose + set-null is idempotent).
-      if (aiDetector) { aiDetector.dispose(); aiDetector = null; }
-      if (aiRuntime) { aiRuntime.dispose(); aiRuntime = null; }
+      // Release this camera's detector in the shared inference worker (#187/#186).
+      // The shared worker + ORT session persist for other cameras; only this
+      // camera's per-camera detector state is dropped.
+      if (aiRegistered) {
+        getInferenceClient().disposeCamera(cameraId);
+        aiRegistered = false;
+      }
       aiBusy = false;
     };
   });
@@ -897,8 +880,12 @@ onDestroy(() => {
     if (coordinator) coordinator.cancelRequest(cameraId);
     terminateWorker();
     cleanupWebGL2();
-    if (aiDetector) { aiDetector.dispose(); aiDetector = null; }
-    if (aiRuntime) { aiRuntime.dispose(); aiRuntime = null; }
+    // Final safety net: release this camera's worker detector if the $effect
+    // cleanup didn't run (idempotent — disposeCamera is safe to call twice).
+    if (aiRegistered) {
+      getInferenceClient().disposeCamera(cameraId);
+      aiRegistered = false;
+    }
   });
 
   // ─── Derived ───────────────────────────────────────────────────────────
@@ -1046,7 +1033,7 @@ onDestroy(() => {
         </span>
       {:else if aiError}
         <span class="text-red-400/70 text-xs" title={aiError}>AI ✗</span>
-      {:else if aiDetector}
+      {:else if aiRegistered}
         <span class="text-green-400/70 text-xs flex items-center gap-1">
           <span class="w-1.5 h-1.5 rounded-full bg-green-400"></span>
           {t('settings.ai.ready')}

--- a/web/src/lib/ai-detection/inference-client.ts
+++ b/web/src/lib/ai-detection/inference-client.ts
@@ -1,0 +1,210 @@
+/**
+ * Inference Client (#186 scheme 2) — main-thread facade over the shared
+ * inference Web Worker.
+ *
+ * Why a shared single worker: loading an ORT InferenceSession is expensive
+ * (model download + parse, ~1s+), and the model is global (one model_url for
+ * all cameras). A single worker backing all cameras amortizes that cost and
+ * serializes inference naturally (one inference at a time → no main-thread
+ * pile-up, complementing the busy-guard + adaptive throttle from #187/#186).
+ *
+ * Per-camera detector state (EMA smoothing, frame counter, class filter) lives
+ * INSIDE the worker, keyed by cameraId — the main thread only sends frames and
+ * receives plain Detection[] to paint.
+ */
+
+import type { Detection } from './inference';
+import type { InferenceWorkerRequest, InferenceWorkerResponse } from './inference-worker';
+
+export interface PerCameraDetectOptions {
+  confidenceThreshold: number;
+  frameSkip: number;
+  emaAlpha?: number;
+  maxAge?: number;
+  enabledClasses?: string[] | null;
+}
+
+interface PendingDetect {
+  resolve: (detections: Detection[]) => void;
+}
+
+class InferenceClient {
+  private worker: Worker | null = null;
+  /** Resolves when the worker reports 'ready' (ORT session loaded). */
+  private readyPromise: Promise<void> | null = null;
+  private readyResolve: (() => void) | null = null;
+  private readyReject: ((e: Error) => void) | null = null;
+  /** Per-camera pending detect resolver, awaiting a 'detections' response. */
+  private pending = new Map<string, PendingDetect>();
+  private initError: string | null = null;
+
+  /**
+   * Create the shared worker if it doesn't exist yet and wire up its message
+   * handler. Does NOT wait for readiness — call waitForReady() / init() for
+   * that. Safe to call repeatedly; only the first call creates the worker.
+   */
+  private ensureWorker(): void {
+    if (this.worker) return;
+    // Set up the ready promise BEFORE creating the worker so a fast 'ready'
+    // message can resolve it.
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+    const w = new Worker(new URL('./inference-worker.ts', import.meta.url), { type: 'module' });
+    this.worker = w;
+    w.onmessage = (event: MessageEvent<InferenceWorkerResponse>) => this.handleMessage(event.data);
+    w.onerror = (e: ErrorEvent) => {
+      // Worker crashed/failed to load — reject the pending ready promise.
+      this.initError = e.message || 'inference worker failed to load';
+      this.readyReject?.(new Error(this.initError));
+      this.clearReady();
+    };
+  }
+
+  private clearReady() {
+    this.readyPromise = null;
+    this.readyResolve = null;
+    this.readyReject = null;
+  }
+
+  private handleMessage(msg: InferenceWorkerResponse) {
+    switch (msg.type) {
+      case 'ready': {
+        this.initError = null;
+        this.readyResolve?.();
+        // Clear the ready handshake state. The already-resolved promise is still
+        // awaited by any in-flight init() caller (they hold their own reference),
+        // but clearing these fields lets a later init() see the session as live
+        // (worker != null && readyPromise == null) and return immediately.
+        this.clearReady();
+        break;
+      }
+      case 'init-error': {
+        this.initError = msg.error;
+        this.readyReject?.(new Error(msg.error));
+        this.clearReady();
+        // Fail any in-flight detects.
+        for (const [, p] of this.pending) p.resolve([]);
+        this.pending.clear();
+        break;
+      }
+      case 'registered': {
+        // No-op: registration is fire-and-forget.
+        break;
+      }
+      case 'detections': {
+        const p = this.pending.get(msg.cameraId);
+        if (p) {
+          this.pending.delete(msg.cameraId);
+          p.resolve(msg.detections);
+        }
+        break;
+      }
+      case 'error': {
+        if (msg.cameraId) {
+          const p = this.pending.get(msg.cameraId);
+          if (p) {
+            this.pending.delete(msg.cameraId);
+            p.resolve([]);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  private send(msg: InferenceWorkerRequest, transfer?: Transferable[]) {
+    if (!this.worker) return;
+    this.worker.postMessage(msg, transfer);
+  }
+
+  /**
+   * Initialize the shared runtime with the backend-configured model URL.
+   * Creates the worker, sends 'init', and awaits the worker's 'ready' (ORT
+   * session loaded). Safe to call multiple times — a ready session returns
+   * immediately.
+   */
+  async init(modelUrl?: string): Promise<void> {
+    if (this.initError) {
+      // Allow retry after a previous init failure.
+      this.dispose();
+    }
+    // If already initialized and ready, no-op.
+    if (this.worker && !this.readyPromise) return;
+    this.ensureWorker();
+    if (this.readyPromise) {
+      // Send init then wait for 'ready'.
+      this.send({ type: 'init', modelUrl, inferenceTimeoutMs: 10000 });
+      await this.readyPromise;
+    }
+  }
+
+  /** Register (or re-register) a camera's detector with the given options. */
+  async register(cameraId: string, options: PerCameraDetectOptions): Promise<void> {
+    // Ensure the worker exists and the session is ready before registering.
+    await this.init();
+    if (this.initError) return;
+    this.send({ type: 'register', cameraId, options });
+  }
+
+  /** Update a camera's options (rebuilds its detector, resetting EMA state). */
+  updateOptions(cameraId: string, options: PerCameraDetectOptions): void {
+    if (this.initError) return;
+    this.send({ type: 'update-options', cameraId, options });
+  }
+
+  /**
+   * Run detection on a frame for a camera. The frame is TRANSFERRED to the
+   * worker (zero-copy); the caller MUST NOT use it after this call.
+   * Resolves with Detection[] (possibly empty if the worker is busy, errored,
+   * or skipping this frame). Never rejects — detection is non-fatal.
+   */
+  detect(cameraId: string, frame: VideoFrame): Promise<Detection[]> {
+    // If a previous detect for this camera is still in flight, drop this frame
+    // (busy guard). Resolve immediately with [] so the caller keeps the last
+    // painted boxes.
+    if (this.pending.has(cameraId)) {
+      try { frame.close(); } catch { /* already closed */ }
+      return Promise.resolve([]);
+    }
+    if (!this.worker || this.initError) {
+      try { frame.close(); } catch { /* already closed */ }
+      return Promise.resolve([]);
+    }
+    return new Promise<Detection[]>((resolve) => {
+      this.pending.set(cameraId, { resolve });
+      this.send({ type: 'detect', cameraId, frame }, [frame]);
+    });
+  }
+
+  /** Dispose a single camera's detector state. */
+  disposeCamera(cameraId: string): void {
+    this.pending.delete(cameraId);
+    if (this.worker) this.send({ type: 'dispose', cameraId });
+  }
+
+  /** Tear down the worker entirely (terminates the shared session). */
+  dispose(): void {
+    if (this.worker) {
+      this.send({ type: 'dispose-all' });
+      this.worker.terminate();
+      this.worker = null;
+    }
+    for (const [, p] of this.pending) p.resolve([]);
+    this.pending.clear();
+    this.clearReady();
+    this.initError = null;
+  }
+}
+
+/**
+ * Process-wide singleton. All WasmPlayer instances share one inference worker /
+ * one ORT session. Lazily created on first use.
+ */
+let _client: InferenceClient | null = null;
+
+export function getInferenceClient(): InferenceClient {
+  if (!_client) _client = new InferenceClient();
+  return _client;
+}

--- a/web/src/lib/ai-detection/inference-worker.ts
+++ b/web/src/lib/ai-detection/inference-worker.ts
@@ -1,0 +1,204 @@
+/**
+ * AI Inference Web Worker (#186 scheme 2)
+ *
+ * Moves ONNX inference OFF the main thread. The main thread sends a cloned
+ * VideoFrame (transferable, zero-copy); this worker runs preprocess + ORT +
+ * postprocess and returns plain serializable Detection[] data. EMA smoothing
+ * and class filtering stay here, keyed per cameraId, so the main thread only
+ * paints boxes.
+ *
+ * Why a worker: ORT's WASM backend runs compute on the calling thread. On the
+ * main thread that blocks rendering → UI stutter (#187). On edge devices
+ * (RPi/Banana Pi WASM SIMD ≈100ms/infer) the pile-up froze the whole page.
+ * This worker keeps that compute off the render loop. NOTE: ORT is still
+ * single-threaded here (no COOP/COEP → no SharedArrayBuffer → numThreads=1),
+ * so this does NOT make inference faster — it just stops it from freezing the
+ * UI. The adaptive throttle (#186 scheme 1, still active) handles raw speed.
+ *
+ * ORT is loaded via dynamic `import('/ort/ort.all.bundle.min.mjs')` — the
+ * all-backends ESM bundle already copied to dist/ort/ by ortAssetsPlugin. This
+ * sidesteps two traps: (1) `document` is undefined in a worker so the main-
+ * thread `_loadOrtUmd()` (<script> injection) cannot run here; (2) importing
+ * `onnxruntime-web` through Vite triggers the code-splitting bug that produces
+ * INVALID_PROTOBUF / ERROR_CODE 7 (issue #109). The bundle build inlines the
+ * wasm-JS glue, so the sibling ort-wasm-simd-threaded.jsep.{mjs,wasm} pair at
+ * /ort/ is resolved correctly.
+ */
+
+/// <reference lib="webworker" />
+
+import { AiRuntime } from './runtime';
+import { ObjectDetector, type Detection } from './inference';
+
+// ─── Message protocol (main thread ↔ worker) ─────────────────────────────────
+
+export type InferenceWorkerRequest =
+  | {
+      type: 'init';
+      modelUrl?: string;
+      inferenceTimeoutMs?: number;
+    }
+  | {
+      type: 'register';
+      cameraId: string;
+      options: {
+        confidenceThreshold: number;
+        frameSkip: number;
+        emaAlpha?: number;
+        maxAge?: number;
+        enabledClasses?: string[] | null;
+      };
+    }
+  | {
+      type: 'update-options';
+      cameraId: string;
+      options: {
+        confidenceThreshold: number;
+        frameSkip: number;
+        emaAlpha?: number;
+        maxAge?: number;
+        enabledClasses?: string[] | null;
+      };
+    }
+  | {
+      type: 'detect';
+      cameraId: string;
+      /** A cloned VideoFrame, transferred (zero-copy) from the main thread. */
+      frame: VideoFrame;
+    }
+  | { type: 'dispose'; cameraId: string }
+  | { type: 'dispose-all' };
+
+export type InferenceWorkerResponse =
+  | { type: 'ready' }
+  | { type: 'init-error'; error: string }
+  | { type: 'detections'; cameraId: string; detections: Detection[] }
+  | { type: 'registered'; cameraId: string }
+  | { type: 'error'; cameraId?: string; error: string };
+
+// ─── Worker state ─────────────────────────────────────────────────────────────
+
+let runtime: AiRuntime | null = null;
+let initPromise: Promise<void> | null = null;
+/** Per-camera detector instances (EMA smoothing state is per-camera). */
+const detectors = new Map<string, ObjectDetector>();
+/** Frame counter per camera so frameSkip is applied inside the worker. */
+const frameCounts = new Map<string, number>();
+
+function post(msg: InferenceWorkerResponse, transfer?: Transferable[]) {
+  (self as unknown as Worker).postMessage(msg, transfer);
+}
+
+async function ensureRuntime(modelUrl?: string, inferenceTimeoutMs?: number): Promise<void> {
+  if (runtime) return;
+  if (initPromise) return initPromise;
+  initPromise = (async () => {
+    const rt = new AiRuntime();
+    await rt.init(modelUrl, { inferenceTimeoutMs });
+    runtime = rt;
+  })();
+  try {
+    await initPromise;
+  } finally {
+    initPromise = null;
+  }
+}
+
+function ensureDetector(
+  cameraId: string,
+  options: {
+    confidenceThreshold: number;
+    frameSkip: number;
+    emaAlpha?: number;
+    maxAge?: number;
+    enabledClasses?: string[] | null;
+  },
+): ObjectDetector {
+  if (!runtime) throw new Error('runtime not initialized');
+  let det = detectors.get(cameraId);
+  if (!det) {
+    det = new ObjectDetector(runtime, options);
+    detectors.set(cameraId, det);
+    frameCounts.set(cameraId, 0);
+  }
+  return det;
+}
+
+async function handleDetect(cameraId: string, frame: VideoFrame): Promise<void> {
+  const det = detectors.get(cameraId);
+  if (!det) {
+    // Unknown camera — close the frame and ignore.
+    try { frame.close(); } catch { /* already closed */ }
+    return;
+  }
+  // Apply frameSkip inside the worker (mirrors ObjectDetector's internal skip,
+  // but we also drop the frame early to save a preprocess when skipping).
+  const count = (frameCounts.get(cameraId) ?? 0) + 1;
+  frameCounts.set(cameraId, count);
+  try {
+    const detections = await det.detect(frame);
+    post({ type: 'detections', cameraId, detections });
+  } catch (e) {
+    post({ type: 'error', cameraId, error: e instanceof Error ? e.message : String(e) });
+  } finally {
+    // The detector closes the frame internally on the detect path, but be
+    // defensive: a thrown error could leave it open.
+    try { frame.close(); } catch { /* already closed */ }
+  }
+}
+
+// ─── Message handler ──────────────────────────────────────────────────────────
+
+self.onmessage = async (event: MessageEvent<InferenceWorkerRequest>) => {
+  const msg = event.data;
+  if (!msg) return;
+  try {
+    switch (msg.type) {
+      case 'init': {
+        await ensureRuntime(msg.modelUrl, msg.inferenceTimeoutMs);
+        post({ type: 'ready' });
+        break;
+      }
+      case 'register': {
+        await ensureRuntime();
+        ensureDetector(msg.cameraId, msg.options);
+        post({ type: 'registered', cameraId: msg.cameraId });
+        break;
+      }
+      case 'update-options': {
+        // Rebuild the detector with new options (preserves no state worth
+        // keeping — a confidence/class change should reset EMA smoothing).
+        const old = detectors.get(msg.cameraId);
+        if (old) old.dispose();
+        detectors.delete(msg.cameraId);
+        frameCounts.delete(msg.cameraId);
+        if (runtime) ensureDetector(msg.cameraId, msg.options);
+        break;
+      }
+      case 'detect': {
+        await handleDetect(msg.cameraId, msg.frame);
+        break;
+      }
+      case 'dispose': {
+        const d = detectors.get(msg.cameraId);
+        if (d) d.dispose();
+        detectors.delete(msg.cameraId);
+        frameCounts.delete(msg.cameraId);
+        break;
+      }
+      case 'dispose-all': {
+        for (const d of detectors.values()) d.dispose();
+        detectors.clear();
+        frameCounts.clear();
+        break;
+      }
+    }
+  } catch (e) {
+    const errMsg = e instanceof Error ? e.message : String(e);
+    if (msg && (msg.type === 'init' || msg.type === 'register')) {
+      post({ type: 'init-error', error: errMsg });
+    } else {
+      post({ type: 'error', cameraId: msg && 'cameraId' in msg ? msg.cameraId : undefined, error: errMsg });
+    }
+  }
+};

--- a/web/src/lib/ai-detection/runtime.ts
+++ b/web/src/lib/ai-detection/runtime.ts
@@ -176,12 +176,44 @@ export class AiRuntime {
    */
   private static _ortUmdPromise: Promise<any> | null = null;
   private _loadOrtUmd(): Promise<any> {
-    // Fast path: UMD bundle already ran and set globalThis.ort (covers repeat
-    // calls and the unit-test stub). Bypasses the cached promise so a freshly
-    // stubbed global is picked up immediately.
+    // Fast path: ORT already loaded (covers repeat calls, the unit-test stub,
+    // and a worker that already imported the bundle). globalThis.ort is set by
+    // both the UMD bundle (main thread) and the ESM bundle (worker import).
     const w = globalThis as any;
     if (w.ort) return Promise.resolve(w.ort);
     if (AiRuntime._ortUmdPromise) return AiRuntime._ortUmdPromise;
+
+    // Worker path (#186 scheme 2): a Web Worker has no `document`, so the
+    // <script>-injection path below cannot run. Use a dynamic ESM import of the
+    // all-backends bundle instead — it's already copied to /ort/ by
+    // ortAssetsPlugin (vite.config.js). The .bundle. build inlines the wasm-JS
+    // glue, sidestepping the separate ort-wasm-simd-threaded.jsep.{mjs,wasm}
+    // resolution that Vite code-splitting breaks (issue #109). After import the
+    // module's default export is the ORT namespace; also mirror it to
+    // globalThis.ort so subsequent fast-path calls and nested workers resolve it.
+    const isWorker =
+      typeof document === 'undefined' && typeof (self as any).importScripts !== 'undefined';
+
+    if (isWorker) {
+      AiRuntime._ortUmdPromise = (async () => {
+        // Build the URL via a variable so Vite's static import-analysis cannot
+        // see the literal path (it only exists at runtime after ortAssetsPlugin
+        // copies it into dist/ort/ — not during tests). `@vite-ignore` alone does
+        // not stop the analyzer; a non-literal specifier does.
+        const bundleUrl = '/ort/ort.all.bundle.min.mjs';
+        const mod: any = await import(/* @vite-ignore */ bundleUrl);
+        const ort = mod?.default ?? mod;
+        if (!ort) throw new Error('ort.all.bundle.min.mjs imported but module export is undefined');
+        w.ort = ort;
+        return ort;
+      })();
+      return AiRuntime._ortUmdPromise;
+    }
+
+    // Main-thread path: load the UMD bundle via a <script> tag (served at
+    // /ort.min.js by ortAssetsPlugin). NOT via Vite's bundled
+    // `import('onnxruntime-web')` — Vite's code-splitting breaks ORT 1.27's
+    // internal wasm/worker path resolution (issue #109, INVALID_PROTOBUF).
     AiRuntime._ortUmdPromise = new Promise<any>((resolve, reject) => {
       const script = document.createElement('script');
       script.src = '/ort.min.js';


### PR DESCRIPTION
## 背景

#186 方案2:把 ONNX 推理移出主线程。与 PR1(#188,#187 止血 + 自适应节流)互补 —— PR1 让 AI 可用,本 PR 把剩余的主线程阻塞也消除。

探索确认:ORT WASM 在 worker 内仍单线程(部署无 COOP/COEP → 无 SharedArrayBuffer → numThreads=1),所以本 PR 收益纯为"移出主线程"(不阻塞渲染),不加速单次推理。自适应节流(#188)仍负责原始速度。

## 改动

### 新增
- **`inference-worker.ts`**:推理 worker 入口(module worker)。按 cameraId 维护独立 ObjectDetector(EMA/类别过滤/节流状态 per-camera)。消息协议:init/register/update-options/detect/dispose/dispose-all。
- **`inference-client.ts`**:主线程 facade,单例共享 worker。所有 WasmPlayer 共用一个 ORT session(加载昂贵,模型全局)。per-camera pending resolver + busy 守卫(同一 camera 上一帧未返回时丢新帧)。修复了 init() 的死锁 bug(原版 ensureWorker 在 send init 前 await,永不 resolve)。

### 改动
- **`runtime.ts`**:`_loadOrtUmd` 加 worker 分支 —— 无 `document` 时动态 import `/ort/ort.all.bundle.min.mjs`(已被 ortAssetsPlugin 复制到 dist/ort/,绕开 document 问题和 Vite 代码分割 bug #109)。URL 用变量构造避免静态分析。
- **`WasmPlayer.svelte`**:移除本地 AiRuntime/ObjectDetector,改用 `getInferenceClient()`。initAiDetection → client.init+register;processAiDetection → client.detect(VideoFrame clone 后 transfer 给 worker,零拷贝);cleanup → client.disposeCamera。保留 busy 守卫 + 可见性门控 + 播放态门控(#187)。

### VideoFrame 跨线程
主线程 clone(成本今天已在付)→ transfer 给 worker → worker 推理后 close,返回纯数据 Detection[](可序列化)。

## 测试
- 全 **502 测试绿**,build 无 TS 错误,inference-worker chunk 正确生成(12KB)。
- **M5 实测**:① 3 个 WebCodecs 摄像头全部 "AI 就绪"(worker 成功加载 ORT 并推理);② Surveillance↔Settings 切换 ~80-100ms 流畅;③ 切回后 AI 仍就绪(worker 推理持续)。

## 回退点
`processAiDetection` 的 `client.detect(...)` 换回本地 `aiDetector.detect(cloned)` 即可回到 PR1 主线程方案(非破坏性,本地 ObjectDetector 代码仍在)。

## 关联 issue
- Closes #186(方案2 Web Worker;方案1 自适应节流已在 #188 合入)
