### PR TITLE
fix(ai): 置信度上限提到 0.99 + 2 位小数精度(支持 0.95 降噪阈值)

### DIFF
--- a/web/src/lib/api/ai.ts
+++ b/web/src/lib/api/ai.ts
@@ -128,7 +128,12 @@ export async function resolveAiSettings(): Promise<AiDetectionSettings> {
 
 function clampConfidence(value: number): number {
   if (typeof value !== 'number' || isNaN(value)) return DEFAULTS.confidenceThreshold;
-  return Math.round(Math.min(0.9, Math.max(0.1, value)) * 10) / 10;
+  // Upper bound 0.99 (was 0.9): YOLOv11-nano on complex scenes produces
+  // background false positives in the 0.85–0.92 range; pushing the threshold
+  // to 0.95 filters most of them while keeping real persons (>0.93). Two
+  // decimal places so 0.95 is representable (the old 1-decimal rounding turned
+  // 0.95 into 0.9 or 1.0).
+  return Math.round(Math.min(0.99, Math.max(0.1, value)) * 100) / 100;
 }
 
 function clampFrameSkip(value: number): number {

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -425,8 +425,8 @@
             class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
             bind:value={aiConfidenceThreshold}
             min="0.1"
-            max="0.9"
-            step="0.1"
+            max="0.99"
+            step="0.01"
           />
           <p class="text-xs th-text-tertiary mt-1">{t('settings.ai.confidenceHint')}</p>
         </div>
@@ -670,8 +670,8 @@
                     type="range"
                     class="w-full h-2 rounded-full appearance-none cursor-pointer th-bg-tertiary accent-blue-600"
                     min="0.1"
-                    max="0.9"
-                    step="0.1"
+                    max="0.99"
+                    step="0.01"
                     value={getCameraConfig(cam.id).confidenceThreshold ?? 0.5}
                     oninput={(e) => updatePerCamera(cam.id, { confidenceThreshold: parseFloat(e.currentTarget.value) })}
                   />


### PR DESCRIPTION
## 背景

YOLOv11-nano 在复杂场景(树叶/墙角/反光/衣物堆)会把背景纹理误判为 person,置信度常落在 0.85-0.92。原来置信度滑块上限 0.9 挡不住这些误检,且 clamp 用 1 位小数四舍五入(`round(*10)/10`)会把 0.95 变成 0.9 或 1.0,无法表达 0.95 这种有效的降噪阈值。

## 改动
- `clampConfidence`:上限 0.9 → 0.99,精度 1 位 → 2 位小数(0.95 可表示)。
- `AIPanel` 全局 + per-camera 置信度滑块:`max` 0.9 → 0.99,`step` 0.1 → 0.01。

## 测试
- 全 502 测试绿,build 无 TS 错误。
- M5 实测:设置页置信度滑块 `max:0.99, step:0.01`,当前值 0.95 正确显示。

## 关联
配合类别过滤(person-only)+ maxAge=3,是 nano 模型不画 ROI 前提下最强的降噪组合。
