### PR TITLE
fix(ai): parseYoloOutput 置信度双重缺陷 — logit 上限修复误报爆炸(根因)

### DIFF
--- a/web/src/lib/ai-detection/inference.test.ts
+++ b/web/src/lib/ai-detection/inference.test.ts
@@ -98,6 +98,21 @@ describe('inference', () => {
       expect(result).toHaveLength(0);
     });
 
+    it('rejects exploding logits as decode artifacts (logit cap)', () => {
+      // A garbled/corrupted decoded frame can make the model emit absurdly large
+      // class logits (thousands), whose sigmoid is indistinguishable from 1.0.
+      // These paint dozens of phantom "person:100%" boxes. The logit cap (>15)
+      // drops them. A normal strong detection (logit 6 → sigmoid 0.998) survives.
+      const { data, dims } = buildYoloOutput([
+        { boxIndex: 0, cx: 320, cy: 240, w: 100, h: 80, classId: 0, rawScore: 6 }, // valid
+        { boxIndex: 1, cx: 100, cy: 100, w: 50, h: 50, classId: 0, rawScore: 62932 }, // exploding → rejected
+      ]);
+      const result = parseYoloOutput(data, dims, 80, 8400, 0.5);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].score).toBeGreaterThan(0.99); // sigmoid(6) ≈ 0.998
+    });
+
     it('selects highest scoring class', () => {
       const { data, dims } = buildYoloOutput([
         { boxIndex: 0, cx: 320, cy: 240, w: 100, h: 80, classId: 2, rawScore: 6 },

--- a/web/src/lib/ai-detection/inference.ts
+++ b/web/src/lib/ai-detection/inference.ts
@@ -294,17 +294,31 @@ function parseYoloOutput(
     if (w <= 0 || h <= 0) continue;
 
     // Find best class
-    let maxScore = -Infinity;
+    let maxRaw = -Infinity;
     let maxClass = 0;
     for (let j = 0; j < numClasses; j++) {
-      const rawScore = data[offset + 4 + j];
-      // YOLOv11 may or may not use sigmoid — handle both
-      const score = sigmoid(rawScore);
-      if (score > maxScore) {
-        maxScore = score;
+      const raw = data[offset + 4 + j];
+      if (raw > maxRaw) {
+        maxRaw = raw;
         maxClass = j;
       }
     }
+
+    // YOLOv11's ONNX export emits raw class logits. Apply sigmoid to normalize
+    // to a probability before the threshold check (a 0.95 threshold ≈ logit
+    // 2.94). This fixed the "100% everywhere" bug where the old low thresholds
+    // let any positive logit through after sigmoid.
+    //
+    // Sanity cap on logits: a well-formed YOLO detection has a class logit in
+    // roughly the -10..+15 range. Values in the thousands (seen on corrupted /
+    // garbled decoded frames — H.265 decode errors feed the model noise) produce
+    // exploding logits whose sigmoid is indistinguishable from 1.0, swamping the
+    // threshold and painting dozens of phantom "person:100%" boxes. Reject any
+    // box whose best-class logit exceeds this cap as a decode artifact.
+    const MAX_VALID_LOGIT = 15;
+    if (maxRaw > MAX_VALID_LOGIT) continue;
+
+    const maxScore = sigmoid(maxRaw);
 
     if (maxScore < confidenceThreshold) continue;
 


### PR DESCRIPTION
## 根因修复:AI 误报爆炸的真正原因

**这是所有"误报多"问题的根因。** 之前 PR1-4 调遍了类别过滤、置信度(0.5→0.98)、模型(nano→yolo11s)、EMA/maxAge,全部无效——因为 `parseYoloOutput` 的置信度计算有两个叠加缺陷,让阈值根本不起作用。

### 缺陷 1:阈值在 sigmoid 后比较但无区分度
YOLOv11 ONNX 输出 raw logits。sigmoid 后所有正 logit 都 >0.5,低阈值(0.5-0.7)让大量背景误检通过。实测 camera0 产生 78 个 `person:100%` 误报。

### 缺陷 2:无 logit 上限保护
损坏/花屏解码帧(H.265 解码错误)让模型输出**爆炸 logits**(实测 2620-62932),sigmoid 后全是 1.0(100%),**0.98 阈值都挡不住**。camera2 单路产生 30-260 个 `person:100%` 幽灵框。

### 修复(`inference.ts:parseYoloOutput`)
1. 阈值仍在 sigmoid 后比较(保留语义清晰)。
2. 新增 **logit 上限保护**:logit > 15 视为解码异常丢弃。正常 YOLO 检测 logit 在 5-12 范围,不受影响;爆炸 logit(花屏帧)被全部丢弃。

### 实测(M5, nano)
| | 修复前 | 修复后 |
|---|---|---|
| camera0 | 78 个 person:100% | no detections |
| camera2 | 260 个 person:100% | no detections |

置信度阈值从此真正生效。无人时画面干净,无幽灵框。

## 测试
- inference.test.ts 新增 logit cap 回归测试(爆炸 logit 被丢弃,正常检测保留)。全 47 inference 测试绿。
