### PR TITLE
fix(web): 推流复制地址/删除推流失效 — clipboard fallback + 写后失效缓存 (#197)

### DIFF
--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -302,6 +302,28 @@ export const DEFAULT_PROTOCOLS: ProtocolInfo[] = [
 let fullListEtag: string | null = null;
 let cachedFullList: Camera[] | null = null;
 
+/**
+ * Discard the full-list ETag cache so the next listCameras() issues a full GET
+ * instead of returning a stale body on a 304.
+ *
+ * The server's full-list ETag is hashed from camera count + ID + Status +
+ * LastSeen only — it does NOT cover fields like push_targets, name,
+ * transcoding, audio_enabled, ... So any write that mutates such a field leaves
+ * the ETag unchanged, the next listCameras() gets a 304, and the caller renders
+ * the pre-write cached copy. This is exactly the "deleted push-out target
+ * reappears" regression in issue #197.
+ *
+ * Rather than keep the ETag hash in sync with every field (fragile — the next
+ * new field reintroduces the bug), we decouple correctness from caching: every
+ * mutating camera call invalidates the cache on success, forcing a fresh GET.
+ * The ETag still pays off for the read-only Dashboard 30s poll. This is the
+ * structural fix: correctness no longer depends on which fields the hash covers.
+ */
+export function invalidateCameraListCache() {
+  fullListEtag = null;
+  cachedFullList = null;
+}
+
 export async function listCameras(signal?: AbortSignal): Promise<Camera[]> {
   const headers: Record<string, string> = {};
   if (fullListEtag) headers['If-None-Match'] = fullListEtag;
@@ -372,11 +394,13 @@ export async function listCamerasSummary(signal?: AbortSignal): Promise<CameraSu
 }
 
 export async function createCamera(data: CreateCameraRequest, signal?: AbortSignal): Promise<Camera> {
-  return apiRequest<Camera>('/cameras', {
+  const camera = await apiRequest<Camera>('/cameras', {
     method: 'POST',
     body: JSON.stringify(data),
     signal,
   });
+  invalidateCameraListCache();
+  return camera;
 }
 
 export async function getCamera(id: string, signal?: AbortSignal): Promise<Camera> {
@@ -384,11 +408,13 @@ export async function getCamera(id: string, signal?: AbortSignal): Promise<Camer
 }
 
 export async function updateCamera(id: string, data: UpdateCameraRequest, signal?: AbortSignal): Promise<Camera> {
-  return apiRequest<Camera>(`/cameras/${id}`, {
+  const camera = await apiRequest<Camera>(`/cameras/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
     signal,
   });
+  invalidateCameraListCache();
+  return camera;
 }
 
 /** Fetch live push-out relay status for a camera (per-target state + bitrate). */
@@ -397,10 +423,11 @@ export async function getPushStatus(id: string, signal?: AbortSignal): Promise<P
 }
 
 export async function deleteCamera(id: string, signal?: AbortSignal): Promise<void> {
-  return apiRequest<void>(`/cameras/${id}`, {
+  await apiRequest<void>(`/cameras/${id}`, {
     method: 'DELETE',
     signal,
   });
+  invalidateCameraListCache();
 }
 
 export interface CameraRecordingStats {
@@ -413,17 +440,21 @@ export async function getCameraRecordingStats(id: string, signal?: AbortSignal):
 }
 
 export async function startCamera(id: string, signal?: AbortSignal): Promise<{ status: string }> {
-  return apiRequest<{ status: string }>(`/cameras/${id}/start`, {
+  const res = await apiRequest<{ status: string }>(`/cameras/${id}/start`, {
     method: 'POST',
     signal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 export async function stopCamera(id: string, signal?: AbortSignal): Promise<{ status: string }> {
-  return apiRequest<{ status: string }>(`/cameras/${id}/stop`, {
+  const res = await apiRequest<{ status: string }>(`/cameras/${id}/stop`, {
     method: 'POST',
     signal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 // Manually trigger IP self-healing for a camera whose network address may have
@@ -438,10 +469,12 @@ export async function rediscoverCamera(
   // restart time, so use a generous client-side timeout rather than the default
   // 30s. Caller-supplied signal takes precedence.
   const effectiveSignal = signal ?? AbortSignal.timeout(90000);
-  return apiRequest<{ found: boolean; status?: string; reason?: string }>(`/cameras/${id}/rediscover`, {
+  const res = await apiRequest<{ found: boolean; status?: string; reason?: string }>(`/cameras/${id}/rediscover`, {
     method: 'POST',
     signal: effectiveSignal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 /**
@@ -456,11 +489,13 @@ export async function activateCamera(
   signal?: AbortSignal,
 ): Promise<{ status: string }> {
   const effectiveSignal = signal ?? AbortSignal.timeout(60000);
-  return apiRequest<{ status: string }>(`/cameras/${id}/activate`, {
+  const res = await apiRequest<{ status: string }>(`/cameras/${id}/activate`, {
     method: 'POST',
     body: JSON.stringify(credentials),
     signal: effectiveSignal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 export function getDashboardCameras(signal?: AbortSignal): Promise<Camera[]> {
@@ -531,18 +566,22 @@ export async function updateMergeConfig(
   config: MergeConfig,
   signal?: AbortSignal,
 ): Promise<{ status: string }> {
-  return apiRequest<{ status: string }>(`/cameras/${cameraId}/merge-config`, {
+  const res = await apiRequest<{ status: string }>(`/cameras/${cameraId}/merge-config`, {
     method: 'PUT',
     body: JSON.stringify(config),
     signal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 export async function deleteCameraMergeConfig(cameraId: string, signal?: AbortSignal): Promise<{ status: string }> {
-  return apiRequest<{ status: string }>(`/cameras/${cameraId}/merge-config`, {
+  const res = await apiRequest<{ status: string }>(`/cameras/${cameraId}/merge-config`, {
     method: 'DELETE',
     signal,
   });
+  invalidateCameraListCache();
+  return res;
 }
 
 // --- PTZ ---

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { copyText } from './clipboard';
+
+// copyText exists because navigator.clipboard is undefined on plain HTTP origins
+// (the NVR's default Docker/LAN deployment), which silently broke the "copy
+// push-out URL" and "copy API key" buttons (issue #197). These tests pin both the
+// secure-context path and the execCommand fallback.
+
+describe('copyText', () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Restore navigator.clipboard and document.execCommand for other test files.
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+    document.execCommand = originalExecCommand;
+    Object.defineProperty(window, 'isSecureContext', {
+      value: false,
+      configurable: true,
+    });
+  });
+
+  it('uses the async Clipboard API on a secure context', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    document.execCommand = vi.fn(() => true);
+
+    const ok = await copyText('rtmp://example/live');
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('rtmp://example/live');
+    // Must NOT fall through to the legacy path when the async API succeeds.
+    expect(document.execCommand).not.toHaveBeenCalled();
+  });
+
+  it('falls back to execCommand on a non-secure context (plain HTTP + IP)', async () => {
+    // This is the issue #197 scenario: Docker/LAN deploy via http://<ip>:9090.
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    // navigator.clipboard may be entirely absent on non-secure contexts.
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    const exec = vi.fn(() => true);
+    document.execCommand = exec;
+
+    const ok = await copyText('http://192.168.1.10:9090/key');
+    expect(ok).toBe(true);
+    expect(exec).toHaveBeenCalledWith('copy');
+  });
+
+  it('returns false when both clipboard API and execCommand fail', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: false, configurable: true });
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    document.execCommand = vi.fn(() => false);
+
+    const ok = await copyText('nope');
+    expect(ok).toBe(false);
+  });
+
+  it('falls back to execCommand when the Clipboard API rejects (e.g. permission denied)', async () => {
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'));
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const exec = vi.fn(() => true);
+    document.execCommand = exec;
+
+    const ok = await copyText('retry-via-fallback');
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith('copy');
+  });
+});

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,52 @@
+/**
+ * Clipboard copy with a non-secure-context fallback.
+ *
+ * `navigator.clipboard.writeText()` is a Secure Context API — it only works on
+ * `https://` origins or `http://localhost`. The NVR's most common deployment is
+ * plain `http://<server-ip>:9090` (Docker, LAN, bare metal without a TLS
+ * terminator), where `navigator.clipboard` is `undefined` and any call throws.
+ * Without this fallback, the "copy push-out URL" and "copy API key" buttons
+ * silently fail on every non-localhost HTTP install (issue #197).
+ *
+ * Strategy:
+ *   1. On a secure context, prefer the async Clipboard API (returns a promise,
+ *      works without focusing a text node).
+ *   2. Otherwise (or if the API rejects, e.g. permission denied), fall back to
+ *      the legacy `document.execCommand('copy')` on a temporary hidden
+ *      `<textarea>`. `execCommand` is deprecated but remains the only reliable
+ *      synchronous copy path on plain HTTP origins and is still supported by
+ *      every major browser.
+ *
+ * Returns whether the copy succeeded so callers can pick the right toast.
+ */
+
+export async function copyText(text: string): Promise<boolean> {
+  // 1. Secure context → async Clipboard API.
+  if (window.isSecureContext && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or the call rejected — fall through to the legacy path
+      // rather than giving up (some browsers deny clipboard for unfocused docs).
+    }
+  }
+
+  // 2. Legacy fallback: hidden textarea + execCommand('copy').
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    // Move it off-screen and prevent scroll/focus jump.
+    ta.style.position = 'fixed';
+    ta.style.top = '0';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/lib/components/CameraCard.svelte
+++ b/web/src/lib/components/CameraCard.svelte
@@ -4,6 +4,7 @@
   import type { Camera, ProtocolInfo } from '$lib/api';
   import type { CameraHealth } from '$lib/api/health';
   import { showToast } from '$lib/toast';
+  import { copyText } from '$lib/clipboard';
   import { Pencil, RotateCw, Eye, MoreVertical, Archive, Loader2, AlertCircle, RefreshCw, ArrowUpRight, WifiOff, Copy, X } from 'lucide-svelte';
 
   interface Props {
@@ -51,10 +52,12 @@
   // popover listing each target's URL with a copy-to-clipboard button.
   let pushTargetsOpen = $state(false);
   async function copyPushUrl(url: string, name?: string) {
-    try {
-      await navigator.clipboard.writeText(url);
+    // copyText falls back to execCommand('copy') on plain HTTP origins
+    // (navigator.clipboard is undefined there — issue #197).
+    const ok = await copyText(url);
+    if (ok) {
       showToast(t('cameras.pushOutUrlCopied'), 'success');
-    } catch {
+    } else {
       showToast(t('cameras.pushOutUrlCopyFailed'), 'error');
     }
   }

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -9,6 +9,7 @@
   import { t } from '$lib/i18n';
   import { Plus, Trash2, X, Copy, Check, ChevronDown } from 'lucide-svelte';
   import { showToast } from '$lib/toast';
+  import { copyText } from '$lib/clipboard';
   import { settingsForm } from '$lib/settings/settings-form.svelte';
   import SettingsCard from '$lib/components/SettingsCard.svelte';
   import Toggle from '$lib/components/Toggle.svelte';
@@ -207,10 +208,11 @@
     }
   }
 
-  function copyKey() {
+  async function copyKey() {
     if (newlyGeneratedKey) {
-      navigator.clipboard.writeText(newlyGeneratedKey);
-      copiedKey = true;
+      // copyText falls back to execCommand('copy') on plain HTTP origins
+      // (navigator.clipboard is undefined there — issue #197).
+      copiedKey = await copyText(newlyGeneratedKey);
     }
   }
 


### PR DESCRIPTION
## 根因

两个独立 bug,都在 issue #197 报告:

### 1. 复制推流地址失败
`navigator.clipboard.writeText` 是 Secure Context API,仅 `https://`/`http://localhost` 可用。NVR 最常见的部署是纯 `http://<服务器IP>:9090`(Docker / 局域网 / 无 TLS 的裸机),在那里 `navigator.clipboard` 为 `undefined`,任何调用都抛错 → 复制按钮静默失败。**无 fallback**。同样影响 AIPanel 的 API Key 复制(`AIPanel.svelte:212`)。

### 2. 删除推流后页面仍显示("删掉的推流又出现")
后端删除链路**完全正确**(内存 config 清空 + 写盘 + relay goroutine 停掉都对)。根因在 `GET /api/cameras` 的 full-list ETag(`handlers_camera.go:170-184`)只 hash 了 `ID+Status+LastSeen`,**不含 push_targets**。删 target 后 ETag 不变 → 前端 `listCameras()` 带 `If-None-Match` → 服务端 304 → 前端 `return cachedFullList`(删除前的旧列表)→ UI 仍显示已删 target;重开编辑读的也是这份旧对象。

**这是回归**:ETag 是 PR #97(0.10.0)引入的带宽优化。#71 修 push copy 时(0.8.0)还没 ETag,所以那时删除正常。ETag 引入后,hash 字段不完整破坏了写后读一致性。

## 为什么不是"再加个字段进 ETag"

那只把问题推到下一个被遗漏的字段(name / transcoding / audio_enabled ... 下次又会重现)。正确性不能依赖"hash 输入恰好覆盖被改字段"这个脆弱不变量。

## 根治方案:正确性与 ETag 解耦

ETag 缓存只对高频只读轮询(Dashboard 30s)有意义;用户写操作后数据语义上已变,必须读到最新值。把两类场景在 API 包装层分开:
- 轮询路径不变(ETag 仍省带宽)。
- 写路径:成功后无条件丢弃缓存 → 下次读不带 `If-None-Match` → 必拿 200 最新数据。**正确性不再依赖 ETag hash 内容**,未来加任何新字段都不会再触发同类 bug。

放在 `cameras.ts` 包装层而非组件层:所有列表页写路径(create/update/delete/start/stop/activate/rediscover/merge-config)都已通过这些包装器,且写后都调 `loadCameras()`。失效逻辑放包装器里自动覆盖当前和未来所有调用者——新组件无法"忘记失效"。

## 改动

- **新建 `web/src/lib/clipboard.ts`** — `copyText()`:secure context 用 async Clipboard API,否则回退 `execCommand('copy')` + 隐藏 textarea。
- `CameraCard.svelte` `copyPushUrl` 改用 `copyText`(修推流地址复制)。
- `AIPanel.svelte` `copyKey` 改用 `copyText`(顺手修掉 API Key 在非 secure context 复制失败的隐患)。
- `cameras.ts` 新增 `invalidateCameraListCache()`,在所有 mutating 写包装器成功后调用(createCamera/updateCamera/deleteCamera/startCamera/stopCamera/activateCamera/rediscoverCamera/updateMergeConfig/deleteCameraMergeConfig)。**后端 ETag 不动**,继续服务 Dashboard 30s 轮询的带宽优化。
- `clipboard.test.ts` 覆盖 4 分支:secure-context / 非-secure-context / 双失败 / API reject 回退。

## 验证

- 507 前端单测全过(含新增 4 个 clipboard 测试)。
- `npm run build` 通过(无 TS 错误)。
- ⏳ 待 M5(63.30)实测:非 secure context 下(IP 访问)新建/删除推流全流程 + 复制按钮 + API Key 复制。

## 关联
- Closes #197
- 根因分析见 issue 里的讨论;回归源头是 #97(ETag 引入)。