### PR TITLE
docs(upgrade): 手工 schema 修复指南 — 0.3.0-0.8.0 直升 0.10.0 的自助修复 (#196)

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -389,6 +389,16 @@ Or use the in-app downloader: **Settings → Transcoding → Download FFmpeg**
 
 ## Recording Issues
 
+### Recordings page shows `failed to list recordings` (after upgrade)
+
+**Symptom**: After upgrading straight from an old version (v0.3.0 – v0.8.0) to 0.10.0, the Recordings page reports `failed to list recordings`, but the `.mp4` segments are clearly still on disk. You may also see adding/editing a camera fail with `no such column: stable_id`.
+
+**Cause**: The 0.10.0 DB schema is incompatible with the old one. The legacy `recordings` / `cameras` tables are missing columns that 0.10.0 queries reference (`merge_status`, `merge_quality`, `stable_id`, ...), so the query fails with `no such column`. The recording data itself is intact — only the table structure is out of sync.
+
+**Fix**: Run the repair script in [Upgrade Guide → Manual schema repair when you can't roll back](./upgrade-guide.md#manual-schema-repair-when-you-cant-roll-back). It's idempotent and won't lose data.
+
+---
+
 ### No Recordings Created
 
 #### No Disk Space

--- a/docs/en/upgrade-guide.md
+++ b/docs/en/upgrade-guide.md
@@ -154,6 +154,125 @@ You **cannot** upgrade directly from below v0.9.x to 0.10.0. There is no startup
 
 **Correct path:** upgrade to the latest v0.9.x first, let it run once to normalize the DB, then upgrade to 0.10.0.
 
+### Manual schema repair when you can't roll back
+
+If you already upgraded straight to 0.10.0, your recordings are still on disk, but the UI errors out — and you can't or don't want to roll back to v0.9.x — you can **manually bring the DB schema up to 0.10.0** with the script below. Your recording files are not touched; only the missing columns get added.
+
+> ⚠️ **Back up first.** This edits the DB directly; the backup is your only rollback.
+
+**Symptom checklist — you're affected if:**
+
+- the Recordings page shows `failed to list recordings` but the `.mp4` segments are clearly still on disk;
+- adding/editing a camera errors out (e.g. `no such column: stable_id`);
+- any "database" error appeared after jumping from any v0.3.0 – v0.8.0 straight to 0.10.0.
+
+**Step 1 — stop the service and back up the DB.**
+
+Bare metal (systemd):
+
+```bash
+systemctl stop mibee-nvr
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-fix   # adjust to your Storage.root_dir
+```
+
+Docker:
+
+```bash
+docker compose stop mibee-nvr
+cp ./data/nvr.db ./data/nvr.db.pre-fix          # default volume is ./data:/data; DB filename is under Storage.root_dir
+```
+
+**Step 2 — save this repair script as `fix-schema.sql`** (copy in full):
+
+```sql
+-- ===== MiBeeNvr manual schema repair (0.3.0-0.8.0 -> 0.10.0) =====
+-- Each ADD COLUMN runs independently; if a column already exists you'll see
+-- "duplicate column name" -- that error can be ignored, the rest still apply.
+-- Re-running is idempotent (it won't damage data).
+
+-- ----- recordings -----
+ALTER TABLE recordings ADD COLUMN merge_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE recordings ADD COLUMN merge_path TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_error TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_tier TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_progress INTEGER DEFAULT 0;
+ALTER TABLE recordings ADD COLUMN merge_quality TEXT DEFAULT 'complete';
+ALTER TABLE recordings ADD COLUMN archived INTEGER DEFAULT 0;
+ALTER TABLE recordings ADD COLUMN ai_status TEXT DEFAULT NULL;
+ALTER TABLE recordings ADD COLUMN ai_processed_at TEXT DEFAULT NULL;
+ALTER TABLE recordings ADD COLUMN ai_error TEXT DEFAULT NULL;
+-- Migrate legacy merged=1 rows into merge_status (only effective if the merged column still exists)
+UPDATE recordings SET merge_status='merged' WHERE merged=1 AND merge_status='pending';
+
+-- ----- cameras -----
+ALTER TABLE cameras ADD COLUMN merge_enabled INTEGER;
+ALTER TABLE cameras ADD COLUMN merge_check_interval TEXT;
+ALTER TABLE cameras ADD COLUMN merge_window_size TEXT;
+ALTER TABLE cameras ADD COLUMN merge_batch_limit INTEGER;
+ALTER TABLE cameras ADD COLUMN merge_min_segment_age TEXT;
+ALTER TABLE cameras ADD COLUMN merge_min_segments_to_merge INTEGER;
+ALTER TABLE cameras ADD COLUMN onvif_endpoint TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN profile_token TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN stream_encoding TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN archived INTEGER DEFAULT 0;
+ALTER TABLE cameras ADD COLUMN archived_at DATETIME DEFAULT NULL;
+ALTER TABLE cameras ADD COLUMN archive_retention_days INTEGER DEFAULT 0;
+ALTER TABLE cameras ADD COLUMN merge_duration TEXT DEFAULT 'natural-day';
+ALTER TABLE cameras ADD COLUMN stream_key TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN srt_passphrase TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN srt_stream_id TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN activation_state TEXT DEFAULT 'active';
+ALTER TABLE cameras ADD COLUMN stable_id TEXT DEFAULT '';
+
+-- ----- schema_meta / feature_flags cleanup -----
+INSERT OR IGNORE INTO schema_meta(key,value) VALUES('schema_version','29');
+UPDATE schema_meta SET value='29' WHERE key='schema_version';
+INSERT OR IGNORE INTO feature_flags(key,value) VALUES('protocol.srt',1);
+INSERT OR IGNORE INTO feature_flags(key,value) VALUES('protocol.rtmp',1);
+```
+
+**Step 3 — run the repair script.** The NVR's Docker runtime image (Alpine-based) does **not** ship `sqlite3`, so pick whichever fits your setup:
+
+- **Option A — host already has sqlite3** (bare metal):
+
+  ```bash
+  sqlite3 /var/lib/mibee-nvr/nvr.db < fix-schema.sql
+  ```
+  A few `duplicate column name: ...` lines are expected (they mean the column already exists); only other errors need attention.
+
+- **Option B — throwaway Alpine container** (recommended for Docker, nothing to install on the host):
+
+  ```bash
+  docker run --rm -v "$PWD/data:/data" -v "$PWD/fix-schema.sql:/fix-schema.sql:ro" alpine \
+    sh -c "apk add --no-cache sqlite >/dev/null && sqlite3 /data/nvr.db < /fix-schema.sql"
+  ```
+  Replace `$PWD/data` with your actual volume directory (default `./data:/data`). `duplicate column name` errors are safe to ignore.
+
+**Step 4 — verify the repair** (same sqlite3 session):
+
+```bash
+# Option A
+sqlite3 /var/lib/mibee-nvr/nvr.db "SELECT merge_quality FROM recordings LIMIT 1;"
+sqlite3 /var/lib/mibee-nvr/nvr.db "SELECT stable_id FROM cameras LIMIT 1;"
+
+# Option B (Docker)
+docker run --rm -v "$PWD/data:/data" alpine \
+  sh -c "apk add --no-cache sqlite >/dev/null && sqlite3 /data/nvr.db 'SELECT merge_quality FROM recordings LIMIT 1;'"
+```
+
+Both should no longer report `no such column` (the first returns `complete`, the second an empty string or a serial) — that means the repair worked.
+
+**Step 5 — restart and confirm the Recordings page loads normally.**
+
+```bash
+# Bare metal
+systemctl start mibee-nvr
+# Docker
+docker compose start mibee-nvr
+```
+
+> This script is **idempotent**: re-running it on an already-0.10.0 schema just prints a bunch of `duplicate column name` and harms nothing. When in doubt about which columns you're missing, just run the full thing — it's the simplest path.
+
 ---
 
 ## General upgrade best practices

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -381,6 +381,16 @@ sudo apk add ffmpeg
 #SY|
 ## 录制问题
 
+### 录像页报 `failed to list recordings`（升级后）
+
+**症状**：从旧版本（0.3.0 ~ 0.8.0）直升到 0.10.0 后，录像页面报 `failed to list recordings`，但硬盘里的 `.mp4` 录像片段明明都还在。可能还伴随：新增/编辑摄像头报 `no such column: stable_id`。
+
+**原因**：0.10.0 的数据库 schema 和旧版本不兼容。旧库的 `recordings` / `cameras` 表缺 0.10.0 查询时引用的列（`merge_status`、`merge_quality`、`stable_id` 等），查询直接报 `no such column`。录像数据本身完好，只是表结构对不上。
+
+**解决**：按 [升级指南 → 无法回退版本时的手工 schema 修复](./upgrade-guide.md#无法回退版本时的手工-schema-修复) 执行修复脚本（幂等，可重复执行，不丢数据）。
+
+---
+
 ### 未创建录像
 
 #### 无磁盘空间

--- a/docs/zh/upgrade-guide.md
+++ b/docs/zh/upgrade-guide.md
@@ -154,6 +154,124 @@ curl http://localhost:9090/api/health
 
 **正确路径：** 先升级到最新的 v0.9.x，让它跑一次以规范化数据库，再升级到 0.10.0。
 
+### 无法回退版本时的手工 schema 修复
+
+如果你已经直升到 0.10.0、录像数据都还在磁盘上、但页面报错用不了，又不想/无法回退到 v0.9.x 中转，可以用下面的脚本**手工把数据库 schema 补齐到 0.10.0**。录像文件不会丢，只是补上缺失的列。
+
+> ⚠️ **先备份。** 这一步直接改库，出错只能靠备份恢复。
+
+**对号入座 —— 哪些症状说明你中招了：**
+
+- 录像页报 `failed to list recordings`，但硬盘里 `.mp4` 录像片段明明都在；
+- 新增/编辑摄像头报错或加不上（`no such column: stable_id`）；
+- 从 0.3.0 ~ 0.8.0 任一版本直升 0.10.0 后出现的“数据库相关”报错。
+
+**第 1 步：停服 + 备份数据库。**
+
+裸机（systemd）：
+
+```bash
+systemctl stop mibee-nvr
+cp /var/lib/mibee-nvr/nvr.db /var/lib/mibee-nvr/nvr.db.pre-fix   # 路径以你的 Storage.root_dir 为准
+```
+
+Docker：
+
+```bash
+docker compose stop mibee-nvr
+cp ./data/nvr.db ./data/nvr.db.pre-fix          # 默认卷映射是 ./data:/data，DB 文件名见 Storage.root_dir
+```
+
+**第 2 步：把下面的修复脚本存成 `fix-schema.sql`**（完整复制）：
+
+```sql
+-- ===== MiBeeNvr 手工 schema 修复(0.3.0-0.8.0 → 0.10.0) =====
+-- 每条 ADD COLUMN 独立执行;某列已存在会报 "duplicate column name" —— 该报错可忽略,
+-- 其余语句照常生效。重复执行幂等(不会损坏数据)。
+
+-- ----- recordings -----
+ALTER TABLE recordings ADD COLUMN merge_status TEXT NOT NULL DEFAULT 'pending';
+ALTER TABLE recordings ADD COLUMN merge_path TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_error TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_tier TEXT DEFAULT '';
+ALTER TABLE recordings ADD COLUMN merge_progress INTEGER DEFAULT 0;
+ALTER TABLE recordings ADD COLUMN merge_quality TEXT DEFAULT 'complete';
+ALTER TABLE recordings ADD COLUMN archived INTEGER DEFAULT 0;
+ALTER TABLE recordings ADD COLUMN ai_status TEXT DEFAULT NULL;
+ALTER TABLE recordings ADD COLUMN ai_processed_at TEXT DEFAULT NULL;
+ALTER TABLE recordings ADD COLUMN ai_error TEXT DEFAULT NULL;
+-- 把旧的 merged=1 行迁移到 merge_status(仅当 merged 列还在时生效;已被取代)
+UPDATE recordings SET merge_status='merged' WHERE merged=1 AND merge_status='pending';
+
+-- ----- cameras -----
+ALTER TABLE cameras ADD COLUMN merge_enabled INTEGER;
+ALTER TABLE cameras ADD COLUMN merge_check_interval TEXT;
+ALTER TABLE cameras ADD COLUMN merge_window_size TEXT;
+ALTER TABLE cameras ADD COLUMN merge_batch_limit INTEGER;
+ALTER TABLE cameras ADD COLUMN merge_min_segment_age TEXT;
+ALTER TABLE cameras ADD COLUMN merge_min_segments_to_merge INTEGER;
+ALTER TABLE cameras ADD COLUMN onvif_endpoint TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN profile_token TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN stream_encoding TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN archived INTEGER DEFAULT 0;
+ALTER TABLE cameras ADD COLUMN archived_at DATETIME DEFAULT NULL;
+ALTER TABLE cameras ADD COLUMN archive_retention_days INTEGER DEFAULT 0;
+ALTER TABLE cameras ADD COLUMN merge_duration TEXT DEFAULT 'natural-day';
+ALTER TABLE cameras ADD COLUMN stream_key TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN srt_passphrase TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN srt_stream_id TEXT DEFAULT '';
+ALTER TABLE cameras ADD COLUMN activation_state TEXT DEFAULT 'active';
+ALTER TABLE cameras ADD COLUMN stable_id TEXT DEFAULT '';
+
+-- ----- schema_meta / feature_flags 收尾 -----
+INSERT OR IGNORE INTO schema_meta(key,value) VALUES('schema_version','29');
+UPDATE schema_meta SET value='29' WHERE key='schema_version';
+INSERT OR IGNORE INTO feature_flags(key,value) VALUES('protocol.srt',1);
+INSERT OR IGNORE INTO feature_flags(key,value) VALUES('protocol.rtmp',1);
+```
+
+**第 3 步：执行修复脚本。** NVR 的 Docker 运行镜像（基于 Alpine）**不含** `sqlite3`，所以用哪种方式取决于你的环境：
+
+- **方式 A — 宿主机已装 sqlite3**（裸机用户首选）：
+
+  ```bash
+  sqlite3 /var/lib/mibee-nvr/nvr.db < fix-schema.sql
+  ```
+  出现若干 `duplicate column name: ...` 是正常的（说明该列已存在），其余报错才需要处理。
+
+- **方式 B — 用一次性 Alpine 容器**（Docker 用户推荐，无需在宿主机装任何东西）：
+
+  ```bash
+  docker run --rm -v "$PWD/data:/data" -v "$PWD/fix-schema.sql:/fix-schema.sql:ro" alpine \
+    sh -c "apk add --no-cache sqlite >/dev/null && sqlite3 /data/nvr.db < /fix-schema.sql"
+  ```
+  `$PWD/data` 换成你实际的卷映射目录（默认 `./data:/data`）。同样，`duplicate column name` 报错可忽略。
+
+**第 4 步：验证修复成功**（用同一个 sqlite3 会话）：
+
+```bash
+# 方式 A
+sqlite3 /var/lib/mibee-nvr/nvr.db "SELECT merge_quality FROM recordings LIMIT 1;"
+sqlite3 /var/lib/mibee-nvr/nvr.db "SELECT stable_id FROM cameras LIMIT 1;"
+
+# 方式 B(Docker)
+docker run --rm -v "$PWD/data:/data" alpine \
+  sh -c "apk add --no-cache sqlite >/dev/null && sqlite3 /data/nvr.db 'SELECT merge_quality FROM recordings LIMIT 1;'"
+```
+
+两条都不再报 `no such column`（第一条返回 `complete`，第二条返回空串或序列号）即修复成功。
+
+**第 5 步：重启服务，刷新页面确认录像列表正常加载。**
+
+```bash
+# 裸机
+systemctl start mibee-nvr
+# Docker
+docker compose start mibee-nvr
+```
+
+> 这套脚本是**幂等**的：在已经是 0.10.0 schema 的库上重跑只会报一堆 `duplicate column name`，不会损坏任何数据。所以不确定自己缺哪些列时，直接全量跑一遍最省事。
+
 ---
 
 ## 通用升级最佳实践


### PR DESCRIPTION
## 背景

用户从 docker 0.7.0 直升 0.10.0 后,录像页报 `failed to list recordings`,但硬盘里的录像片段明明都在。

**根因**:旧库的 `recordings` / `cameras` 表缺 0.10.0 查询时引用的列(`merge_status`、`merge_quality`、`stable_id` 等)。0.10.0 的 `Init()` 用 `CREATE TABLE IF NOT EXISTS`(全列基线),对已存在的表是 no-op,不会补列;唯一的 `migrateV28ToV29` 只删 `merged` 列,不补缺失列。于是 `ListRecordings` 的 16 列 SELECT 抛 `no such column: merge_status` → HTTP 500。**录像数据本身完好**,只是 schema 对不上。

## 决策:不改代码,走文档

按发布说明已有的方向("<0.9.x 不支持直升级,需先走 0.9.x 中转"),本 PR **不做代码自愈**,改为补充文档指导用户自助修复。理由:
- 这是有意的设计取舍(0.10.0 删掉了 v1-v28 的 27 个增量 `ALTER TABLE` 迁移,改用基线 `CREATE TABLE IF NOT EXISTS`),代码里加"逐列补齐"会重新引入维护负担;
- 跨大版本直升本就应走中转版本,这是用户操作路径问题,不是功能 bug。

## 改动

- **`docs/{zh,en}/upgrade-guide.md`** — 在已有"< v0.9.x → v0.10.0: NOT supported"一节后追加 `### Manual schema repair when you can't roll back`:
  - 症状清单(对号入座);
  - 第 1 步停服 + 备份;
  - 第 2 步完整幂等修复 SQL(`recordings` 补 10 列 + `merged=1`→`merge_status` 数据迁移 + `cameras` 补 18 列 + `schema_meta`/feature_flags 收尾);
  - 第 3 步两种执行方式 —— 裸机 `sqlite3` / **Docker 一次性 alpine 容器**(运行镜像基于 alpine,不含 `sqlite3`,所以给了一行 `docker run` 命令);
  - 第 4 步验证命令;`duplicate column name` 报错可忽略的说明(已存在的列);
  - 第 5 步重启。
- **`docs/{zh,en}/troubleshooting.md`** — 新增"录像页报 `failed to list recordings`(升级后)"条目,链回升级指南。

## Docker VM 实测验证(63.197)

全部命令逐字验证过:
1. 构造一个 0.7.0 风格 schema 的库 → 复现 `no such column: merge_status`(#196 的确切错误);
2. 执行修复 SQL → `recordings` 补齐 10 列、`cameras` 补齐 18 列,16 列 `ListRecordings` SELECT 成功返回行;
3. **数据完整性**:旧的 `merged=1` 行正确迁移为 `merge_status='merged'`,`merge_quality` 默认 `complete`,`schema_version` 推到 29;
4. **幂等性**:在已修复的库上重跑只报一堆 `duplicate column name`,不损坏数据,SELECT 仍正常;
5. **Docker 方式端到端**:`docker run --rm -v ...:/data alpine sh -c "apk add sqlite && sqlite3 ..."` 成功返回修复后的数据。

## 关联
- Closes #196
- 与 #202(#197 代码修复)独立,可分别合并。