### PR TITLE
feat(update): Watchtower sidecar auto-update profile + docs (#206)

### DIFF
--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -59,3 +59,52 @@ services:
       timeout: 5s
       start_period: 10s
       retries: 3
+    labels:
+      # Opt-in marker for Watchtower: with WATCHTOWER_LABEL_ENABLE=true, Watchtower
+      # only updates containers carrying this label, so it manages MiBee NVR and
+      # leaves the user's other containers untouched. See deploy/docs/auto-update.md.
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  # --------------------------------------------------------------------------- #
+  # Optional automatic updates via Watchtower. OFF by default.
+  #
+  # Enable with:
+  #   docker compose --profile auto-update up -d
+  #
+  # Watchtower pulls a new mibeenvr image on a schedule and recreates ONLY the
+  # mibee-nvr container (the label above + WATCHTOWER_LABEL_ENABLE scope it).
+  # Recordings/DB/config live in ./data, so recreation never touches your data.
+  #
+  # ghcr.io is a private/org registry: Watchtower needs credentials to pull.
+  # After a one-time `docker login ghcr.io` (use a GitHub PAT with read:packages),
+  # mount the resulting ~/.docker/config.json read-only below. Without it the
+  # pull fails with a misleading "denied" error.
+  #
+  # WATCHTOWER_CLEANUP=false deliberately keeps the old image so you can roll
+  # back by changing the image tag and recreating. Do NOT combine :latest with
+  # cleanup if you want rollback.
+  # --------------------------------------------------------------------------- #
+  watchtower:
+    profiles: ["auto-update"]
+    image: containrrr/watchtower:latest
+    container_name: mibee-nvr-watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Required for ghcr.io auth. Run once on the host:
+      #   docker login ghcr.io -u <github-user> --password-stdin  (PAT: read:packages)
+      - ~/.docker/config.json:/config.json:ro
+    environment:
+      # Only manage containers labeled com.centurylinklabs.watchtower.enable=true.
+      - WATCHTOWER_LABEL_ENABLE=true
+      # Keep old images for rollback (do NOT enable cleanup).
+      - WATCHTOWER_CLEANUP=false
+      # 6-field cron (sec min hour dom mon dow): check daily at 04:00 (off-peak).
+      - WATCHTOWER_SCHEDULE=0 0 4 * * *
+      - WATCHTOWER_NO_STARTUP_MESSAGE=true
+      # Notifications (Shoutrrr) — uncomment one and fill in:
+      # Discord:    WATCHTOWER_NOTIFICATION_URL=discord://webhookid@webhooktoken
+      # Telegram:   WATCHTOWER_NOTIFICATION_URL=telegram://<token>@telegram?chats=<chat-id>
+      # - WATCHTOWER_NOTIFICATION_URL=discord://webhookid@webhooktoken
+      # Conservative mode: only notify, never update (use to evaluate first):
+      # - WATCHTOWER_MONITOR_ONLY=true

--- a/docs/en/deployment-autoupdate.md
+++ b/docs/en/deployment-autoupdate.md
@@ -1,0 +1,88 @@
+# Auto-update (Docker)
+
+> How to keep the MiBee NVR Docker image up to date. The in-app version check (the **sensing** layer, [Settings → About](../en/configuration.md)) tells you a new version exists; this guide covers the **execution** layer — actually replacing the image. Choose manual (recommended for recording-critical setups) or optional automatic updates via Watchtower.
+
+## Two layers, kept separate by design
+
+| Layer | What it does | How |
+|-------|--------------|-----|
+| **Sensing** (built in) | Polls GitHub Releases, shows a badge + About panel | `GET /api/update/check`; no action taken |
+| **Execution** (this guide) | Pulls a new image and recreates the container | Manual `docker compose`, or Watchtower |
+
+They are deliberately separate: a NAS box holds recordings and config that must not be silently changed, so the app never upgrades itself (Docker containers are immutable anyway). The user always authorizes the change — directly, or by opting into Watchtower.
+
+## Manual update (recommended)
+
+The safest path for anything recording video:
+
+```bash
+cd <the-dir-with-your-compose-file>
+docker compose pull          # pulls the new image
+docker compose up -d         # recreates the container with the new image
+```
+
+Data under `./data` (recordings, SQLite DB, config, AI models) is untouched — recreation only swaps the image.
+
+### Rollback
+
+Pin the image tag to a specific release to make rollback trivial. The `mibeenvr` image publishes `{version}`, `{major}.{minor}`, `{major}`, and `latest` for every release. Set a fixed tag in your compose, e.g.:
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:0.10.0   # pinned, reproducible
+```
+
+To roll back, change the tag to the previous release and `docker compose up -d`. Avoid combining `:latest` with automatic cleanup if you want a rollback image to remain on the host.
+
+## Automatic updates via Watchtower (optional)
+
+[Watchtower](https://github.com/containrrr/watchtower) watches running containers and recreates them when their registry image updates. The bundled profile is **off by default** — you opt in explicitly.
+
+### Enable
+
+```bash
+# 1. One-time: authenticate to ghcr.io (Watchtower needs this to pull).
+#    Use a GitHub Personal Access Token with read:packages scope.
+docker login ghcr.io -u <your-github-user> --password-stdin <<< "<your-PAT>"
+
+# 2. Start with the auto-update profile.
+docker compose --profile auto-update up -d
+```
+
+Watchtower now checks daily at 04:00 (host time) and recreates **only** the `mibee-nvr` container when a new image exists.
+
+### Why it's safe the way it's configured
+
+- **Scoped to MiBee NVR only.** `WATCHTOWER_LABEL_ENABLE=true` + the `com.centurylinklabs.watchtower.enable=true` label on the NVR service mean Watchtower ignores every other container on the host.
+- **Old images are kept.** `WATCHTOWER_CLEANUP=false` leaves the previous image on disk so you can roll back. Do not enable cleanup if you want rollback.
+- **Off-peak schedule.** `WATCHTOWER_SCHEDULE=0 0 4 * * *` (6-field cron) runs at 04:00 to avoid clashing with active recording.
+- **Data is never touched.** Only the image is replaced; `./data` persists.
+
+### What Watchtower does NOT do
+
+- **No health-gated rollback.** If the new image starts but is unhealthy, Watchtower will not revert automatically. The NVR ships a healthcheck (`mibee-nvr health`) that the container runtime honors for status reporting, but automatic rollback requires manual action: change the image tag back to the last known-good release and `docker compose up -d`. Pair this with the in-app version badge so you notice a bad upgrade.
+- **No configuration migration.** The app handles its own DB/config migrations on startup.
+
+### Disable
+
+```bash
+docker compose --profile auto-update stop watchtower
+# or remove the profile usage entirely and run `docker compose up -d` (default, no Watchtower).
+```
+
+## Notifications
+
+Watchtower supports [Shoutrrr](https://containrrr.dev/shoutrrr/) notification URLs. Uncomment `WATCHTOWER_NOTIFICATION_URL` in the compose file and set a Discord / Telegram / Slack / webhook URL to get a message whenever it updates (or, in monitor-only mode, whenever it notices a new image).
+
+## Per-platform notes
+
+| Platform | Best update path |
+|----------|------------------|
+| unRAID | [CA Application Auto Update](https://forums.unraid.net/topic/51959-plugin-ca-application-auto-update/) plugin (native), or Watchtower |
+| iStoreOS / OpenWrt | `docker compose pull && up -d`, or Watchtower |
+| 飞牛 fnOS | `.fpk` app lifecycle (`upgrade_init` / `upgrade_callback`) — native, preferred on fnOS |
+| Synology DSM | Container Manager: rebuild from new image, or Watchtower |
+| QNAP QTS | Container Station: rebuild, or Watchtower |
+
+See the per-platform deployment docs for specifics.

--- a/docs/zh/deployment-autoupdate.md
+++ b/docs/zh/deployment-autoupdate.md
@@ -1,0 +1,88 @@
+# 自动升级（Docker）
+
+> 如何保持 MiBee NVR 的 Docker 镜像为最新。应用内置的版本检测（**感知**层，[设置 → 关于](../zh/configuration.md)）告诉你有新版本；本指南覆盖**执行**层——真正替换镜像。可选择手动（录像关键场景推荐）或用 Watchtower 可选自动升级。
+
+## 两层设计，刻意分离
+
+| 层 | 作用 | 方式 |
+|----|------|------|
+| **感知层**（内置） | 轮询 GitHub Releases，显示红点 + 关于面板 | `GET /api/update/check`；不执行任何动作 |
+| **执行层**（本指南） | 拉取新镜像并重建容器 | 手动 `docker compose`，或 Watchtower |
+
+二者刻意分离：NAS 守护着录像和配置等持久数据，不能被静默更改（Docker 容器本身也不可变）。升级始终由用户授权——直接操作，或显式开启 Watchtower。
+
+## 手动升级（推荐）
+
+对任何正在录像的部署，这是最安全的路径：
+
+```bash
+cd <你的 compose 文件所在目录>
+docker compose pull          # 拉取新镜像
+docker compose up -d         # 用新镜像重建容器
+```
+
+`./data` 下的数据（录像、SQLite 数据库、配置、AI 模型）不受影响——重建只替换镜像。
+
+### 回滚
+
+把镜像 tag 固定到某个发布版本，回滚就很轻松。`mibeenvr` 镜像每次发布都推送 `{version}`、`{major}.{minor}`、`{major}`、`latest`。在 compose 里设固定 tag，如：
+
+```yaml
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:0.10.0   # 固定，可复现
+```
+
+回滚时把 tag 改回上一个版本，`docker compose up -d` 即可。若想保留回滚镜像，**不要**把 `:latest` 和自动清理一起用。
+
+## 用 Watchtower 自动升级（可选）
+
+[Watchtower](https://github.com/containrrr/watchtower) 监视运行中的容器，当其 registry 镜像更新时重建它。内置的 profile **默认关闭**——需显式开启。
+
+### 开启
+
+```bash
+# 1. 一次性：登录 ghcr.io（Watchtower 拉镜像需要鉴权）。
+#    使用带 read:packages 权限的 GitHub 个人访问令牌（PAT）。
+docker login ghcr.io -u <你的-github-用户名> --password-stdin <<< "<你的-PAT>"
+
+# 2. 用 auto-update profile 启动。
+docker compose --profile auto-update up -d
+```
+
+此后 Watchtower 每天 04:00（宿主时间）检查一次，仅在出现新镜像时重建 **mibee-nvr** 容器。
+
+### 这样配置为什么安全
+
+- **只管 MiBee NVR。** `WATCHTOWER_LABEL_ENABLE=true` + NVR 服务上的 `com.centurylinklabs.watchtower.enable=true` label，意味着 Watchtower 忽略宿主上的其它容器。
+- **保留旧镜像。** `WATCHTOWER_CLEANUP=false` 把上一个镜像留在磁盘上以便回滚。想要回滚能力就别开 cleanup。
+- **避开高峰。** `WATCHTOWER_SCHEDULE=0 0 4 * * *`（6 字段 cron）在 04:00 执行，避开活跃录像时段。
+- **数据绝不动。** 只替换镜像；`./data` 持久保留。
+
+### Watchtower 不会做的事
+
+- **不做健康闸门回滚。** 若新镜像启动了但不健康，Watchtower 不会自动回退。NVR 自带健康检查（`mibee-nvr health`），容器运行时会据此上报状态，但自动回滚仍需手动：把镜像 tag 改回上一个已知可靠的版本，`docker compose up -d`。建议配合应用内的版本红点，以便及时察觉升级异常。
+- **不做配置迁移。** 配置/数据库迁移由应用在启动时自行处理。
+
+### 关闭
+
+```bash
+docker compose --profile auto-update stop watchtower
+# 或完全不用 profile，直接 docker compose up -d（默认，不起 Watchtower）。
+```
+
+## 通知
+
+Watchtower 支持 [Shoutrrr](https://containrrr.dev/shoutrrr/) 通知 URL。在 compose 文件里取消 `WATCHTOWER_NOTIFICATION_URL` 的注释，填入 Discord / Telegram / Slack / webhook URL，即可在每次更新（或 monitor-only 模式下的每次发现）时收到消息。
+
+## 各平台要点
+
+| 平台 | 最佳升级路径 |
+|------|-------------|
+| unRAID | [CA Application Auto Update](https://forums.unraid.net/topic/51959-plugin-ca-application-auto-update/) 插件（原生），或 Watchtower |
+| iStoreOS / OpenWrt | `docker compose pull && up -d`，或 Watchtower |
+| 飞牛 fnOS | `.fpk` 应用生命周期（`upgrade_init` / `upgrade_callback`）——原生，飞牛上首选 |
+| 群晖 DSM | Container Manager：从新镜像重建，或 Watchtower |
+| 威联通 QTS | Container Station：重建，或 Watchtower |
+
+详见各平台部署文档。


### PR DESCRIPTION
Execution layer of the upgrade design (#204). Closes #206. Pairs with the sensing layer already in main (#208).

## What
An **OFF-by-default** Watchtower sidecar in `deploy/docker/docker-compose.yml`, scoped to update only the MiBee NVR container, plus bilingual docs covering manual/automatic updates and rollback. Default `docker compose up -d` behavior is unchanged.

| File | Change |
|------|--------|
| `deploy/docker/docker-compose.yml` | NVR service gets `com.centurylinklabs.watchtower.enable=true` label; new `watchtower` service behind `profiles: [auto-update]` |
| `docs/en/deployment-autoupdate.md` | Manual + automatic + rollback, two-layer rationale, per-platform paths, \"no health-gated rollback\" caveat |
| `docs/zh/deployment-autoupdate.md` | 中文镜像 |

## Configuration choices (and why)
- **`profiles: [auto-update]`** — opt-in; existing users see no change. Enable: `docker compose --profile auto-update up -d`.
- **`WATCHTOWER_LABEL_ENABLE=true`** + label on NVR — Watchtower manages only MiBee NVR, never the user's other containers.
- **`WATCHTOWER_CLEANUP=false`** — keeps the previous image on disk for rollback. The image publishes `{version}`/`{major}.{minor}`/`{major}`/`latest`; pin a tag to roll back.
- **`WATCHTOWER_SCHEDULE=0 0 4 * * *`** — daily 04:00, off-peak for recording.
- **ghcr auth via `~/.docker/config.json:ro`** — ghcr.io needs a PAT (`read:packages`); without it Watchtower fails with a misleading \"denied\".
- **No health-gated rollback** — documented honestly: Watchtower won't auto-revert; the NVR's healthcheck reports status, but rollback is manual (change tag + `up -d`). Pair with the in-app badge from #208 to notice bad upgrades.

## Conflict footprint
Pure `deploy/` + `docs/` additions (zero-conflict cold zone per #204 analysis). No `internal/`/`pkg/`/`web/` touched.

## Validation
- ✅ YAML parses; structure asserted (NVR labeled, watchtower profile=`auto-update`, env+volume mounts present)
- ⚠️ Not runtime-tested here (no Docker on this host) — see test plan

## Test plan
- [ ] `docker compose up -d` (default, no profile) → only `mibee-nvr` starts (watchtower absent); existing behavior preserved
- [ ] `docker login ghcr.io` (PAT read:packages) then `docker compose --profile auto-update up -d` → both containers start; watchtower logs show it scoped to mibee-nvr only
- [ ] Push a newer image tag → at 04:00 (or manual trigger) watchtower recreates only mibee-nvr; `./data` intact
- [ ] Rollback: change image tag to a previous release → `docker compose up -d` recreates with old image