### PR TITLE
docs(distribution): wave-2 NAS deploy guides — Synology/QNAP/极空间 (#198)

### DIFF
--- a/docs/en/deployment-qnap.md
+++ b/docs/en/deployment-qnap.md
@@ -1,0 +1,61 @@
+# Deploy on QNAP QTS / QuTShero
+
+> Run MiBee NVR in Docker on QNAP via **Container Station → Application** (docker-compose). Container Station 3.x honors `network_mode: host` in a compose file, which is what ONVIF camera auto-discovery needs.
+
+## Why host networking
+
+ONVIF WS-Discovery uses UDP multicast (`239.255.255.250:3702`), which Docker's default **bridge** blocks. The compose file therefore pins `network_mode: host`. Container Station 2's GUI historically did **not** expose host mode, but CS 3.x's compose/Application path accepts it and runs the container on the host network. Prefer the **Application (compose)** path below over the single-container GUI.
+
+## Install via Container Station → Application
+
+1. Install/enable **Container Station** (3.x recommended) from the App Center.
+2. In **Container Station → Applications → Create**, paste a compose file:
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # required for ONVIF auto-discovery
+       volumes:
+         - /share/Container/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   Container Station creates a shared folder named `Container` on install; map data there (e.g. `/share/Container/mibee-nvr/data`).
+3. **Validate → Deploy**. The multi-arch image is pulled and the container starts.
+4. Open `http://<nas-ip>:9090` and complete the setup wizard.
+
+If the Application path blocks host mode on your firmware, the fallback is SSH:
+```bash
+ssh admin@<nas-ip>
+mkdir -p /share/Container/mibee-nvr && cd /share/Container/mibee-nvr
+# place the compose file above as docker-compose.yml, then:
+docker compose up -d
+```
+
+## Port conflicts
+
+QNAP QTS uses `8080` (HTTP management) / `443` (HTTPS) / `80` (Web Server, if enabled) for itself. These do not clash with MiBee NVR's `9090` (Web) or `2121` (FTP). If a QNAP service occupies a port you need, change that service's port in the QTS **Control Panel → Network** rather than remapping the NVR.
+
+To change the NVR's own port (if `9090`/`2121` is taken by another container), edit `mibee-nvr.yaml`:
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## Updates & rollback
+
+See [Auto-update guide](deployment-autoupdate.md). Redeploy from the Application after `docker compose pull`, or pin a tag (`mibeenvr:0.10.0`) for reproducible rollbacks. Data under `/share/Container/mibee-nvr/data` persists across recreation.
+
+## Native `.qpkg` — when it's worth it (optional)
+
+QNAP's **App Center** is comparatively open to self-publishing via [QDK](https://github.com/qnap-dev/QDK), and you can even self-host a third-party App source so users subscribe and install. Wrapping the Docker container as a QPKG is documented in the community. But for a working install you do not need a QPKG — the Compose/Application path above is sufficient. Invest in QPKG packaging only if App Center discoverability matters to you, and reuse the same multi-arch image (QPKG can wrap a container rather than ship per-arch binaries).

--- a/docs/en/deployment-synology.md
+++ b/docs/en/deployment-synology.md
@@ -1,0 +1,60 @@
+# Deploy on Synology DSM
+
+> Run MiBee NVR in Docker on Synology DSM 7.2+ via **Container Manager → Project** (docker-compose). The compose path supports `network_mode: host`, which is what ONVIF camera auto-discovery needs. No `.spk` package is required for a working install.
+
+## Why host networking
+
+ONVIF WS-Discovery uses UDP multicast (`239.255.255.250:3702`), which Docker's default **bridge** blocks. The compose file therefore pins `network_mode: host`; Container Manager honors it in a Project. Do **not** also declare `ports:` in a host-network service — the two conflict and DSM will reject the compose.
+
+## Install via Container Manager → Project
+
+1. In **File Station**, create a folder for the project, e.g. `/volume1/docker/mibee-nvr/`.
+2. Open **Container Manager → Container → Project → Add**.
+3. Set **Project name** = `mibee-nvr`, **Path** = the folder from step 1.
+4. Under **Source**, choose **Create docker-compose.yml** and paste the host-network compose:
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # required for ONVIF auto-discovery
+       volumes:
+         - /volume1/docker/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   (This is the same as [`deploy/compose/docker-compose.host.yml`](../../deploy/compose/docker-compose.host.yml) with the host path filled in.)
+5. **Next → Done**. Container Manager pulls the multi-arch image and starts the container.
+6. Open `http://<nas-ip>:9090` and complete the setup wizard.
+
+## Port conflicts
+
+On host networking the container binds directly to the NAS. MiBee NVR uses `9090` (Web/API) and `2121` (FTP) — these do **not** clash with DSM's own ports. DSM reserves `5000` (HTTP) / `5001` (HTTPS) for its UI, and `20/21` for its optional built-in FTP. If you also enabled DSM's FTP, note it is a separate service from MiBee NVR's FTP (2121) — do not confuse them.
+
+If `9090` or `2121` is taken by another container, change the app's own port in `mibee-nvr.yaml` (not a port remap):
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## Updates & rollback
+
+See [Auto-update guide](deployment-autoupdate.md). In short: `docker compose pull && up -d` from the project folder, or pin a tag (`mibeenvr:0.10.0`) for reproducible rollbacks. Data under `/volume1/docker/mibee-nvr/data` is never touched by recreation.
+
+## Native `.spk` package — when it's worth it (optional)
+
+A `.spk` package in Synology's **Package Center** gets you store discoverability, but the cost is high: DSM 7 requires a publisher signing certificate + functional review, and you must build per-architecture packages. Two pragmatic options:
+
+- **Compose-only (this guide):** zero packaging cost, works today, no signing. Recommended for most users.
+- **Wrap the Docker image as a `.spk`:** Synology's developer guide documents a [Compile Docker Package](https://help.synology.com/developer-guide/examples/compile_docker_package.html) flow that ships a container as a Package Center entry. This is the lowest-effort path to store presence if you decide you need it — it reuses the same image, no per-arch rebuild.
+
+For an independent NVR project, start with Compose-only and only invest in `.spk` packaging if Package Center discoverability is worth the signing/review overhead.

--- a/docs/en/deployment-zspace.md
+++ b/docs/en/deployment-zspace.md
@@ -1,0 +1,66 @@
+# Deploy on 极空间 ZSpace (ZOS)
+
+> Run MiBee NVR in Docker on a 极空间 (ZSpace) NAS via the built-in **Docker → Compose 项目**. ZOS supports host networking in compose, which ONVIF camera auto-discovery needs. 极空间 has no private package format — "apps" here are just Docker containers.
+
+## Why host networking
+
+ONVIF WS-Discovery uses UDP multicast (`239.255.255.250:3702`), which Docker's default **bridge** blocks. ZOS Docker supports host / macvlan / bridge; the compose pins `network_mode: host` so camera discovery works with no extra setup.
+
+## Install via Docker → Compose
+
+1. In **文件管理**, pick a folder on your storage pool for persistent data, e.g. an external-disk or large-share path.
+2. Open **系统 → Docker → Compose → 新建项目** (or **Docker → 项目** on older firmware).
+3. Name the project `mibee-nvr` and paste:
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # required for ONVIF auto-discovery
+       volumes:
+         - <your-storage-path>/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   Replace `<your-storage-path>` with the path from step 1 (recordings fill disk fast — use a large pool or external drive, not the system volume).
+4. Save and start the project. The multi-arch image is pulled (x86 models get `amd64`, ARM models like Z2Pro/T6 get `arm64`).
+5. Open `http://<nas-ip>:9090` and complete the setup wizard.
+
+## Port conflicts
+
+On host networking the container binds directly to the NAS. MiBee NVR uses `9090` (Web) and `2121` (FTP); if either clashes with another service or container, change the app's own port in `mibee-nvr.yaml` (not a port remap):
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## How this differs from 极空间's built-in 监控中心
+
+极空间 ships its own **监控中心** (a lightweight RTSP/ONVIF preview tool). The two can coexist; they serve different needs:
+
+| | 极空间 监控中心 | MiBee NVR |
+|---|---|---|
+| Live preview | yes | yes |
+| Browser-side AI detection (ONNX) | no | **yes** |
+| Recording to disk + retention/merge | limited | **full** (pure-Go merge, no FFmpeg needed) |
+| FTP / WebDAV / WebRTC streaming | no | **yes** |
+| Multi-arch, runs on x86 + ARM models | — | yes |
+
+Think of 监控中心 as quick preview, MiBee NVR as AI analysis + long-term recording.
+
+## Updates & rollback
+
+See [Auto-update guide](deployment-autoupdate.md). `docker compose pull && up -d` from the project, or pin a tag (`mibeenvr:0.10.0`) for rollback. Data under your mapped path persists across recreation.
+
+## Reaching the official app store (optional)
+
+极空间's official store lists a curated set of "Docker apps" and "third-party apps", but there is **no public self-service developer portal** — entering it requires contacting 极空间 business development. Note that 监控中心 overlaps with this NVR, so a store discussion should lead with the differentiation above. For now, the Compose path plus a community template (e.g. submitting to a community compose-template library) is the immediate, zero-friction way to reach 极空间 users.

--- a/docs/zh/deployment-qnap.md
+++ b/docs/zh/deployment-qnap.md
@@ -1,0 +1,61 @@
+# 在威联通 QNAP QTS / QuTShero 上部署
+
+> 通过 **Container Station → 应用程序**（docker-compose）在 QNAP 上以 Docker 运行 MiBee NVR。Container Station 3.x 在 compose 中支持 `network_mode: host`，正是 ONVIF 摄像头自动发现所需要的。
+
+## 为什么用 host 网络
+
+ONVIF WS-Discovery 使用 UDP 多播（`239.255.255.250:3702`），Docker 默认的 **bridge** 会阻断它。因此 compose 固定 `network_mode: host`。Container Station 2 的 GUI 历史上**不支持** host 模式，但 CS 3.x 的 compose/应用程序路径可以接受并按 host 网络运行。请优先用下面的**应用程序（compose）**路径，而非单容器 GUI。
+
+## 通过 Container Station → 应用程序安装
+
+1. 从 App Center 安装/启用 **Container Station**（推荐 3.x）。
+2. 在 **Container Station → 应用程序 → 创建** 里粘贴 compose 文件：
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # ONVIF 自动发现所需
+       volumes:
+         - /share/Container/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   Container Station 安装时会创建名为 `Container` 的共享文件夹，把数据映射到这里（如 `/share/Container/mibee-nvr/data`）。
+3. **校验 → 部署**。多架构镜像被拉取，容器启动。
+4. 打开 `http://<NAS-IP>:9090` 完成初始化向导。
+
+若你的固件在应用程序路径下阻止 host 模式，可用 SSH 兜底：
+```bash
+ssh admin@<NAS-IP>
+mkdir -p /share/Container/mibee-nvr && cd /share/Container/mibee-nvr
+# 把上面的 compose 存为 docker-compose.yml，然后：
+docker compose up -d
+```
+
+## 端口冲突
+
+QNAP QTS 自身用 `8080`（HTTP 管理）/ `443`（HTTPS）/ `80`（Web Server，若启用）。这些与 MiBee NVR 的 `9090`（Web）或 `2121`（FTP）不冲突。若某个 QNAP 服务占用了你需要的端口，请在 QTS **控制面板 → 网络**里改该服务的端口，不要重映射 NVR。
+
+若要改 NVR 自己的端口（如 `9090`/`2121` 被其它容器占用），编辑 `mibee-nvr.yaml`：
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## 升级与回滚
+
+见[自动升级指南](deployment-autoupdate.md)。`docker compose pull` 后在应用程序里重新部署，或固定 tag（`mibeeenvr:0.10.0`）以便可复现回滚。`/share/Container/mibee-nvr/data` 下的数据在重建中保持不变。
+
+## 原生 `.qpkg`——何时值得（可选）
+
+威联通 **App Center** 对自助上架相对开放（用 [QDK](https://github.com/qnap-dev/QDK)），甚至可自建第三方 App 源让用户订阅安装。社区有把 Docker 容器封装成 QPKG 的做法。但要正常使用并不需要 QPKG——上面的 Compose/应用程序路径已足够。仅当 App Center 曝光对你重要时才投入 QPKG 打包，并复用同一多架构镜像（QPKG 可封装容器而非逐架构发二进制）。

--- a/docs/zh/deployment-synology.md
+++ b/docs/zh/deployment-synology.md
@@ -1,0 +1,60 @@
+# 在群晖 Synology DSM 上部署
+
+> 通过 **Container Manager → 项目**（docker-compose）在 Synology DSM 7.2+ 上以 Docker 运行 MiBee NVR。compose 路径支持 `network_mode: host`，正是 ONVIF 摄像头自动发现所需要的。无需 `.spk` 套件即可正常安装。
+
+## 为什么用 host 网络
+
+ONVIF WS-Discovery 使用 UDP 多播（`239.255.255.250:3702`），Docker 默认的 **bridge** 会阻断它。因此 compose 固定 `network_mode: host`；Container Manager 的「项目」会正确识别它。**不要**在 host 网络服务里同时声明 `ports:`——二者冲突，DSM 会拒绝该 compose。
+
+## 通过 Container Manager → 项目安装
+
+1. 在 **File Station** 里为项目建一个文件夹，如 `/volume1/docker/mibee-nvr/`。
+2. 打开 **Container Manager → 容器 → 项目 → 新增**。
+3. **项目名称** = `mibee-nvr`，**路径** = 第 1 步的文件夹。
+4. **来源** 选 **「创建 docker-compose.yml」**，粘贴 host 网络 compose：
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # ONVIF 自动发现所需
+       volumes:
+         - /volume1/docker/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   （这与 [`deploy/compose/docker-compose.host.yml`](../../deploy/compose/docker-compose.host.yml) 一致，仅填入宿主路径。）
+5. **下一步 → 完成**。Container Manager 拉取多架构镜像并启动容器。
+6. 打开 `http://<NAS-IP>:9090` 完成初始化向导。
+
+## 端口冲突
+
+host 网络下容器直接监听 NAS 端口。MiBee NVR 用 `9090`（Web/API）和 `2121`（FTP）——这俩**不与** DSM 自身端口冲突。DSM 保留 `5000`（HTTP）/ `5001`（HTTPS）给其管理界面，`20/21` 给可选的内置 FTP。如果你也开了 DSM 的 FTP，请注意它与本 NVR 的 FTP（2121）是两套独立服务，别混淆。
+
+若 `9090` 或 `2121` 被其它容器占用，改 `mibee-nvr.yaml` 里应用自己的端口（不要重映射端口）：
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## 升级与回滚
+
+见[自动升级指南](deployment-autoupdate.md)。简言之：在项目目录 `docker compose pull && up -d`，或固定 tag（`mibeenvr:0.10.0`）以便可复现回滚。`/volume1/docker/mibee-nvr/data` 下的数据不受重建影响。
+
+## 原生 `.spk` 套件——何时值得（可选）
+
+在群晖**套件中心**上架 `.spk` 能获得商店曝光，但成本不低：DSM 7 要求发布者签名证书 + 功能审核，且要为每个架构分别打包。两个务实选择：
+
+- **仅用 Compose（本指南）：** 零打包成本，今天就能用，无需签名。推荐大多数用户。
+- **把 Docker 镜像封装成 `.spk`：** 群晖开发者指南有 [Compile Docker Package](https://help.synology.com/developer-guide/examples/compile_docker_package.html) 流程，把容器作为套件中心条目发布。这是要进商店时成本最低的路径——复用同一镜像，无需逐架构重编译。
+
+对独立 NVR 项目，建议先用 Compose，仅当套件中心曝光确实值得签名/审核成本时再做 `.spk`。

--- a/docs/zh/deployment-zspace.md
+++ b/docs/zh/deployment-zspace.md
@@ -1,0 +1,66 @@
+# 在极空间 ZSpace（ZOS）上部署
+
+> 通过极空间内置的 **Docker → Compose 项目** 以 Docker 运行 MiBee NVR。ZOS 在 compose 中支持 host 网络，正是 ONVIF 摄像头自动发现所需要的。极空间无私有包格式——这里的「应用」就是 Docker 容器。
+
+## 为什么用 host 网络
+
+ONVIF WS-Discovery 使用 UDP 多播（`239.255.255.250:3702`），Docker 默认的 **bridge** 会阻断它。ZOS 的 Docker 支持 host / macvlan / bridge；compose 固定 `network_mode: host`，摄像头发现无需额外配置即可工作。
+
+## 通过 Docker → Compose 安装
+
+1. 在 **文件管理** 里，从存储池选一个文件夹存放持久数据（如外接硬盘或大共享上的路径）。
+2. 打开 **系统 → Docker → Compose → 新建项目**（旧固件可能是 **Docker → 项目**）。
+3. 项目命名 `mibee-nvr`，粘贴：
+   ```yaml
+   services:
+     mibee-nvr:
+       image: ghcr.io/mi-bee-studio/mibeenvr:latest
+       container_name: mibee-nvr
+       restart: unless-stopped
+       network_mode: host          # ONVIF 自动发现所需
+       volumes:
+         - <你的存储路径>/mibee-nvr/data:/data
+       environment:
+         - NVR_DATA_DIR=/data
+       healthcheck:
+         test: ["CMD", "mibee-nvr", "health"]
+         interval: 30s
+         timeout: 5s
+         retries: 3
+   ```
+   把 `<你的存储路径>` 换成第 1 步的路径（录像很占空间——用大存储池或外接盘，别用系统盘）。
+4. 保存并启动项目。多架构镜像被拉取（x86 机型取 `amd64`，Z2Pro/T6 等 ARM 机型取 `arm64`）。
+5. 打开 `http://<NAS-IP>:9090` 完成初始化向导。
+
+## 端口冲突
+
+host 网络下容器直接监听 NAS 端口。MiBee NVR 用 `9090`（Web）和 `2121`（FTP）；若与其它服务或容器冲突，改 `mibee-nvr.yaml` 里应用自己的端口（不要重映射）：
+```yaml
+server:
+  listen: ":8080"
+ftp:
+  port: 2121
+  passive_port_range: "2122-2140"
+```
+
+## 与极空间自带「监控中心」的区别
+
+极空间自带 **监控中心**（轻量 RTSP/ONVIF 预览工具）。两者可共存，定位不同：
+
+| | 极空间 监控中心 | MiBee NVR |
+|---|---|---|
+| 实时预览 | 有 | 有 |
+| 浏览器端 AI 检测（ONNX） | 无 | **有** |
+| 录像到磁盘 + 保留/合并 | 有限 | **完整**（纯 Go 合并，无需 FFmpeg） |
+| FTP / WebDAV / WebRTC 流媒体 | 无 | **有** |
+| 多架构，x86 + ARM 机型通吃 | — | 是 |
+
+监控中心用于快速看预览，MiBee NVR 用于 AI 智能分析与长期录像。
+
+## 升级与回滚
+
+见[自动升级指南](deployment-autoupdate.md)。在项目里 `docker compose pull && up -d`，或固定 tag（`mibeenvr:0.10.0`）以便回滚。映射路径下的数据在重建中保持不变。
+
+## 进入官方应用商店（可选）
+
+极空间官方商店收录精选的「Docker 应用」和「第三方应用」，但**没有公开的自助开发者门户**——进驻需联系极空间商务。注意监控中心与本 NVR 功能重叠，所以商务沟通时应以上面的差异化定位切入。目前，Compose 路径 + 社区模板（如提交到社区 compose 模板库）是触达极空间用户的即时、零门槛方式。


### PR DESCRIPTION
Closes the wave-2 documentation gap in #198. Documentation-only — no code, no packaging, zero conflict risk.

## What
Bilingual (en+zh) Docker deployment guides for the three wave-2 platforms. All reuse the existing host-network compose base ([`deploy/compose/docker-compose.host.yml`](../../blob/main/deploy/compose/docker-compose.host.yml)); the docs just fill in per-platform volume paths, port-conflict notes, and the install UI path.

| Platform | Compose entry | host network | Native-package path documented |
|----------|---------------|--------------|--------------------------------|
| Synology DSM 7.2 | Container Manager → Project | ✅ (verified) | `.spk` via Compile-Docker-Package (optional, signing required) |
| QNAP QTS (CS3) | Container Station → Application | ✅ (CS3; SSH fallback) | QDK self-publish / third-party source (optional) |
| 极空间 ZOS | Docker → Compose 项目 | ✅ | store entry via BD contact (no public portal) |

## Why docs-only for wave 2
Per the #198 analysis, wave-2 platforms (Synology/QNAP/极空间) are best served by the **Docker route**, not native packages:
- The app is already a multi-arch Docker image — Compose deployment works today at zero packaging cost.
- Native packages (.spk signing+review, QDK per-arch, 极空间 BD contact) carry high cost for low marginal benefit on an independent NVR.
- The docs document the native-package path **honestly as optional** with cost/benefit, so users who do want store presence know the route.

## 极空间 specifics
The 监控中心 overlap is called out with a differentiation table (AI detection / recording+merge / FTP / WebRTC as the differentiators) — useful both for users deciding and for any future BD/store conversation.

## Conflict footprint
6 new files under `docs/`. No `internal/`, `pkg/`, `web/`, or existing docs touched.

## Test plan
- [ ] Reviewer spot-checks: host-network compose renders in Container Manager Project (Synology) / Application (QNAP) / Compose 项目 (极空间)
- [ ] Cross-doc links resolve (each platform doc links to `deployment-autoupdate.md`, which exists)