### PR TITLE
docs: cross-link NAS platform guides + auto-update from README/deployment/getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ Perfect for homelab enthusiasts. Self-hosted, no subscriptions, works with any R
 | [Configuration](docs/en/configuration.md) | Full config reference |
 | [API Reference](docs/en/api/README.md) | REST API documentation |
 | [MediaMTX Guide](docs/en/mediamtx-guide.md) | MediaMTX integration for CSI cameras |
-| [Deployment](docs/en/deployment.md) | systemd, reverse proxy, cross-compile |
+| [Deployment](docs/en/deployment.md) | systemd, reverse proxy, cross-compile, and per-platform **NAS** guides (unRAID / fnOS / iStoreOS / Synology / QNAP / 极空间) |
+| [Auto-update (Docker)](docs/en/deployment-autoupdate.md) | Manual + optional Watchtower auto-updates and rollback |
 | [Xiaomi Setup](docs/en/xiaomi-setup.md) | Xiaomi cloud camera integration |
 | [ONVIF Guide](docs/en/onvif-guide.md) | ONVIF camera setup, PTZ control, troubleshooting |
 | [Camera Guide](docs/en/camera-guide.md) | Camera setup, protocols, troubleshooting |

--- a/README.zh.md
+++ b/README.zh.md
@@ -132,7 +132,8 @@ make build
 | [配置说明](docs/zh/configuration.md) | 完整配置参考 |
 | [API 文档](docs/zh/api/README.md) | REST API 接口文档 |
 | [MediaMTX 指南](docs/zh/mediamtx-guide.md) | MediaMTX CSI 摄像头集成 |
-| [部署指南](docs/zh/deployment.md) | systemd、反向代理、交叉编译 |
+| [部署指南](docs/zh/deployment.md) | systemd、反向代理、交叉编译，及各 **NAS** 平台指南（unRAID / 飞牛 / iStoreOS / 群晖 / 威联通 / 极空间） |
+| [Docker 自动升级](docs/zh/deployment-autoupdate.md) | 手动升级 + 可选 Watchtower 自动升级与回滚 |
 | [摄像头指南](docs/zh/camera-guide.md) | 摄像头设置、协议、故障排除 |
 | [Xiaomi 设置](docs/zh/xiaomi-setup.md) | 小米云摄像头集成 |
 | [ONVIF 指南](docs/zh/onvif-guide.md) | ONVIF 摄像头设置、云台控制、故障排除 |

--- a/docs/en/deployment.md
+++ b/docs/en/deployment.md
@@ -118,6 +118,22 @@ services:
 
 No extra steps needed — the `docker-compose.yml` uses the pre-built image by default.
 
+#### Deploying on a NAS OS
+
+The same multi-arch Docker image installs on most NAS operating systems. All NAS deployments share one design choice: **`network_mode: host` is required** — ONVIF camera auto-discovery uses UDP multicast (`239.255.255.250:3702`), which Docker's default bridge blocks. Per-platform guides (with the exact UI path, volume paths, and port-conflict notes):
+
+| Platform | Guide |
+|----------|-------|
+| unRAID | [deployment-unraid.md](deployment-unraid.md) — Community Applications template |
+| 飞牛 fnOS | [deployment-fnos.md](deployment-fnos.md) — `.fpk` package |
+| iStoreOS / OpenWrt | [deployment-istoreos.md](deployment-istoreos.md) — Compose (default host networking) |
+| Synology DSM | [deployment-synology.md](deployment-synology.md) — Container Manager → Project |
+| QNAP QTS | [deployment-qnap.md](deployment-qnap.md) — Container Station → Application |
+| 极空间 ZSpace | [deployment-zspace.md](deployment-zspace.md) — Docker → Compose |
+
+For keeping the image current (manual pull, or optional Watchtower), see the [auto-update guide](deployment-autoupdate.md).
+
+
 **Option B: Build locally**
 
 If you need custom builds or want the latest source code:
@@ -486,6 +502,8 @@ Caveats:
 - **Approaches NOT adopted** (they conflict with the project's design constraints): a resident in-memory ring buffer needs a large constant RAM allocation, incompatible with the RPi 3B's 1 GB target; enlarging the muxer write buffer risks losing hundreds of MB on power loss and corrupts the MP4 moov atom, violating the atomic-write (temp → rename) crash-safety principle. The project therefore sticks with the memory-friendly "small segments + async merge + optional tmpfs (deployment layer)" approach.
 
 ## Updating
+
+For Docker deployments — manual `docker compose pull && up -d`, optional Watchtower auto-updates, and rollback — see the [auto-update guide](deployment-autoupdate.md). For breaking-change migrations between specific versions, see the [Upgrade Guide](upgrade-guide.md).
 
 ### Using install.sh (Recommended)
 

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -48,6 +48,10 @@ Open http://localhost:9090 in your browser.
 
 > **Note**: No config preparation needed! MiBee NVR auto-initializes when started without a config file.
 
+> **Running on a NAS (Synology / QNAP / unRAID / fnOS / iStoreOS / 极空间)?** See the per-platform guides in the [Deployment Guide](deployment.md#deploying-on-a-nas-os) — they cover host networking (required for ONVIF camera auto-discovery), volume paths, and port conflicts.
+
+
+
 #### Changing the Storage Location
 
 By default, recordings are stored in `./data` on the host (mapped to `/data` inside the container).

--- a/docs/zh/deployment.md
+++ b/docs/zh/deployment.md
@@ -118,6 +118,22 @@ services:
 
 直接使用 `docker-compose.yml` 中的默认镜像地址即可，无需额外操作。
 
+#### 在 NAS OS 上部署
+
+同一个多架构 Docker 镜像可安装到大多数 NAS 操作系统。所有 NAS 部署共享一个设计选择：**必须用 `network_mode: host`** —— ONVIF 摄像头自动发现使用 UDP 多播（`239.255.255.250:3702`），Docker 默认的 bridge 会阻断它。各平台指南（含精确的 UI 路径、数据卷路径、端口冲突提示）：
+
+| 平台 | 指南 |
+|------|------|
+| unRAID | [deployment-unraid.md](deployment-unraid.md) —— Community Applications 模板 |
+| 飞牛 fnOS | [deployment-fnos.md](deployment-fnos.md) —— `.fpk` 应用包 |
+| iStoreOS / OpenWrt | [deployment-istoreos.md](deployment-istoreos.md) —— Compose（默认 host 网络） |
+| Synology DSM | [deployment-synology.md](deployment-synology.md) —— Container Manager → 项目 |
+| 威联通 QNAP QTS | [deployment-qnap.md](deployment-qnap.md) —— Container Station → 应用程序 |
+| 极空间 ZSpace | [deployment-zspace.md](deployment-zspace.md) —— Docker → Compose |
+
+镜像如何保持最新（手动拉取，或可选的 Watchtower），见[自动升级指南](deployment-autoupdate.md)。
+
+
 **选项 B：本地构建**
 
 如果需要自定义构建或使用最新源码：
@@ -485,6 +501,8 @@ sudo mount -t tmpfs -o size=2G tmpfs /mnt/nvr-tmp
 - **不采用的方案**（与项目设计约束冲突）：常驻内存的环形缓冲（Ring Buffer）需要恒定占用一大块内存，与"树莓派 3B 仅 1 GB RAM"的兼容目标冲突；增大 muxer 写缓冲会在断电时丢失数百 MB 数据并损坏 MP4 的 moov atom，违反原子写（temp → rename）的崩溃安全原则。因此本项目坚持"小分片 + 异步合并 + tmpfs（部署层可选）"的内存友好方案。
 
 ## 更新
+
+Docker 部署的更新方式——手动 `docker compose pull && up -d`、可选的 Watchtower 自动升级与回滚——见[自动升级指南](deployment-autoupdate.md)。特定版本间的破坏性变更迁移，见[升级指南](upgrade-guide.md)。
 
 ### 使用安装脚本（推荐）
 

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -48,6 +48,10 @@ docker compose --project-directory . -f deploy/docker/docker-compose.yml up -d
 
 > **注意**：无需准备配置文件！MiBee NVR 在没有配置文件的情况下启动时会自动初始化。
 
+> **在 NAS 上运行（群晖 / 威联通 / unRAID / 飞牛 / iStoreOS / 极空间）？** 请参阅[部署指南](deployment.md#在-nas-os-上部署)中的各平台指南——涵盖 host 网络（ONVIF 摄像头自动发现所需）、数据卷路径与端口冲突。
+
+
+
 #### 修改录像存储位置
 
 默认情况下，录像存储在宿主机的 `./data` 目录（映射到容器内的 `/data`）。


### PR DESCRIPTION
Documentation navigation pass. The 7 per-platform NAS deploy guides (unRAID / fnOS / iStoreOS / Synology / QNAP / 极空间 + auto-update) shipped in #207 / #209 / #210 were orphaned — only findable by browsing `docs/`. This wires them into the surfaces users actually read.

## Changes (docs-only, 6 files, +48 lines)
- **README.md / README.zh.md** — docs table now lists the NAS deploy + auto-update guides
- **deployment.md (en+zh)** — new \"Deploying on a NAS OS\" table indexes all 6 platform guides; \"Updating\" section points to the auto-update + upgrade guides
- **getting-started.md (en+zh)** — Docker section points NAS users to the platform guides

## Why this matters
A user arriving at README or the main Deployment Guide now discovers that unRAID/Synology/QNAP/etc. guides exist, instead of having to guess the filename. Each platform guide already had full content; this is pure discoverability.

## Validation
- All 14 linked docs (en+zh × 7) confirmed to exist
- All 6 new cross-links (relative paths) verified to resolve
- No code files touched (README + docs/ only)

## Test plan
- [ ] Click through README docs table → NAS deploy guide → auto-update guide (en + zh)
- [ ] deployment.md \"Deploying on a NAS OS\" table renders and all 6 links open