### PR TITLE
fix(ai): ListAIEvents 列表查询始终返回空 — 恢复被误删的 append

### DIFF
--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -133,6 +133,7 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 		e.BBox = bbox.String
 		e.SnapshotPath = snapshotPath.String
 		e.Metadata = metadata.String
+		events = append(events, e)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
@@ -198,9 +199,6 @@ func (d *DB) GetAIEventStats(ctx context.Context, cameraID string, since time.Ti
 			return nil, err
 		}
 		stats = append(stats, s)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/storage/db_ai_test.go
+++ b/internal/storage/db_ai_test.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListAIEventsReturnsInsertedRows is a regression test for issue #212:
+// ListAIEvents returned an empty slice (while total was correct) because the
+// rows.Next() loop was missing `events = append(events, e)` — a line deleted
+// by commit de002b8 ("chore(lint): nolint deferred findings") when it added the
+// rows.Err() check. This test inserts a few events and asserts they come back.
+func TestListAIEventsReturnsInsertedRows(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_ai_events.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	const camID = "cam-test-ai"
+	// Insert three events across two event_types.
+	inserts := []*AIEvent{
+		{CameraID: camID, EventType: "zone_intrusion", Severity: "info", Confidence: 0.9, BBox: "[0.1,0.2,0.3,0.4]"},
+		{CameraID: camID, EventType: "zone_intrusion", Severity: "warning", Confidence: 0.7},
+		{CameraID: camID, EventType: "loitering", Severity: "info", Confidence: 0.5},
+		{CameraID: "cam-other", EventType: "zone_intrusion", Severity: "info", Confidence: 0.3},
+	}
+	for _, e := range inserts {
+		_, err := db.InsertAIEvent(ctx, e)
+		require.NoError(t, err)
+	}
+
+	// 1) No filter → all 4 rows returned (not nil/empty).
+	got, total, err := db.ListAIEvents(ctx, AIEventFilter{Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, 4, total, "total count must reflect all inserted rows")
+	require.Len(t, got, 4, "regression #212: events slice must not be empty when rows exist")
+
+	// 2) Filter by camera_id.
+	got, total, err = db.ListAIEvents(ctx, AIEventFilter{CameraID: camID, Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+	require.Len(t, got, 3, "camera_id filter must return matching rows")
+
+	// 3) Filter by event_type.
+	got, total, err = db.ListAIEvents(ctx, AIEventFilter{CameraID: camID, EventType: "zone_intrusion", Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, 2, total)
+	require.Len(t, got, 2)
+	for _, e := range got {
+		require.Equal(t, "zone_intrusion", e.EventType)
+	}
+
+	// 4) Default ordering is DESC by created_at/id — newest first. The cam-other
+	// row was inserted last, so it must be got[0] in the unfiltered list.
+	got, _, err = db.ListAIEvents(ctx, AIEventFilter{Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, "cam-other", got[0].CameraID, "DESC ordering: last-inserted row must come first")
+}
+
+// TestListAIEventsEmptyWhenNoRows confirms the empty case returns a non-nil
+// slice (handler normalizes nil→[]) and total=0, so the frontend gets a clean
+// "no events" state rather than a misleading total>0 with empty rows.
+func TestListAIEventsEmptyWhenNoRows(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_ai_events_empty.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	got, total, err := db.ListAIEvents(ctx, AIEventFilter{Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, 0, total)
+	require.Empty(t, got)
+}


### PR DESCRIPTION
## Closes #212

`GET /api/ai/events` 永远返回 `events:[]` 而 `total` 正确,导致前端 AIEvents 页面和录像回放时间轴的 AI 事件标记 overlay 无法展示任何事件。外部 AI 事件消费方写入正常(单条查询 `GET /api/ai/events/{id}` 和 `GET /api/ai/stats` 都正常),只有列表查询坏掉。

## 根因

回归。commit de002b8(2026-07-05,*chore(lint): nolint deferred findings with tracking issues*,#51)在给 `ListAIEvents` 补 `rows.Err()` 检查(满足 `rowserrcheck` lint)时,**误删了循环体末尾的 `events = append(events, e)`**:

```diff
 		e.Metadata = metadata.String
-		events = append(events, e)
+	}
+		if err := rows.Err(); err != nil {
+			return nil, 0, err
 	}
 	return events, total, nil
```

每行 scan 进局部变量 `e` 后没有追加到 `events` slice,函数始终返回 nil/空。而 `total` 来自独立的 `SELECT COUNT(*)`,数值正确——所以表现为"有统计、有总数,就是没列表",隐蔽性高。

全仓 38 个 `for rows.Next()` 循环里只有这一个漏 append(其余 37 个均正确,包括同文件的 `GetAIEventStats`)。

## 修复

- `internal/storage/db_ai.go`:`ListAIEvents` 循环内恢复 `events = append(events, e)`
- 顺手清理同 commit 在 `GetAIEventStats` 留的两段重复 `rows.Err()` 检查(back-to-back 完全相同,纯清理)

## 测试

新增 `internal/storage/db_ai_test.go` 回归测试:
- 插入 4 条事件(2 摄像头 × 2 event_type)后,断言 `ListAIEvents` 无过滤 / 按 camera_id / 按 event_type 过滤均返回正确行数与 total
- 验证默认 DESC 排序(最后插入的行在最前)
- 覆盖空表场景(total=0,空 slice)

## 影响范围

- 前端 `AIEvents.svelte`(列表页)和 `TimelineBar.svelte`(回放 overlay)此前拿不到事件,修复后零改动即可正常展示
- 不影响写入链路(POST)、单条查询、stats 聚合——它们本来就正常

## 验证方式

部署后:
\`\`\`bash
curl -s -u \"admin:<pwd>\" \"http://<host>:9090/api/ai/events?limit=5\"
# 修复前: {\"events\":[],...,\"total\":45}
# 修复后: {\"events\":[{...},{...}],...,\"total\":45}  ← events 非空
\`\`\`