### PR TITLE
fix(recordings)+feat(ai-events): #215 follow-up — countCacheKey 补漏 + AI 事件中文标签

### DIFF
--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -320,6 +320,10 @@ func countCacheKey(f model.RecordingFilter) string {
 	b.WriteString(merged)
 	b.WriteByte('|')
 	b.WriteString(archived)
+	b.WriteByte('|')
+	// AiClass must be part of the key: without it, ?ai_class=person collides
+	// with the unfiltered count cache entry and returns the wrong total.
+	b.WriteString(f.AiClass)
 	return b.String()
 }
 

--- a/internal/storage/db_recording_test.go
+++ b/internal/storage/db_recording_test.go
@@ -223,3 +223,19 @@ func TestPathIsRecordingFile(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, got, "path under a different camera should not match")
 }
+
+// TestCountCacheKeyIncludesAiClass guards against a regression where the AI
+// class filter was omitted from the count-cache key: without AiClass in the
+// key, ?ai_class=person collided with the unfiltered entry and the list API
+// returned the wrong total (the whole-table count), making the "含人" filter
+// look broken in the UI.
+func TestCountCacheKeyIncludesAiClass(t *testing.T) {
+	base := model.RecordingFilter{CameraID: "cam-1", Format: model.FormatH264}
+	noClass := countCacheKey(base)
+	withPerson := countCacheKey(model.RecordingFilter{CameraID: "cam-1", Format: model.FormatH264, AiClass: "person"})
+	withCar := countCacheKey(model.RecordingFilter{CameraID: "cam-1", Format: model.FormatH264, AiClass: "car"})
+
+	require.NotEqual(t, noClass, withPerson, "AiClass=person must not share the cache key of the unfiltered query")
+	require.NotEqual(t, noClass, withCar, "AiClass=car must not share the cache key of the unfiltered query")
+	require.NotEqual(t, withPerson, withCar, "different AiClass values must produce different cache keys")
+}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1785214833451';
+const CACHE_VERSION = 'mibee-nvr-1785743985030';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/web/src/lib/ai-labels.ts
+++ b/web/src/lib/ai-labels.ts
@@ -1,0 +1,147 @@
+/**
+ * 中文标签映射 —— 把 AI 事件里的英文代码标识符翻译成新手能看懂的中文。
+ *
+ * 为什么放这里而不放 i18n JSON:
+ * - event_type / severity 是固定枚举,但 class_name 来自 COCO 80 类,放进 i18n JSON
+ *   会让字典臃肿;且 t() 对缺失键会返回带点号的 key 字符串(如 "aiEvents.class.chair"),
+ *   反而更难读。
+ * - 这里统一兜底:任何未覆盖的值原样返回,保证不会显示乱码。
+ *
+ * 用法:在 AIEvents.svelte 里用 eventTypeLabel(evt.event_type) 等。
+ */
+
+// COCO (Common Objects in Context) 80 类完整中文表。
+// 顺序与 ai-detection/inference.ts 的 COCO_CLASSES 一致,便于核对。
+const COCO_LABELS_ZH: Record<string, string> = {
+  person: '人',
+  bicycle: '自行车',
+  car: '汽车',
+  motorcycle: '摩托车',
+  airplane: '飞机',
+  bus: '公交车',
+  train: '火车',
+  truck: '卡车',
+  boat: '船',
+  'traffic light': '交通灯',
+  'fire hydrant': '消火栓',
+  'stop sign': '停车标志',
+  'parking meter': '停车计时器',
+  bench: '长椅',
+  bird: '鸟',
+  cat: '猫',
+  dog: '狗',
+  horse: '马',
+  sheep: '羊',
+  cow: '牛',
+  elephant: '大象',
+  bear: '熊',
+  zebra: '斑马',
+  giraffe: '长颈鹿',
+  backpack: '背包',
+  umbrella: '雨伞',
+  handbag: '手提包',
+  tie: '领带',
+  suitcase: '行李箱',
+  frisbee: '飞盘',
+  skis: '滑雪板(双板)',
+  snowboard: '滑雪板(单板)',
+  'sports ball': '运动球',
+  kite: '风筝',
+  'baseball bat': '棒球棒',
+  'baseball glove': '棒球手套',
+  skateboard: '滑板',
+  surfboard: '冲浪板',
+  'tennis racket': '网球拍',
+  bottle: '瓶子',
+  'wine glass': '酒杯',
+  cup: '杯子',
+  fork: '叉子',
+  knife: '刀',
+  spoon: '勺子',
+  bowl: '碗',
+  banana: '香蕉',
+  apple: '苹果',
+  sandwich: '三明治',
+  orange: '橙子',
+  broccoli: '西兰花',
+  carrot: '胡萝卜',
+  'hot dog': '热狗',
+  pizza: '披萨',
+  donut: '甜甜圈',
+  cake: '蛋糕',
+  chair: '椅子',
+  couch: '沙发',
+  'potted plant': '盆栽',
+  bed: '床',
+  'dining table': '餐桌',
+  toilet: '马桶',
+  tv: '电视',
+  laptop: '笔记本电脑',
+  mouse: '鼠标',
+  remote: '遥控器',
+  keyboard: '键盘',
+  'cell phone': '手机',
+  microwave: '微波炉',
+  oven: '烤箱',
+  toaster: '烤面包机',
+  sink: '水槽',
+  refrigerator: '冰箱',
+  book: '书',
+  clock: '时钟',
+  vase: '花瓶',
+  scissors: '剪刀',
+  'teddy bear': '泰迪熊',
+  'hair drier': '吹风机',
+  toothbrush: '牙刷',
+};
+
+// 事件类型 → 通俗中文。未知类型原样返回(不硬翻,避免误导)。
+const EVENT_TYPE_LABELS_ZH: Record<string, string> = {
+  zone_intrusion: '进入区域',
+  line_crossing: '越线',
+  loitering: '逗留',
+  object_detected: '检测到物体',
+  custom: '自定义',
+};
+
+// 严重度 → 中文。
+const SEVERITY_LABELS_ZH: Record<string, string> = {
+  info: '提示',
+  warning: '警告',
+  critical: '严重',
+};
+
+// 内置 zone 名 → 中文(仅翻译程序生成的固定 zone,用户自定义的 zone 原样保留)。
+const ZONE_LABELS_ZH: Record<string, string> = {
+  'full-frame': '全画面',
+};
+
+/** 把英文首字母大写,作为未知 event_type 的可读兜底。 */
+function titleCase(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/** 检测物体类别 → 中文;查不到则原样返回英文。空值返回空串。 */
+export function classLabel(name?: string): string {
+  if (!name) return '';
+  return COCO_LABELS_ZH[name] ?? name;
+}
+
+/** 事件类型 → 中文;未知类型把首字母大写兜底。空值返回空串。 */
+export function eventTypeLabel(type?: string): string {
+  if (!type) return '';
+  return EVENT_TYPE_LABELS_ZH[type] ?? titleCase(type);
+}
+
+/** 严重度 → 中文;未知值原样返回。空值返回空串。 */
+export function severityLabel(severity?: string): string {
+  if (!severity) return '';
+  return SEVERITY_LABELS_ZH[severity] ?? severity;
+}
+
+/** zone 名 → 中文;仅翻译内置 zone,用户自定义的 zone 原样返回。空值返回空串。 */
+export function zoneLabel(name?: string): string {
+  if (!name) return '';
+  return ZONE_LABELS_ZH[name] ?? name;
+}

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -15,6 +15,7 @@
   "ai.statusStopped": "Stopped",
   "ai.title": "AI Detection",
   "aiEvents.allCameras": "All Cameras",
+  "aiEvents.allTypes": "All Types",
   "aiEvents.goToSettings": "Go to Settings",
   "aiEvents.noEvents": "No AI events yet",
   "aiEvents.notConnectedDesc": "Configure MiBeeVision integration in Settings to start receiving AI detection events.",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -15,6 +15,7 @@
   "ai.statusStopped": "已停止",
   "ai.title": "AI 检测状态",
   "aiEvents.allCameras": "所有摄像头",
+  "aiEvents.allTypes": "全部类型",
   "aiEvents.goToSettings": "前往设置",
   "aiEvents.noEvents": "暂无 AI 事件",
   "aiEvents.notConnectedDesc": "在设置页配置 MiBeeVision 集成,即可开始接收 AI 检测事件。",

--- a/web/src/routes/AIEvents.svelte
+++ b/web/src/routes/AIEvents.svelte
@@ -7,6 +7,7 @@
   import { getMiBeeVisionConnected, getMiBeeVisionLoaded, refreshMiBeeVisionStatus } from '$lib/mibeevision-status.svelte';
   import { t } from '$lib/i18n';
   import { formatDate } from '$lib/format';
+  import { classLabel, eventTypeLabel, severityLabel, zoneLabel } from '$lib/ai-labels';
   import { AlertCircle, Brain, ChevronDown, Settings } from 'lucide-svelte';
   import Pagination from '../components/Pagination.svelte';
 
@@ -22,13 +23,14 @@
   let stats = $state<AIEventStats[]>([]);
   const pageSize = 20;
 
+  // 事件类型下拉框:label 与列表显示保持一致(中文),value 仍是后端用的英文 key。
   const eventTypes = [
-    { value: '', label: 'All Types' },
-    { value: 'zone_intrusion', label: 'Zone Intrusion' },
-    { value: 'line_crossing', label: 'Line Crossing' },
-    { value: 'loitering', label: 'Loitering' },
-    { value: 'object_detected', label: 'Object Detected' },
-    { value: 'custom', label: 'Custom' },
+    { value: '', label: t('aiEvents.allTypes') },
+    { value: 'zone_intrusion', label: eventTypeLabel('zone_intrusion') },
+    { value: 'line_crossing', label: eventTypeLabel('line_crossing') },
+    { value: 'loitering', label: eventTypeLabel('loitering') },
+    { value: 'object_detected', label: eventTypeLabel('object_detected') },
+    { value: 'custom', label: eventTypeLabel('custom') },
   ];
 
   const severityColors: Record<string, string> = {
@@ -185,17 +187,17 @@
           >
             <!-- Severity badge -->
             <span class="px-2 py-0.5 rounded text-xs font-medium border {severityColors[evt.severity] || severityColors.info}">
-              {evt.severity}
+              {severityLabel(evt.severity)}
             </span>
             <!-- Event info -->
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
-                <span class="font-medium th-text-primary text-sm">{evt.event_type}</span>
+                <span class="font-medium th-text-primary text-sm">{eventTypeLabel(evt.event_type)}</span>
                 {#if evt.class_name}
-                  <span class="text-xs th-text-muted">· {evt.class_name}</span>
+                  <span class="text-xs th-text-muted">· {classLabel(evt.class_name)}</span>
                 {/if}
                 {#if evt.zone_name}
-                  <span class="text-xs th-text-muted">· {evt.zone_name}</span>
+                  <span class="text-xs th-text-muted">· {zoneLabel(evt.zone_name)}</span>
                 {/if}
               </div>
               <div class="text-xs th-text-muted mt-0.5">

--- a/web/src/routes/Recordings.svelte
+++ b/web/src/routes/Recordings.svelte
@@ -418,11 +418,9 @@ let selectedPresetCamera = $state<string>('');
 
     try {
       const useCursor = cursor !== '';
+      // 复用 sharedFilterParams()(含 ai_class),避免列表加载漏掉过滤参数。
       const baseParams = {
-        camera_id: cameraId || undefined,
-        search: searchQuery || undefined,
-        merged: mergedFilter === 'true' ? true : mergedFilter === 'false' ? false : undefined,
-        archived: showArchived ? true : undefined,
+        ...sharedFilterParams(),
         limit,
         sort_by: sortBy,
         order: sortOrder,


### PR DESCRIPTION
本 PR 是 #215(已合并)的 follow-up,含两个独立 commit,作者 @蓝宝石的傻话(另一团队已提交至远程)。

## 1. `fix(recordings)`: countCacheKey 漏 AiClass + 列表加载漏 ai_class

两个叠加 bug 导致 `?ai_class=person` 在**录像列表**不生效(日历/时间轴正常):

1. **`countCacheKey()` 缺 `AiClass` 字段**:带 `ai_class` 的查询与不带的总数缓存键碰撞,返回错误 total(未过滤的全表计数)。修复:把 `AiClass` 写入缓存键。
2. **`loadListDataCursor()` 单独构造请求参数**(`camera_id/search/merged/archived`),绕过 `sharedFilterParams()`,漏掉 `ai_class`。修复:展开 `sharedFilterParams()`。

附 `TestCountCacheKeyIncludesAiClass` 回归测试。

## 2. `feat(ai-events)`: AI 事件页改用中文标签

原 AI 事件列表直接显示英文符号(`class_name` 如 `person`、`event_type` 如 `zone_intrusion`、`severity` 如 `warning`),新手看不懂。

新增 `web/src/lib/ai-labels.ts`:
- `COCO_LABELS_ZH`:完整 80 类中文映射
- `classLabel()` / `eventTypeLabel()` / `severityLabel()` / `zoneLabel()`:查表,未知值回退原值
- `AIEvents.svelte` 4 处展示 + 下拉选项改用 label 函数
- i18n 加 `aiEvents.allTypes`

## 说明
- 两个 commit 在原 `feat/recordings-ai-filter` 分支上已存在(commit `063620c` / `e740db5`),但该分支含 4 个 commit(其中 #214/#215 已 squash 合并),直接开 PR 会显示大量重复 diff。本分支基于最新 main 重新 cherry-pick 这 2 个 commit,作者归属保留原样,PR diff 干净。
- 与 #215 无功能冲突(cherry-pick 零冲突验证通过)。