### PR TITLE
fix(stream): 录像长 GOP 摄像头实时预览永久卡缓冲 — IDR fast-start + 解码停滞看门狗

### DIFF
--- a/internal/model/nalutil/nalutil.go
+++ b/internal/model/nalutil/nalutil.go
@@ -51,6 +51,46 @@ func ExtractParamSetsH264(au [][]byte) (sps, pps []byte) {
 	return sps, pps
 }
 
+// ExtractParamSetsH265 scans an H.265 access unit and returns the most recently
+// observed VPS (NAL type 32), SPS (NAL type 33), and PPS (NAL type 34), without
+// the start-code prefix. Returns nil for any that are not present. Used by the
+// StreamHub IDR fast-start cache to validate that a cached IDR carries a complete
+// parameter set before replaying it to a new consumer (an incomplete parameter
+// set cannot configure a decoder).
+func ExtractParamSetsH265(au [][]byte) (vps, sps, pps []byte) {
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		switch (nalu[0] >> 1) & 0x3F {
+		case 32: // VPS_NUT
+			vps = nalu
+		case 33: // SPS_NUT
+			sps = nalu
+		case 34: // PPS_NUT
+			pps = nalu
+		}
+	}
+	return vps, sps, pps
+}
+
+// HasCompleteParamSets reports whether an access unit contains the full set of
+// parameter-set NALUs needed to (re)configure a decoder for that codec:
+//   - H.264: SPS (type 7) AND PPS (type 8)
+//   - H.265: VPS (type 32) AND SPS (type 33) AND PPS (type 34)
+//
+// isH265 selects the codec. Returns true for empty AUs only when the codec needs
+// no parameter sets (never the case for H.264/H.265 video), so callers can use
+// this as a gate before replaying a cached IDR.
+func HasCompleteParamSets(au [][]byte, isH265 bool) bool {
+	if isH265 {
+		vps, sps, pps := ExtractParamSetsH265(au)
+		return vps != nil && sps != nil && pps != nil
+	}
+	sps, pps := ExtractParamSetsH264(au)
+	return sps != nil && pps != nil
+}
+
 // EqualParamSets reports whether two SPS/PPS NAL units are byte-identical.
 // nil comparisons are treated as equal-to-nil only (nil != non-nil).
 func EqualParamSets(a, b []byte) bool {

--- a/internal/model/stream.go
+++ b/internal/model/stream.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 )
 
 // FrameCallback is called for each decoded video frame.
@@ -98,6 +100,20 @@ type StreamHub struct {
 	OnAudioDrop func(cameraID string)
 	cameraID    string // set by SetCameraID after construction
 
+	// IDR fast-start cache — stores the most recent N keyframe access units so a
+	// newly-subscribed consumer can begin decoding immediately, without waiting up
+	// to one full GOP for the next natural IDR. This is essential for cameras with
+	// long GOPs (e.g. 8s): without replay, a consumer that connects mid-GOP and
+	// misses the IDR's inline parameter sets waits indefinitely for a keyframe and
+	// the decoder emits nothing ("buffering" forever). See HasCompleteParamSets for
+	// the integrity gate that prevents replaying an IDR lacking VPS/SPS/PPS.
+	//
+	// All access is guarded by h.mu (set in distributeFrame under h.mu; read &
+	// drained in Subscribe under h.mu), matching the locking discipline of
+	// consumers — no separate lock is needed.
+	idrCache     []FrameMsg
+	idrCacheSize int // max cached IDRs (ring); 0 disables replay (legacy behavior)
+
 	// Jitter buffer state — only activated when out-of-order frames are detected.
 	jitterBufferEnabled  atomic.Bool
 	jitterBufferSize     int           // max frames to buffer before flush (default: 5)
@@ -119,6 +135,12 @@ type StreamHub struct {
 	OnJitterReorder func(cameraID string)
 }
 
+// DefaultIDRCacheSize is the number of most-recent IDR access units StreamHub
+// keeps for fast-start replay to new subscribers. 3 balances memory (a few frames)
+// against giving a late joiner a keyframe near the current playhead. Set
+// StreamHub.idrCacheSize = 0 to disable replay entirely (legacy behavior).
+const DefaultIDRCacheSize = 3
+
 // NewStreamHub creates a new StreamHub with no consumers.
 func NewStreamHub() *StreamHub {
 	return &StreamHub{
@@ -128,6 +150,7 @@ func NewStreamHub() *StreamHub {
 		jitterBufferSize:      5,   // buffer up to 5 frames before forced flush
 		jitterBufferTimeout:   500 * time.Millisecond,
 		dropRateWarnThreshold: 0.30,
+		idrCacheSize:          DefaultIDRCacheSize,
 	}
 }
 
@@ -156,7 +179,76 @@ func (h *StreamHub) Subscribe(id string, cb FrameCallback) error {
 	}
 	h.consumers[id] = entry
 	go entry.drain()
+
+	// Fast-start: replay the most recent cached IDR whose access unit carries a
+	// complete parameter set (VPS+SPS+PPS for H.265, SPS+PPS for H.264) into the
+	// new consumer's channel so its decoder can configure and produce output
+	// immediately — instead of waiting up to one full GOP for the next natural
+	// IDR. This is what lets long-GOP cameras (e.g. 8s) be watchable. We walk the
+	// cache newest-first and replay only the first complete one: a single valid
+	// keyframe + parameter set is sufficient to bootstrap decoding, and replaying
+	// stale older IDRs adds no value while risking decoder confusion.
+	//
+	// Safe because we hold h.mu (distributeFrame also needs h.mu to populate the
+	// cache), entry.ch is buffered (consumerBufferSize, default 150), and drain
+	// cannot have closed the channel (closed is set only in Unsubscribe, which
+	// also needs h.mu). The non-blocking send guards against any pathological
+	// buffer-too-small case by skipping replay (the consumer still gets future
+	// frames normally).
+	h.replayCachedIDRLocked(entry)
 	return nil
+}
+
+// cacheIDRLocked appends a deep copy of an IDR access unit to the IDR ring
+// buffer. Must be called with h.mu held (caller is distributeFrame, which
+// already holds the lock). The ring keeps at most h.idrCacheSize entries,
+// evicting the oldest when full.
+func (h *StreamHub) cacheIDRLocked(pts int64, au [][]byte) {
+	cp := make([][]byte, len(au))
+	for i, nalu := range au {
+		c := make([]byte, len(nalu))
+		copy(c, nalu)
+		cp[i] = c
+	}
+	if len(h.idrCache) >= h.idrCacheSize {
+		// Ring: drop oldest. copy-in-place keeps the backing array.
+		copy(h.idrCache, h.idrCache[1:])
+		h.idrCache[len(h.idrCache)-1] = FrameMsg{PTS: pts, AU: cp, IsKeyframe: true}
+	} else {
+		h.idrCache = append(h.idrCache, FrameMsg{PTS: pts, AU: cp, IsKeyframe: true})
+	}
+}
+
+// replayCachedIDRLocked pushes the most recent parameter-set-complete cached IDR
+// into a freshly-subscribed consumer's channel. Must be called with h.mu held.
+// No-op when the cache is empty, disabled (idrCacheSize==0), or contains no IDR
+// with a complete parameter set (in which case the consumer falls back to
+// waiting for the next natural IDR — legacy behavior, no worse than before).
+func (h *StreamHub) replayCachedIDRLocked(entry *consumerEntry) {
+	if h.idrCacheSize == 0 || len(h.idrCache) == 0 {
+		return
+	}
+	// Walk newest-first: the newest complete IDR is closest to the live edge and
+	// the only one a decoder needs to bootstrap. (Replaying older IDRs would just
+	// add stale frames the consumer must discard.)
+	for i := len(h.idrCache) - 1; i >= 0; i-- {
+		msg := h.idrCache[i]
+		if msg.AU == nil {
+			continue
+		}
+		// StreamHub is codec-agnostic; try both H.264 and H.265 parameter-set
+		// extraction. A real IDR for either codec will satisfy exactly one.
+		if nalutil.HasCompleteParamSets(msg.AU, true) || nalutil.HasCompleteParamSets(msg.AU, false) {
+			select {
+			case entry.ch <- msg:
+			default:
+				// Buffer unexpectedly full (shouldn't happen for a brand-new entry
+				// with a 150-slot buffer) — skip replay; consumer still receives
+				// live frames normally.
+			}
+			return
+		}
+	}
 }
 
 // Unsubscribe removes the consumer with the given ID.
@@ -223,6 +315,15 @@ func (h *StreamHub) Broadcast(pts int64, au [][]byte, isIDR bool) {
 // This is the direct (no jitter buffer) path.
 func (h *StreamHub) distributeFrame(pts int64, au [][]byte, isIDR bool) {
 	h.mu.Lock()
+	// Cache IDR access units for fast-start replay to future subscribers. Done
+	// under h.mu (same lock that guards consumers) so Subscribe — which reads &
+	// drains the cache under h.mu — sees a consistent snapshot. Deep-copy the AU:
+	// upstream recorders don't mutate slices after Broadcast today, but there's no
+	// enforced contract, and a cached reference could outlive the producer's
+	// intended lifetime. The copy cost (one IDR per GOP) is negligible.
+	if isIDR && h.idrCacheSize > 0 {
+		h.cacheIDRLocked(pts, au)
+	}
 	type entryWithID struct {
 		id    string
 		entry *consumerEntry

--- a/internal/model/stream_test.go
+++ b/internal/model/stream_test.go
@@ -1349,11 +1349,11 @@ func TestStreamHub_ReplayRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Producers: continuously broadcast IDRs and P-frames.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			for j := 0; j < 200; j++ {
+			for j := range 200 {
 				pts := int64(n*1000 + j)
 				if j%5 == 0 {
 					hub.Broadcast(pts, h265IDRAU(), true)
@@ -1365,11 +1365,11 @@ func TestStreamHub_ReplayRace(t *testing.T) {
 	}
 
 	// Subscribers: continuously subscribe/unsubscribe.
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				id := fmt.Sprintf("r-%d-%d", n, j)
 				cb := func(int64, [][]byte) {
 					subs.Add(1)

--- a/internal/model/stream_test.go
+++ b/internal/model/stream_test.go
@@ -1098,3 +1098,289 @@ func TestJitterBuffer_NonBlocking(t *testing.T) {
 	close(blockCh)
 	hub.Unsubscribe("slow")
 }
+
+// ─── IDR fast-start cache tests ────────────────────────────────────────────
+//
+// The next group covers the StreamHub IDR replay feature: a newly-subscribed
+// consumer immediately receives the most recent parameter-set-complete cached
+// IDR, so it can begin decoding without waiting up to one full GOP for the next
+// natural keyframe. This is the fix for long-GOP cameras (e.g. 8s) whose live
+// preview would otherwise stall in "buffering" forever if the subscriber missed
+// the IDR's inline parameter sets.
+
+// NAL first-byte constants that satisfy nalutil's type checks, so the cache's
+// parameter-set-completeness gate (HasCompleteParamSets) accepts them as a real
+// IDR carrying inline params.
+//
+//	H.264: SPS type 7 (0x67), PPS type 8 (0x68), IDR slice type 5 (0x65)
+//	H.265: VPS type 32 (0x40), SPS type 33 (0x42), PPS type 34 (0x44),
+//	       IDR_W_RADL type 19 (0x26).
+const (
+	nalH264SPS = 0x67
+	nalH264PPS = 0x68
+	nalH264IDR = 0x65
+	nalH265VPS = 0x40
+	nalH265SPS = 0x42
+	nalH265PPS = 0x44
+	nalH265IDR = 0x26
+)
+
+// h264IDRAU builds a minimal H.264 IDR access unit with inline SPS+PPS+IDR.
+func h264IDRAU() [][]byte {
+	return [][]byte{{nalH264SPS, 0x01}, {nalH264PPS, 0x02}, {nalH264IDR, 0xAA}}
+}
+
+// h265IDRAU builds a minimal H.265 IDR access unit with inline VPS+SPS+PPS+IDR.
+func h265IDRAU() [][]byte {
+	return [][]byte{{nalH265VPS, 0x01}, {nalH265SPS, 0x02}, {nalH265PPS, 0x03}, {nalH265IDR, 0xBB}}
+}
+
+// TestStreamHub_ReplaysIDROnSubscribe verifies the core fast-start behavior: a
+// consumer that subscribes AFTER an IDR has been broadcast immediately receives
+// that cached IDR, without needing a second Broadcast.
+func TestStreamHub_ReplaysIDROnSubscribe(t *testing.T) {
+	hub := newTestStreamHub(t)
+
+	// Broadcast one H.265 IDR (with complete VPS/SPS/PPS) BEFORE any subscriber.
+	hub.Broadcast(1000, h265IDRAU(), true)
+
+	// Now subscribe — the new consumer should receive the cached IDR immediately.
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("late", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) >= 1
+	}, time.Second, 5*time.Millisecond, "late subscriber should receive the replayed IDR")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 1, "exactly the replayed IDR (no older frames in cache)")
+	require.Equal(t, int64(1000), received[0].pts, "replayed IDR must carry the original PTS")
+	require.True(t, len(received[0].au) >= 4, "replayed AU must include VPS+SPS+PPS+IDR NALUs")
+}
+
+// TestStreamHub_ReplaysH264IDR verifies the H.264 branch of the completeness
+// gate (SPS+PPS required).
+func TestStreamHub_ReplaysH264IDR(t *testing.T) {
+	hub := newTestStreamHub(t)
+	hub.Broadcast(42, h264IDRAU(), true)
+
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) >= 1
+	}, time.Second, 5*time.Millisecond, "H.264 IDR should be replayed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, int64(42), received[0].pts)
+}
+
+// TestStreamHub_NoReplayWhenCacheEmpty confirms that subscribing before any IDR
+// has been broadcast delivers nothing (legacy behavior preserved; the consumer
+// just waits for the next live frame).
+func TestStreamHub_NoReplayWhenCacheEmpty(t *testing.T) {
+	hub := newTestStreamHub(t)
+
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+
+	// Give the drain goroutine a moment, then assert nothing arrived.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, received, "no IDR replay when cache is empty")
+}
+
+// TestStreamHub_IDRCacheRingSize verifies the ring buffer evicts the oldest IDR
+// once the cache reaches idrCacheSize, so only the most recent N are kept.
+func TestStreamHub_IDRCacheRingSize(t *testing.T) {
+	hub := newTestStreamHub(t)
+	hub.idrCacheSize = 2 // small ring for a deterministic test
+
+	// Broadcast 3 IDRs (PTS 10, 20, 30) plus a non-IDR to confirm non-IDRs are
+	// NOT cached.
+	hub.Broadcast(10, h265IDRAU(), true)
+	hub.Broadcast(15, [][]byte{{0x02}}, false) // P-frame, must not enter cache
+	hub.Broadcast(20, h265IDRAU(), true)
+	hub.Broadcast(30, h265IDRAU(), true) // this should evict PTS=10
+
+	// Subscribe — should receive only the newest complete IDR (PTS=30). The
+	// replay walks newest-first and stops at the first complete one, so even
+	// though the ring holds [20, 30], only 30 is delivered.
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) >= 1
+	}, time.Second, 5*time.Millisecond, "replay should deliver the newest cached IDR")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 1, "only the newest complete IDR is replayed")
+	require.Equal(t, int64(30), received[0].pts)
+
+	// Verify the ring itself evicted the oldest.
+	hub.mu.Lock()
+	ringPTS := make([]int64, len(hub.idrCache))
+	for i, m := range hub.idrCache {
+		ringPTS[i] = m.PTS
+	}
+	hub.mu.Unlock()
+	require.Equal(t, []int64{20, 30}, ringPTS, "ring must hold only the last 2 IDRs")
+}
+
+// TestStreamHub_ReplaySkipsIncompleteIDR confirms the completeness gate: an IDR
+// whose access unit lacks the full parameter set is NOT replayed. We seed the
+// cache with one incomplete IDR followed by one complete IDR and assert only the
+// complete one is replayed.
+func TestStreamHub_ReplaySkipsIncompleteIDR(t *testing.T) {
+	hub := newTestStreamHub(t)
+
+	// Incomplete H.265 IDR: VPS + IDR slice, but NO SPS/PPS.
+	incomplete := [][]byte{{nalH265VPS, 0x01}, {nalH265IDR, 0xBB}}
+	hub.Broadcast(100, incomplete, true)
+	// Complete H.265 IDR.
+	hub.Broadcast(200, h265IDRAU(), true)
+
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) >= 1
+	}, time.Second, 5*time.Millisecond, "complete IDR should be replayed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 1)
+	require.Equal(t, int64(200), received[0].pts, "the incomplete IDR (PTS=100) must be skipped")
+}
+
+// TestStreamHub_NoReplayWhenAllIncomplete confirms that if NO cached IDR has a
+// complete parameter set, nothing is replayed (fall back to legacy behavior).
+func TestStreamHub_NoReplayWhenAllIncomplete(t *testing.T) {
+	hub := newTestStreamHub(t)
+	incomplete := [][]byte{{nalH265VPS, 0x01}, {nalH265IDR, 0xBB}} // no SPS/PPS
+	hub.Broadcast(100, incomplete, true)
+
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, received, "no replay when cached IDR lacks complete param sets")
+}
+
+// TestStreamHub_DisabledIDRCacheNoReplay confirms idrCacheSize=0 disables replay
+// entirely (legacy behavior), even after IDRs are broadcast.
+func TestStreamHub_DisabledIDRCacheNoReplay(t *testing.T) {
+	hub := newTestStreamHub(t)
+	hub.idrCacheSize = 0
+	hub.Broadcast(1000, h265IDRAU(), true)
+
+	var (
+		mu       sync.Mutex
+		received []frameInfo
+	)
+	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+		mu.Lock()
+		received = append(received, frameInfo{pts: pts, au: au})
+		mu.Unlock()
+	}))
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, received, "idrCacheSize=0 disables replay")
+}
+
+// TestStreamHub_ReplayRace exercises concurrent Broadcast (IDR) + Subscribe
+// under the race detector to confirm the cache is lock-safe.
+func TestStreamHub_ReplayRace(t *testing.T) {
+	hub := newTestStreamHub(t)
+	var subs atomic.Int64
+	var wg sync.WaitGroup
+
+	// Producers: continuously broadcast IDRs and P-frames.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				pts := int64(n*1000 + j)
+				if j%5 == 0 {
+					hub.Broadcast(pts, h265IDRAU(), true)
+				} else {
+					hub.Broadcast(pts, [][]byte{{0x02}}, false)
+				}
+			}
+		}(i)
+	}
+
+	// Subscribers: continuously subscribe/unsubscribe.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				id := fmt.Sprintf("r-%d-%d", n, j)
+				cb := func(int64, [][]byte) {
+					subs.Add(1)
+				}
+				_ = hub.Subscribe(id, cb)
+				hub.Unsubscribe(id)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// No data race => race detector passes; subs > 0 confirms callbacks ran.
+	require.Greater(t, subs.Load(), int64(0))
+}

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -427,6 +427,9 @@ function handleWebGpuLost() {
 
         if (msg.type === 'frame' && msg.data instanceof VideoFrame) {
           const frame = msg.data;
+          // Decoder produced output → the stall watchdog's reconnect tally no
+          // longer applies; reset it so a future stall starts fresh.
+          cm?.resetDecodeStallCount();
           // Track canvas dimensions for AI overlay
           if (canvasEl) {
             if (canvasWidth !== frame.displayWidth || canvasHeight !== frame.displayHeight) {
@@ -449,6 +452,7 @@ function handleWebGpuLost() {
           }
         } else if (msg.type === 'wasm-frame' && msg.data) {
           // HTTP H.265 path: raw RGBA from libde265 WASM (no VideoFrame).
+          cm?.resetDecodeStallCount();
           renderWasmFrame(msg.data);
           if (streamState !== 'playing') {
             updateState('playing');
@@ -473,6 +477,15 @@ function handleWebGpuLost() {
           // Decoder configured — resume frame delivery (paused in onCodecInfo).
           if (cm) {
             cm.setPaused(false);
+          }
+        } else if (msg.type === 'decode-stall') {
+          // Decoder configured but produced no output within DECODE_STALL_MS
+          // (long-GOP camera feeding P-frames with no keyframe). Let the
+          // ConnectionManager decide: reconnect (to grab a keyframe on the fresh
+          // stream) or, after repeated stalls, report offline so the orchestrator
+          // demotes to another protocol.
+          if (cm) {
+            cm.handleDecoderStall();
           }
         }
       };

--- a/web/src/lib/webcodecs-player/connection.test.ts
+++ b/web/src/lib/webcodecs-player/connection.test.ts
@@ -1096,3 +1096,64 @@ describe('backpressure', () => {
     expect(cm.frameDropCount).toBe(3);
   });
 });
+
+// ─── decode-stall (decoder configured but producing no output) ─────────────
+//
+// These cover the failure mode the zombie detector can't see: the WS keeps
+// delivering P-frames (so _lastFrameTime stays fresh and the zombie never
+// trips), but the decoder never gets a keyframe and emits nothing. The decoder
+// fires a stall signal; handleDecoderStall reconnects (to catch an IDR on a
+// fresh stream) up to MAX_DECODE_STALL_RECONNECTS times, then reports offline so
+// the orchestrator can demote to another protocol.
+describe('decode-stall', () => {
+  it('handleDecoderStall triggers a reconnect via the coordinator', () => {
+    const coordinator = createMockCoordinator();
+    coordinator.requestReconnect.mockReturnValue(1000);
+    const onStateChange = vi.fn();
+    const cm = createManager({ coordinator, cameraId: 'cam-1', onStateChange });
+    cm.connect();
+
+    cm.handleDecoderStall();
+
+    expect(coordinator.requestReconnect).toHaveBeenCalledWith('cam-1', expect.any(Function));
+  });
+
+  it('reports offline after MAX_DECODE_STALL_RECONNECTS consecutive stalls', () => {
+    const coordinator = createMockCoordinator();
+    coordinator.requestReconnect.mockReturnValue(1000);
+    const onCameraOffline = vi.fn();
+    const onStateChange = vi.fn();
+    const cm = createManager({ coordinator, cameraId: 'cam-1', onStateChange, onCameraOffline });
+    cm.connect();
+
+    // MAX_DECODE_STALL_RECONNECTS = 3: stalls 1..3 each reconnect, the 4th trips
+    // offline.
+    cm.handleDecoderStall(); // stall #1 → reconnect
+    cm.handleDecoderStall(); // stall #2 → reconnect
+    cm.handleDecoderStall(); // stall #3 → reconnect
+    expect(onCameraOffline).not.toHaveBeenCalled();
+
+    cm.handleDecoderStall(); // stall #4 → offline
+    expect(onCameraOffline).toHaveBeenCalledTimes(1);
+    expect(onStateChange).toHaveBeenLastCalledWith('offline');
+  });
+
+  it('resetDecodeStallCount lets the decoder recover between stall stretches', () => {
+    const coordinator = createMockCoordinator();
+    coordinator.requestReconnect.mockReturnValue(1000);
+    const onCameraOffline = vi.fn();
+    const cm = createManager({ coordinator, cameraId: 'cam-1', onCameraOffline });
+    cm.connect();
+
+    // Two stalls, then the decoder produces output → caller resets the tally.
+    cm.handleDecoderStall();
+    cm.handleDecoderStall();
+    cm.resetDecodeStallCount();
+
+    // Now three more stalls should NOT trip offline (tally started fresh).
+    cm.handleDecoderStall();
+    cm.handleDecoderStall();
+    cm.handleDecoderStall();
+    expect(onCameraOffline).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/webcodecs-player/connection.ts
+++ b/web/src/lib/webcodecs-player/connection.ts
@@ -134,6 +134,17 @@ export class ConnectionManager {
   // rejection (never opened) from a post-open drop (zombie/reconnect territory).
   private _socketOpened = false;
 
+  // ─── Decode-stall detection ─────────────────────────────────────────────
+  // Distinct from the zombie detector above: zombie keys on WS frame ARRIVAL
+  // (_lastFrameTime), so it never trips when a long-GOP camera keeps sending
+  // P-frames but the decoder never gets a keyframe and emits nothing. The
+  // decoder itself fires the stall signal (worker 'decode-stall' →
+  // handleDecoderStall). We cap consecutive stall-triggered reconnects just
+  // like zombie reconnects; exceeding the cap reports offline so the orchestrator
+  // can demote to another protocol (e.g. wasm → hls).
+  private _decodeStallReconnectCount = 0;
+  private static readonly MAX_DECODE_STALL_RECONNECTS = 3;
+
   // Backpressure
   private _paused = false;
   private _frameDropCount = 0;
@@ -384,6 +395,43 @@ export class ConnectionManager {
     this._stopCoordinatedTimer();
     this._cancelCoordinatorRequest();
     this._scheduleCoordinatedReconnect();
+  }
+
+  /**
+   * Called when the decoder reports a stall (configured but no output for
+   * DECODE_STALL_MS). This is the failure mode the zombie detector can't see:
+   * the WS keeps delivering P-frames (so _lastFrameTime stays fresh and the
+   * zombie never trips) yet the decoder never receives a keyframe and produces
+   * nothing — UI stuck in "buffering". We reconnect (a fresh stream start is the
+   * best chance to catch an IDR, especially now that the backend replays a
+   * cached IDR to new subscribers) up to MAX_DECODE_STALL_RECONNECTS times;
+   * beyond that we report offline so the orchestrator demotes to another
+   * protocol.
+   */
+  handleDecoderStall(): void {
+    if (this._destroyed) return;
+    this._decodeStallReconnectCount++;
+    if (this._decodeStallReconnectCount > ConnectionManager.MAX_DECODE_STALL_RECONNECTS) {
+      // Exhausted stall-driven reconnects — give up on this protocol so the
+      // orchestrator can demote (e.g. wasm/webcodecs → hls).
+      this._setState('offline');
+      this._opts.onCameraOffline?.();
+      return;
+    }
+    // Reset the zombie cycle cap so this reconnect isn't blocked by the
+    // zombie-reconnect limiter (these are independent failure signals).
+    this._zombieReconnectCount = 0;
+    this.reconnect();
+  }
+
+  /**
+   * Reset the decode-stall reconnect counter. Called when the decoder produces
+   * output (a decoded frame reaches the main thread), proving the pipeline
+   * works — so a future stall starts the reconnect count fresh rather than
+   * building on a stale tally from a previous bad stretch.
+   */
+  resetDecodeStallCount(): void {
+    this._decodeStallReconnectCount = 0;
   }
 
   /** Full cleanup — no further operations possible. */

--- a/web/src/lib/webcodecs-player/decoder.test.ts
+++ b/web/src/lib/webcodecs-player/decoder.test.ts
@@ -22,6 +22,10 @@ interface MockDecoderInstance {
   close: ReturnType<typeof vi.fn>;
   state: string;
   decodeQueueSize: number;
+  // Saved constructor output/error callbacks so tests can simulate decoded
+  // frame delivery (used by the decode-stall watchdog tests).
+  _output?: (frame: any) => void;
+  _error?: (e: Error) => void;
 }
 
 let mockDecoderInstances: MockDecoderInstance[] = [];
@@ -37,6 +41,8 @@ function createMockDecoderClass(): any {
     decodeQueueSize = 0;
 
     constructor(init: { output: (frame: any) => void; error: (e: Error) => void }) {
+      this._output = init.output;
+      this._error = init.error;
       this.configure = vi.fn().mockImplementation(async (config: any) => {
         this.state = 'configured';
       });
@@ -1010,6 +1016,69 @@ describe('Decoder', () => {
       expect(decoder.frameDropCount).toBe(95);
       expect(decoder.pendingDecodeCount).toBe(5);
       expect(() => decoder.close()).not.toThrow();
+    });
+  });
+
+  // ─── Decode-stall watchdog ──────────────────────────────────────────────
+
+  describe('decode-stall watchdog', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('fires onStall when configured but no output arrives within DECODE_STALL_MS', async () => {
+      const decoder = new Decoder();
+      const onStall = vi.fn();
+      decoder.onStall(onStall);
+      await decoder.configure(makeH265CodecInfo());
+
+      // No output delivered — advance past the stall window.
+      vi.advanceTimersByTime(16000);
+
+      expect(onStall).toHaveBeenCalledTimes(1);
+      decoder.close();
+    });
+
+    it('does NOT fire onStall when a decoded frame arrives in time', async () => {
+      const decoder = new Decoder();
+      const onStall = vi.fn();
+      decoder.onStall(onStall);
+      await decoder.configure(makeH265CodecInfo());
+
+      // Simulate the decoder producing output by invoking the captured output
+      // callback before the stall window elapses.
+      const inst = mockDecoderInstances.at(-1)!;
+      inst._output!({ close() {}, displayWidth: 16, displayHeight: 16, timestamp: 0 } as any);
+
+      vi.advanceTimersByTime(16000);
+      expect(onStall).not.toHaveBeenCalled();
+      decoder.close();
+    });
+
+    it('does not arm the stall timer when no onStall listener is registered', async () => {
+      const decoder = new Decoder();
+      // No decoder.onStall(...) call — the timer should be skipped entirely.
+      await decoder.configure(makeH265CodecInfo());
+
+      // If a timer were armed, advancing time must not throw (there's no
+      // listener to call). The real assertion is that close() cleans up without
+      // a pending-timer fire causing issues.
+      expect(() => vi.advanceTimersByTime(16000)).not.toThrow();
+      decoder.close();
+    });
+
+    it('cancels the stall timer on close', async () => {
+      const decoder = new Decoder();
+      const onStall = vi.fn();
+      decoder.onStall(onStall);
+      await decoder.configure(makeH265CodecInfo());
+      decoder.close();
+
+      vi.advanceTimersByTime(16000);
+      expect(onStall).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/lib/webcodecs-player/decoder.ts
+++ b/web/src/lib/webcodecs-player/decoder.ts
@@ -23,6 +23,15 @@ const FALLBACK_H264_CODEC = 'avc1.42001E'; // Baseline L3.0
 const FALLBACK_H265_CODEC = 'hvc1.1.6.L93.B0'; // Main L3.1
 const BACKPRESSURE_THRESHOLD = 5;
 
+// DECODE_STALL_MS: if the decoder is configured but produces zero output frames
+// within this many milliseconds, it is "stalled" and the onStall callback fires.
+// This catches the long-GOP failure mode where the WS keeps delivering P-frames
+// (so the connection-layer zombie detector, which keys on frame ARRIVAL, never
+// trips) but the decoder never gets a keyframe and emits nothing — leaving the
+// UI stuck in "buffering" forever. 15s comfortably exceeds one 8s GOP plus init
+// latency, so it won't false-fire on slow-starting streams.
+const DECODE_STALL_MS = 15000;
+
 // ─── Codec string builders ────────────────────────────────────────────────
 
 /**
@@ -150,6 +159,18 @@ export class Decoder {
   private _backpressureCallback: ((paused: boolean) => void) | null = null;
   private _decoderEpoch = 0;
 
+  // ─── Decode-stall detection ─────────────────────────────────────────────
+  // _configuredAt stamps when configure() last succeeded with no output yet;
+  // _lastOutputAt stamps the last decoded frame. _outputCount tracks total
+  // outputs so we can tell "never produced anything" (the dangerous case) from
+  // "produced then went quiet" (recoverable). _stallTimer arms after configure
+  // and fires onStall if no output arrives within DECODE_STALL_MS.
+  private _configuredAt = 0;
+  private _lastOutputAt = 0;
+  private _outputCount = 0;
+  private _stallTimer: ReturnType<typeof setTimeout> | null = null;
+  private _onStallCallback: (() => void) | null = null;
+
   /**
    * Configure the decoder with codec info.
    *
@@ -204,6 +225,9 @@ export class Decoder {
   reset(): void {
     if (this._closed) return;
 
+    // Cancel any pending stall watchdog; a re-configure will re-arm it.
+    this._clearStallTimer();
+
     // Reset WASM decoder
     if (this._wasmDecoder) {
       this._wasmDecoder.reset();
@@ -247,6 +271,7 @@ export class Decoder {
     this._closed = true;
     this._configured = false;
     this._mode = null;
+    this._clearStallTimer();
 
     if (this._decoder) {
       try {
@@ -360,6 +385,7 @@ export class Decoder {
     this._configured = true;
     this._lastCodecInfo = ci;
     this._errorCount = 0;
+    this._armStallTimer();
   }
 
   /** Configure WASM H.265 fallback decoder. */
@@ -369,6 +395,50 @@ export class Decoder {
     this._configured = true;
     this._lastCodecInfo = ci;
     this._errorCount = 0;
+    this._armStallTimer();
+  }
+
+  // ─── Decode-stall watchdog ──────────────────────────────────────────────
+
+  /**
+   * Arm the stall timer after a successful configure. If no decoded frame
+   * arrives within DECODE_STALL_MS, fire onStall so the caller (worker → main →
+   * ConnectionManager) can reconnect or demote. Re-armable: each configure and
+   * each output cancels and reschedules.
+   */
+  private _armStallTimer(): void {
+    this._clearStallTimer();
+    this._configuredAt = performance.now();
+    if (this._onStallCallback === null) return; // no listener — skip the timer
+    this._stallTimer = setTimeout(() => {
+      this._stallTimer = null;
+      // Only fire if STILL no output since this configure (output cancels the
+      // timer, but guard against a race where output arrived just as the timer
+      // elapsed).
+      if (this._outputCount === 0 || this._lastOutputAt < this._configuredAt) {
+        try {
+          this._onStallCallback?.();
+        } catch {
+          /* listener threw — ignore */
+        }
+      }
+    }, DECODE_STALL_MS);
+  }
+
+  /** Cancel any pending stall timer. */
+  private _clearStallTimer(): void {
+    if (this._stallTimer !== null) {
+      clearTimeout(this._stallTimer);
+      this._stallTimer = null;
+    }
+  }
+
+  /**
+   * Register the stall callback. Pass null to disable. Must be set BEFORE
+   * configure to observe the first stall window.
+   */
+  onStall(cb: (() => void) | null): void {
+    this._onStallCallback = cb;
   }
 
   /** Decode via WebCodecs. */
@@ -467,6 +537,15 @@ export class Decoder {
       }
       return;
     }
+
+    // Record that the decoder produced output. This is the single chokepoint
+    // for decoded frames (both WebCodecs and WASM paths funnel through it), so
+    // stamping here lets the stall watchdog distinguish "WS alive, decoder
+    // silent" from "decoder working". Cancel the pending stall timer: any
+    // output proves the pipeline is functioning.
+    this._lastOutputAt = performance.now();
+    this._outputCount++;
+    this._clearStallTimer();
 
     this._pendingDecodeCount--;
 

--- a/web/src/lib/webcodecs-player/worker.ts
+++ b/web/src/lib/webcodecs-player/worker.ts
@@ -133,6 +133,15 @@ async function handleCodecInfo(data: {
     self.postMessage({ type: 'backpressure', paused });
   });
 
+  // Set stall callback — decoder is configured but produced no output for
+  // DECODE_STALL_MS (e.g. long-GOP camera where P-frames keep arriving but no
+  // keyframe ever reaches the decoder). Forward to main thread so the
+  // ConnectionManager can reconnect (hoping to catch a keyframe on the fresh
+  // stream) or demote to another protocol.
+  decoder.onStall(() => {
+    self.postMessage({ type: 'decode-stall' });
+  });
+
   try {
     await decoder.configure({
       codec: data.codec as any,


### PR DESCRIPTION
## 问题

长 GOP 摄像头(实测一台 IPCAM-HI,IDR 间隔 **8 秒**,而正常摄像头 2 秒)的实时预览会**永久卡在"缓冲中"**,且只有重启 NVR 才恢复。

## 根因(已定位)

两层缺陷叠加:

1. **后端 StreamHub 不缓存 IDR**:`Subscribe` 只注册消费者 channel,不重放任何关键帧。新订阅者必须苦等到下一个自然 IDR(最坏 8 秒);若连接时序没赶上 IDR 内联的参数集,前端永久拿不到关键帧。
2. **前端 zombie 检测的盲区**:`connection.ts` 的 zombie 检测在 **WS 原始消息到达**时刷新 `_lastFrameTime`。长 GOP 摄像头的 P 帧源源不断 → zombie 永不触发,且 `_everReceivedFrame=true` 还废掉了挂钟守卫 `NO_MEDIA_TOTAL_MS`。于是"WS 活着、帧在来、但解码器无输出"的状态永远不自愈。

## 修复(双层防御)

### 后端:StreamHub IDR fast-start(治本)
- StreamHub 缓存最近 N(默认 3)个 IDR access unit。`distributeFrame` 在 `h.mu` 下深拷贝每个 IDR AU 进 ring。
- `Subscribe` 把**最新的、参数集完整的**缓存 IDR 重放进新消费者 channel(经 `nalutil.HasCompleteParamSets` 校验:H.265 需 VPS+SPS+PPS,H.264 需 SPS+PPS),让新订阅者立即开始解码。
- 所有消费者(WS/HLS/FLV)受益 —— 它们都需要关键帧启动。
- `idrCacheSize=0` 可禁用(回退到旧行为)。

### 前端:解码停滞看门狗(纵深防御)
- Decoder 在 configure 后 arm 一个 15 秒(`DECODE_STALL_MS`)计时器;若零解码帧产出(`handleOutput` 是唯一输出汇点),触发 `onStall`。
- worker 转发 `decode-stall`;WasmPlayer 路由到 ConnectionManager。
- `ConnectionManager.handleDecoderStall` 重连(此时后端 fast-start 会给 IDR)最多 3 次,超限上报 `offline` 让编排器降级到下一协议。`resetDecodeStallCount` 在任何解码输出时触发,避免残留旧计数。
- 区别于 zombie:zombie = WS 帧到达;stall = 解码器实际输出。长 GOP 场景 zombie 一直被喂、解码器沉默,只有新看门狗能看到。

## 测试
- **后端**:`internal/model` 包新增 9 个 IDR replay/ring/empty/validate/race 测试,`go test -race ./internal/model/...` 全绿(现有 1100 行测试无需调整)。
- **前端**:decoder 新增 4 个 stall 测试,connection 新增 3 个,`npm run build` 成功 + 全量 514 vitest 绿。

## 不在范围
- 不改摄像头 GOP(NVR 应自身防御各种摄像头)。
- 不动 WebRTC(它本就只支持 H.264,独立限制)。
- 不改 recorder 编码探测(已确认正确 trust the stream)。

## 说明
- 这是纯 NVR 前后端播放修复,核心数据来自对一台 8 秒 GOP 摄像头的实测排查(IDR 间隔 ffprobe 实测、StreamHub 源码审查、前端 zombie 逻辑追踪)。
- 后端改动是 StreamHub 核心路径,但持锁时序分析确认无竞态(Subscribe 全程持 `h.mu`,distributeFrame 也需 `h.mu`);N=3 缓存内存可忽略。