### PR TITLE
fix(wsstream): 序列化所有 conn 写入 — 修复关闭路径 "concurrent write" panic

### DIFF
--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -202,15 +202,55 @@ func (m *Manager) UnregisterStream(camID string) {
 	entry.viewerMu.Lock()
 	eosMsg := []byte{byte(MsgTypeEOS)}
 	for _, v := range entry.viewers {
-		// Send EOS to viewer before closing
-		_ = v.conn.WriteMessage(websocket.BinaryMessage, eosMsg)
+		// Signal EOS by enqueuing it onto the viewer's channel (best-effort,
+		// non-blocking) rather than writing conn directly. Writing conn here would
+		// race the ServeWS frame-loop writer on the same conn — gorilla/websocket
+		// requires all writes to a conn to be serialized, and the frame loop is the
+		// single designated writer. The frame loop drains remaining channel
+		// messages (including this EOS) on its way out via viewerCtx cancellation.
+		// We do NOT close v.ch: a close would race distributeVideoFrame's
+		// `case v.ch <-` send (send-on-closed-channel panic). The channel is GC'd
+		// once the ServeWS goroutine exits and drops its reference.
+		sendNonBlocking(v.ch, eosMsg)
 		v.cancel()
-		close(v.ch)
 	}
 	entry.viewerMu.Unlock()
 	wsLogger.Load().Info("WebSocket stream unregistered", "camera_id", camID)
 	if cnt := entry.dropCount.Load(); cnt > 0 {
 		wsLogger.Load().Info("stream drop count", "camera_id", camID, "total_drops", cnt)
+	}
+}
+
+// sendNonBlocking attempts a non-blocking send of msg onto ch. If ch is full or
+// closed, the send is skipped (best-effort). This is the safe way to deliver
+// out-of-band messages (EOS, idle-timeout) to a viewer's writer goroutine
+// without risking a panic on a closed channel or a blocked sender.
+func sendNonBlocking(ch chan []byte, msg []byte) {
+	select {
+	case ch <- msg:
+	default:
+	}
+}
+
+// drainViewerCh flushes any pending messages buffered in ch by writing them to
+// conn via the single-writer discipline (the caller IS the single writer). Used
+// on viewer shutdown so an EOS enqueued by the idle watchdog or
+// UnregisterStream is actually emitted before the conn closes, rather than
+// being dropped when the ctx cancels. Non-blocking: stops as soon as the
+// channel is empty or a write fails. A failed write is expected on shutdown.
+func drainViewerCh(ch chan []byte, conn *websocket.Conn) {
+	for {
+		select {
+		case data, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
+				return
+			}
+		default:
+			return
+		}
 	}
 }
 
@@ -583,8 +623,11 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 
-	// Start idle watchdog
-	lastActivity := time.Now()
+	// Start idle watchdog. lastActivity is read here (watchdog goroutine) and
+	// written by the frame loop below (ServeWS goroutine) — use atomic to avoid
+	// a data race under -race. Stored as unix nanoseconds.
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
 	idleTicker := time.NewTicker(m.idleTimeout / 2)
 	defer idleTicker.Stop()
 	go func() {
@@ -593,9 +636,14 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 			case <-viewerCtx.Done():
 				return
 			case <-idleTicker.C:
-				if time.Since(lastActivity) > m.idleTimeout {
-					// Send EOS before closing so frontend can show offline status
-					_ = conn.WriteMessage(websocket.BinaryMessage, []byte{byte(MsgTypeEOS)})
+				last := time.Unix(0, lastActivity.Load())
+				if time.Since(last) > m.idleTimeout {
+					// Signal EOS via the channel (the frame loop is the single
+					// writer to conn) — do NOT write conn here, that races the
+					// frame loop. The frame loop's ctx-done drain will emit it.
+					// Best-effort: if the channel is full, skip (the cancel below
+					// still closes the viewer).
+					sendNonBlocking(viewerCh, []byte{byte(MsgTypeEOS)})
 					viewerCancel()
 					return
 				}
@@ -603,16 +651,25 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 		}
 	}()
 
-	// Write frames to WebSocket until disconnect
+	// Write frames to WebSocket until disconnect. This goroutine is the SOLE
+	// writer to conn (codec-info preamble above + this loop). Out-of-band
+	// signals (EOS from idle watchdog or UnregisterStream) are enqueued onto
+	// viewerCh and emitted here, never written directly — gorilla/websocket
+	// requires all conn writes to be serialized.
 	for {
 		select {
 		case <-viewerCtx.Done():
+			// Drain any pending messages (e.g. an EOS enqueued by the idle
+			// watchdog or UnregisterStream) before returning, so they are emitted
+			// by this single writer rather than lost. A write failure here is
+			// expected on shutdown and is ignored.
+			drainViewerCh(viewerCh, conn)
 			return nil
 		case data, ok := <-viewerCh:
 			if !ok {
 				return nil // channel closed
 			}
-			lastActivity = time.Now()
+			lastActivity.Store(time.Now().UnixNano())
 			if err := conn.WriteMessage(websocket.BinaryMessage, data); err != nil {
 				if !strings.Contains(err.Error(), "use of closed") {
 					wsLogger.Load().Warn("WebSocket write error", "camera_id", camID, "viewer_id", viewerID, "error", err)

--- a/internal/wsstream/manager_test.go
+++ b/internal/wsstream/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -850,6 +851,153 @@ func TestManagerInterface(t *testing.T) {
 }
 
 // Benchmark writing frames through the manager.
+// ─── concurrent-write regression tests (#248) ────────────────────────────
+//
+// gorilla/websocket requires all writes to a single conn to be serialized.
+// Before the fix, UnregisterStream and the idle watchdog wrote EOS directly
+// to conn, racing the ServeWS frame-loop writer → panic "concurrent write to
+// websocket connection" (gorilla's internal check, also caught by -race).
+// These tests exercise the race: stream frames concurrently while triggering
+// each EOS path, and assert no panic + clean shutdown.
+
+// TestServeWS_NoConcurrentWriteOnUnregister streams frames while calling
+// UnregisterStream mid-flight. Under the old code this panicked; now the EOS
+// is enqueued onto the viewer channel and emitted by the single writer.
+func TestServeWS_NoConcurrentWriteOnUnregister(t *testing.T) {
+	m := NewManager()
+	hub := newTestHub(t)
+	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	conn := dialWS(t, wsURL)
+	defer conn.Close()
+
+	// CodecInfo handshake
+	_, err := readMessage(t, conn)
+	require.NoError(t, err)
+	waitForViewer(t, m, "cam1")
+
+	// Stream frames continuously in the background while we unregister.
+	idrNALU := []byte{0x65, 0x01, 0x02, 0x03}
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := int64(0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				broadcastFrame(t, hub, 90000*i, [][]byte{idrNALU})
+				i++
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+	// Let a few frames flow so the frame-loop writer is actively writing.
+	time.Sleep(20 * time.Millisecond)
+
+	// UnregisterStream must not panic (previously: concurrent write to conn).
+	m.UnregisterStream("cam1")
+
+	close(stop)
+	wg.Wait()
+
+	// Viewer is torn down.
+	eventually(t, func() bool { return m.viewerCount("cam1") == 0 }, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestServeWS_EOSDeliveredBeforeClose confirms the drain logic: after
+// UnregisterStream, the client receives the EOS message (0xFF) before the
+// connection closes. This proves the EOS enqueued via the channel actually
+// reaches the wire (single writer drains on ctx-done exit).
+func TestServeWS_EOSDeliveredBeforeClose(t *testing.T) {
+	m := NewManager()
+	hub := newTestHub(t)
+	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	conn := dialWS(t, wsURL)
+	defer conn.Close()
+
+	_, err := readMessage(t, conn) // CodecInfo
+	require.NoError(t, err)
+	waitForViewer(t, m, "cam1")
+
+	m.UnregisterStream("cam1")
+
+	// Read until we see EOS (0xFF) or the conn closes. A short deadline bounds
+	// the wait; the drain should deliver EOS promptly after the ctx cancels.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	gotEOS := false
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break // conn closed
+		}
+		if len(msg) > 0 && msg[0] == MsgTypeEOS {
+			gotEOS = true
+			break
+		}
+	}
+	assert.True(t, gotEOS, "client should receive EOS (0xFF) before conn closes")
+}
+
+// TestServeWS_NoConcurrentWriteOnIdle forces the idle watchdog to fire (no
+// frames → idle timeout) and asserts the EOS path via the channel does not
+// race the writer. Uses a tiny idle timeout to trigger it quickly.
+func TestServeWS_NoConcurrentWriteOnIdle(t *testing.T) {
+	m := NewManager(WithIdleTimeout(80 * time.Millisecond))
+	hub := newTestHub(t)
+	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/"
+	conn := dialWS(t, wsURL)
+	defer conn.Close()
+
+	_, err := readMessage(t, conn) // CodecInfo
+	require.NoError(t, err)
+	waitForViewer(t, m, "cam1")
+
+	// Don't stream any frames — let the idle watchdog fire. It enqueues EOS via
+	// the channel (not a direct write) and cancels the viewer. No panic should
+	// occur; the client should receive EOS then close.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	gotEOS := false
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		if len(msg) > 0 && msg[0] == MsgTypeEOS {
+			gotEOS = true
+			break
+		}
+	}
+	assert.True(t, gotEOS, "idle watchdog should deliver EOS via the channel")
+	eventually(t, func() bool { return m.viewerCount("cam1") == 0 }, 2*time.Second, 10*time.Millisecond)
+}
+
 func BenchmarkWriteFrame(b *testing.B) {
 	m := NewManager(WithWriteBufSize(100))
 	hub := model.NewStreamHub()


### PR DESCRIPTION
Closes #248.

## 问题

`systemctl restart` / `StopAll` 等进程关闭路径偶发 panic:
```
panic: concurrent write to websocket connection
  gorilla/websocket conn.go:617
  wsstream.UnregisterStream manager.go:206
  wsstream.StopAll → App.Stop → main.main
```

服务随即被 systemd 重启,运行时不触发,平时不易察觉。

## 根因

gorilla/websocket 要求同一 `*websocket.Conn` 的所有写串行。`internal/wsstream` 有 5 个写点,设计意图是 ServeWS 帧循环(viewer.ch 的唯一读者)作为唯一写者,但 **2 个写点绕过 channel 直接写 conn**:
- **空闲看门狗**:idle 超时直接写 EOS 到 conn
- **UnregisterStream**:对每个 viewer 直接写 EOS,然后 `close(v.ch)`

两者与帧循环写者并发 → 关闭路径 panic。该 panic 长期潜伏(时序难撞),但 #218 的 IDR replay 增大了关闭时帧写进行中的概率,使其在部署/重启时稳定复现。

## 修复

所有对 viewer conn 的写都经 `viewer.ch`,由 ServeWS 帧循环唯一写出(复用已有的串行化基础设施,不引入新锁):

1. **UnregisterStream**:EOS 非阻塞投递到 `v.ch`,然后 cancel。**不再 `close(v.ch)`**(消除 distributeVideoFrame 的 send-on-closed panic;channel 由 GC 回收)。
2. **空闲看门狗**:EOS 非阻塞投递到 `viewerCh`,然后 cancel。
3. **帧循环退出 drain**:`viewerCtx.Done` 时先非阻塞排空 `viewerCh`(把残余含 EOS 写出)再返回,确保 EOS 送达。
4. **`lastActivity` 数据竞争**(顺带):裸 `time.Time`(帧循环写、看门狗读,-race 必报)→ `atomic.Int64`(unix nano)。

新增 `sendNonBlocking` / `drainViewerCh` 辅助让纪律显式。

## 测试
- `TestServeWS_NoConcurrentWriteOnUnregister`:帧流活跃时调 UnregisterStream,断言无 panic(修复前会 panic)+ viewer 归 0
- `TestServeWS_EOSDeliveredBeforeClose`:断言客户端在 conn close 前收到 EOS(0xFF)— drain 生效
- `TestServeWS_NoConcurrentWriteOnIdle`:触发空闲看门狗,断言 EOS 经 channel 送达

`go test -race ./internal/wsstream/...` 通过,`go vet` 干净。

## 不一并修 #230
#230 是 `internal/hls` 的 `m.mu ↔ entry.mu` 锁周期——不同包、不同根因(锁周期 vs 并发写)。保持独立 P2 issue 单独处理。

## 验证计划
- CI(build/lint/test)绿
- M5 部署后重启服务(此前 PR#218 部署时该 panic 稳定复现),确认不再 panic