### PR TITLE
fix(deps): bump undici to 7.29.0 — 关闭 5 个 Dependabot 安全告警 (#24-#28)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3309,9 +3309,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmmirror.com/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
   },
   "overrides": {
     "js-yaml": "^4.2.0",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "protobufjs": "^7.6.5"
   }
 }


### PR DESCRIPTION
## 问题

仓库当前有 **5 个 open 的 Dependabot 安全告警 (#24–#28)**,全部来自同一个传递依赖 **`undici`**(npm),且全部落在同一受影响版本区间 `>=7.0.0, <7.29.0` —— 升一个版本即可一次解决全部。

| # | 等级 | CVE | 简述 |
|---|------|-----|------|
| #25 | 🔴 high | CVE-2026-13697 | 畸形 private cache 指令致跨用户信息泄露 + 解析崩溃 |
| #24 | 🟡 medium | CVE-2026-16728 | retry interceptor 致下游响应去同步 |
| #26 | 🟡 medium | CVE-2026-16729 | 未消毒 domain + 未解析 setCookie 致 cookie 属性注入 |
| #27 | 🟡 medium | CVE-2026-14643 | Cache-Control 空白符致跨用户信息泄露 |
| #28 | 🟡 medium | CVE-2026-15157 | blob-like body 'type' 属性 CRLF 注入 |

## 风险评估

实际风险远低于标签所暗示的等级:

- `undici` 经 **`jsdom`** 引入,而 `jsdom` 是 **devDependency**,仅用于前端单元测试(`decoder.test.ts` / `renderer.test.ts` / `dispatch.ts`)。
- **不进生产 SPA bundle,不随 NVR Go 二进制发布**,攻击面仅限本机测试环境。
- 因此 1 个 "high" 在该上下文里实际接近 medium。

## 修复

- `web/package.json`: `overrides.undici` floor `^7.28.0` → `^7.29.0`
- 刷新 `web/package-lock.json` → 拉取 `undici@7.29.0`

## 验证

- ✅ `npm run test` —— **28 files / 514 tests 全绿**(无回归)
- ✅ `npm audit`(对官方 registry)—— **undici 已从告警列表消失**
- ✅ undici 7.29.0 的 integrity 哈希与官方 `registry.npmjs.org` 一致

## 后续

合并后这 5 个告警会自动转为 `fixed`(无需手动 dismiss)。

> **注意(非本次范围):** `npm audit` 另发现 `brace-expansion`(high,经 eslint)与 `postcss`(moderate,经 vite)各 1 个 —— 二者同样是 dev-only 依赖链。Dependabot 目前尚未就这两个开告警,留待后续单独处理。

## 关联

沿用团队既有惯例(独立 deps PR,不绑 feature issue):PR #47、PR #100。