### PR TITLE
fix(deps): bump brace-expansion@5.0.9 + postcss@8.5.25 — 关闭 2 个 dev-only 安全漏洞

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1611,16 +1611,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {
@@ -2909,9 +2909,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## 问题

`npm audit`(对官方 registry)发现 2 个 dev 依赖链漏洞,均为 semver-compatible 升级(无需 override):

| 包 | 等级 | 引入链 | Advisory |
|----|------|--------|----------|
| `brace-expansion` 5.0.7 → **5.0.9** | 🔴 high | eslint → minimatch | GHSA-mh99-v99m-4gvg (DoS — unbounded expansion length 致 OOM)、GHSA-rgw5-rvv9-x895 (绕过 CVE-2026-14257 缓解) |
| `postcss` 8.5.22 → **8.5.25** | 🟡 moderate | vite | GHSA-fxqj-rqcc-2cmp (GHSA-6g55-p6wh-862q 不完整修复 — attacker-controlled sourceMappingURL 在 `from` 未设置时读任意 .map 文件) |

## 风险评估

两者均经 **devDependency** 链引入(eslint / vite),仅用于本地 lint + 构建,**不进生产 SPA bundle,不随 NVR Go 二进制发布**。

## 修复

`npm update brace-expansion postcss` 刷新 `package-lock.json`(7 行变更,仅这 2 个包)。

## 验证

- ✅ `npm run test` —— **28 files / 514 tests 全绿**
- ✅ `npm audit` —— brace-expansion 与 postcss 已从告警列表消失

## 与 #251 的关系

本 PR **不含 undici 改动**(仍 7.28.0,留给 #251 升到 7.29.0)。两个 PR 互不依赖,合入顺序任意。