### PR TITLE
fix(onvif,test): stub Discover in handler tests — unblock CI (#221)

### DIFF
--- a/internal/api/handlers_timelapse_test.go
+++ b/internal/api/handlers_timelapse_test.go
@@ -631,6 +631,7 @@ func TestTimelapseMerge_DurationAccepted(t *testing.T) {
 	}
 
 	h := NewHandler(db, store, noopAuthMW(), cfg, nil, nil, "", nil, nil, nil)
+	defer h.Close() // join merge goroutine before TempDir cleanup (#152, flake #221)
 
 	rr := doRequest(t, h.Routes(), "POST", "/api/timelapse/cam-1/merge?duration=8h&date=2026-06-06", nil, "", "")
 	if rr.Code != http.StatusAccepted {

--- a/internal/api/onvif_test.go
+++ b/internal/api/onvif_test.go
@@ -1,17 +1,34 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/stretchr/testify/require"
 )
 
+// stubDiscoverEmpty makes onvif.Discover deterministic for tests by returning
+// an empty device list without performing real UDP multicast WS-Discovery,
+// which is network-dependent (issue #221: a CI runner sharing a LAN with a
+// real ONVIF camera caused the old "len(devices)==0" assertion to fail). The
+// restore func is returned for the caller to defer.
+func stubDiscoverEmpty(t *testing.T) {
+	t.Helper()
+	restore := onvif.SetDiscoverFuncForTest(func(ctx context.Context, timeout time.Duration, enrich bool) *onvif.DiscoveryResult {
+		return &onvif.DiscoveryResult{Devices: []onvif.DiscoveredDevice{}}
+	})
+	t.Cleanup(restore)
+}
+
 func TestONVIFDiscoverEndpoint(t *testing.T) {
 	t.Parallel()
+	stubDiscoverEmpty(t)
 	h := TestHandler(nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/onvif/discover", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -19,7 +36,7 @@ func TestONVIFDiscoverEndpoint(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 
-	// Discovery now works — returns 200 with empty devices list
+	// Discovery is stubbed — returns 200 with an empty devices list.
 	require.Equal(t, http.StatusOK, w.Code)
 
 	var resp map[string]interface{}
@@ -27,11 +44,12 @@ func TestONVIFDiscoverEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	devices, ok := resp["devices"].([]interface{})
 	require.True(t, ok, "response should have 'devices' field")
-	require.Equal(t, 0, len(devices), "no ONVIF devices in test environment")
+	require.Equal(t, 0, len(devices), "stubbed discovery returns no devices")
 }
 
 func TestONVIFDiscoverDefaultTimeout(t *testing.T) {
 	t.Parallel()
+	stubDiscoverEmpty(t)
 	h := TestHandler(nil, nil)
 	body := `{}`
 	req := httptest.NewRequest(http.MethodPost, "/api/onvif/discover", strings.NewReader(body))
@@ -40,7 +58,7 @@ func TestONVIFDiscoverDefaultTimeout(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 
-	// Discovery succeeds — returns 200 with empty devices
+	// Discovery is stubbed — returns 200 with empty devices.
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -64,6 +82,7 @@ func TestONVIFDiscoverTimeoutTooLarge(t *testing.T) {
 
 func TestONVIFDiscoverNegativeTimeout(t *testing.T) {
 	t.Parallel()
+	stubDiscoverEmpty(t)
 	h := TestHandler(nil, nil)
 	body := `{"timeout": -1}`
 	req := httptest.NewRequest(http.MethodPost, "/api/onvif/discover", strings.NewReader(body))
@@ -72,7 +91,7 @@ func TestONVIFDiscoverNegativeTimeout(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 
-	// Negative timeout defaults to 5s, discovery runs and returns
+	// Negative timeout defaults to 5s; with discovery stubbed it returns 200.
 	require.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/internal/onvif/discovery.go
+++ b/internal/onvif/discovery.go
@@ -76,6 +76,36 @@ type deviceInfoEnvelope struct {
 	} `xml:"Body"`
 }
 
+// discoverFunc is the backing implementation of Discover / DiscoverNoEnrich.
+// It is a package-level variable so that tests in this module can stub it out
+// (set discoverFunc = ...) to avoid the real UDP multicast WS-Discovery, which
+// is network-dependent and non-deterministic in CI sandboxes (issue #221:
+// TestONVIFDiscoverEndpoint assumed "no devices on the network" and asserted
+// len(devices)==0, which failed when a CI runner shared a LAN with a real ONVIF
+// camera). Production code must never reassign this; only test code does.
+var discoverFunc = discover
+
+// SetDiscoverFuncForTest replaces the discovery implementation for the
+// duration of a test. Pass nil to restore the default (real WS-Discovery). It
+// exists so callers in other packages (e.g. internal/api handler tests) can
+// make the /api/onvif/discover endpoint deterministic without performing real
+// network multicast. The returned restore func MUST be deferred by the caller.
+//
+// Usage:
+//
+//	restore := onvif.SetDiscoverFuncForTest(func(ctx context.Context, timeout time.Duration, enrich bool) *onvif.DiscoveryResult {
+//	    return &onvif.DiscoveryResult{Devices: []onvif.DiscoveredDevice{}}
+//	})
+//	defer restore()
+func SetDiscoverFuncForTest(fn func(ctx context.Context, timeout time.Duration, enrich bool) *DiscoveryResult) (restore func()) {
+	prev := discoverFunc
+	if fn == nil {
+		fn = discover
+	}
+	discoverFunc = fn
+	return func() { discoverFunc = prev }
+}
+
 // Discover performs WS-Discovery to find ONVIF devices on the local network
 // via UDP multicast, then enriches each device with GetDeviceInformation.
 // The enrichment runs in parallel and does not require authentication.
@@ -88,7 +118,7 @@ type deviceInfoEnvelope struct {
 // Adder.HandleDiscovered) should use DiscoverNoEnrich to avoid a redundant
 // GetDeviceInformation round-trip per device (issue #161).
 func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
-	return discover(ctx, timeout, true)
+	return discoverFunc(ctx, timeout, true)
 }
 
 // DiscoverNoEnrich is the same as Discover but WITHOUT the internal
@@ -100,7 +130,7 @@ func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
 // The returned devices have Endpoint/XAddrs/Scopes populated but
 // Manufacturer/Model/Firmware/Serial empty (filled in later by the caller).
 func DiscoverNoEnrich(ctx context.Context, timeout time.Duration) *DiscoveryResult {
-	return discover(ctx, timeout, false)
+	return discoverFunc(ctx, timeout, false)
 }
 
 // discover is the shared core of Discover / DiscoverNoEnrich. When enrich is


### PR DESCRIPTION
## 问题 (#221)

`TestONVIFDiscoverEndpoint` / `DiscoverDefaultTimeout` / `DiscoverNegativeTimeout` 调用真实的 `onvif.Discover`(UDP 多播 WS-Discovery)并断言 `len(devices)==0`。这是**环境耦合**的假设 —— 当 CI runner 所在网段恰好有真实 ONVIF 摄像头时,discover 真的会找到设备,导致:

```
expected 0 got 1
```

这阻塞了 `main` 的唯一必需状态检查(CI),**任何 PR 都无法合并**。

## 修复

**1. ONVIF 测试注入接缝(主修复)**
- `internal/onvif/discovery.go`:抽出包级变量 `discoverFunc`(默认指向真正的 `discover`),`Discover`/`DiscoverNoEnrich` 经它转发。新增导出的 `SetDiscoverFuncForTest(fn) → restore func` 供跨包测试注入桩。生产行为零变化;所有现有 caller 签名不变。
- `internal/api/onvif_test.go`:新增 `stubDiscoverEmpty(t)` helper(用 `t.Cleanup` 自动恢复),在 3 个执行真实发现的测试里注入返回空设备列表的桩,使断言**确定性成立**。

**2. 顺带修一个 CI flake(否则本 PR 自己也被 flake 阻塞)**

调试中发现:`#253` 自己的 CI 也失败,但失败的不是 ONVIF 测试,而是:
```
--- FAIL: TestTimelapseMerge_DurationAccepted (0.08s)
    TempDir RemoveAll cleanup: unlinkat ...: directory not empty
```
该测试 POST merge → spawn 后台 merge goroutine(`mergeWg`),但**漏了 `defer h.Close()`** —— 与本文件其它 ~40 个同类测试(均有 `defer h.Close() // #152`)不一致。补上后,VM 验证 `-race -count=10` 全绿。这是阻塞**所有** PR 的同一道 CI 门,顺带解掉。

## 验证

- ✅ CI 三项全绿:`test` 6m17s pass、`build` pass、`lint` pass
- ✅ Docker VM:`go test -race -count=10 TestTimelapseMerge_DurationAccepted` 全绿
- ✅ `go build`/`go vet`/`gofmt` 干净
- ✅ 生产 caller 审计:`onvif.Discover`/`DiscoverNoEnrich` 出现 3 处,均不受影响

## 验收 (#221)

- [x] ONVIF 测试经桩后确定性(不再依赖网络)
- [x] 生产代码未改语义
- [x] CI 门禁解锁(含顺带修的 timelapse flake)

Closes #221