### PR TITLE
fix(event): guard unbuffered-channel drain + non-blocking send (#220)

### DIFF
--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -158,11 +158,24 @@ func (b *EventBus) Publish(ctx context.Context, topic string, data any) {
 			s.mu.Unlock()
 			continue
 		}
-		// Ring-buffer overflow: if channel full, drain one (oldest) then send.
-		if len(s.ch) == cap(s.ch) {
-			<-s.ch // drop oldest
+		// Ring-buffer overflow: if the buffered channel is full, drain the
+		// oldest event to make room. cap>0 guard: on an unbuffered channel
+		// (cap==0) len==cap is 0==0 and the drain would block forever on the
+		// empty channel while holding s.mu, deadlocking the whole bus (#220).
+		if cap(s.ch) > 0 && len(s.ch) == cap(s.ch) {
+			select {
+			case <-s.ch: // drop oldest
+			default: // lost a race with another sender's drain; skip
+			}
 		}
-		s.ch <- evt
+		// Non-blocking send: an unbuffered channel with no current reader, or a
+		// full buffered channel, drops the newest event instead of blocking.
+		// This keeps the "never blocks on any single subscriber" contract even
+		// for a dead/slow consumer (status events are lossy by design).
+		select {
+		case s.ch <- evt:
+		default: // unbuffered-and-no-reader, or full — drop newest
+		}
 		s.mu.Unlock()
 	}
 
@@ -192,11 +205,20 @@ func (b *EventBus) Publish(ctx context.Context, topic string, data any) {
 			s.mu.Unlock()
 			continue
 		}
-		// Ring-buffer overflow: if channel full, drain one (oldest) then send.
-		if len(s.ch) == cap(s.ch) {
-			<-s.ch // drop oldest
+		// Ring-buffer overflow: drain oldest when the buffered channel is full.
+		// cap>0 guard avoids the unbuffered-channel deadlock (#220); see the
+		// topic-subscriber block above for the full rationale.
+		if cap(s.ch) > 0 && len(s.ch) == cap(s.ch) {
+			select {
+			case <-s.ch: // drop oldest
+			default: // lost a race with another sender's drain; skip
+			}
 		}
-		s.ch <- evt
+		// Non-blocking send: drop newest rather than block on a dead consumer.
+		select {
+		case s.ch <- evt:
+		default: // unbuffered-and-no-reader, or full — drop newest
+		}
 		s.mu.Unlock()
 	}
 }

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -332,3 +332,81 @@ func TestSubscribeByPrefix_AndExactSubscribe(t *testing.T) {
 		t.Fatalf("prefix: expected 2 events, got %d", len(prefixEvents))
 	}
 }
+
+// TestPublishUnbufferedChannelDoesNotDeadlock guards the fix for #220: a
+// subscriber registered with an UNBUFFERED channel (cap==0) and no concurrent
+// reader must not deadlock Publish. Previously the len==cap drain guard
+// evaluated 0==0 → true and the blocking <-s.ch wedged the bus while holding
+// s.mu. Publish must return promptly (within the guard timeout) and the event
+// is simply dropped (non-blocking send).
+func TestPublishUnbufferedChannelDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+	bus := helperNewBus(t, 16)
+	// Unbuffered topic subscriber, never read from.
+	unbuf := make(chan Event)
+	if err := bus.Subscribe("unbuf.topic", unbuf, 0); err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		bus.Publish(context.Background(), "unbuf.topic", "no-reader")
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Publish returned without blocking — pass.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish deadlocked on an unbuffered channel with no reader (#220)")
+	}
+}
+
+// TestPublishUnbufferedPrefixChannelDoesNotDeadlock is the prefix-subscriber
+// counterpart of the test above, exercising the second drain+send site.
+func TestPublishUnbufferedPrefixChannelDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+	bus := helperNewBus(t, 16)
+	unbuf := make(chan Event) // unbuffered, never read
+	if err := bus.SubscribeByPrefix("unbuf.", unbuf, 0); err != nil {
+		t.Fatalf("SubscribeByPrefix failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		bus.Publish(context.Background(), "unbuf.something", "no-reader")
+		close(done)
+	}()
+	select {
+	case <-done:
+		// pass
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish deadlocked on an unbuffered prefix channel with no reader (#220)")
+	}
+}
+
+// TestPublish_DeadConsumerDoesNotBlockPublisher ensures a full buffered channel
+// (consumer stopped reading) cannot stall the publisher — the non-blocking send
+// drops the newest event instead. This is the defense-in-depth guarantee.
+func TestPublish_DeadConsumerDoesNotBlockPublisher(t *testing.T) {
+	t.Parallel()
+	bus := helperNewBus(t, 4)
+	full := make(chan Event, 1) // tiny buffer, will fill immediately
+	if err := bus.Subscribe("full.topic", full, 1); err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		// Publish far more than the buffer can hold with no reader.
+		for range 50 {
+			bus.Publish(context.Background(), "full.topic", "fill")
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+		// pass — publisher was never blocked by the saturated subscriber
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on a full buffered channel (dead consumer should not stall publisher)")
+	}
+}


### PR DESCRIPTION
## 问题 (#220)

`internal/event/bus.go` 的 `Publish` 在两个 send 站点(topic + prefix 订阅者)用:

```go
if len(s.ch) == cap(s.ch) {
    <-s.ch // drop oldest
}
s.ch <- evt
```

对**无缓冲 channel**(`cap==0`),`len==cap` 是 `0==0` 恒真 → `<-s.ch` 在空 channel 上**永久阻塞**,且此时持有 `s.mu` → **整个 bus 死锁**。

`busAdapter` 内部用 `make(chan Event, 64)` 是安全的,但 `Subscribe` / `SubscribeByPrefix` 是**公开 API** —— 任何传入无缓冲 channel 的 caller 都触发。

## 修复

两个 send 站点对称处理(防御纵深):

1. **drain 加 `cap > 0` guard** —— 无缓冲 channel 跳过 drain,不再触发恒真的 `0==0`。
2. **drain 用 `select-default`** —— 防止与另一 sender 的 drain 竞态。
3. **send 改非阻塞 `select-default`** —— 无缓冲且无 reader、或缓冲满时,丢弃**最新**事件,保证 `Never blocks on any single subscriber` 契约对**死消费者**也成立。

`drop-oldest` 语义对缓冲 channel **完全保留**(`TestOverflow_DropsOldest` 仍绿)。

> **审计澄清:** #220 已说明原审计把 "b.mu held during send" 标为**误报** —— `bus.go` 已用 snapshot 模式(`RLock→copy→RUnlock`),send 期间只持 `s.mu`(序列化 sender 以保 drop-oldest),非 `b.mu`。本 PR 不改这部分。

## 验证

- ✅ `go test -race ./internal/event/...` —— **全绿**(3.586s)
- ✅ 4 个针对性测试全部 PASS(含回归):
  - `TestPublishUnbufferedChannelDoesNotDeadlock`(topic 路径)
  - `TestPublishUnbufferedPrefixChannelDoesNotDeadlock`(prefix 路径)
  - `TestPublish_DeadConsumerDoesNotBlockPublisher`(满缓冲不死锁)
  - `TestOverflow_DropsOldest`(回归 —— drop-oldest 语义保留)
- ✅ `go build` / `go vet` / `gofmt`(LF 规范化)均干净

## 验收对照 (#220 acceptance)

- [x] Drain guarded with `cap > 0` check
- [x] Send uses non-blocking select-default
- [x] New unit test: `TestPublishUnbufferedChannelDoesNotDeadlock`
- [x] `go test -race ./internal/event/...` passes

Closes #220