### PR TITLE
fix(recorder): SPS/PPS/VPS 数据竞争 → atomic.Pointer[codecParams] (#219)

### DIFF
--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -275,27 +275,25 @@ func unwrapDelegate(rec model.Recorder) model.Recorder {
 }
 
 // getCodecParams extracts codec parameters from a recorder.
-// Uses HLSProvider interface first, then falls back to concrete type access.
+// Uses the HLSProvider interface first (covering H264/H265/Ingest/Xiaomi
+// recorders via a single atomic codec-snapshot read), then falls back to a
+// concrete type switch for JPEG/MJPEG cameras which have no codec parameter sets.
 func getCodecParams(rec model.Recorder) (codec model.Format, sps, pps, vps []byte) {
-	if provider, ok := rec.(model.HLSProvider); ok {
+	// Unwrap delegates (e.g. ONVIFRecorder → concrete H264/H265) so the
+	// HLSProvider check sees the real recorder that owns the codec params.
+	actualRec := unwrapDelegate(rec)
+	if provider, ok := actualRec.(model.HLSProvider); ok {
 		codec, sps, pps, vps = provider.CodecParams()
-		if sps != nil && pps != nil {
+		// Return as soon as we have a usable param set. codec is always set even
+		// when params are still nil (before the first keyframe) — callers treat a
+		// non-nil codec with nil sps/pps as "stream initializing" (503) and a nil
+		// codec as "not a codec-streaming camera" (e.g. JPEG/MJPEG).
+		if codec != "" {
 			return
 		}
-		// HLSProvider returned empty params — fall through to concrete type switch
 	}
 
-	actualRec := unwrapDelegate(rec)
-	switch r := actualRec.(type) {
-	case *recorder.H264Recorder:
-		codec = model.FormatH264
-		sps = r.SPS()
-		pps = r.PPS()
-	case *recorder.H265Recorder:
-		codec = model.FormatH265
-		vps = r.VPS()
-		sps = r.SPS()
-		pps = r.PPS()
+	switch actualRec.(type) {
 	case *recorder.HTTPJPEGRecorder:
 		// ESP32 MiBeeCam and other HTTP JPEG cameras. Live preview is served via
 		// latest-frame polling (MjpegLivePlayer), advertised as the "mjpeg" protocol

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -231,10 +231,12 @@ type baseRecorder struct {
 	lastFrameTime time.Time
 
 	// Codec parameter sets (populated from SDP + in-band NALUs).
-	// vps is H.265-only; always nil for H.264.
-	vps []byte
-	sps []byte
-	pps []byte
+	// Stored as an immutable snapshot behind atomic.Pointer so the live-preview
+	// (HLS/WebRTC/WS) goroutines can read SPS/PPS/VPS concurrently with the
+	// writeFrames goroutine's writes without a data race or torn triplet reads
+	// (SPS from one config, PPS from another). vps is H.265-only; always nil
+	// for H.264. See codecSnapshot / setCodecParams (#219).
+	codec atomic.Pointer[codecParams]
 
 	// Audio state (populated during connectAndRecord; read during segment
 	// creation to add the audio track to the muxer).
@@ -256,6 +258,42 @@ type baseRecorder struct {
 
 	// Throttled logging for storage health failures.
 	lastHealthLogAt time.Time
+}
+
+// codecParams is an immutable snapshot of the video codec parameter sets
+// (SPS/PPS/VPS). It is written by setCodecParams (deep-copying the inputs) and
+// read via codecSnapshot's single atomic load. Immutability after construction
+// is what makes the concurrent reader path (live preview via SPS()/PPS()/VPS())
+// race-free without a mutex (#219). vps is H.265-only; always nil for H.264.
+type codecParams struct {
+	sps []byte
+	pps []byte
+	vps []byte
+}
+
+// setCodecParams atomically replaces the codec parameter snapshot. The slices
+// are deep-copied so the stored snapshot is independent of the caller's buffers
+// (which may be reused RTP scratch buffers). Intended to be called from the
+// single writer path (writeFrames via the driver's handleParamSet, and the SDP
+// pre-seed in connectAndRecord) — concurrent callers must not interleave
+// partial updates; build the full triplet first, then Store.
+func (b *baseRecorder) setCodecParams(sps, pps, vps []byte) {
+	b.codec.Store(&codecParams{
+		sps: append([]byte(nil), sps...),
+		pps: append([]byte(nil), pps...),
+		vps: append([]byte(nil), vps...),
+	})
+}
+
+// codecSnapshot returns the current SPS/PPS/VPS via a single atomic load,
+// guaranteeing a consistent triplet (no torn read where SPS comes from one
+// configuration and PPS from another). Returns all-nil before the first
+// keyframe/SDP arrives.
+func (b *baseRecorder) codecSnapshot() (sps, pps, vps []byte) {
+	if cp := b.codec.Load(); cp != nil {
+		return cp.sps, cp.pps, cp.vps
+	}
+	return nil, nil, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -387,11 +425,11 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 	for data := range b.frameCh {
 		// Always parse NALUs to capture codec parameter sets (VPS/SPS/PPS), even
 		// in live-only mode (RecordEnabled=false). Live preview (HLS/WebRTC/WS)
-		// needs these via getCodecParams(); if we skip parsing here, SPS()/VPS()/
-		// PPS() stay nil and every live-preview endpoint returns 503 "waiting for
-		// video stream" → permanent grey/black screen for cameras with recording
-		// disabled. (Only the SDP pre-seed in connectAndRecord runs otherwise,
-		// which is empty for cameras that send params in-band only.)
+		// needs these via getCodecParams(); if we skip parsing here, the codec
+		// snapshot stays nil and every live-preview endpoint returns 503 "waiting
+		// for video stream" → permanent grey/black screen for cameras with
+		// recording disabled. (Only the SDP pre-seed in connectAndRecord runs
+		// otherwise, which is empty for cameras that send params in-band only.)
 		if len(data) < b.driver.minNALUDataLen() {
 			continue
 		}

--- a/internal/recorder/codec_race_test.go
+++ b/internal/recorder/codec_race_test.go
@@ -1,0 +1,146 @@
+package recorder
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests guard the fix for #219: the baseRecorder codec parameter sets
+// (SPS/PPS/VPS) are read cross-goroutine by live-preview handlers
+// (SPS()/PPS()/VPS()/CodecParams()) and written by the writeFrames goroutine
+// (handleParamSet) + connectAndRecord (SDP pre-seed). Previously these were
+// plain []byte fields → a torn/unsynchronized read under -race. They are now
+// an atomic.Pointer[codecParams] snapshot. The tests prove that concurrent
+// writers + readers run cleanly under `go test -race`.
+
+// sampleParamSets returns distinct SPS/PPS/VPS byte slices for h264/h265.
+func sampleParamSets(variant int) (sps, pps, vps []byte) {
+	sps = []byte{0x67, 0x64, 0x00, byte(variant)}
+	pps = []byte{0x68, byte(variant)}
+	vps = []byte{0x40, 0x01, 0x0C, byte(variant)}
+	return
+}
+
+// TestCodecParams_ConcurrentReadWrite_H264 spins writer goroutines that update
+// the H.264 recorder's codec snapshot (simulating handleParamSet + SDP seed)
+// while reader goroutines invoke every public accessor. Must not trigger the
+// race detector and must not panic.
+func TestCodecParams_ConcurrentReadWrite_H264(t *testing.T) {
+	t.Parallel()
+	rec := NewH264Recorder(H264Config{CameraID: "race-h264"}, nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers — update the snapshot continuously, varying the param bytes so the
+	// race detector is more likely to catch a torn read if the atomic guard
+	// regresses. Also exercises the HLSProvider CodecParams() read path.
+	const writers = 2
+	for w := range writers {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 1; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sps, pps, _ := sampleParamSets(w*1000 + i)
+				rec.setCodecParams(sps, pps, nil) // H.264: vps always nil
+			}
+		}()
+	}
+
+	// Readers — call all public codec accessors concurrently.
+	const readers = 4
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Single-snapshot read path (the recommended fix).
+				_, _, _, _ = rec.CodecParams()
+				// Legacy single-field accessors (thin wrappers over the snapshot).
+				_ = rec.SPS()
+				_ = rec.PPS()
+			}
+		}()
+	}
+
+	// Let the race detector observe contention, then stop.
+	close(stop)
+	wg.Wait()
+
+	// Final state is consistent: the accessors return a coherent triplet.
+	_, sps, pps, vps := rec.CodecParams()
+	if sps != nil {
+		require.NotNil(t, pps, "H264 must have PPS whenever SPS is set")
+	}
+	require.Nil(t, vps, "H264 must never report a VPS")
+}
+
+// TestCodecParams_ConcurrentReadWrite_H265 is the H.265 counterpart, also
+// exercising the VPS accessor and the full VPS/SPS/PPS triplet writes.
+func TestCodecParams_ConcurrentReadWrite_H265(t *testing.T) {
+	t.Parallel()
+	rec := NewH265Recorder(H265Config{CameraID: "race-h265"}, nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	const writers = 2
+	for w := range writers {
+		w := w
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 1; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sps, pps, vps := sampleParamSets(w*1000 + i)
+				rec.setCodecParams(vps, sps, pps)
+			}
+		}()
+	}
+
+	const readers = 4
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, _, _ = rec.CodecParams()
+				_ = rec.VPS()
+				_ = rec.SPS()
+				_ = rec.PPS()
+			}
+		}()
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Consistent final state: if any of VPS/SPS/PPS is set, all three are.
+	vps, sps, pps, _ := rec.CodecParams()
+	if sps != nil {
+		require.NotNil(t, pps, "H265 must have PPS whenever SPS is set")
+		require.NotNil(t, vps, "H265 must have VPS whenever SPS is set")
+	}
+}

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -55,18 +55,15 @@ type H264Config = BaseConfig
 // H264NALDriver implements codecDriver for H.264 video.
 type H264NALDriver struct{}
 
-func (d H264NALDriver) codecLabel() string { return "h264" }
-func (d H264NALDriver) segmentFormat() model.Format { return model.FormatH264 }
-func (d H264NALDriver) rtpFormat() format.Format { return &format.H264{} }
-func (d H264NALDriver) minNALUDataLen() int { return 5 }
-func (d H264NALDriver) naluType(firstByte byte) int { return int(firstByte & 0x1F) }
-func (d H264NALDriver) isIDR(typ int) bool { return typ == 5 }
-func (d H264NALDriver) isParameterSet(typ int) bool { return typ == 7 || typ == 8 }
-func (d H264NALDriver) isVCL(typ int) bool { return typ == 1 || typ == 5 }
-func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool {
-	sps, pps, _ := b.codecSnapshot()
-	return sps != nil && pps != nil
-}
+func (d H264NALDriver) codecLabel() string                  { return "h264" }
+func (d H264NALDriver) segmentFormat() model.Format         { return model.FormatH264 }
+func (d H264NALDriver) rtpFormat() format.Format            { return &format.H264{} }
+func (d H264NALDriver) minNALUDataLen() int                 { return 5 }
+func (d H264NALDriver) naluType(firstByte byte) int         { return int(firstByte & 0x1F) }
+func (d H264NALDriver) isIDR(typ int) bool                  { return typ == 5 }
+func (d H264NALDriver) isParameterSet(typ int) bool         { return typ == 7 || typ == 8 }
+func (d H264NALDriver) isVCL(typ int) bool                  { return typ == 1 || typ == 5 }
+func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool { sps, pps, _ := b.codecSnapshot(); return sps != nil && pps != nil }
 
 func (d H264NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) bool {
 	// Load the current snapshot once; this method runs only on the single

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -63,7 +63,10 @@ func (d H264NALDriver) naluType(firstByte byte) int         { return int(firstBy
 func (d H264NALDriver) isIDR(typ int) bool                  { return typ == 5 }
 func (d H264NALDriver) isParameterSet(typ int) bool         { return typ == 7 || typ == 8 }
 func (d H264NALDriver) isVCL(typ int) bool                  { return typ == 1 || typ == 5 }
-func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool { sps, pps, _ := b.codecSnapshot(); return sps != nil && pps != nil }
+func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool {
+	sps, pps, _ := b.codecSnapshot()
+	return sps != nil && pps != nil
+}
 
 func (d H264NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) bool {
 	// Load the current snapshot once; this method runs only on the single

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -55,14 +55,14 @@ type H264Config = BaseConfig
 // H264NALDriver implements codecDriver for H.264 video.
 type H264NALDriver struct{}
 
-func (d H264NALDriver) codecLabel() string                  { return "h264" }
-func (d H264NALDriver) segmentFormat() model.Format         { return model.FormatH264 }
-func (d H264NALDriver) rtpFormat() format.Format            { return &format.H264{} }
-func (d H264NALDriver) minNALUDataLen() int                 { return 5 }
-func (d H264NALDriver) naluType(firstByte byte) int         { return int(firstByte & 0x1F) }
-func (d H264NALDriver) isIDR(typ int) bool                  { return typ == 5 }
-func (d H264NALDriver) isParameterSet(typ int) bool         { return typ == 7 || typ == 8 }
-func (d H264NALDriver) isVCL(typ int) bool                  { return typ == 1 || typ == 5 }
+func (d H264NALDriver) codecLabel() string { return "h264" }
+func (d H264NALDriver) segmentFormat() model.Format { return model.FormatH264 }
+func (d H264NALDriver) rtpFormat() format.Format { return &format.H264{} }
+func (d H264NALDriver) minNALUDataLen() int { return 5 }
+func (d H264NALDriver) naluType(firstByte byte) int { return int(firstByte & 0x1F) }
+func (d H264NALDriver) isIDR(typ int) bool { return typ == 5 }
+func (d H264NALDriver) isParameterSet(typ int) bool { return typ == 7 || typ == 8 }
+func (d H264NALDriver) isVCL(typ int) bool { return typ == 1 || typ == 5 }
 func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool {
 	sps, pps, _ := b.codecSnapshot()
 	return sps != nil && pps != nil

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -55,14 +55,14 @@ type H264Config = BaseConfig
 // H264NALDriver implements codecDriver for H.264 video.
 type H264NALDriver struct{}
 
-func (d H264NALDriver) codecLabel() string                  { return "h264" }
-func (d H264NALDriver) segmentFormat() model.Format         { return model.FormatH264 }
-func (d H264NALDriver) rtpFormat() format.Format            { return &format.H264{} }
-func (d H264NALDriver) minNALUDataLen() int                 { return 5 }
-func (d H264NALDriver) naluType(firstByte byte) int         { return int(firstByte & 0x1F) }
-func (d H264NALDriver) isIDR(typ int) bool                  { return typ == 5 }
-func (d H264NALDriver) isParameterSet(typ int) bool         { return typ == 7 || typ == 8 }
-func (d H264NALDriver) isVCL(typ int) bool                  { return typ == 1 || typ == 5 }
+func (d H264NALDriver) codecLabel() string          { return "h264" }
+func (d H264NALDriver) segmentFormat() model.Format { return model.FormatH264 }
+func (d H264NALDriver) rtpFormat() format.Format    { return &format.H264{} }
+func (d H264NALDriver) minNALUDataLen() int         { return 5 }
+func (d H264NALDriver) naluType(firstByte byte) int { return int(firstByte & 0x1F) }
+func (d H264NALDriver) isIDR(typ int) bool          { return typ == 5 }
+func (d H264NALDriver) isParameterSet(typ int) bool { return typ == 7 || typ == 8 }
+func (d H264NALDriver) isVCL(typ int) bool          { return typ == 1 || typ == 5 }
 func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool {
 	sps, pps, _ := b.codecSnapshot()
 	return sps != nil && pps != nil

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -63,24 +63,32 @@ func (d H264NALDriver) naluType(firstByte byte) int         { return int(firstBy
 func (d H264NALDriver) isIDR(typ int) bool                  { return typ == 5 }
 func (d H264NALDriver) isParameterSet(typ int) bool         { return typ == 7 || typ == 8 }
 func (d H264NALDriver) isVCL(typ int) bool                  { return typ == 1 || typ == 5 }
-func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool { return b.sps != nil && b.pps != nil }
+func (d H264NALDriver) paramSetsReady(b *baseRecorder) bool {
+	sps, pps, _ := b.codecSnapshot()
+	return sps != nil && pps != nil
+}
 
 func (d H264NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) bool {
+	// Load the current snapshot once; this method runs only on the single
+	// writeFrames goroutine, so load-then-store is race-free. We always rebuild
+	// and store the full triplet so a concurrent reader (live preview via
+	// codecSnapshot) never sees a torn mix of old+new params (#219).
+	sps, pps, _ := b.codecSnapshot()
 	switch typ {
 	case 7: // SPS
-		if b.sps != nil && !bytes.Equal(b.sps, nalu) {
+		if sps != nil && !bytes.Equal(sps, nalu) {
 			b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.sps = append([]byte(nil), nalu...)
+			b.setCodecParams(nalu, pps, nil)
 			return true
 		}
-		b.sps = append([]byte(nil), nalu...)
+		b.setCodecParams(nalu, pps, nil)
 	case 8: // PPS
-		if b.pps != nil && !bytes.Equal(b.pps, nalu) {
+		if pps != nil && !bytes.Equal(pps, nalu) {
 			b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.pps = append([]byte(nil), nalu...)
+			b.setCodecParams(sps, nalu, nil)
 			return true
 		}
-		b.pps = append([]byte(nil), nalu...)
+		b.setCodecParams(sps, nalu, nil)
 	}
 	return false
 }
@@ -98,7 +106,8 @@ func (d H264NALDriver) extractParamSets(b *baseRecorder, au [][]byte) {
 }
 
 func (d H264NALDriver) addTrack(m *muxer.MP4Muxer, b *baseRecorder) (int, error) {
-	return m.AddH264Track(b.sps, b.pps)
+	sps, pps, _ := b.codecSnapshot()
+	return m.AddH264Track(sps, pps)
 }
 
 // H264Recorder records H.264 video from an RTSP source.
@@ -162,10 +171,22 @@ func (r *H264Recorder) Status() model.RecorderStatus {
 func (r *H264Recorder) GetHub() *model.StreamHub { return r.Hub }
 
 // SPS returns the current H264 Sequence Parameter Set NAL unit (without start bytes).
-func (r *H264Recorder) SPS() []byte { return r.sps }
+// Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
+func (r *H264Recorder) SPS() []byte { s, _, _ := r.codecSnapshot(); return s }
 
 // PPS returns the current H264 Picture Parameter Set NAL unit (without start bytes).
-func (r *H264Recorder) PPS() []byte { return r.pps }
+// Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
+func (r *H264Recorder) PPS() []byte { _, p, _ := r.codecSnapshot(); return p }
+
+// CodecParams implements model.HLSProvider, returning the current H.264 codec
+// and parameter-set snapshot in a single atomic read. This lets getCodecParams
+// (handlers_stream.go) use the HLSProvider fast-path instead of the concrete
+// type switch, and guarantees a consistent (non-torn) SPS/PPS pair (#219).
+// vps is always nil for H.264.
+func (r *H264Recorder) CodecParams() (codec model.Format, sps, pps, vps []byte) {
+	sps, pps, vps = r.codecSnapshot()
+	return model.FormatH264, sps, pps, vps
+}
 
 // AudioCodec returns the audio codec name ("aac", "g711", or "" for no audio).
 func (r *H264Recorder) AudioCodec() string { return r.audioCodec }
@@ -221,13 +242,17 @@ func (r *H264Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 		return fmt.Errorf("SETUP: %w", err), false
 	}
 
-	// Store initial parameter sets from SDP.
+	// Store initial parameter sets from SDP. Merge with any params already
+	// captured (rare, but keeps the snapshot consistent) and store atomically as
+	// a full triplet so concurrent live-preview reads see a consistent pair (#219).
+	sps, pps, _ := r.codecSnapshot()
 	if forma.SPS != nil {
-		r.sps = append([]byte(nil), forma.SPS...)
+		sps = forma.SPS
 	}
 	if forma.PPS != nil {
-		r.pps = append([]byte(nil), forma.PPS...)
+		pps = forma.PPS
 	}
+	r.setCodecParams(sps, pps, nil)
 
 	// Audio setup: find AAC or G.711 format if AudioEnabled.
 	var audioDec *rtpmpeg4audio.Decoder

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -34,14 +34,14 @@ type H265Config = BaseConfig
 // H265NALDriver implements codecDriver for H.265/HEVC video.
 type H265NALDriver struct{}
 
-func (d H265NALDriver) codecLabel() string          { return "h265" }
+func (d H265NALDriver) codecLabel() string { return "h265" }
 func (d H265NALDriver) segmentFormat() model.Format { return model.FormatH265 }
-func (d H265NALDriver) rtpFormat() format.Format    { return &format.H265{} }
-func (d H265NALDriver) minNALUDataLen() int         { return 6 }
+func (d H265NALDriver) rtpFormat() format.Format { return &format.H265{} }
+func (d H265NALDriver) minNALUDataLen() int { return 6 }
 func (d H265NALDriver) naluType(firstByte byte) int { return int((firstByte >> 1) & 0x3F) }
-func (d H265NALDriver) isIDR(typ int) bool          { return typ == 19 || typ == 20 }
+func (d H265NALDriver) isIDR(typ int) bool { return typ == 19 || typ == 20 }
 func (d H265NALDriver) isParameterSet(typ int) bool { return typ == 32 || typ == 33 || typ == 34 }
-func (d H265NALDriver) isVCL(typ int) bool          { return typ < 32 }
+func (d H265NALDriver) isVCL(typ int) bool { return typ < 32 }
 func (d H265NALDriver) paramSetsReady(b *baseRecorder) bool {
 	vps, sps, pps := b.codecSnapshot()
 	return vps != nil && sps != nil && pps != nil

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -34,14 +34,14 @@ type H265Config = BaseConfig
 // H265NALDriver implements codecDriver for H.265/HEVC video.
 type H265NALDriver struct{}
 
-func (d H265NALDriver) codecLabel() string { return "h265" }
+func (d H265NALDriver) codecLabel() string          { return "h265" }
 func (d H265NALDriver) segmentFormat() model.Format { return model.FormatH265 }
-func (d H265NALDriver) rtpFormat() format.Format { return &format.H265{} }
-func (d H265NALDriver) minNALUDataLen() int { return 6 }
+func (d H265NALDriver) rtpFormat() format.Format    { return &format.H265{} }
+func (d H265NALDriver) minNALUDataLen() int         { return 6 }
 func (d H265NALDriver) naluType(firstByte byte) int { return int((firstByte >> 1) & 0x3F) }
-func (d H265NALDriver) isIDR(typ int) bool { return typ == 19 || typ == 20 }
+func (d H265NALDriver) isIDR(typ int) bool          { return typ == 19 || typ == 20 }
 func (d H265NALDriver) isParameterSet(typ int) bool { return typ == 32 || typ == 33 || typ == 34 }
-func (d H265NALDriver) isVCL(typ int) bool { return typ < 32 }
+func (d H265NALDriver) isVCL(typ int) bool          { return typ < 32 }
 func (d H265NALDriver) paramSetsReady(b *baseRecorder) bool {
 	vps, sps, pps := b.codecSnapshot()
 	return vps != nil && sps != nil && pps != nil

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -43,32 +43,38 @@ func (d H265NALDriver) isIDR(typ int) bool          { return typ == 19 || typ ==
 func (d H265NALDriver) isParameterSet(typ int) bool { return typ == 32 || typ == 33 || typ == 34 }
 func (d H265NALDriver) isVCL(typ int) bool          { return typ < 32 }
 func (d H265NALDriver) paramSetsReady(b *baseRecorder) bool {
-	return b.vps != nil && b.sps != nil && b.pps != nil
+	vps, sps, pps := b.codecSnapshot()
+	return vps != nil && sps != nil && pps != nil
 }
 
 func (d H265NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) bool {
+	// Load the current snapshot once; this method runs only on the single
+	// writeFrames goroutine, so load-then-store is race-free. We always rebuild
+	// and store the full triplet (VPS/SPS/PPS) so a concurrent reader (live
+	// preview via codecSnapshot) never sees a torn mix of old+new params (#219).
+	vps, sps, pps := b.codecSnapshot()
 	switch typ {
 	case 32: // VPS
-		if b.vps != nil && !bytes.Equal(b.vps, nalu) {
+		if vps != nil && !bytes.Equal(vps, nalu) {
 			b.log.Info("VPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.vps = append([]byte(nil), nalu...)
+			b.setCodecParams(nalu, sps, pps)
 			return true
 		}
-		b.vps = append([]byte(nil), nalu...)
+		b.setCodecParams(nalu, sps, pps)
 	case 33: // SPS
-		if b.sps != nil && !bytes.Equal(b.sps, nalu) {
+		if sps != nil && !bytes.Equal(sps, nalu) {
 			b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.sps = append([]byte(nil), nalu...)
+			b.setCodecParams(vps, nalu, pps)
 			return true
 		}
-		b.sps = append([]byte(nil), nalu...)
+		b.setCodecParams(vps, nalu, pps)
 	case 34: // PPS
-		if b.pps != nil && !bytes.Equal(b.pps, nalu) {
+		if pps != nil && !bytes.Equal(pps, nalu) {
 			b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.pps = append([]byte(nil), nalu...)
+			b.setCodecParams(vps, sps, nalu)
 			return true
 		}
-		b.pps = append([]byte(nil), nalu...)
+		b.setCodecParams(vps, sps, nalu)
 	}
 	return false
 }
@@ -86,7 +92,8 @@ func (d H265NALDriver) extractParamSets(b *baseRecorder, au [][]byte) {
 }
 
 func (d H265NALDriver) addTrack(m *muxer.MP4Muxer, b *baseRecorder) (int, error) {
-	return m.AddH265Track(b.vps, b.sps, b.pps)
+	vps, sps, pps := b.codecSnapshot()
+	return m.AddH265Track(vps, sps, pps)
 }
 
 // H265Recorder records H.265/HEVC video from an RTSP source.
@@ -150,13 +157,25 @@ func (r *H265Recorder) Status() model.RecorderStatus {
 func (r *H265Recorder) GetHub() *model.StreamHub { return r.Hub }
 
 // VPS returns the current H265 Video Parameter Set NAL unit (without start bytes).
-func (r *H265Recorder) VPS() []byte { return r.vps }
+// Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
+func (r *H265Recorder) VPS() []byte { _, _, v := r.codecSnapshot(); return v }
 
 // SPS returns the current H265 Sequence Parameter Set NAL unit (without start bytes).
-func (r *H265Recorder) SPS() []byte { return r.sps }
+// Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
+func (r *H265Recorder) SPS() []byte { s, _, _ := r.codecSnapshot(); return s }
 
 // PPS returns the current H265 Picture Parameter Set NAL unit (without start bytes).
-func (r *H265Recorder) PPS() []byte { return r.pps }
+// Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
+func (r *H265Recorder) PPS() []byte { _, p, _ := r.codecSnapshot(); return p }
+
+// CodecParams implements model.HLSProvider, returning the current H.265 codec
+// and parameter-set snapshot in a single atomic read. This lets getCodecParams
+// (handlers_stream.go) use the HLSProvider fast-path instead of the concrete
+// type switch, and guarantees a consistent (non-torn) VPS/SPS/PPS triplet (#219).
+func (r *H265Recorder) CodecParams() (codec model.Format, sps, pps, vps []byte) {
+	sps, pps, vps = r.codecSnapshot()
+	return model.FormatH265, sps, pps, vps
+}
 
 // AudioCodec returns the audio codec name ("aac", "g711", or "" for no audio).
 func (r *H265Recorder) AudioCodec() string { return r.audioCodec }
@@ -212,16 +231,20 @@ func (r *H265Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 		return fmt.Errorf("SETUP: %w", err), false
 	}
 
-	// Store initial parameter sets from SDP.
+	// Store initial parameter sets from SDP. Merge with any params already
+	// captured and store atomically as a full triplet so concurrent live-preview
+	// reads see a consistent VPS/SPS/PPS set (#219).
+	vps, sps, pps := r.codecSnapshot()
 	if forma.VPS != nil {
-		r.vps = append([]byte(nil), forma.VPS...)
+		vps = forma.VPS
 	}
 	if forma.SPS != nil {
-		r.sps = append([]byte(nil), forma.SPS...)
+		sps = forma.SPS
 	}
 	if forma.PPS != nil {
-		r.pps = append([]byte(nil), forma.PPS...)
+		pps = forma.PPS
 	}
+	r.setCodecParams(vps, sps, pps)
 
 	// Audio setup: find AAC or G.711 format if AudioEnabled.
 	var audioDec *rtpmpeg4audio.Decoder


### PR DESCRIPTION
## 问题 (#219)

`baseRecorder` 的 `vps/sps/pps []byte` 被两条 goroutine 跨线程读写:
- **写端**:`writeFrames` 经 `handleParamSet` + `connectAndRecord` 的 SDP 预置
- **读端**:直播预览(HLS/WebRTC/WS)经 `SPS()/PPS()/VPS()` —— 被 `camera/status.go`、`handlers_hls.go`、`handlers_stream.go` 等 **29 处**调用

Go slice 赋值是 3 word(ptr/len/cap),并发读写可观测**撕裂值**;RPi 3B(Cortex-A53)上表现为直播预览偶发黑屏/解码器初始化失败。`IngestRecorder` 已用 `r.mu` 正确处理,但 **H264/H265 未处理**。

## 修复

### 核心思路:immutable snapshot + `atomic.Pointer`(防撕裂读)
保留 `SPS()/PPS()/VPS()` 访问器签名(29 处调用点零改动即 race-free),底层改为读同一原子快照。

- **`base.go`**:新增 immutable `codecParams{sps,pps,vps}` 类型,字段改为单个 `atomic.Pointer[codecParams]`。`setCodecParams` 深拷贝后 `Store`;`codecSnapshot` 一次 `Load` 返回一致 triplet(防 SPS 来自新配置、PPS 来自旧配置的撕裂读)。
- **`h264.go`/`h265.go`**:`handleParamSet` 的 change-detection 保留(单 writer,load-then-store 无 race),但每次写入**整组 triplet**(`setCodecParams`,保留未变字段);`paramSetsReady`/`addTrack`/SDP-seed 改读快照;`SPS()/PPS()/VPS()` 变薄包装。
- **新增 `CodecParams()`** 让 H264/H265 实现 `model.HLSProvider`(`model.FormatH264`/`H265`),激活 `getCodecParams` 的 HLSProvider 快速路径;删除其死掉的 H264/H265 type-switch 分支(改为**先 unwrap 再判 HLSProvider**,兼容 `ONVIFRecorder` delegate)。
- 访问器签名不变 → `camera/status.go`、`handlers_hls.go` 等调用点**零改动**即 race-free。

### 范围说明
#219 也点名 **Xiaomi recorder** 同源 race,但它是独立 struct(非 `baseRecorder`)。本 PR 只做 **H264/H265**(`baseRecorder`,核心攻击面)。Xiaomi 拆后续 PR —— 见 PR 描述后续。

## 验证(在 Docker VM `192.168.63.197`,go1.26 linux/amd64)

> ⚠️ Windows 上 `syscall.Statfs` 无法编译,故在 Docker VM 验证。

| 检查 | 结果 |
|------|------|
| `go build ./internal/recorder/ ./internal/api/` | ✅ 干净 |
| `go vet` 同上 | ✅ 干净 |
| `go test -race ./internal/recorder/`(含新 race 测试 + 全部 RTSP 集成测试) | ✅ 通过(100.1s) |
| `go test -race ./internal/api/`(HLS/stream/codec) | ✅ 通过(4.6s) |
| `go test -race ./internal/camera/`(`status.go` 重度用 SPS/PPS/CodecParams) | ✅ 通过(50.1s) |

新增 `codec_race_test.go`:2 个 writer 调 `setCodecParams` + 4 个 reader 调 `SPS()/PPS()/VPS()/CodecParams()`,`go test -race` 全绿 —— 证明原子快照无 race。

## 验收对照 (#219 acceptance)

- [x] `atomic.Pointer[codecParams]` 加到 `baseRecorder`;`setCodecParams` 从 h264/h265 的 `handleParamSet` + `connectAndRecord` 调用
- [x] `getCodecParams` 改走 `CodecParams()`(H264/H265 现实现 HLSProvider)
- [x] `go test -race ./internal/recorder/ ./internal/api/` passes
- [x] `go vet` clean

(Xiaomi recorder 的同源修复留作后续 PR。)

Closes #219