### PR TITLE
fix(wsstream): read-pump deadline 2× idleTimeout — 让 EOS 在 read 超时前投递

### DIFF
--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -601,7 +601,12 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 		wsLogger.Load().Debug("WebSocket viewer disconnected", "camera_id", camID, "viewer_id", viewerID)
 	}()
 
-	// Start read pump to detect client disconnect.
+	// Start read pump to detect client disconnect. The read deadline is set to
+	// 2× the idle timeout so the idle watchdog (which fires at idleTimeout and
+	// enqueues EOS via the channel) reliably runs FIRST. If both used the same
+	// deadline, the read pump's timeout could cancel the viewer before the
+	// watchdog enqueued EOS, dropping the EOS and closing the conn without the
+	// graceful idle signal (#250 follow-up).
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -614,7 +619,7 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 				return
 			default:
 			}
-			conn.SetReadDeadline(time.Now().Add(m.idleTimeout))
+			conn.SetReadDeadline(time.Now().Add(2 * m.idleTimeout))
 			_, _, err := conn.ReadMessage()
 			if err != nil {
 				viewerCancel()


### PR DESCRIPTION
## 问题

`TestServeWS_NoConcurrentWriteOnIdle` 在 CI/VM 上 **~33% 概率失败**(非偶发,可稳定复现):

```
--- FAIL: TestServeWS_NoConcurrentWriteOnIdle (0.08s)
    idle watchdog should deliver EOS via the channel
```

**这个 flake 正在阻塞其它 PR 的 CI**(recorder race #255 等)——因为 branch protection 强制要求 test 通过。

## 根因(race,非偶发)

`ServeWS` 的 idle watchdog 与 read pump **都在 ~idleTimeout 时点触发**,且两者都调 `viewerCancel()`:

| 组件 | 触发时点 | 行为 |
|------|---------|------|
| **idle watchdog** | ticker=`idleTimeout/2`,在 `idleTimeout` 时 `sendNonBlocking(EOS)` + `cancel` | 负责 enqueue EOS |
| **read pump** | `SetReadDeadline(now+idleTimeout)`,`ReadMessage` 超时 → `cancel` | 负责**检测客户端断连** |

两者 deadline 相同时,若 **read pump 超时先返回**(80ms):
1. read pump `cancel()` viewer
2. frame loop 经 `<-ctx.Done()` 退出 → `drainViewerCh`
3. 但此时 **watchdog 还没 enqueue EOS**(它要等下一个 40ms tick 才检测 idle,而此时 ctx 已 cancel → watchdog 直接 `return`,**不发 EOS**)
4. drain 取不到 EOS → conn 关闭 → 客户端收不到 EOS → **测试失败**

## 修复

`read pump` 的 `SetReadDeadline` 改为 **`2 × idleTimeout`**:

```go
conn.SetReadDeadline(time.Now().Add(2 * m.idleTimeout))
```

这样 watchdog(在 `idleTimeout` 触发)**必然先** enqueue EOS 并 cancel,frame loop 的 drain 能取到 EOS 投递给客户端;read pump 的 `2×` 超时永远不会先于 watchdog 触发(除非真正的客户端断连,那时 err 路径正常 cancel,本就该关)。

**read pump 的职责是检测客户端断连,不是 idle 判定** —— 两者本不该用同一 deadline 竞争。

## 验证

- ✅ VM: `go test -race -count=20 TestServeWS_NoConcurrentWriteOnIdle` **全绿**(2.7s)—— 修复前 3 次必挂 1 次
- ✅ VM: full `internal/wsstream` pkg `-race` 绿(1.9s)
- ✅ gofumpt clean

这是 #250(wsstream concurrent-write panic)的 follow-up——当时修了并发写,但 idle EOS 投递的 race 漏了。