### PR TITLE
api: #222 分页 helper + #223 错误格式统一 + #213 ai/stats 全局聚合

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -298,6 +299,32 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func WriteError(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// parsePagination parses the limit/offset query params with a caller-specified
+// default limit and a hard upper bound. It is the single source of truth for the
+// limit/offset parsing that was previously duplicated (with subtly different
+// default/max values) across the recording, archive, AI, timelapse, and
+// transcode list handlers (#222).
+//
+// defaultLimit is used when ?limit is absent or invalid; maxLimit<=0 disables
+// the upper-bound clamp. offset defaults to 0 and is never negative.
+func parsePagination(r *http.Request, defaultLimit, maxLimit int) (limit, offset int) {
+	limit = defaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if maxLimit > 0 && limit > maxLimit {
+		limit = maxLimit
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return limit, offset
 }
 
 func writeAPIError(w http.ResponseWriter, status int, err error) {

--- a/internal/api/handlers_ai.go
+++ b/internal/api/handlers_ai.go
@@ -133,16 +133,7 @@ func (h *Handler) handleListAIEvents(w http.ResponseWriter, r *http.Request) {
 		CameraID:  r.URL.Query().Get("camera_id"),
 		EventType: r.URL.Query().Get("event_type"),
 	}
-	if lim := r.URL.Query().Get("limit"); lim != "" {
-		if v, err := strconv.Atoi(lim); err == nil && v > 0 {
-			f.Limit = v
-		}
-	}
-	if off := r.URL.Query().Get("offset"); off != "" {
-		if v, err := strconv.Atoi(off); err == nil && v >= 0 {
-			f.Offset = v
-		}
-	}
+	f.Limit, f.Offset = parsePagination(r, 0, 0) // no default/cap; ListAIEvents clamps to 50 internally
 	// Time-range filtering for timeline overlay support.
 	if startStr := r.URL.Query().Get("start"); startStr != "" {
 		if t, err := time.Parse(time.RFC3339Nano, startStr); err == nil {
@@ -211,11 +202,9 @@ func (h *Handler) handleGetAIEventStats(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// camera_id is optional: when omitted, stats aggregate across ALL cameras
+	// (global view). When present, stats are scoped to that camera (#213).
 	cameraID := r.URL.Query().Get("camera_id")
-	if cameraID == "" {
-		WriteError(w, http.StatusBadRequest, "camera_id is required")
-		return
-	}
 
 	period := r.URL.Query().Get("period")
 	since := getDefaultStatsSince(period)

--- a/internal/api/handlers_archive.go
+++ b/internal/api/handlers_archive.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -63,16 +62,7 @@ func (h *Handler) handleListArchiveRecordings(w http.ResponseWriter, r *http.Req
 		CameraID: cameraID,
 		Archived: &trueVal,
 	}
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			filter.Limit = n
-		}
-	}
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			filter.Offset = n
-		}
-	}
+	filter.Limit, filter.Offset = parsePagination(r, 0, 0)
 	filter.SortBy = r.URL.Query().Get("sort_by")
 	filter.SortOrder = r.URL.Query().Get("order")
 

--- a/internal/api/handlers_hls.go
+++ b/internal/api/handlers_hls.go
@@ -301,7 +301,7 @@ func (h *Handler) handleSnapshot(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if snapshotURL == "" {
-		http.Error(w, "Snapshot URL not configured", http.StatusNotFound)
+		WriteError(w, http.StatusNotFound, "Snapshot URL not configured")
 		return
 	}
 
@@ -377,5 +377,5 @@ func serveStaleOrError(w http.ResponseWriter, cached *snapshotCache, ok bool, ca
 		return
 	}
 	logger.Warn("failed to fetch snapshot", "camera_id", cameraID, "error", err)
-	http.Error(w, "Failed to fetch snapshot", http.StatusBadGateway)
+	WriteError(w, http.StatusBadGateway, "Failed to fetch snapshot")
 }

--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -50,26 +50,9 @@ func (h *Handler) handleListRecordings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			filter.Limit = n
-		}
-	}
-	// Enforce a safe default + upper bound to prevent accidental full-table scans.
-	// Without this, omitting ?limit= returns the entire recordings table.
-	if filter.Limit == 0 || filter.Limit > 500 {
-		if filter.Limit > 500 {
-			filter.Limit = 500
-		} else {
-			filter.Limit = 50 // safe default
-		}
-	}
-
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			filter.Offset = n
-		}
-	}
+	// limit/offset parsing centralized in parsePagination (#222); recordings use a
+	// safe default of 50 and a hard cap of 500 to prevent accidental full-table scans.
+	filter.Limit, filter.Offset = parsePagination(r, 50, 500)
 
 	// Keyset (cursor) pagination: ?cursor=<RFC3339 started_at of last row on prev page>.
 	// When provided with default sort, the DB uses WHERE started_at < cursor (O(1) deep page)
@@ -643,7 +626,7 @@ func (h *Handler) handleDownloadRecording(w http.ResponseWriter, r *http.Request
 				}
 			}
 		}
-		http.Error(w, "frame not found", http.StatusNotFound)
+		WriteError(w, http.StatusNotFound, "frame not found")
 		return
 	}
 

--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -311,23 +311,8 @@ func (h *Handler) handleTimelapseMergeProgress(w http.ResponseWriter, r *http.Re
 func (h *Handler) handleTimelapseList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Parse pagination params with abuse prevention
-	limit := 0
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
-	}
-	if limit > 1000 {
-		limit = 1000
-	}
-
-	offset := 0
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			offset = n
-		}
-	}
+	// Parse pagination params with abuse prevention (cap 1000, no default).
+	limit, offset := parsePagination(r, 0, 1000)
 
 	// Parse optional filters
 	cameraID := r.URL.Query().Get("camera_id")
@@ -925,21 +910,7 @@ func (h *Handler) handleListTimelapseMerges(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	limit := 100
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
-	}
-	if limit > 1000 {
-		limit = 1000
-	}
-	offset := 0
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			offset = n
-		}
-	}
+	limit, offset := parsePagination(r, 100, 1000)
 
 	f := storage.TimelapseMergeFilter{
 		CameraID:      r.URL.Query().Get("camera_id"),

--- a/internal/api/handlers_transcode.go
+++ b/internal/api/handlers_transcode.go
@@ -268,23 +268,17 @@ func (h *Handler) handleTranscodingTasksList(w http.ResponseWriter, r *http.Requ
 		CameraID: r.URL.Query().Get("camera_id"),
 	}
 
-	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
-			filter.Limit = v
-		}
-	}
-	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
-		if v, err := strconv.Atoi(offsetStr); err == nil && v >= 0 {
-			filter.Offset = v
-		}
-	} else if pageStr := r.URL.Query().Get("page"); pageStr != "" {
-		// Support page-based pagination (1-indexed).
-		// Convert page to offset: offset = (page - 1) * limit.
-		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
-			if filter.Limit <= 0 {
-				filter.Limit = 50
+	filter.Limit, filter.Offset = parsePagination(r, 0, 0)
+	// When offset is not supplied, support page-based pagination (1-indexed):
+	// offset = (page - 1) * limit, with a default limit of 50.
+	if r.URL.Query().Get("offset") == "" {
+		if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+			if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
+				if filter.Limit <= 0 {
+					filter.Limit = 50
+				}
+				filter.Offset = (p - 1) * filter.Limit
 			}
-			filter.Offset = (p - 1) * filter.Limit
 		}
 	}
 

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -183,10 +183,24 @@ type AIEventStats struct {
 	Count     int    `json:"count"`
 }
 
-// GetAIEventStats returns event type counts for a camera within a time period.
+// GetAIEventStats returns event type counts within a time period. When cameraID
+// is non-empty, stats are scoped to that camera; when empty, stats aggregate
+// across ALL cameras (global view, #213). The query groups by event_type only,
+// so the result shape is identical in both modes.
 func (d *DB) GetAIEventStats(ctx context.Context, cameraID string, since time.Time) ([]AIEventStats, error) {
-	q := `SELECT event_type, COUNT(*) as cnt FROM ai_events WHERE camera_id = ? AND created_at >= ? GROUP BY event_type ORDER BY cnt DESC`
-	rows, err := d.readConn().QueryContext(ctx, q, cameraID, since.Format("2006-01-02 15:04:05"))
+	var where []string
+	var args []interface{}
+	if cameraID != "" {
+		where = append(where, "camera_id = ?")
+		args = append(args, cameraID)
+	}
+	where = append(where, "created_at >= ?")
+	args = append(args, since.Format("2006-01-02 15:04:05"))
+
+	q := `SELECT event_type, COUNT(*) as cnt FROM ai_events WHERE ` +
+		strings.Join(where, " AND ") +
+		` GROUP BY event_type ORDER BY cnt DESC`
+	rows, err := d.readConn().QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 内容

一个 PR 解决 3 个 API 层 issue(均动 API 层,合并提交减少协调成本):

### #222 — 抽取分页 helper
新增 \`parsePagination(r, defaultLimit, maxLimit) (limit, offset)\`(handler.go),统一 6 处 limit/offset 解析(此前各处 default/max 不一致地复制):
- recordings(50/500)、timelapse list(0/1000)、timelapse merges(100/1000)
- ai/archive/transcode(0/0,无 default/cap)
- transcode 保留 page→offset 换算分支

### #223 — 统一错误响应格式
3 处 \`http.Error()\` plain-text 改 \`WriteError()\`(JSON \`{"error":...}\`):
- handlers_hls.go:304(Snapshot URL not configured → 404)
- handlers_hls.go:380(Failed to fetch snapshot → 502)
- handlers_recording.go:646(frame not found → 404)

### #213 — GET /api/ai/stats 支持无 camera_id 全局聚合
- handler:删除 camera_id 必填的 400 guard(camera_id 缺省时聚合所有摄像头)
- storage \`GetAIEventStats\`:cameraID 为空时不加 WHERE camera_id 过滤(GROUP BY event_type 不变,结果 shape 一致)

## 验证

VM(192.168.63.197)go1.26:
- ✅ gofumpt clean(8 文件)
- ✅ go build + go vet 干净
- ✅ go test -race ./internal/api/ 全绿(63s,含全部 handler 测试)
- ✅ go test -race ./internal/storage/ 全绿(17s)

Closes #222, Closes #223, Closes #213