### PR TITLE
refactor: #238 删 joinStrings + #231 merge_cameras 不再跨层直打 DB

### DIFF
--- a/cmd/mibee-nvr/merge_cameras.go
+++ b/cmd/mibee-nvr/merge_cameras.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -203,11 +202,23 @@ func runMergeCameras() int {
 		fmt.Fprintf(os.Stderr, "Error counting recordings for %q: %v\n", f.sourceID, err)
 		return 1
 	}
-	healthCount := countRowsByCamera(ctx, db.DB(), "camera_health_events", f.sourceID)
-	aiCount := countRowsByCamera(ctx, db.DB(), "ai_events", f.sourceID)
-	transcodeCount := countRowsByCamera(ctx, db.DB(), "transcoding_tasks", f.sourceID)
+	healthCount, err := db.CountRowsByCamera(ctx, "camera_health_events", f.sourceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error counting health events for %q: %v\n", f.sourceID, err)
+		return 1
+	}
+	aiCount, err := db.CountRowsByCamera(ctx, "ai_events", f.sourceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error counting AI events for %q: %v\n", f.sourceID, err)
+		return 1
+	}
+	transcodeCount, err := db.CountRowsByCamera(ctx, "transcoding_tasks", f.sourceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error counting transcoding tasks for %q: %v\n", f.sourceID, err)
+		return 1
+	}
 
-	recordings, err := listRecordingsByCamera(ctx, db.DB(), f.sourceID)
+	filePaths, err := db.ListRecordingFilePathsByCamera(ctx, f.sourceID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error listing recordings for %q: %v\n", f.sourceID, err)
 		return 1
@@ -219,10 +230,10 @@ func runMergeCameras() int {
 
 	var orphanCount int
 	var fileList []string
-	for _, rec := range recordings {
-		if rec.filePath != "" {
-			fileList = append(fileList, rec.filePath)
-			if _, err := os.Stat(rec.filePath); errors.Is(err, fs.ErrNotExist) {
+	for _, p := range filePaths {
+		if p != "" {
+			fileList = append(fileList, p)
+			if _, err := os.Stat(p); errors.Is(err, fs.ErrNotExist) {
 				orphanCount++
 			}
 		}
@@ -437,39 +448,6 @@ func applyTargetOverrides(cfg *config.Config, targetID string, f mergeCamerasFla
 			_ = b
 		}
 	}
-}
-
-func countRowsByCamera(ctx context.Context, d *sql.DB, table, cameraID string) int {
-	var count int
-	err := d.QueryRowContext(ctx,
-		fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE camera_id=?", table), cameraID).Scan(&count)
-	if err != nil {
-		return 0
-	}
-	return count
-}
-
-type recordingInfo struct {
-	filePath string
-}
-
-func listRecordingsByCamera(ctx context.Context, d *sql.DB, cameraID string) ([]recordingInfo, error) {
-	rows, err := d.QueryContext(ctx,
-		"SELECT file_path FROM recordings WHERE camera_id=?", cameraID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var result []recordingInfo
-	for rows.Next() {
-		var r recordingInfo
-		if err := rows.Scan(&r.filePath); err != nil {
-			return nil, err
-		}
-		result = append(result, r)
-	}
-	return result, rows.Err()
 }
 
 // mergeDiskDirectories moves all files from srcDir into dstDir, preserving

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -93,7 +93,7 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 
 	whereClause := ""
 	if len(where) > 0 {
-		whereClause = " WHERE " + joinStrings(where, " AND ")
+		whereClause = " WHERE " + strings.Join(where, " AND ")
 	}
 
 	// Count
@@ -218,10 +218,6 @@ func (d *DB) GetAIEventStats(ctx context.Context, cameraID string, since time.Ti
 		return nil, err
 	}
 	return stats, nil
-}
-
-func joinStrings(ss []string, sep string) string {
-	return strings.Join(ss, sep)
 }
 
 // MarshalBBox converts a [4]float64 to JSON string for storage.

--- a/internal/storage/db_stats.go
+++ b/internal/storage/db_stats.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sort"
 	"strconv"
 	"time"
@@ -47,6 +48,51 @@ func (d *DB) CountRecordingsByCamera(ctx context.Context, cameraID string) (int,
 	var count int
 	err := d.readConn().QueryRowContext(ctx, "SELECT COUNT(*) FROM recordings WHERE camera_id=?", cameraID).Scan(&count)
 	return count, err
+}
+
+// countableTables is the fixed allowlist of tables that CountRowsByCamera may
+// query. Listing them as constants (instead of interpolating a caller-supplied
+// table name into SQL) eliminates the injection surface and keeps schema names
+// inside the storage layer (#231).
+var countableTables = map[string]string{
+	"camera_health_events": "SELECT COUNT(*) FROM camera_health_events WHERE camera_id=?",
+	"ai_events":            "SELECT COUNT(*) FROM ai_events WHERE camera_id=?",
+	"transcoding_tasks":    "SELECT COUNT(*) FROM transcoding_tasks WHERE camera_id=?",
+}
+
+// CountRowsByCamera returns the row count for cameraID in the named table.
+// table MUST be one of the keys in countableTables; any other value returns an
+// error rather than being interpolated into SQL. This is the storage-layer
+// replacement for the CLI's old countRowsByCamera helper (#231).
+func (d *DB) CountRowsByCamera(ctx context.Context, table, cameraID string) (int, error) {
+	q, ok := countableTables[table]
+	if !ok {
+		return 0, fmt.Errorf("storage: CountRowsByCamera: unknown table %q", table)
+	}
+	var count int
+	err := d.readConn().QueryRowContext(ctx, q, cameraID).Scan(&count)
+	return count, err
+}
+
+// ListRecordingFilePathsByCamera returns the file_path of every recording row
+// for cameraID (including empty paths, which the caller filters). It is the
+// storage-layer replacement for the CLI's old listRecordingsByCamera helper,
+// keeping raw SQL out of cmd/ (#231).
+func (d *DB) ListRecordingFilePathsByCamera(ctx context.Context, cameraID string) ([]string, error) {
+	rows, err := d.readConn().QueryContext(ctx, "SELECT file_path FROM recordings WHERE camera_id=?", cameraID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
 }
 
 // GetRecordingTrends returns daily aggregated recording statistics.


### PR DESCRIPTION
## 内容(2 个 storage/CLI 清理 issue)

### #238 — 删除多余 joinStrings 包装
`db_ai.go` 的 \`joinStrings\` 只是 \`strings.Join\` 的包装,只被调用 1 次。直接用 \`strings.Join\`,删包装函数。

### #231 — merge_cameras.go 不再跨过 storage 层直打 DB
此前 \`cmd/mibee-nvr/merge_cameras.go\` 用 \`db.DB()\` 拿到 \`*sql.DB\` 直接查询,且 \`countRowsByCamera\` 用 \`fmt.Sprintf\` 拼接表名(**注入面**,虽当前 input 是硬编码常量)。改为走 storage 层:

- 新增 \`storage.DB.CountRowsByCamera(ctx, table, cameraID)\`:\`table\` 必须命中 \`countableTables\` **白常量表**(\`camera_health_events\`/\`ai_events\`/\`transcoding_tasks\`),非法表名报错而非拼进 SQL —— 彻底消除注入模式
- 新增 \`storage.DB.ListRecordingFilePathsByCamera(ctx, cameraID)\`:返回 \`[]string\` file_path,替代 merge_cameras 的本地 \`listRecordingsByCamera\` + \`recordingInfo\` struct
- merge_cameras.go 删除两个本地 helper + \`recordingInfo\` + \`database/sql\` import,改调 storage 方法。**所有 raw SQL 现在都在 \`internal/storage/\` 内**

## 验证
- ✅ VM gofumpt clean(3 文件)
- ✅ go build ./internal/storage/ 干净
- ✅ go test -race ./internal/storage/ 全绿(17s)
- (cmd/mibee-nvr 构建需 internal/ui/static embed 资源,storage 层与语法已验证;CI 会跑完整 build)

Closes #238, Closes #231