### PR TITLE
refactor(api): #245 统一 camera 路由参数为 {id}

### DIFF
--- a/docs/en/api/archives.md
+++ b/docs/en/api/archives.md
@@ -28,7 +28,7 @@ curl -u username:password \
 
 ## List Archive Recordings
 
-**Endpoint:** `GET /api/archives/{cameraID}/recordings`
+**Endpoint:** `GET /api/archives/{id}/recordings`
 
 List recordings for a specific archive.
 
@@ -55,7 +55,7 @@ curl -u username:password \
 
 ## Delete Archive Group
 
-**Endpoint:** `DELETE /api/archives/{cameraID}`
+**Endpoint:** `DELETE /api/archives/{id}`
 
 Delete an entire archive group for a camera.
 
@@ -75,7 +75,7 @@ curl -u username:password \
 
 ## Delete Archive Recording
 
-**Endpoint:** `DELETE /api/archives/{cameraID}/recordings/{recordingID}`
+**Endpoint:** `DELETE /api/archives/{id}/recordings/{recordingID}`
 
 Delete a specific recording from an archive.
 
@@ -95,7 +95,7 @@ curl -u username:password \
 
 ## Set Archive Retention
 
-**Endpoint:** `PUT /api/archives/{cameraID}/retention`
+**Endpoint:** `PUT /api/archives/{id}/retention`
 
 Set retention period for an archive group.
 

--- a/docs/en/api/health-monitoring.md
+++ b/docs/en/api/health-monitoring.md
@@ -130,7 +130,7 @@ curl -u username:password \
 
 ## Per-Camera Stability
 
-**Endpoint:** `GET /api/health/stability/{camera_id}`
+**Endpoint:** `GET /api/health/stability/{id}`
 
 Get stability quality data for a single camera.
 

--- a/docs/zh/api/archives.md
+++ b/docs/zh/api/archives.md
@@ -28,7 +28,7 @@ curl -u username:password \
 
 ## 查询归档录制列表
 
-**端点：** `GET /api/archives/{cameraID}/recordings`
+**端点：** `GET /api/archives/{id}/recordings`
 
 列出指定归档中的录制。
 
@@ -55,7 +55,7 @@ curl -u username:password \
 
 ## 删除归档分组
 
-**端点：** `DELETE /api/archives/{cameraID}`
+**端点：** `DELETE /api/archives/{id}`
 
 删除指定摄像头的整个归档分组。
 
@@ -75,7 +75,7 @@ curl -u username:password \
 
 ## 删除归档录制
 
-**端点：** `DELETE /api/archives/{cameraID}/recordings/{recordingID}`
+**端点：** `DELETE /api/archives/{id}/recordings/{recordingID}`
 
 从归档中删除指定的录制。
 
@@ -95,7 +95,7 @@ curl -u username:password \
 
 ## 设置归档保留期
 
-**端点：** `PUT /api/archives/{cameraID}/retention`
+**端点：** `PUT /api/archives/{id}/retention`
 
 设置归档分组的保留期限。
 

--- a/docs/zh/api/health-monitoring.md
+++ b/docs/zh/api/health-monitoring.md
@@ -130,7 +130,7 @@ curl -u username:password \
 
 ## 单个摄像头稳定性
 
-**端点：** `GET /api/health/stability/{camera_id}`
+**端点：** `GET /api/health/stability/{id}`
 
 获取单个摄像头的稳定性质量数据。
 

--- a/internal/api/handlers_archive.go
+++ b/internal/api/handlers_archive.go
@@ -54,7 +54,7 @@ func (h *Handler) handleListArchives(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleListArchiveRecordings(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraID")
+	cameraID := chi.URLParam(r, "id")
 	ctx := r.Context()
 
 	trueVal := true
@@ -81,7 +81,7 @@ func (h *Handler) handleListArchiveRecordings(w http.ResponseWriter, r *http.Req
 }
 
 func (h *Handler) handleDeleteArchiveGroup(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraID")
+	cameraID := chi.URLParam(r, "id")
 	ctx := r.Context()
 
 	// Verify camera is archived
@@ -130,7 +130,7 @@ func (h *Handler) handleDeleteArchiveGroup(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *Handler) handleDeleteArchiveRecording(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraID")
+	cameraID := chi.URLParam(r, "id")
 	recordingID := chi.URLParam(r, "recordingID")
 	ctx := r.Context()
 
@@ -181,7 +181,7 @@ func (h *Handler) handleDeleteArchiveRecording(w http.ResponseWriter, r *http.Re
 }
 
 func (h *Handler) handleSetArchiveRetention(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraID")
+	cameraID := chi.URLParam(r, "id")
 	ctx := r.Context()
 
 	var body struct {
@@ -207,9 +207,9 @@ func (h *Handler) handleSetArchiveRetention(w http.ResponseWriter, r *http.Reque
 func (h *Handler) registerArchiveRoutes(r chi.Router) {
 	r.Route("/api/archives", func(r chi.Router) {
 		r.Get("/", h.handleListArchives)
-		r.Get("/{cameraID}/recordings", h.handleListArchiveRecordings)
-		r.Delete("/{cameraID}", h.handleDeleteArchiveGroup)
-		r.Delete("/{cameraID}/recordings/{recordingID}", h.handleDeleteArchiveRecording)
-		r.Put("/{cameraID}/retention", h.handleSetArchiveRetention)
+		r.Get("/{id}/recordings", h.handleListArchiveRecordings)
+		r.Delete("/{id}", h.handleDeleteArchiveGroup)
+		r.Delete("/{id}/recordings/{recordingID}", h.handleDeleteArchiveRecording)
+		r.Put("/{id}/retention", h.handleSetArchiveRetention)
 	})
 }

--- a/internal/api/handlers_health.go
+++ b/internal/api/handlers_health.go
@@ -116,7 +116,7 @@ func (h *Handler) handleGetStability(w http.ResponseWriter, r *http.Request) {
 
 // handleGetCameraStability returns stability quality data for a single camera.
 func (h *Handler) handleGetCameraStability(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "camera_id")
+	cameraID := chi.URLParam(r, "id")
 	if cameraID == "" {
 		WriteError(w, http.StatusBadRequest, "missing camera id")
 		return
@@ -141,5 +141,5 @@ func (h *Handler) registerHealthRoutes(r chi.Router) {
 	r.Get("/api/health/status", h.handleGetHealthStatus)
 	r.Get("/api/health/events", h.handleGetHealthEvents)
 	r.Get("/api/health/stability", h.handleGetStability)
-	r.Get("/api/health/stability/{camera_id}", h.handleGetCameraStability)
+	r.Get("/api/health/stability/{id}", h.handleGetCameraStability)
 }

--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -214,11 +214,11 @@ func (h *Handler) handleTimelapseStatus(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// handleTimelapseMergeProgress handles GET /api/timelapse/merge/progress/{cameraId}.
+// handleTimelapseMergeProgress handles GET /api/timelapse/merge/progress/{id}.
 // SSE endpoint that streams merge progress updates for a specific camera.
 // It sends progress events as the merge progresses and closes when complete.
 func (h *Handler) handleTimelapseMergeProgress(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraId")
+	cameraID := chi.URLParam(r, "id")
 
 	if h.timelapseMergeMgr == nil {
 		WriteError(w, http.StatusServiceUnavailable, "timelapse merge manager not available")
@@ -750,10 +750,10 @@ func (h *Handler) handleRetryTimelapseMerge(w http.ResponseWriter, r *http.Reque
 }
 
 // --- Task 7: Merge Cancellation ---
-// handleTimelapseMergeCancel handles DELETE /api/timelapse/{cameraId}/merge.
+// handleTimelapseMergeCancel handles DELETE /api/timelapse/{id}/merge.
 // Cancels an active rolling merge for the specified camera.
 func (h *Handler) handleTimelapseMergeCancel(w http.ResponseWriter, r *http.Request) {
-	cameraID := chi.URLParam(r, "cameraId")
+	cameraID := chi.URLParam(r, "id")
 
 	if h.timelapseMergeMgr == nil {
 		WriteError(w, http.StatusServiceUnavailable, "timelapse merge manager not available")
@@ -1056,11 +1056,11 @@ func (h *Handler) registerTimelapseRoutes(r chi.Router) {
 	r.Get("/api/timelapse/merges/{id}/download", h.handleDownloadTimelapseMerge)
 	r.Delete("/api/timelapse/merges/{id}", h.handleDeleteTimelapseMerge)
 	r.Post("/api/timelapse/{id}/merge", h.handleTimelapseMerge)
-	r.Delete("/api/timelapse/{cameraId}/merge", h.handleTimelapseMergeCancel)
+	r.Delete("/api/timelapse/{id}/merge", h.handleTimelapseMergeCancel)
 	r.Post("/api/timelapse/{id}/pause", h.handleTimelapsePause)
 	r.Post("/api/timelapse/{id}/resume", h.handleTimelapseResume)
 	r.Get("/api/timelapse/{id}", h.handleTimelapseGet)
 	r.Delete("/api/timelapse/{id}", h.handleTimelapseDelete)
 	r.Post("/api/timelapse/{id}/download", h.handleTimelapseDownload)
-	r.Get("/api/timelapse/merge/progress/{cameraId}", h.handleTimelapseMergeProgress)
+	r.Get("/api/timelapse/merge/progress/{id}", h.handleTimelapseMergeProgress)
 }


### PR DESCRIPTION
## 问题 (#245)

camera 相关路由参数命名不一致,7 个路由用了 3 种非规范名,其余都用 \`{id}\`:
- \`{cameraId}\`(camelCase,2 路由)
- \`{cameraID}\`(capital D,4 路由)
- \`{camera_id}\`(snake_case,1 路由)

## 修复

全部统一为 \`{id}\`:

| 变体 | 路由数 | 文件 |
|------|--------|------|
| \`{cameraId}\` → \`{id}\` | 2 | handlers_timelapse.go(DELETE merge + GET progress) |
| \`{cameraID}\` → \`{id}\` | 4 | handlers_archive.go(/api/archives 下 4 个) |
| \`{camera_id}\` → \`{id}\` | 1 | handlers_health.go(stability) |

handler 内 \`chi.URLParam\` 读取(7 处)+ doc comment 同步;docs/\{en,zh\}/api/ archives.md + health-monitoring.md 端点示例同步。

## 无冲突风险
chi 按 method+pattern 路由。各 \`{id}\` 子路径无 sibling 冲突 —— 例如 \`DELETE /timelapse/{id}/merge\` 与既有 \`POST /timelapse/{id}/merge\` 方法不同,不冲突。

## 前端
URL 用 path-segment 值(cam-id),不依赖参数名 → **无需改前端代码**(\`recordings.ts\` 的 \`cameraId\`/\`cameraID\` 是 JS 局部变量名,与服务器参数名无关)。前端测试 514/514 全绿。

## 验证
- ✅ VM gofumpt clean
- ✅ go build + go vet ./internal/api/ 干净
- ✅ go test -race ./internal/api/(timelapse/archive/health 路由测试)全绿
- ✅ 前端 npm test 514/514

Closes #245