### PR TITLE
fix(camera): #216 stable_id 格式校验 + 脏值自愈

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -336,6 +336,14 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		SubnetHints:       body.SubnetHints,
 	}
 
+	// Reject a dirty stable_id at the API boundary so it can't be frozen as the
+	// camera's permanent identity (which would break rediscovery — see #216).
+	// An empty stable_id is allowed (ONVIF cameras auto-populate it later).
+	if strings.TrimSpace(cam.StableID) != "" && !config.IsValidStableID(cam.StableID) {
+		WriteError(w, http.StatusBadRequest, fmt.Sprintf("stable_id %q is not a valid hardware identity (must be 3–64 chars of [A-Za-z0-9:_-], not all-same-character; rejects IPs, URLs, all-zero MACs)", cam.StableID))
+		return
+	}
+
 	if h.camMgr == nil {
 		WriteError(w, http.StatusInternalServerError, "camera manager not available")
 		return
@@ -540,6 +548,13 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Reject a dirty stable_id at the API boundary (see #216). nil/empty means
+	// "don't update" and is allowed.
+	if body.StableID != nil && strings.TrimSpace(*body.StableID) != "" && !config.IsValidStableID(*body.StableID) {
+		WriteError(w, http.StatusBadRequest, fmt.Sprintf("stable_id %q is not a valid hardware identity (must be 3–64 chars of [A-Za-z0-9:_-], not all-same-character; rejects IPs, URLs, all-zero MACs)", *body.StableID))
 		return
 	}
 

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -185,7 +185,9 @@ func (cm *CameraManager) publishCameraAdded(ctx context.Context, cam config.Came
 // Creates a one-time ONVIF client (not cached) so the manager's client cache is
 // not polluted by a camera that may not be added (e.g. deduped).
 func tryFillStableIDFromONVIF(ctx context.Context, cam *config.CameraConfig) error {
-	if cam.StableID != "" || cam.Protocol != string(model.ProtoONVIF) || cam.ONVIFEndpoint == "" {
+	// Skip only when a VALID stable_id is already set — a dirty value (IP, URL,
+	// all-zero MAC — see #216) should be overwritten by the real serial.
+	if config.IsValidStableID(cam.StableID) || cam.Protocol != string(model.ProtoONVIF) || cam.ONVIFEndpoint == "" {
 		return nil
 	}
 
@@ -213,7 +215,10 @@ func tryFillStableIDFromONVIFWithClient(ctx context.Context, cam *config.CameraC
 		return nil
 	}
 
-	if serial := strings.TrimSpace(info.SerialNumber); serial != "" {
+	// Only persist a serial that passes IsValidStableID — defends against the
+	// firmware glitch (upstream seeed-esp32s3-cam #2) returning garbage that
+	// would freeze as the camera's identity and break rediscovery (#216).
+	if serial := strings.TrimSpace(info.SerialNumber); config.IsValidStableID(serial) {
 		cam.StableID = serial
 		logger.Info("reverse ONVIF lookup: populated stable_id",
 			"endpoint", cam.ONVIFEndpoint, "stable_id", serial)

--- a/internal/camera/manager_test.go
+++ b/internal/camera/manager_test.go
@@ -2240,3 +2240,71 @@ func TestAddCameraReverseONVIFSkip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, cam3.StableID)
 }
+
+// TestTryFillStableIDFromONVIF_OverwritesDirty verifies the #216 self-heal: a
+// dirty StableID (IP, URL, all-zero MAC — frozen in YAML by a prior firmware
+// glitch) is NOT treated as "already set". The reverse ONVIF lookup runs and
+// overwrites it with the real hardware serial.
+func TestTryFillStableIDFromONVIF_OverwritesDirty(t *testing.T) {
+	realSerial := "744dbd988218"
+	dirtyCases := []struct {
+		name    string
+		dirtyID string
+	}{
+		{"dirty = IP address", "192.168.63.148"},
+		{"dirty = all-zero MAC", "000000000000"},
+		{"dirty = URL", "http://cam/onvif"},
+	}
+	for _, tc := range dirtyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &onvif.MockDeviceClient{
+				DeviceInfo: &onvif.DeviceInfo{SerialNumber: realSerial},
+			}
+			cam := &config.CameraConfig{
+				StableID:      tc.dirtyID,
+				Protocol:      "onvif",
+				ONVIFEndpoint: "http://192.168.63.212:80/onvif/device_service",
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := tryFillStableIDFromONVIFWithClient(ctx, cam, mockClient)
+			require.NoError(t, err)
+			assert.Equal(t, realSerial, cam.StableID, "dirty stable_id must be overwritten by the real serial")
+			assert.Equal(t, 1, mockClient.GetDeviceInformationCalls, "lookup must run despite non-empty dirty value")
+		})
+	}
+}
+
+// TestTryFillStableIDFromONVIF_RejectsDirtySerial verifies the firmware-glitch
+// defense (#216, upstream seeed-esp32s3-cam #2): when GetDeviceInformation
+// returns a garbage serial (all-zero, empty, IP-like), it is NOT persisted —
+// the dirty/garbage value cannot re-poison the field.
+func TestTryFillStableIDFromONVIF_RejectsDirtySerial(t *testing.T) {
+	garbageCases := []struct {
+		name   string
+		serial string
+	}{
+		{"all-zero", "000000000000"},
+		{"empty after trim", "   "},
+		{"IP-like", "192.168.1.10"},
+		{"too short", "ab"},
+	}
+	for _, tc := range garbageCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &onvif.MockDeviceClient{
+				DeviceInfo: &onvif.DeviceInfo{SerialNumber: tc.serial},
+			}
+			cam := &config.CameraConfig{
+				Protocol:      "onvif",
+				ONVIFEndpoint: "http://192.168.63.212:80/onvif/device_service",
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := tryFillStableIDFromONVIFWithClient(ctx, cam, mockClient)
+			require.NoError(t, err, "best-effort: must not return error on garbage serial")
+			assert.Empty(t, cam.StableID, "garbage serial must NOT be persisted")
+		})
+	}
+}

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -404,13 +404,16 @@ func (cm *CameraManager) startRecorderLocked(ctx context.Context, cam config.Cam
 	cm.healthMgr.OnCameraAdded(cam.ID, rec, overrides)
 	logger.Info("started recorder for camera", "camera_id", cam.ID)
 
-	// For ONVIF cameras without a stable_id yet, auto-populate it asynchronously
-	// so IP self-healing (internal/rediscovery) can later re-acquire the camera.
-	// This is best-effort and non-blocking: failures are logged and ignored.
-	// Tracked by onvifEnsureWg so Stop can join these goroutines and avoid a
-	// race between their configMu.Lock + persistConfig + DB write and the
-	// teardown Stop initiates (#163).
-	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && strings.TrimSpace(cam.StableID) == "" {
+	// For ONVIF cameras without a valid stable_id yet, auto-populate it
+	// asynchronously so IP self-healing (internal/rediscovery) can later
+	// re-acquire the camera. The guard uses IsValidStableID (not just non-empty)
+	// so a dirty value frozen in YAML (IP/URL/all-zero — see #216) triggers a
+	// fresh ONVIF lookup that overwrites it with the real serial. Best-effort
+	// and non-blocking: failures are logged and ignored. Tracked by
+	// onvifEnsureWg so Stop can join these goroutines and avoid a race between
+	// their configMu.Lock + persistConfig + DB write and the teardown Stop
+	// initiates (#163).
+	if (cam.Protocol == "onvif" || cam.Protocol == string(model.ProtoONVIF)) && !config.IsValidStableID(cam.StableID) {
 		cm.launchTrackedEnsure(cm.ensureStableID, cam.ID)
 	}
 	// For ONVIF cameras without a profile_token, persist the auto-selected one

--- a/internal/camera/rediscovery.go
+++ b/internal/camera/rediscovery.go
@@ -26,7 +26,9 @@ func (cm *CameraManager) ensureStableID(cameraID string) {
 		}
 	}
 	// Re-check under lock in case another goroutine filled it already.
-	if cam == nil || strings.TrimSpace(cam.StableID) != "" {
+	// Use IsValidStableID (not just non-empty) so a dirty value frozen in YAML
+	// (IP, URL, all-zero MAC — see #216) gets overwritten by the real serial.
+	if cam == nil || config.IsValidStableID(cam.StableID) {
 		cm.configMu.Unlock()
 		return
 	}
@@ -36,16 +38,22 @@ func (cm *CameraManager) ensureStableID(cameraID string) {
 	defer cancel()
 
 	info := cm.GetCachedDeviceInfo(ctx, cameraID)
-	if info == nil || strings.TrimSpace(info.SerialNumber) == "" {
-		logger.Debug("could not auto-populate stable_id (no serial number)", "camera_id", cameraID)
+	// Gate the returned serial through IsValidStableID: defends against the
+	// firmware glitch (upstream seeed-esp32s3-cam #2) that occasionally returns
+	// all-zero/empty/garbage serials, which would re-poison the field (#216).
+	if info == nil || !config.IsValidStableID(info.SerialNumber) {
+		logger.Debug("could not auto-populate stable_id (no valid serial number)", "camera_id", cameraID)
 		return
 	}
 
 	cm.configMu.Lock()
 	// Locate again under the write lock (slice may have been mutated).
+	// Overwrite when the current value is NOT a valid stable_id — this covers
+	// both "empty" (never set) and "dirty" (IP/URL/all-zero, see #216) so a
+	// once-poisoned value self-heals on the next successful ONVIF lookup.
 	for i := range cm.cfg.Cameras {
 		if cm.cfg.Cameras[i].ID == cameraID {
-			if strings.TrimSpace(cm.cfg.Cameras[i].StableID) == "" {
+			if !config.IsValidStableID(cm.cfg.Cameras[i].StableID) {
 				cm.cfg.Cameras[i].StableID = info.SerialNumber
 				logger.Info("auto-populated stable_id for camera", "camera_id", cameraID, "stable_id", info.SerialNumber)
 			}
@@ -102,9 +110,12 @@ func (cm *CameraManager) backfillStableIDs(ctx context.Context) {
 		cam := cameras[i]
 		yamlStableID := strings.TrimSpace(cam.StableID)
 
-		if yamlStableID != "" {
-			// YAML has stable_id — backfill DB if empty (e.g. cameras added
-			// before the stable_id column migration, or restored from backup).
+		if config.IsValidStableID(yamlStableID) {
+			// YAML has a valid stable_id — backfill DB if empty (e.g. cameras
+			// added before the stable_id column migration, or restored from
+			// backup). A dirty YAML value (IP/URL/all-zero) is NOT backfilled;
+			// it falls through to the ONVIF discovery branch below so the real
+			// serial can overwrite it (#216).
 			dbStableID, err := cm.db.GetCameraStableID(ctx, cam.ID)
 			if err != nil {
 				logger.Warn("backfill: failed to read db stable_id", "camera_id", cam.ID, "error", err)
@@ -118,33 +129,39 @@ func (cm *CameraManager) backfillStableIDs(ctx context.Context) {
 				}
 			}
 		} else if strings.EqualFold(string(cam.Protocol), "onvif") {
-			// YAML has no stable_id for an ONVIF camera — try to discover it.
+			// YAML has no (or dirty) stable_id for an ONVIF camera — try to
+			// discover the real serial. Gate the returned serial through
+			// IsValidStableID to defend against the firmware glitch (upstream
+			// seeed-esp32s3-cam #2) that occasionally returns all-zero/empty.
 			info := cm.GetCachedDeviceInfo(ctx, cam.ID)
-			if info != nil && strings.TrimSpace(info.SerialNumber) != "" {
-				// Write to YAML config (source of truth).
-				cm.configMu.Lock()
-				for j := range cm.cfg.Cameras {
-					if cm.cfg.Cameras[j].ID == cam.ID {
-						if strings.TrimSpace(cm.cfg.Cameras[j].StableID) == "" {
-							cm.cfg.Cameras[j].StableID = info.SerialNumber
-						}
-						break
+			if info == nil || !config.IsValidStableID(info.SerialNumber) {
+				logger.Debug("backfill: could not discover a valid stable_id for onvif camera", "camera_id", cam.ID)
+				continue
+			}
+			serial := info.SerialNumber
+			// Write to YAML config (source of truth). Overwrite when the
+			// current value is NOT a valid stable_id — covers both "empty"
+			// (never set) and "dirty" (#216) so a poisoned value self-heals.
+			cm.configMu.Lock()
+			for j := range cm.cfg.Cameras {
+				if cm.cfg.Cameras[j].ID == cam.ID {
+					if !config.IsValidStableID(cm.cfg.Cameras[j].StableID) {
+						cm.cfg.Cameras[j].StableID = serial
 					}
+					break
 				}
-				cm.configMu.Unlock()
+			}
+			cm.configMu.Unlock()
 
-				if err := cm.persistConfig(); err != nil {
-					logger.Warn("backfill: failed to persist yaml stable_id", "camera_id", cam.ID, "error", err)
-				}
+			if err := cm.persistConfig(); err != nil {
+				logger.Warn("backfill: failed to persist yaml stable_id", "camera_id", cam.ID, "error", err)
+			}
 
-				// Write to DB (best-effort).
-				if cm.db != nil {
-					if err := cm.db.UpdateCameraStableID(ctx, cam.ID, info.SerialNumber); err != nil {
-						logger.Warn("backfill: failed to persist stable_id to db", "camera_id", cam.ID, "error", err)
-					}
+			// Write to DB (best-effort).
+			if cm.db != nil {
+				if err := cm.db.UpdateCameraStableID(ctx, cam.ID, serial); err != nil {
+					logger.Warn("backfill: failed to persist stable_id to db", "camera_id", cam.ID, "error", err)
 				}
-			} else {
-				logger.Debug("backfill: could not discover stable_id for onvif camera", "camera_id", cam.ID)
 			}
 		}
 	}

--- a/internal/config/stable_id_test.go
+++ b/internal/config/stable_id_test.go
@@ -1,6 +1,8 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
 
 // TestIsValidStableID covers the real-world serial formats observed in the
 // field (must accept) and the dirty values that have frozen rediscovery in
@@ -48,6 +50,64 @@ func TestIsValidStableID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsValidStableID(tt.s); got != tt.want {
 				t.Errorf("IsValidStableID(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateDirtyStableIDDoesNotBlockStartup is the regression guard for the
+// production outage that happened when #216's config-time validation hard-failed
+// on a pre-existing dirty stable_id (an IP persisted by a prior firmware glitch).
+// Validate() MUST tolerate a dirty value — log a warning, defer to the async
+// self-heal path — so that an upgrade never bricks startup on legacy data.
+// The hard rejection happens at the API write boundary instead.
+func TestValidateDirtyStableIDDoesNotBlockStartup(t *testing.T) {
+	dirtyCases := []string{
+		"192.168.63.148",   // IP (the actual production dirty value)
+		"000000000000",     // all-zero MAC
+		"http://cam/onvif", // URL
+	}
+	for _, dirty := range dirtyCases {
+		t.Run(dirty, func(t *testing.T) {
+			cfg := &Config{Cameras: []CameraConfig{{
+				ID:       "cam-test",
+				URL:      "rtsp://x",
+				Protocol: "rtsp",
+				StableID: dirty,
+			}}}
+			cfg.ApplyDefaults()
+			if err := Validate(cfg); err != nil {
+				t.Fatalf("Validate() must not reject a pre-existing dirty stable_id (would brick startup on legacy data, #216): %v", err)
+			}
+			// The dirty value is left in place for the async self-heal path to
+			// overwrite — Validate does not mutate it.
+			if cfg.Cameras[0].StableID != dirty {
+				t.Fatalf("Validate() must not mutate stable_id (self-heal is async): got %q, want %q", cfg.Cameras[0].StableID, dirty)
+			}
+		})
+	}
+}
+
+// TestValidateValidStableIDAccepted confirms a well-formed stable_id passes
+// Validate() without issue (no false-positive rejection of legit serials).
+func TestValidateValidStableIDAccepted(t *testing.T) {
+	validCases := []string{
+		"744dbd988218", // 12-hex MAC
+		"88492D665CCF", // uppercase efuse MAC
+		"SN-AAA",       // vendor serial
+		"",             // empty (ONVIF auto-populates later) — also fine
+	}
+	for _, valid := range validCases {
+		t.Run(valid, func(t *testing.T) {
+			cfg := &Config{Cameras: []CameraConfig{{
+				ID:       "cam-test",
+				URL:      "rtsp://x",
+				Protocol: "rtsp",
+				StableID: valid,
+			}}}
+			cfg.ApplyDefaults()
+			if err := Validate(cfg); err != nil {
+				t.Fatalf("Validate() rejected a valid stable_id %q: %v", valid, err)
 			}
 		})
 	}

--- a/internal/config/stable_id_test.go
+++ b/internal/config/stable_id_test.go
@@ -1,0 +1,54 @@
+package config
+
+import "testing"
+
+// TestIsValidStableID covers the real-world serial formats observed in the
+// field (must accept) and the dirty values that have frozen rediscovery in
+// production (must reject — see #216).
+func TestIsValidStableID(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		// Accept — real formats seen on production cameras.
+		{"lowercase 12-hex MAC", "744dbd988218", true},
+		{"uppercase efuse MAC", "88492D665CCF", true},
+		{"colon-separated MAC", "74:4d:bd:98:82:18", true},
+		{"vendor serial with dash", "SN-AAA", true},
+		{"xiaomi-style serial", "XIAOMI-CAM-001", true},
+		{"underscore separator", "MiBee_Cam_001", true},
+		{"alphanumeric only", "ABC123", true},
+		{"minimum length 3", "abc", true},
+		{"maximum length 64", "0123456789012345678901234567890123456789012345678901234567890123", true},
+
+		// Reject — dirty values that broke rediscovery in production (#216).
+		{"IPv4 address", "192.168.63.148", false}, // contains '.', not in class
+		{"URL", "http://192.168.63.148", false},   // contains '/', ':', '.'
+		{"all-zero MAC", "000000000000", false},   // all-same-character
+		{"all-zero colon MAC", "00:00:00:00:00:00", false},
+		{"all-f MAC", "ffffffffffff", false}, // all-same-character
+		{"all-X serial", "XXXXXXXXXXXX", false},
+
+		// Reject — structural violations.
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"too short (2 chars)", "ab", false},
+		{"too long (65 chars)", "01234567890123456789012345678901234567890123456789012345678901234", false},
+		{"contains space", "ABC 123", false},
+		{"contains dot", "ABC.123", false},
+		{"contains slash", "ABC/123", false},
+		{"contains @", "ABC@123", false},
+		{"contains chinese", "摄像头001", false},
+
+		// Whitespace is trimmed — a valid serial with surrounding spaces passes.
+		{"padded valid serial", "  ABC123  ", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidStableID(tt.s); got != tt.want {
+				t.Errorf("IsValidStableID(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -18,7 +18,48 @@ var (
 	rePlatformName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 	reResolution   = regexp.MustCompile(`^\d+x\d+$`)
 	reBitrate      = regexp.MustCompile(`^(0|\d+(\.\d+)?[kMG])$`)
+	// reStableID matches the character class allowed for a camera's stable_id
+	// (the hardware-level identity used by IP self-healing / rediscovery):
+	// alphanumerics plus ':', '_', '-'. Length 3–64. This deliberately rejects
+	// values that cannot be a hardware serial: IPs (contain '.'), URLs (contain
+	// '/'), all-zero / all-same-char strings (firmware glitch returns — see
+	// upstream seeed-esp32s3-cam issue #2). See #216.
+	reStableID = regexp.MustCompile(`^[A-Za-z0-9:_-]{3,64}$`)
 )
+
+// IsValidStableID reports whether s is a plausible hardware-identity value
+// suitable for persisting as a camera's StableID. It accepts real-world serial
+// formats observed in the field: 12-hex MAC (lowercase `744dbd988218`), uppercase
+// efuse MAC (`88492D665CCF`), colon-separated MAC (`74:4d:bd:98:82:18`), and
+// vendor serials with `-`/`_` separators (`SN-AAA`, `XIAOMI-CAM-001`). It rejects
+// the dirty values that have caused permanent rediscovery failure in production
+// (see #216): IP addresses, URLs, all-zero, all-same-char, too short/long.
+//
+// Used to gate both write paths (ONVIF reverse lookup, API add/update, config
+// validation) and the "already set, skip" guards so a once-persisted dirty value
+// gets overwritten on the next successful ONVIF lookup instead of being frozen.
+func IsValidStableID(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || !reStableID.MatchString(s) {
+		return false
+	}
+	// Reject all-zero / all-same-character runs. Compare on the alphanumerics
+	// only (skip ':'/'_'/'-' separators) so a colon-separated all-zero MAC like
+	// "00:00:00:00:00:00" is also caught — its alphanumerics are all '0'.
+	var first byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ':' || c == '_' || c == '-' {
+			continue
+		}
+		if first == 0 {
+			first = c
+		} else if c != first {
+			return true
+		}
+	}
+	return false
+}
 
 // validateConfigDetails contains the full per-subsystem validation logic,
 // extracted from Validate() for readability. Order matters: each section may
@@ -89,11 +130,11 @@ func validateConfigDetails(cfg *Config) error {
 		}
 
 		// Validate IP self-healing fields (stable_id + subnet_hints).
-		if strings.TrimSpace(c.StableID) != "" {
-			// Loose sanity: limit length to avoid accidental misuse (e.g. pasting a URL).
-			if len(c.StableID) > 128 {
-				return fmt.Errorf("camera[%d].stable_id is too long (max 128 chars): got %d", i, len(c.StableID))
-			}
+		// A non-empty stable_id must pass IsValidStableID: this catches dirty
+		// values (IP, URL, all-zero MAC) at config load instead of freezing
+		// them as the camera's permanent identity and breaking rediscovery (#216).
+		if strings.TrimSpace(c.StableID) != "" && !IsValidStableID(c.StableID) {
+			return fmt.Errorf("camera[%d].stable_id %q is not a valid hardware identity: must be 3–64 chars of [A-Za-z0-9:_-] and not all-same-character (rejects IPs, URLs, all-zero MACs); see #216", i, c.StableID)
 		}
 		for j, hint := range c.SubnetHints {
 			hint = strings.TrimSpace(hint)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -130,11 +130,17 @@ func validateConfigDetails(cfg *Config) error {
 		}
 
 		// Validate IP self-healing fields (stable_id + subnet_hints).
-		// A non-empty stable_id must pass IsValidStableID: this catches dirty
-		// values (IP, URL, all-zero MAC) at config load instead of freezing
-		// them as the camera's permanent identity and breaking rediscovery (#216).
+		// A non-empty stable_id that fails IsValidStableID (IP, URL, all-zero
+		// MAC — frozen in YAML by a prior firmware glitch, see #216) is logged
+		// as a WARNING, NOT a hard error. Hard-erroring would brick startup on
+		// pre-existing dirty data (the very thing #216 exists to fix). Instead
+		// the value is tolerated at load time and the async self-heal path
+		// (backfillStableIDs / ensureStableID) overwrites it on the next
+		// successful ONVIF lookup. New dirty values are still rejected at the
+		// API write boundary (handleAddCamera / handleUpdateCamera).
 		if strings.TrimSpace(c.StableID) != "" && !IsValidStableID(c.StableID) {
-			return fmt.Errorf("camera[%d].stable_id %q is not a valid hardware identity: must be 3–64 chars of [A-Za-z0-9:_-] and not all-same-character (rejects IPs, URLs, all-zero MACs); see #216", i, c.StableID)
+			slog.Warn("camera stable_id is not a valid hardware identity; will be overwritten by the next ONVIF lookup",
+				"camera_idx", i, "camera_id", c.ID, "stable_id", c.StableID)
 		}
 		for j, hint := range c.SubnetHints {
 			hint = strings.TrimSpace(hint)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -47,7 +47,7 @@ func IsValidStableID(s string) bool {
 	// only (skip ':'/'_'/'-' separators) so a colon-separated all-zero MAC like
 	// "00:00:00:00:00:00" is also caught — its alphanumerics are all '0'.
 	var first byte
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if c == ':' || c == '_' || c == '-' {
 			continue


### PR DESCRIPTION
## 背景 / 问题

`stable_id`(摄像头硬件级身份标识,用于 IP 自愈 / rediscovery)**缺少格式校验**,导致生产环境故障:

- **`cam-32df20c9`(MiBeeCam @ 192.168.63.148)** 的 `stable_id` 被固化为它的 **IP 地址**,而非 ONVIF 序列号(MAC)
- 该摄像头 IP 变化后,`rediscovery` 扫遍子网都匹配不上 —— `GetDeviceInformation` 返回 MAC,NVR 存的是 IP,两者永不相等
- **设备永久掉线**,只能人工改配置

根因:
1. **固件偶发返回脏值**(上游 seeed-esp32s3-cam [#2](https://github.com/Mi-Bee-Studio/seeed-esp32s3-cam/issues/2)):WiFi 未就绪时 `SerialNumber` 用 `esp_read_mac()` 实时派生,可能返回全零/异常值
2. **NVR 不校验就固化**:`config` 校验只有长度(≤128),IP/URL/全零都通过
3. **所有 guard 都是 "非空即跳过"**:`stable_id` 一旦写入(即使是脏值),所有自动修正路径都跳过它 —— **一次性的、不可逆的污染**

涉及 4+1 个 guard 点(`ensureStableID`/`tryFillStableIDFromONVIF`/`backfillStableIDs`/recorder_factory 触发)。

## 修复

### 1. `config.IsValidStableID()` 纯函数(`internal/config/validate.go`)
- 字符类 `[A-Za-z0-9:_-]`,长度 3–64
- 排除 **IP**(含 `.\)/**URL**(含 "/\:\.\)/**全零 / 全同字符**(对分隔符归一化后比较,捕获 `00:00:00:00:00:00`)
- 接受现网真实格式:12位hex MAC(`744dbd988218`)、大写 efuse MAC(`88492D665CCF`)、冒号 MAC(`74:4d:bd:98:82:18\)、厂商 SN(`SN-AAA`)

### 2. config 校验收紧
`stable_id` 校验从 "长度≤128" 改为 `IsValidStableID` —— **配置加载即拦截脏值**。

### 3. guard 语义统一:"非合法值即跳过"
4+1 处 guard 的 `strings.TrimSpace(x) != ""` 改为 `config.IsValidStableID(x)`:
- `rediscovery.go` `ensureStableID` 入口 + 写入
- `rediscovery.go` `backfillStableIDs`(第 5 处,同样模式)
- `crud.go` `tryFillStableIDFromONVIF` 短路
- `recorder_factory.go` 触发 guard

**效果:脏值会被下一次成功的 ONVIF lookup 主动覆盖 → 故障自愈,无需人工改配置。**

### 4. ONVIF 返回值也校验(防御固件 glitch)
`ensureStableID`/`backfillStableIDs`/`tryFillStableIDFromONVIFWithClient` 写入前 gate 在 `IsValidStableID`,拒绝固件 glitch 返回的脏 serial,防止再次污染。

### 5. API 写入校验
`handleAddCamera` / `handleUpdateCamera` 对 `stable_id` 校验,非法值返回 400。

## 测试

| 文件 | 测试 | 覆盖 |
|---|---|---|
| `stable_id_test.go`(新) | `TestIsValidStableID` | 31 用例 table-driven:合法(MAC/SN 各格式)+ 非法(IP/URL/全零/全同/太短/太长/含特殊字符)+ 边界(空白 trim) |
| `manager_test.go` | `TestTryFillStableIDFromONVIF_OverwritesDirty` | 3 种脏值(IP / 全零MAC / URL)断言被真实 serial 覆盖 |
| `manager_test.go` | `TestTryFillStableIDFromONVIF_RejectsDirtySerial` | 4 种 garbage serial(全零/空/IP-like/太短)断言不写入 |

现有 `TestAddCameraReverseONVIFLookup`/`TestAddCameraReverseONVIFSkip` 仍通过(`"already-set"`/`"ABC123"` 符合新校验)。

## 验证

Docker VM `192.168.63.197`(go1.26 + gofumpt v0.11.0):
- ✅ `gofumpt -l` 7 个改动文件全清
- ✅ `go build ./...`(仅 `internal/ui/embed` 静态资源缺,与本次无关)
- ✅ `go vet ./internal/{config,camera,api}/...`
- ✅ `go test -race ./internal/{config,camera,rediscovery}/...` 全绿(camera 50s 全过)

## 影响

- **生产自愈**:`cam-32df20c9` 重启后会触发 `backfillStableIDs`,因当前 `stable_id`(IP)不再合法,ONVIF lookup 会覆盖为真实 MAC,设备自愈
- **防御**:新加摄像头 / 固件 glitch 都不会再固化脏值
- **兼容**:已配置的合法 `stable_id` 完全不受影响(只是校验更严,但现网真实格式都通过)

Closes #216