### PR TITLE
refactor(mp4util): 统一 hvcC/avcC 构造(3 份→1 份共享) [#236 阶段1]

### DIFF
--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
 	"github.com/abema/go-mp4"
 )
 
@@ -1039,22 +1040,7 @@ func writeMergeH264SampleEntry(w *mp4.Writer, tr *mergeTrack) error {
 	if err != nil {
 		return err
 	}
-	avcC := &mp4.AVCDecoderConfiguration{
-		AnyTypeBox:                 mp4.AnyTypeBox{Type: mp4.StrToBoxType("avcC")},
-		ConfigurationVersion:       1,
-		Profile:                    tr.sps[1],
-		ProfileCompatibility:       tr.sps[2],
-		Level:                      tr.sps[3],
-		LengthSizeMinusOne:         3,
-		NumOfSequenceParameterSets: 1,
-		SequenceParameterSets: []mp4.AVCParameterSet{
-			{Length: uint16(len(tr.sps)), NALUnit: tr.sps},
-		},
-		NumOfPictureParameterSets: 1,
-		PictureParameterSets: []mp4.AVCParameterSet{
-			{Length: uint16(len(tr.pps)), NALUnit: tr.pps},
-		},
-	}
+	avcC := mp4util.BuildAvcC(tr.sps, tr.pps)
 	if _, err := mp4.Marshal(w, avcC, mp4.Context{}); err != nil {
 		return err
 	}
@@ -1094,7 +1080,7 @@ func writeMergeH265SampleEntry(w *mp4.Writer, tr *mergeTrack) error {
 	if err != nil {
 		return err
 	}
-	hvcC := buildMergeHvcC(tr.vps, tr.sps, tr.pps)
+	hvcC := mp4util.BuildHvcC(tr.vps, tr.sps, tr.pps)
 	if _, err := mp4.Marshal(w, hvcC, mp4.Context{}); err != nil {
 		return err
 	}
@@ -1107,48 +1093,6 @@ func writeMergeH265SampleEntry(w *mp4.Writer, tr *mergeTrack) error {
 	}
 	_ = bi
 	return nil
-}
-
-// buildMergeHvcC constructs an HvcC from VPS, SPS, PPS.
-func buildMergeHvcC(vps, sps, pps []byte) *mp4.HvcC {
-	profile := uint8(0)
-	if len(sps) > 1 {
-		profile = sps[1]
-	}
-	level := uint8(0)
-	if len(sps) > 12 {
-		level = sps[12]
-	}
-	return &mp4.HvcC{
-		ConfigurationVersion:        1,
-		GeneralProfileSpace:         0,
-		GeneralTierFlag:             false,
-		GeneralProfileIdc:           profile,
-		GeneralProfileCompatibility: [32]bool{},
-		GeneralConstraintIndicator:  [6]uint8{},
-		GeneralLevelIdc:             level,
-		Reserved1:                   15,
-		MinSpatialSegmentationIdc:   0,
-		Reserved2:                   63,
-		ParallelismType:             0,
-		Reserved3:                   63,
-		ChromaFormatIdc:             1,
-		Reserved4:                   31,
-		BitDepthLumaMinus8:          0,
-		Reserved5:                   31,
-		BitDepthChromaMinus8:        0,
-		AvgFrameRate:                0,
-		ConstantFrameRate:           0,
-		NumTemporalLayers:           1,
-		TemporalIdNested:            1,
-		LengthSizeMinusOne:          3,
-		NumOfNaluArrays:             3,
-		NaluArrays: []mp4.HEVCNaluArray{
-			{Completeness: true, NaluType: 32, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(vps)), NALUnit: vps}}},
-			{Completeness: true, NaluType: 33, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(sps)), NALUnit: sps}}},
-			{Completeness: true, NaluType: 34, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(pps)), NALUnit: pps}}},
-		},
-	}
 }
 
 // writeMergeFtyp writes a minimal ftyp box to the output file.

--- a/internal/merge/mp4merge_test.go
+++ b/internal/merge/mp4merge_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/abema/go-mp4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -832,5 +834,51 @@ func TestLimitedWriter_SeekError(t *testing.T) {
 	}
 	if err.Error() != "seek error" {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestMergeHvcC_ByteAlignment is the merge-package mirror of timelapse's
+// TestBuildHvcC_ConservativeTierAndCompat. Before #236, the merge package had
+// NO byte-level hvcC test — only a round-trip ParseSegment check that would
+// silently accept a subtly-wrong hvcC. This test pins the conservative
+// Main-tier / zeroed-compat defaults that make ONVIF SPS inconsistencies
+// (cam-fa049182) playable in Edge, now that the construction is shared via
+// mp4util.BuildHvcC.
+func TestMergeHvcC_ByteAlignment(t *testing.T) {
+	// Inconsistent SPS captured from cam-fa049182 (Main profile + High tier +
+	// stray compat bit). See timelapse TestBuildHvcC_ConservativeTierAndCompat
+	// for the byte-by-byte decode.
+	inconsistentSPS := []byte{
+		0x42, 0x01, 0x21, 0x40, 0x00, 0x00, 0x03,
+		0x00, 0x90, 0x00, 0x00, 0x03, 0x00,
+		0x96, 0xa0, 0x01, 0x40, 0x20, 0x05, 0xa1,
+	}
+	pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x89}
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60}
+
+	// The merge path now builds hvcC via the shared mp4util.BuildHvcC and
+	// marshals it inside writeMergeH265SampleEntry. Marshal here the same way
+	// to inspect the exact bytes that reach the output file.
+	var buf bytes.Buffer
+	hvcC := mp4util.BuildHvcC(vps, inconsistentSPS, pps)
+	if _, err := mp4.Marshal(&buf, hvcC, mp4.Context{}); err != nil {
+		t.Fatalf("mp4.Marshal(hvcC) failed: %v", err)
+	}
+	out := buf.Bytes()
+
+	// Byte 1 must be 0x01 (Main tier forced + Main profile), NOT 0x21.
+	if got := out[1]; got != 0x01 {
+		t.Errorf("hvcC[1] = 0x%02x (space=%d tier=%d profile_idc=%d), want 0x01 "+
+			"(Main tier forced; Edge rejects tier=1 + profile_idc=1)", got, got>>6, (got>>5)&1, got&0x1F)
+	}
+	// Bytes 2-5 (profile compat) and 6-11 (constraint) must be zeroed.
+	for i := 2; i <= 11; i++ {
+		if out[i] != 0x00 {
+			t.Errorf("hvcC[%d] = 0x%02x, want 0x00 (forced to zero)", i, out[i])
+		}
+	}
+	// numOfArrays (byte 22) must be 3.
+	if out[22] != 3 {
+		t.Errorf("hvcC[22] (numOfArrays) = %d, want 3", out[22])
 	}
 }

--- a/internal/mp4util/codecconfig.go
+++ b/internal/mp4util/codecconfig.go
@@ -1,0 +1,134 @@
+// Package mp4util holds shared helpers for constructing MP4 decoder
+// configuration records (avcC / hvcC) used by the timelapse, merge, and muxer
+// packages.
+//
+// Before this package existed, three near-identical copies of the hvcC builder
+// and two of the avcC builder lived across internal/timelapse (hand-rolled
+// bytes.Buffer style), internal/merge, and internal/muxer (typed *mp4.HvcC /
+// *mp4.AVCDecoderConfiguration style). PR #92 had to keep them byte-aligned by
+// hand. This package is the single source of truth; see issue #236.
+package mp4util
+
+import (
+	"github.com/abema/go-mp4"
+)
+
+// Default HEVC profile / level used when the SPS is too short to read them
+// (e.g. a truncated/garbage SPS). These are the "safe" values that make a
+// non-conformant stream playable by the widest set of decoders: Main profile
+// (1), Level 4.0 (120). They mirror the defaults the timelapse hand-rolled
+// builder always used; the merge/muxer typed builders previously fell back to
+// 0/0, which is a latent bug — this package unifies on the safer Main/4.0
+// defaults. See #236.
+const (
+	defaultHEVCProfile = 1   // Main
+	defaultHEVCLevel   = 120 // Level 4.0
+)
+
+// Default AVC profile / compat / level used when the H.264 SPS is shorter than
+// 4 bytes (too short to read profile_idc / compat / level). Baseline (66) /
+// Level 3.0 (30) match what the timelapse hand-rolled buildAvcC always used;
+// the merge/muxer inline avcC literals read sps[1..3] unguarded and would
+// panic on a truncated SPS. This package unifies on the safe guarded form.
+const (
+	defaultAVCProfile = 66 // Baseline
+	defaultAVCCompat  = 0xC0
+	defaultAVCLevel   = 30 // Level 3.0
+)
+
+// BuildHvcC constructs an HEVCDecoderConfigurationRecord (*mp4.HvcC) from raw
+// VPS, SPS, and PPS NAL units (Annex-B payload without the start code).
+//
+// The record uses conservative Main-tier defaults (tier=0, profile_space=0,
+// zeroed profile-compatibility and constraint-indicator flags) regardless of
+// what the SPS advertises. This is deliberate: several ONVIF cameras emit
+// self-inconsistent SPS (Main profile + High tier + stray compat bits) that
+// Windows Edge's HEVC extension rejects with
+// DEMUXER_ERROR_NO_SUPPORTED_STREAMS. Only sps[1] (profile_idc) and sps[12]
+// (level_idc) are read; everything else is forced to safe defaults. See PR #92
+// and AGENTS.md "H.265 timelapse hvcC compliance".
+//
+// go-mp4 marshals GeneralProfileIdc as a 5-bit field (HvcC struct tag
+// `mp4:"3,size=5"`), so the low 5 bits of sps[1] are what actually reaches the
+// output byte; the high 3 bits flow into GeneralProfileSpace (2 bits) and
+// GeneralTierFlag (1 bit), which we force to 0 — so the final byte 1 is always
+// 0b00_0_PPPPP (Main tier when profile_idc=1).
+func BuildHvcC(vps, sps, pps []byte) *mp4.HvcC {
+	profile := uint8(defaultHEVCProfile)
+	if len(sps) > 1 {
+		profile = sps[1]
+	}
+	level := uint8(defaultHEVCLevel)
+	if len(sps) > 12 {
+		level = sps[12]
+	}
+	return &mp4.HvcC{
+		ConfigurationVersion:        1,
+		GeneralProfileSpace:         0,
+		GeneralTierFlag:             false,
+		GeneralProfileIdc:           profile,
+		GeneralProfileCompatibility: [32]bool{},
+		GeneralConstraintIndicator:  [6]uint8{},
+		GeneralLevelIdc:             level,
+		Reserved1:                   15,
+		MinSpatialSegmentationIdc:   0,
+		Reserved2:                   63,
+		ParallelismType:             0,
+		Reserved3:                   63,
+		ChromaFormatIdc:             1,
+		Reserved4:                   31,
+		BitDepthLumaMinus8:          0,
+		Reserved5:                   31,
+		BitDepthChromaMinus8:        0,
+		AvgFrameRate:                0,
+		ConstantFrameRate:           0,
+		NumTemporalLayers:           1,
+		TemporalIdNested:            1,
+		LengthSizeMinusOne:          3,
+		NumOfNaluArrays:             3,
+		NaluArrays: []mp4.HEVCNaluArray{
+			{Completeness: true, NaluType: 32, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(vps)), NALUnit: vps}}},
+			{Completeness: true, NaluType: 33, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(sps)), NALUnit: sps}}},
+			{Completeness: true, NaluType: 34, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(pps)), NALUnit: pps}}},
+		},
+	}
+}
+
+// BuildAvcC constructs an AVCDecoderConfigurationRecord
+// (*mp4.AVCDecoderConfiguration) from raw SPS and PPS NAL units (Annex-B
+// payload without the start code). Profile/compat/level are read from
+// sps[1..3]; for H.264 sps[1] IS profile_idc (a full byte), so no masking is
+// needed (unlike H.265's bit-packed profile field). When the SPS is shorter
+// than 4 bytes, safe Baseline / Level 3.0 defaults are used (matching the
+// former timelapse hand-rolled builder; the merge/muxer inline literals
+// panicked on a truncated SPS — #236).
+//
+// The returned struct carries AnyTypeBox{Type: "avcC"} so mp4.Marshal emits it
+// with the correct box type; callers write it as a child of the avc1 sample
+// entry.
+func BuildAvcC(sps, pps []byte) *mp4.AVCDecoderConfiguration {
+	profile := uint8(defaultAVCProfile)
+	compat := uint8(defaultAVCCompat)
+	level := uint8(defaultAVCLevel)
+	if len(sps) >= 4 {
+		profile = sps[1]
+		compat = sps[2]
+		level = sps[3]
+	}
+	return &mp4.AVCDecoderConfiguration{
+		AnyTypeBox:                 mp4.AnyTypeBox{Type: mp4.StrToBoxType("avcC")},
+		ConfigurationVersion:       1,
+		Profile:                    profile,
+		ProfileCompatibility:       compat,
+		Level:                      level,
+		LengthSizeMinusOne:         3,
+		NumOfSequenceParameterSets: 1,
+		SequenceParameterSets: []mp4.AVCParameterSet{
+			{Length: uint16(len(sps)), NALUnit: sps},
+		},
+		NumOfPictureParameterSets: 1,
+		PictureParameterSets: []mp4.AVCParameterSet{
+			{Length: uint16(len(pps)), NALUnit: pps},
+		},
+	}
+}

--- a/internal/mp4util/codecconfig_test.go
+++ b/internal/mp4util/codecconfig_test.go
@@ -1,0 +1,221 @@
+package mp4util
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/abema/go-mp4"
+)
+
+// marshalHvcC serializes the *mp4.HvcC record to its on-wire bytes (the payload
+// of the hvcC box, without the 8-byte box header). Mirrors what mp4.Marshal
+// emits inside the hvc1 sample entry so byte-level assertions match the
+// production output exactly.
+func marshalHvcC(t *testing.T, hvcC *mp4.HvcC) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if _, err := mp4.Marshal(&buf, hvcC, mp4.Context{}); err != nil {
+		t.Fatalf("mp4.Marshal(hvcC) failed: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestBuildHvcC_HeaderFields checks the fixed hvcC header fields and the
+// conservative Main-tier / Main-profile defaults that make ONVIF SPS
+// inconsistencies playable in Edge (PR #92 / #236).
+func TestBuildHvcC_HeaderFields(t *testing.T) {
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff} // arbitrary >1-byte NAL
+	sps := []byte{
+		0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03,
+		0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x5d,
+	}
+	pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x89}
+
+	hvcC := marshalHvcC(t, BuildHvcC(vps, sps, pps))
+
+	if len(hvcC) < 23 {
+		t.Fatalf("hvcC too short: %d bytes (need >= 23 for header)", len(hvcC))
+	}
+	if hvcC[0] != 1 {
+		t.Errorf("configurationVersion = %d, want 1", hvcC[0])
+	}
+	// Byte 1: profile_space(2) | tier_flag(1) | profile_idc(5). We force
+	// space=0 and tier=0, so profile_idc occupies the low 5 bits alone.
+	if hvcC[1]>>6 != 0 {
+		t.Errorf("general_profile_space+tier_flag bits = 0b%03b, want 0 (Main tier)", hvcC[1]>>5)
+	}
+	// numOfArrays (byte 22) must be 3 (VPS/SPS/PPS).
+	if hvcC[22] != 3 {
+		t.Errorf("numOfArrays = %d, want 3", hvcC[22])
+	}
+}
+
+// TestBuildHvcC_ArrayNumNalusIsOne is the regression guard for the bug where
+// numNalus held the NALU byte length instead of 1 (PR #89). Per ISO 14496-15
+// §8.3.3.1.2 each array is [type(1)][numNalus(2)][len(2)][data]; with one NALU
+// per array numNalus must be exactly 1.
+func TestBuildHvcC_ArrayNumNalusIsOne(t *testing.T) {
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60} // 8 bytes (>1, catches len/numNalus confusion)
+	sps := []byte{
+		0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x00,
+		0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x5d, 0xac, 0x09,
+	}
+	pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x89, 0x13, 0x34}
+	if len(vps) <= 1 || len(sps) <= 1 || len(pps) <= 1 {
+		t.Fatalf("test NALUs must be >1 byte")
+	}
+
+	hvcC := marshalHvcC(t, BuildHvcC(vps, sps, pps))
+
+	off := 23                       // header is 23 bytes
+	wantTypes := []byte{32, 33, 34} // VPS, SPS, PPS
+	wantNALUs := [][]byte{vps, sps, pps}
+	for i := range wantTypes {
+		if off+5 > len(hvcC) {
+			t.Fatalf("array %d: ran off end of hvcC at offset %d", i, off)
+		}
+		arrType := hvcC[off] & 0x3F
+		if arrType != wantTypes[i] {
+			t.Errorf("array %d: NAL_unit_type = %d, want %d", i, arrType, wantTypes[i])
+		}
+		numNalus := uint16(hvcC[off+1])<<8 | uint16(hvcC[off+2])
+		if numNalus != 1 {
+			t.Errorf("array %d (type %d): numNalus = %d, want 1", i, wantTypes[i], numNalus)
+		}
+		nalLen := uint16(hvcC[off+3])<<8 | uint16(hvcC[off+4])
+		if nalLen != uint16(len(wantNALUs[i])) {
+			t.Errorf("array %d: nalUnitLength = %d, want %d", i, nalLen, len(wantNALUs[i]))
+		}
+		off += 5 + len(wantNALUs[i])
+	}
+}
+
+// TestBuildHvcC_ConservativeTierAndCompat pins the PR #92 behavior: when an
+// ONVIF camera emits an inconsistent SPS (the production cam-fa049182 SPS with
+// High-tier bits in sps[2] and a stray compat flag), the hvcC must still
+// advertise Main tier + Main profile + zeroed compat/constraint so Edge's HEVC
+// extension accepts the stream.
+//
+// This is the exact fixture from timelapse's TestBuildHvcC_ConservativeTierAndCompat;
+// keeping it here means the shared helper is independently pinned without
+// relying on the timelapse wrapper test.
+func TestBuildHvcC_ConservativeTierAndCompat(t *testing.T) {
+	// Inconsistent SPS captured from cam-fa049182:
+	//   sps[0]=0x42 NAL header (type=33 SPS)
+	//   sps[1]=0x01 layerID=0 + temporalID=1  → profile_idc (low 5 bits) = 1 (Main)
+	//   sps[2]=0x21 profile_space=0 + tier_flag=1 (High!) + profile_idc=1
+	//   sps[3..6]=0x40,0x00,0x00,0x03 compat_flags=0x40000003
+	//   sps[7..12]=0x00,0x90,0x00,0x00,0x03,0x00 (constraint + level_idc=0)
+	inconsistentSPS := []byte{
+		0x42, 0x01, 0x21, 0x40, 0x00, 0x00, 0x03,
+		0x00, 0x90, 0x00, 0x00, 0x03, 0x00,
+		0x96, 0xa0, 0x01, 0x40, 0x20, 0x05, 0xa1,
+	}
+	pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x89}
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60}
+
+	hvcC := marshalHvcC(t, BuildHvcC(vps, inconsistentSPS, pps))
+
+	// Byte 1: profile_space(2) + tier_flag(1) + profile_idc(5).
+	// Must be 0x01 (Main tier forced + Main profile), NOT 0x21 (which would
+	// carry the SPS's High-tier bit). Edge rejects tier=1 paired with
+	// profile_idc=1 as non-compliant.
+	if got := hvcC[1]; got != 0x01 {
+		t.Errorf("hvcC[1] = 0x%02x (space=%d tier=%d profile_idc=%d), want 0x01 "+
+			"(Main tier + Main profile forced)", got, got>>6, (got>>5)&1, got&0x1F)
+	}
+	// Bytes 2-5: general_profile_compatibility_flags — must be zeroed, not the
+	// SPS's 0x40000003. A stray compat bit paired with Main profile is another
+	// Edge rejection trigger.
+	for i := 2; i <= 5; i++ {
+		if hvcC[i] != 0x00 {
+			t.Errorf("hvcC[%d] = 0x%02x, want 0x00 (compat forced to zero)", i, hvcC[i])
+		}
+	}
+	// Bytes 6-11: constraint indicator flags — must be zeroed.
+	for i := 6; i <= 11; i++ {
+		if hvcC[i] != 0x00 {
+			t.Errorf("hvcC[%d] = 0x%02x, want 0x00 (constraint forced to zero)", i, hvcC[i])
+		}
+	}
+}
+
+// TestBuildHvcC_FallbackDefaults verifies the safe fallback when the SPS is too
+// short to read profile/level: Main profile (1) + Level 4.0 (120), not 0/0.
+// This is the behavior change vs. the old merge/muxer typed builders, which
+// fell back to 0/0 — a latent bug fixed by unifying on the timelapse defaults
+// (#236).
+func TestBuildHvcC_FallbackDefaults(t *testing.T) {
+	// SPS too short for both reads: len <= 1 skips the profile read, len <= 12
+	// skips the level read. Use len==1 so BOTH fallbacks trigger.
+	shortSPS := []byte{0x42}
+	vps := []byte{0x40, 0x01}
+	pps := []byte{0x44, 0x01}
+
+	hvcC := marshalHvcC(t, BuildHvcC(vps, shortSPS, pps))
+
+	// Byte 1 low 5 bits = profile_idc fallback = 1 (Main).
+	if got := hvcC[1] & 0x1F; got != defaultHEVCProfile {
+		t.Errorf("profile fallback = %d, want %d (Main)", got, defaultHEVCProfile)
+	}
+	// Byte 12 = level_idc fallback = 120 (Level 4.0).
+	if hvcC[12] != defaultHEVCLevel {
+		t.Errorf("level fallback = %d, want %d (Level 4.0)", hvcC[12], defaultHEVCLevel)
+	}
+}
+
+// TestBuildAvcC verifies the avcC record carries sps[1..3] verbatim and wraps
+// one SPS + one PPS with correct lengths.
+func TestBuildAvcC(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0xc0, 0x1e, 0xda, 0x02, 0xd0} // 7 bytes
+	pps := []byte{0x68, 0xce, 0x3c, 0x80}                   // 4 bytes
+
+	rec := BuildAvcC(sps, pps)
+	if rec.ConfigurationVersion != 1 {
+		t.Errorf("ConfigurationVersion = %d, want 1", rec.ConfigurationVersion)
+	}
+	if rec.Profile != sps[1] {
+		t.Errorf("Profile = 0x%02x, want 0x%02x (sps[1] verbatim)", rec.Profile, sps[1])
+	}
+	if rec.ProfileCompatibility != sps[2] {
+		t.Errorf("ProfileCompatibility = 0x%02x, want 0x%02x (sps[2] verbatim)", rec.ProfileCompatibility, sps[2])
+	}
+	if rec.Level != sps[3] {
+		t.Errorf("Level = 0x%02x, want 0x%02x (sps[3] verbatim)", rec.Level, sps[3])
+	}
+	if rec.LengthSizeMinusOne != 3 {
+		t.Errorf("LengthSizeMinusOne = %d, want 3", rec.LengthSizeMinusOne)
+	}
+	if rec.NumOfSequenceParameterSets != 1 {
+		t.Errorf("NumOfSequenceParameterSets = %d, want 1", rec.NumOfSequenceParameterSets)
+	}
+	if rec.NumOfPictureParameterSets != 1 {
+		t.Errorf("NumOfPictureParameterSets = %d, want 1", rec.NumOfPictureParameterSets)
+	}
+	if len(rec.SequenceParameterSets) != 1 || rec.SequenceParameterSets[0].Length != uint16(len(sps)) {
+		t.Errorf("SPS entry wrong: got %+v", rec.SequenceParameterSets)
+	}
+	if len(rec.PictureParameterSets) != 1 || rec.PictureParameterSets[0].Length != uint16(len(pps)) {
+		t.Errorf("PPS entry wrong: got %+v", rec.PictureParameterSets)
+	}
+}
+
+// TestBuildAvcC_FallbackDefaults verifies the Baseline / Level 3.0 fallback
+// when the SPS is shorter than 4 bytes. This matches the former timelapse
+// hand-rolled builder's behavior and fixes a panic latent in the merge/muxer
+// inline avcC literals (#236).
+func TestBuildAvcC_FallbackDefaults(t *testing.T) {
+	shortSPS := []byte{0x67, 0x42} // len < 4 → fallback kicks in
+	pps := []byte{0x68, 0xce, 0x3c, 0x80}
+
+	rec := BuildAvcC(shortSPS, pps)
+	if rec.Profile != defaultAVCProfile {
+		t.Errorf("Profile fallback = %d, want %d (Baseline)", rec.Profile, defaultAVCProfile)
+	}
+	if rec.ProfileCompatibility != defaultAVCCompat {
+		t.Errorf("ProfileCompatibility fallback = 0x%02x, want 0x%02x", rec.ProfileCompatibility, defaultAVCCompat)
+	}
+	if rec.Level != defaultAVCLevel {
+		t.Errorf("Level fallback = %d, want %d (Level 3.0)", rec.Level, defaultAVCLevel)
+	}
+}

--- a/internal/muxer/mp4mux.go
+++ b/internal/muxer/mp4mux.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
 	"github.com/abema/go-mp4"
 )
 
@@ -758,22 +759,7 @@ func writeH264SampleEntry(w *mp4.Writer, tr *track) error {
 	if err != nil {
 		return err
 	}
-	avcC := &mp4.AVCDecoderConfiguration{
-		AnyTypeBox:                 mp4.AnyTypeBox{Type: mp4.StrToBoxType("avcC")},
-		ConfigurationVersion:       1,
-		Profile:                    tr.sps[1],
-		ProfileCompatibility:       tr.sps[2],
-		Level:                      tr.sps[3],
-		LengthSizeMinusOne:         3,
-		NumOfSequenceParameterSets: 1,
-		SequenceParameterSets: []mp4.AVCParameterSet{
-			{Length: uint16(len(tr.sps)), NALUnit: tr.sps},
-		},
-		NumOfPictureParameterSets: 1,
-		PictureParameterSets: []mp4.AVCParameterSet{
-			{Length: uint16(len(tr.pps)), NALUnit: tr.pps},
-		},
-	}
+	avcC := mp4util.BuildAvcC(tr.sps, tr.pps)
 	if _, err := mp4.Marshal(w, avcC, mp4.Context{}); err != nil {
 		return err
 	}
@@ -814,7 +800,7 @@ func writeH265SampleEntry(w *mp4.Writer, tr *track) error {
 	if err != nil {
 		return err
 	}
-	hvcC := buildHvcC(tr.vps, tr.sps, tr.pps)
+	hvcC := mp4util.BuildHvcC(tr.vps, tr.sps, tr.pps)
 	if _, err := mp4.Marshal(w, hvcC, mp4.Context{}); err != nil {
 		return err
 	}
@@ -1032,48 +1018,6 @@ func buildEsds(audioConfig []byte) *mp4.Esds {
 				Size: 1,
 				Data: []byte{0x02}, // predefined: use timestamps
 			},
-		},
-	}
-}
-
-// buildHvcC constructs an HvcC (HEVCDecoderConfigurationRecord) from VPS, SPS, PPS.
-func buildHvcC(vps, sps, pps []byte) *mp4.HvcC {
-	profile := uint8(0)
-	if len(sps) > 1 {
-		profile = sps[1]
-	}
-	level := uint8(0)
-	if len(sps) > 12 {
-		level = sps[12]
-	}
-	return &mp4.HvcC{
-		ConfigurationVersion:        1,
-		GeneralProfileSpace:         0,
-		GeneralTierFlag:             false,
-		GeneralProfileIdc:           profile,
-		GeneralProfileCompatibility: [32]bool{}, // zeroed
-		GeneralConstraintIndicator:  [6]uint8{},
-		GeneralLevelIdc:             level,
-		Reserved1:                   15,
-		MinSpatialSegmentationIdc:   0,
-		Reserved2:                   63,
-		ParallelismType:             0,
-		Reserved3:                   63,
-		ChromaFormatIdc:             1,
-		Reserved4:                   31,
-		BitDepthLumaMinus8:          0,
-		Reserved5:                   31,
-		BitDepthChromaMinus8:        0,
-		AvgFrameRate:                0,
-		ConstantFrameRate:           0,
-		NumTemporalLayers:           1,
-		TemporalIdNested:            1,
-		LengthSizeMinusOne:          3,
-		NumOfNaluArrays:             3,
-		NaluArrays: []mp4.HEVCNaluArray{
-			{Completeness: true, NaluType: 32, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(vps)), NALUnit: vps}}},
-			{Completeness: true, NaluType: 33, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(sps)), NALUnit: sps}}},
-			{Completeness: true, NaluType: 34, NumNalus: 1, Nalus: []mp4.HEVCNalu{{Length: uint16(len(pps)), NALUnit: pps}}},
 		},
 	}
 }

--- a/internal/timelapse/h264_go_merge.go
+++ b/internal/timelapse/h264_go_merge.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
 	"github.com/abema/go-mp4"
 )
 
@@ -696,45 +697,18 @@ func writeH264Mdat(w *mp4.Writer, framePaths []string, ctx context.Context) erro
 
 // buildAvcC builds the AVCDecoderConfiguration record bytes from raw SPS and PPS
 // NAL units (without start codes). Format per ISO 14496-15.
+//
+// Thin wrapper over mp4util.BuildAvcC (the shared single source of truth for
+// the avcC record — see #236). Returns marshaled bytes so callers and tests
+// keep working with the same []byte contract.
 func buildAvcC(sps, pps []byte) []byte {
-	// Extract profile/compatibility/level from SPS.
-	// Raw SPS NALU layout: [NAL header][profile_idc][constraint_flags][level_idc]...
-	profile := byte(66)  // default: Baseline
-	compat := byte(0xC0) // default
-	level := byte(30)    // default: Level 3.0
-	if len(sps) >= 4 {
-		profile = sps[1]
-		compat = sps[2]
-		level = sps[3]
-	}
-
 	var buf bytes.Buffer
-	// configurationVersion
-	buf.WriteByte(1)
-	// AVCProfileIndication
-	buf.WriteByte(profile)
-	// profile_compatibility
-	buf.WriteByte(compat)
-	// AVCLevelIndication
-	buf.WriteByte(level)
-	// Reserved (6 bits) + lengthSizeMinusOne (2 bits) = 0xFF (length size = 4 bytes)
-	buf.WriteByte(0xFF)
-	// Reserved (3 bits) + numOfSequenceParameterSets (5 bits) = 0xE1 (1 SPS)
-	buf.WriteByte(0xE1)
-
-	// SPS
-	spsLen := len(sps)
-	buf.WriteByte(byte(spsLen >> 8))
-	buf.WriteByte(byte(spsLen))
-	buf.Write(sps)
-
-	// PPS
-	buf.WriteByte(1) // numOfPictureParameterSets
-	ppsLen := len(pps)
-	buf.WriteByte(byte(ppsLen >> 8))
-	buf.WriteByte(byte(ppsLen))
-	buf.Write(pps)
-
+	if _, err := mp4.Marshal(&buf, mp4util.BuildAvcC(sps, pps), mp4.Context{}); err != nil {
+		// Marshal of a fully-populated *mp4.AVCDecoderConfiguration never fails
+		// in practice. Return nil on the impossible failure so the caller
+		// surfaces a clearly broken file rather than panicking.
+		return nil
+	}
 	return buf.Bytes()
 }
 

--- a/internal/timelapse/h265_go_merge.go
+++ b/internal/timelapse/h265_go_merge.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
 	"github.com/abema/go-mp4"
 )
 
@@ -631,114 +632,31 @@ func writeH265Ftyp(w *mp4.Writer) (int64, error) {
 // buildHvcC builds the HEVCDecoderConfigurationRecord bytes from raw VPS, SPS,
 // and PPS NAL units (without start codes). Format per ISO 14496-15.
 //
-// This deliberately uses conservative defaults for the profile_tier_level
-// fields rather than fully parsing them from the SPS. Several H.265 ONVIF
+// This is a thin wrapper over mp4util.BuildHvcC (the shared, single source of
+// truth for the hvcC record used by timelapse, merge, and muxer — see #236).
+// The shared helper uses conservative Main-tier / Main-profile / zeroed-compat
+// defaults rather than fully parsing the SPS, because several H.265 ONVIF
 // cameras in production (cam-fa049182 工作室内, cam-5b24e253 视通) emit an SPS
-// whose profile_tier_level is internally inconsistent — e.g. profile_idc=1
-// (Main) paired with tier=1 (High) and a stray compat bit 0x40000000. Windows
-// Edge's HEVC Video Extension enforces strict HEVC conformance and refuses to
-// play an MP4 whose hvcC header fields don't make sense together (Edge's
-// PipelineStatus::DEMUXER_ERROR_NO_SUPPORTED_STREAMS), while Linux Chromium /
-// Firefox reject all HEVC regardless. Mirroring internal/merge/mp4merge.go's
-// buildMergeHvcC, we read only sps[1] (profile byte, masked to 5 bits) and
-// sps[12] (level byte), and force everything else to safe Main-tier / 8-bit
-// 4:2:0 defaults. This keeps the regular-recording merge (mp4merge.go) and
-// timelapse merge (this file) byte-aligned in their hvcC headers, so both
-// paths are equally Edge-playable.
+// whose profile_tier_level is internally inconsistent (e.g. profile_idc=1 Main
+// paired with tier=1 High + a stray compat bit 0x40000000) — Windows Edge's
+// HEVC Video Extension enforces strict HEVC conformance and refuses to play
+// such an MP4 (DEMUXER_ERROR_NO_SUPPORTED_STREAMS). Marshaling the typed
+// *mp4.HvcC struct produces byte-identical output to the previous hand-rolled
+// buffer because go-mp4 bit-packs GeneralProfileIdc as a 5-bit field, so the
+// low 5 bits of sps[1] reach byte 1 exactly as the old `sps[1] & 0x1F` did.
+//
+// Returns the marshaled bytes so callers (and tests) keep working with the same
+// []byte contract; the struct is the construction mechanism only.
 func buildHvcC(vps, sps, pps []byte) []byte {
 	var buf bytes.Buffer
-
-	// configurationVersion
-	buf.WriteByte(1)
-
-	// Read only the raw profile and level bytes from the SPS — no further
-	// parsing. Falls back to Main profile / Level 4.0 on a too-short SPS.
-	// sps[1] low 5 bits = general_profile_idc (we discard the high 3 bits,
-	// which carry profile_space + tier_flag, to force Main-tier defaults).
-	profileIDC := byte(1) // Main profile
-	levelIDC := byte(120) // Level 4.0 (40 * 3)
-	if len(sps) > 1 {
-		profileIDC = sps[1] & 0x1F
+	if _, err := mp4.Marshal(&buf, mp4util.BuildHvcC(vps, sps, pps), mp4.Context{}); err != nil {
+		// Marshal of a fully-populated *mp4.HvcC never fails in practice (all
+		// fields are concrete, no dynamic lengths beyond the fixed NAL arrays).
+		// Return an empty record on the impossible failure so the caller
+		// surfaces a clearly broken (unplayable) file rather than panicking.
+		return nil
 	}
-	if len(sps) > 12 {
-		levelIDC = sps[12]
-	}
-
-	// general_profile_space(2)=0 + general_tier_flag(1)=0 (Main tier)
-	//   + general_profile_idc(5)
-	// tier is forced to 0 (Main) regardless of the SPS to avoid the
-	// Edge-rejected Main-profile + High-tier mismatch.
-	buf.WriteByte(profileIDC)
-
-	// general_profile_compatibility_flags (32 bits) = 0
-	// (A non-zero value here, e.g. 0x40000000, combined with Main profile is
-	// another trigger for Edge's HEVC conformance rejection.)
-	buf.Write([]byte{0x00, 0x00, 0x00, 0x00})
-
-	// general_constraint_indicator_flags (48 bits) = 0
-	buf.Write([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
-
-	// general_level_idc
-	buf.WriteByte(levelIDC)
-
-	// min_spatial_segmentation_idc (4 reserved + 12 value) = 0
-	buf.WriteByte(0xF0)
-	buf.WriteByte(0x00)
-
-	// parallelismType (6 reserved + 2 value) = 0
-	buf.WriteByte(0xFC)
-
-	// chromaFormat (6 reserved bits = 111111 + 2-bit value 01 = 4:2:0)
-	buf.WriteByte(0xFD)
-
-	// bitDepthLumaMinus8 (5 reserved bits = 11111 + 3-bit value 000 = 8-bit)
-	buf.WriteByte(0xF8)
-
-	// bitDepthChromaMinus8 (5 reserved bits = 11111 + 3-bit value 000 = 8-bit)
-	buf.WriteByte(0xF8)
-
-	// avgFrameRate (16 bits)
-	buf.Write([]byte{0x00, 0x00})
-
-	// constantFrameRate(2) + numTemporalLayers(3) + temporalIdNested(1) + lengthSizeMinusOne(2)
-	// numTemporalLayers=1, lengthSizeMinusOne=3 (4-byte lengths)
-	buf.WriteByte(0x0B)
-
-	// numOfArrays = 3 (VPS, SPS, PPS)
-	buf.WriteByte(3)
-
-	// Write arrays in standard order: VPS, SPS, PPS.
-	writeHvcCArray(&buf, 32, vps) // VPS type 32
-	writeHvcCArray(&buf, 33, sps) // SPS type 33
-	writeHvcCArray(&buf, 34, pps) // PPS type 34
-
 	return buf.Bytes()
-}
-
-// writeHvcCArray writes one NAL array to the hvcC buffer per ISO 14496-15
-// section 8.3.3.1.2 (HEVC NAL Unit Array).
-//
-// Layout per array:
-//
-//	array_completeness(1) | reserved(0) | NAL_unit_type(6)   — 1 byte
-//	numNalus                                              — 2 bytes  (count of NALUs)
-//	for each NALU:
-//	  nalUnitLength                                       — 2 bytes
-//	  nalUnit                                             — nalUnitLength bytes
-//
-// We always write exactly one NALU per array (numNalus = 1), since each call
-// receives a single parameter set (VPS / SPS / PPS).
-func writeHvcCArray(buf *bytes.Buffer, nalType byte, nalu []byte) {
-	// array_completeness(1) | reserved(0) | NAL_unit_type(6)
-	buf.WriteByte(0x80 | (nalType & 0x3F))
-	// numNalus (16 bits) — one NALU in this array.
-	buf.WriteByte(0x00)
-	buf.WriteByte(0x01)
-	// nalUnitLength (16 bits) + nalUnit data
-	naluLen := uint16(len(nalu))
-	buf.WriteByte(byte(naluLen >> 8))
-	buf.WriteByte(byte(naluLen))
-	buf.Write(nalu)
 }
 
 // isH265ParamSet returns true if the NAL unit is a parameter set (VPS, SPS, or PPS).


### PR DESCRIPTION
## 背景(#236 阶段 1)

hvcC/avcC 构造此前散落在 3 个 package,共 5 份重复实现:

| 位置 | 函数 | 风格 |
|---|---|---|
| `internal/timelapse/h265_go_merge.go` | `buildHvcC` | 手写 `bytes.Buffer` |
| `internal/merge/mp4merge.go` | `buildMergeHvcC` | typed `*mp4.HvcC` |
| `internal/muxer/mp4mux.go` | `buildHvcC` | typed(与 mp4merge **逐字节相同**) |
| `internal/merge/mp4merge.go` + `muxer/mp4mux.go` | 内联 avcC | typed(逐字节相同) |
| `internal/timelapse/h264_go_merge.go` | `buildAvcC` | 手写 `bytes.Buffer` |

PR #92 修 hvcC 的 Edge HEVC 兼容时,要手动保持 timelapse 和 merge 两份字节对齐(AGENTS.md:408 硬约束)。典型的重复税。

## 修复

**新建 `internal/mp4util` 共享 package**(无循环依赖 —— merge/muxer/timelapse 都可导入它,它不导入任何三者):
- `BuildHvcC(vps, sps, pps) *mp4.HvcC` —— 采用 timelapse 的更安全 fallback(Main profile 1 / Level 4.0 120,而非 merge/muxer 的 0/0 潜在 bug)
- `BuildAvcC(sps, pps) *mp4.AVCDecoderConfiguration` —— 采用 timelapse 的 Baseline/Level3.0 fallback(而非 merge/muxer 的 `sps[1..3]` 无 guard 读取,会在 truncated SPS 上 panic)

**改动调用点**:
- `merge/mp4merge.go`:删 `buildMergeHvcC` + 内联 avcC → 调 `mp4util`
- `muxer/mp4mux.go`:删本地 `buildHvcC` + 内联 avcC → 调 `mp4util`
- `timelapse/h265_go_merge.go`:`buildHvcC` 改为薄包装(marshal typed struct → `[]byte`,保持测试契约);删 `writeHvcCArray`
- `timelapse/h264_go_merge.go`:`buildAvcC` 同样改为薄包装

## 字节一致性(关键)

go-mp4 的 `HvcC.GeneralProfileIdc` 是 `size=5` bit-field(与 `GeneralProfileSpace`(2bit) + `GeneralTierFlag`(1bit) 共占 1 字节),`mp4.Marshal` 自动截到低 5 位。所以:
- timelapse 的 `sps[1] & 0x1F` 和 merge/muxer 的 raw `sps[1]` **marshal 后产生相同字节**
- 保守 tier/compat/constraint 默认(Main tier + 0 兼容 + 0 约束)由共享 helper 统一强制(PR #92 Edge 兼容)

## 测试

| 文件 | 测试 | 覆盖 |
|---|---|---|
| `mp4util/codecconfig_test.go`(新) | `TestBuildHvcC_HeaderFields` / `_ArrayNumNalusIsOne` / `_ConservativeTierAndCompat` / `_FallbackDefaults` | hvcC header + PR #89/#89 回归 + fallback |
| `mp4util/codecconfig_test.go`(新) | `TestBuildAvcC` / `_FallbackDefaults` | avcC passthrough + Baseline fallback |
| `merge/mp4merge_test.go` | `TestMergeHvcC_ByteAlignment`(新) | **填补 merge 包 hvcC 无字节级测试的空缺**(镜像 timelapse ConservativeTierAndCompat) |
| timelapse 现有 | `TestBuildHvcC_ConservativeTierAndCompat` / `_ArrayNumNalusIsOne` / `TestBuildAvcC` | PR #92/#89 回归守卫,保持绿 |

## 验证

Docker VM `192.168.63.197`(go1.26 + gofumpt v0.11.0):
- ✅ `gofumpt -l` 7 个改动文件全清
- ✅ `go build ./...`
- ✅ `go vet ./internal/{mp4util,merge,muxer,timelapse}/...`
- ✅ `go test -race ./internal/{mp4util,merge,muxer,timelapse}/...` 全绿(timelapse 33s 含 hvcC/avcC/merger 全套)

## 影响

- 纯 dedup,生产字节输出不变(timelapse hvcC/avcC 改用 Marshal 后,go-mp4 bit-packing 保证字节一致 —— TestBuildHvcC_ConservativeTierAndCompat 等硬约束测试兜底)
- **顺带修 2 个潜在 bug**:merge/muxer 的 avcC 在 truncated SPS 上 panic(无 guard),hvcC fallback 用 0/0 而非安全的 Main/4.0 —— 统一到 timelapse 的安全行为
- 部署后浏览器验证:H.265 录像回放 + timelapse 回放可正常播放(无黑屏/Edge 拒绝)

## 后续

阶段 2(单独 PR):timelapse h264/h265 box 骨架(`writeMoov`/`writeMvhd`/...)抽公共基类,满足 #236 验收(每文件 ≤400 LOC)。本阶段是阶段 2 的前置(timelapse 改用 typed hvcC 后,共享 codecMuxer 才能统一持有 config 字段)。

Part of #236