### PR TITLE
feat(install): #268 install.sh 暴露 --port 端口入口 + 交互式 prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # MiBee NVR — One-click installer for Linux
 # Usage: curl -fsSL https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/install.sh | bash
 #        or: ./install.sh --version v0.9.0
+#        or: ./install.sh --port 9091 --version v0.9.0
 #        or: ./install.sh --uninstall
 
 REPO="Mi-Bee-Studio/MiBeeNvr"
@@ -12,6 +13,7 @@ BIN_PATH="/usr/local/bin/mibee-nvr"
 SERVICE_NAME="mibee-nvr"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 SERVICE_URL="https://raw.githubusercontent.com/${REPO}/main/deploy/${SERVICE_NAME}.service"
+LISTEN_PORT=""   # Web UI listen port (--port flag or interactive prompt; default 9090)
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -126,6 +128,19 @@ init_config() {
 
     info "No config file found. Running init..."
     echo ""
+    # Listen port: --port flag wins; else prompt in interactive (TTY) mode;
+    # else default 9090 (pipe/non-interactive must not block).
+    if [[ -z "${LISTEN_PORT:-}" ]]; then
+        if [[ -t 0 ]]; then
+            read -rp "Listen port [9090]: " LISTEN_PORT
+        fi
+        LISTEN_PORT="${LISTEN_PORT:-9090}"
+    fi
+    if ! [[ "${LISTEN_PORT}" =~ ^[0-9]+$ ]] || (( LISTEN_PORT < 1 || LISTEN_PORT > 65535 )); then
+        error "Invalid listen port: ${LISTEN_PORT} (must be 1-65535)."
+        exit 1
+    fi
+
     read -rp "Enter admin password for Web UI: " -s INSTALL_PASSWORD
     echo ""
     if [[ -z "$INSTALL_PASSWORD" ]]; then
@@ -137,9 +152,9 @@ init_config() {
         --password "$INSTALL_PASSWORD" \
         --data-dir "${DATA_DIR}" \
         --config "${DATA_DIR}/mibee-nvr.yaml" \
-        --listen ":9090"
+        --listen ":${LISTEN_PORT}"
 
-    info "Config initialized at ${DATA_DIR}/mibee-nvr.yaml."
+    info "Config initialized at ${DATA_DIR}/mibee-nvr.yaml (listening on :${LISTEN_PORT})."
 }
 
 install_service() {
@@ -299,9 +314,17 @@ do_install() {
                 fi
                 version="$1"
                 ;;
+            --port)
+                shift
+                if [[ $# -eq 0 ]]; then
+                    error "--port requires an argument (e.g. 9091)"
+                    exit 1
+                fi
+                LISTEN_PORT="$1"
+                ;;
             *)
                 error "Unknown option: $1"
-                echo "Usage: $0 [--version <tag>] [--uninstall]"
+                echo "Usage: $0 [--version <tag>] [--port <port>] [--uninstall]"
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
## 背景

端口冲突防护系列 #1（见 `docs/zh/deployment-faq.md` Q2）。

ONVIF WS-Discovery 用 UDP 组播，迫使 NAS compose 全用 `network_mode: host` → Docker 端口映射失效 → 端口冲突只能靠改应用配置 `server.listen` 解决。裸机走 `install.sh`，但脚本硬编码 `--listen :9090`，底层 `init` 已支持 `--listen` flag 却没暴露给用户。

## 改动（仅 `install.sh`，+26/-3）

1. `do_install()` 加 `--port <port>` 参数（与 `--version` 同级）
2. `init_config()` 端口解析顺序：`--port` flag > TTY 交互提示 > 默认 9090
   - **pipe 模式（`curl … | bash`）非 TTY → 走默认 9090，不阻塞**
   - 端口范围校验（1-65535，非数字/越界报错退出）
3. `init --listen` 用解析后的端口（原硬编码 `:9090`）
4. header 用法注释 + 错误 usage 串补 `--port`

`print_success()` 已从 config 文件 grep 端口（L230-233），完成提示 URL 自动用实际端口，无需改动。

## 验证

- `bash -n install.sh` 语法 OK
- 隔离测试 9 个用例：`--port 9091` / 边界值 80/65535 / 无 flag 默认 9090 / 非数字拒绝 / 越界(0/70000)拒绝 / `--version`+`--port` 两种顺序组合 / 缺参数拒绝 —— 全部符合预期

## 行为对照

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| `install.sh --port 9091` | 无此选项 | 监听 9091 |
| `./install.sh`（TTY） | 硬编码 9090 | 提示 `Listen port [9090]:`，回车默认 |
| `curl … \| bash`（pipe） | 硬编码 9090 | 默认 9090（不阻塞） |
| 完成提示 URL | 永远 `:9090` | 实际端口（config grep，已有逻辑） |

Closes #268