### PR TITLE
refactor(timelapse): #236 h264/h265 merge 抽公共 codecMuxer 基类

### DIFF
--- a/internal/timelapse/codec_merge.go
+++ b/internal/timelapse/codec_merge.go
@@ -1,0 +1,663 @@
+// Shared MP4 box-skeleton + frame I/O for the H.264 and H.265 Go mergers.
+//
+// h264_go_merge.go and h265_go_merge.go each previously carried their own
+// byte-identical copy of the moov/mvhd/trak/mdia/minf/stbl box chain (the only
+// real divergence was the sample-entry box: avc1+avcC vs hvc1+hvcC). This file
+// consolidates that skeleton into one codecMuxer type plus the shared frame
+// helpers (splitAnnexB, bitReader, removeEmulationPrevention) that were already
+// de-facto shared across files. See #236.
+package timelapse
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/abema/go-mp4"
+)
+
+// codecMuxer builds the moov box structure for a single-codec video track.
+// It is the shared base of the former h264Muxer / h265Muxer; the only fields
+// that differed between them were the decoder-config payload (avcC vs hvcC
+// bytes) and the sample-entry / config box type names, now parameterized below.
+type codecMuxer struct {
+	frameCount  int
+	sampleSizes []uint32
+	width       int
+	height      int
+	// decoderConfigData is the marshaled avcC / hvcC payload written inside the
+	// config box (avcC / hvcC) child of the visual sample entry.
+	decoderConfigData []byte
+	sampleDur         time.Duration
+	chunkOffset       int64
+	// sampleEntryType is the 4-byte visual sample entry box type ("avc1"/"hvc1").
+	sampleEntryType [4]byte
+	// configBoxType is the 4-byte decoder config box type ("avcC"/"hvcC").
+	configBoxType [4]byte
+}
+
+// writeMoov writes the moov box containing mvhd + a single video trak.
+func (m *codecMuxer) writeMoov(w *mp4.Writer, chunkOffset int64) error {
+	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("moov")})
+	if err != nil {
+		return err
+	}
+	if err := m.writeMvhd(w); err != nil {
+		return err
+	}
+	if err := m.writeTrak(w, chunkOffset); err != nil {
+		return err
+	}
+	_, err = w.EndBox()
+	return err
+}
+
+func (m *codecMuxer) writeMvhd(w *mp4.Writer) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mvhd")})
+	if err != nil {
+		return err
+	}
+
+	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
+
+	mvhd := &mp4.Mvhd{
+		Timescale:   1000,
+		DurationV0:  duration,
+		Rate:        0x00010000,
+		Volume:      0x0100,
+		NextTrackID: 2,
+		Matrix: [9]int32{
+			0x00010000, 0, 0,
+			0, 0x00010000, 0,
+			0, 0, 0x40000000,
+		},
+	}
+	if _, err := mp4.Marshal(w, mvhd, mp4.Context{}); err != nil {
+		return err
+	}
+	_, err = w.EndBox()
+	_ = bi
+	return err
+}
+
+func (m *codecMuxer) writeTrak(w *mp4.Writer, chunkOffset int64) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trak")})
+	if err != nil {
+		return err
+	}
+
+	// tkhd
+	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tkhd")})
+	if err != nil {
+		return err
+	}
+	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
+	tkhd := &mp4.Tkhd{
+		TrackID:    1,
+		DurationV0: duration,
+		Width:      uint32(m.width) << 16,
+		Height:     uint32(m.height) << 16,
+		Matrix: [9]int32{
+			0x00010000, 0, 0,
+			0, 0x00010000, 0,
+			0, 0, 0x40000000,
+		},
+	}
+	if _, err := mp4.Marshal(w, tkhd, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi2
+
+	// mdia
+	if err := m.writeMdia(w, chunkOffset); err != nil {
+		return err
+	}
+
+	_, err = w.EndBox()
+	_ = bi
+	return err
+}
+
+func (m *codecMuxer) writeMdia(w *mp4.Writer, chunkOffset int64) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdia")})
+	if err != nil {
+		return err
+	}
+
+	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
+
+	// mdhd
+	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdhd")})
+	if err != nil {
+		return err
+	}
+	mdhd := &mp4.Mdhd{
+		Timescale:  1000,
+		DurationV0: duration,
+		Language:   [3]byte{0x15, 0xC0, 0x00},
+	}
+	if _, err := mp4.Marshal(w, mdhd, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi2
+
+	// hdlr
+	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hdlr")})
+	if err != nil {
+		return err
+	}
+	hdlr := &mp4.Hdlr{
+		HandlerType: [4]byte{'v', 'i', 'd', 'e'},
+		Name:        "VideoHandler\x00",
+	}
+	if _, err := mp4.Marshal(w, hdlr, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi3
+
+	// minf > stbl
+	if err := m.writeMinf(w, chunkOffset); err != nil {
+		return err
+	}
+
+	_, err = w.EndBox()
+	_ = bi
+	return err
+}
+
+func (m *codecMuxer) writeMinf(w *mp4.Writer, chunkOffset int64) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("minf")})
+	if err != nil {
+		return err
+	}
+
+	// vmhd
+	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("vmhd")})
+	if err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Vmhd{Graphicsmode: 0}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi2
+
+	// dinf > dref > url
+	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dinf")})
+	if err != nil {
+		return err
+	}
+	bi4, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dref")})
+	if err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Dref{EntryCount: 1}, mp4.Context{}); err != nil {
+		return err
+	}
+	bi5, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("url ")})
+	if err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Url{Location: ""}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi5
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi4
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi3
+
+	// stbl
+	if err := m.writeStbl(w, chunkOffset); err != nil {
+		return err
+	}
+
+	_, err = w.EndBox()
+	_ = bi
+	return err
+}
+
+func (m *codecMuxer) writeStbl(w *mp4.Writer, chunkOffset int64) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stbl")})
+	if err != nil {
+		return err
+	}
+
+	n := m.frameCount
+
+	// stsd > <avc1|hvc1> + <avcC|hvcC>
+	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsd")})
+	if err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsd{EntryCount: 1}, mp4.Context{}); err != nil {
+		return err
+	}
+	if err := m.writeSampleEntry(w); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi2
+
+	// stts
+	bi6, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stts")})
+	if err != nil {
+		return err
+	}
+	sampleDelta := uint32(m.sampleDur.Milliseconds())
+	sttsEntries := make([]mp4.SttsEntry, n)
+	for i := range sttsEntries {
+		sttsEntries[i] = mp4.SttsEntry{
+			SampleCount: 1,
+			SampleDelta: sampleDelta,
+		}
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stts{EntryCount: uint32(n), Entries: sttsEntries}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi6
+
+	// stsc
+	bi7, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsc")})
+	if err != nil {
+		return err
+	}
+	stscEntries := []mp4.StscEntry{
+		{FirstChunk: 1, SamplesPerChunk: uint32(n), SampleDescriptionIndex: 1},
+	}
+	if n == 0 {
+		stscEntries = nil
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsc{EntryCount: uint32(len(stscEntries)), Entries: stscEntries}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi7
+
+	// stsz
+	bi8, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsz")})
+	if err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsz{SampleSize: 0, SampleCount: uint32(n), EntrySize: m.sampleSizes}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi8
+
+	// stco
+	bi9, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stco")})
+	if err != nil {
+		return err
+	}
+	stco := &mp4.Stco{EntryCount: 0, ChunkOffset: nil}
+	if n > 0 {
+		stco.EntryCount = 1
+		stco.ChunkOffset = []uint32{uint32(chunkOffset)}
+	}
+	if _, err := mp4.Marshal(w, stco, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi9
+
+	_, err = w.EndBox()
+	_ = bi
+	return err
+}
+
+// writeSampleEntry writes the visual sample entry (avc1/hvc1) with the
+// codec-specific decoder config box (avcC/hvcC) as its child. The box type
+// names and the config payload come from the codecMuxer fields, so the same
+// method serves both codecs.
+func (m *codecMuxer) writeSampleEntry(w *mp4.Writer) error {
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType(string(m.sampleEntryType[:]))})
+	if err != nil {
+		return err
+	}
+
+	vse := &mp4.VisualSampleEntry{
+		SampleEntry: mp4.SampleEntry{
+			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType(string(m.sampleEntryType[:]))},
+			DataReferenceIndex: 1,
+		},
+		Width:           uint16(m.width),
+		Height:          uint16(m.height),
+		Horizresolution: 0x00480000,
+		Vertresolution:  0x00480000,
+		FrameCount:      1,
+		Depth:           0x0018,
+	}
+	if _, err := mp4.Marshal(w, vse, mp4.Context{}); err != nil {
+		return err
+	}
+
+	// decoder config box (avcC/hvcC) — raw payload
+	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType(string(m.configBoxType[:]))})
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(m.decoderConfigData); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi2
+
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_ = bi
+	return nil
+}
+
+// writeCodecFtyp writes the ftyp box for a codec-specific MP4 and returns its
+// total size. compatibleBrand is the codec brand appended to the common
+// isom/iso2/mp41 set ("avc1" for H.264, "hvc1" for H.265).
+func writeCodecFtyp(w *mp4.Writer, compatibleBrand [4]byte) (int64, error) {
+	start, _ := w.Seek(0, 1)
+	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("ftyp")})
+	if err != nil {
+		return 0, err
+	}
+
+	ftyp := &mp4.Ftyp{
+		MajorBrand:   [4]byte{'i', 's', 'o', 'm'},
+		MinorVersion: 0,
+		CompatibleBrands: []mp4.CompatibleBrandElem{
+			{CompatibleBrand: [4]byte{'i', 's', 'o', 'm'}},
+			{CompatibleBrand: [4]byte{'i', 's', 'o', '2'}},
+			{CompatibleBrand: [4]byte{'m', 'p', '4', '1'}},
+			{CompatibleBrand: compatibleBrand},
+		},
+	}
+	if _, err := mp4.Marshal(w, ftyp, mp4.Context{}); err != nil {
+		return 0, err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return 0, err
+	}
+	_ = bi
+
+	end, _ := w.Seek(0, 1)
+	return end - start, nil
+}
+
+// writeCodecMdat writes the mdat box with length-prefixed NALU sample data,
+// stripping parameter sets (which belong only in avcC/hvcC). isParamSet is the
+// codec-specific predicate (isH264ParamSet / isH265ParamSet). Including param
+// sets in sample data causes MEDIA_ERR_SRC_NOT_SUPPORTED in browsers.
+func writeCodecMdat(w *mp4.Writer, framePaths []string, ctx context.Context, isParamSet func([]byte) bool) error {
+	// First pass: compute total mdat payload size (excluding param sets).
+	var totalPayloadSize uint32
+	for _, path := range framePaths {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read frame %s: %w", path, err)
+		}
+		for _, nalu := range splitAnnexB(data) {
+			if isParamSet(nalu) {
+				continue
+			}
+			totalPayloadSize += 4 + uint32(len(nalu))
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	mdatBoxSize := uint64(8 + totalPayloadSize)
+	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdat"), Size: mdatBoxSize})
+	if err != nil {
+		return fmt.Errorf("start mdat: %w", err)
+	}
+
+	// Write each frame as length-prefixed NALUs, skipping param sets.
+	for _, path := range framePaths {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read frame for mdat %s: %w", path, err)
+		}
+
+		for _, nalu := range splitAnnexB(data) {
+			if isParamSet(nalu) {
+				continue
+			}
+			lenBytes := make([]byte, 4)
+			binary.BigEndian.PutUint32(lenBytes, uint32(len(nalu)))
+			if _, err := w.Write(lenBytes); err != nil {
+				return fmt.Errorf("write NALU length: %w", err)
+			}
+			if _, err := w.Write(nalu); err != nil {
+				return fmt.Errorf("write NALU data: %w", err)
+			}
+		}
+	}
+
+	if _, err := w.EndBox(); err != nil {
+		return fmt.Errorf("end mdat: %w", err)
+	}
+	return nil
+}
+
+// listCodecFrameFiles globs and sorts frame_NNNNNN.<ext> files in dir.
+func listCodecFrameFiles(dir, ext string) ([]string, error) {
+	pattern := filepath.Join(dir, "frame_*."+ext)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return matches, nil
+}
+
+// --- Shared Annex-B / SPS-parsing helpers ---
+//
+// These were previously scattered: splitAnnexB + bitReader lived in
+// h264_go_merge.go but were cross-used by h265_go_merge.go (fragile — renaming
+// or moving either would break the other). They are codec-agnostic Annex-B /
+// RBSP helpers and belong here. removeEmulationPrevention was defined in the
+// h265 file; it is also codec-agnostic (works for both H.264 and H.265 RBSP).
+
+// splitAnnexB splits an Annex-B byte stream into individual raw NAL units,
+// stripping the 0x00000001 (or 0x000001) start codes.
+func splitAnnexB(data []byte) [][]byte {
+	var nalus [][]byte
+	start := 0
+	found := false
+
+	for i := 0; i < len(data)-3; i++ {
+		if data[i] == 0 && data[i+1] == 0 {
+			var codeLen int
+			if data[i+2] == 1 {
+				codeLen = 3
+			} else if i+3 < len(data) && data[i+2] == 0 && data[i+3] == 1 {
+				codeLen = 4
+			} else {
+				continue
+			}
+
+			if found {
+				// Extract NALU from start to current position.
+				nalu := data[start:i]
+				// Strip trailing zeros (emulation prevention or padding).
+				for len(nalu) > 0 && nalu[len(nalu)-1] == 0 {
+					nalu = nalu[:len(nalu)-1]
+				}
+				if len(nalu) > 0 {
+					nalus = append(nalus, nalu)
+				}
+			}
+			i += codeLen - 1
+			start = i + 1
+			found = true
+		}
+	}
+
+	// Handle the last NALU.
+	if start < len(data) {
+		nalu := data[start:]
+		for len(nalu) > 0 && nalu[len(nalu)-1] == 0 {
+			nalu = nalu[:len(nalu)-1]
+		}
+		if len(nalu) > 0 {
+			nalus = append(nalus, nalu)
+		}
+	}
+
+	return nalus
+}
+
+// removeEmulationPrevention removes H.264/H.265 emulation prevention bytes
+// (0x00 0x00 0x03 → 0x00 0x00) from RBSP data.
+func removeEmulationPrevention(data []byte) []byte {
+	result := make([]byte, 0, len(data))
+	i := 0
+	for i < len(data) {
+		if i+2 < len(data) && data[i] == 0 && data[i+1] == 0 && data[i+2] == 3 {
+			result = append(result, 0, 0)
+			i += 3
+		} else {
+			result = append(result, data[i])
+			i++
+		}
+	}
+	return result
+}
+
+// bitReader is a bit-level reader for parsing exp-Golomb-coded SPS fields.
+// Used by both the H.264 (parseH264Dimensions) and H.265 (parseH265Dimensions)
+// SPS dimension parsers.
+type bitReader struct {
+	data    []byte
+	pos     int  // bit position (0-7 in current byte)
+	offset  int  // byte offset
+	overran bool // true if we read past the end of data
+}
+
+func (r *bitReader) readBit() uint8 {
+	if r.offset >= len(r.data) {
+		r.overran = true
+		return 0
+	}
+	bit := (r.data[r.offset] >> (7 - r.pos)) & 1
+	r.pos++
+	if r.pos >= 8 {
+		r.pos = 0
+		r.offset++
+	}
+	return bit
+}
+
+// readBits reads n bits as a uint32 (MSB first).
+func (r *bitReader) readBits(n int) uint32 {
+	var val uint32
+	for range n {
+		val = (val << 1) | uint32(r.readBit())
+	}
+	return val
+}
+
+// readUE reads an unsigned exp-golomb coded value.
+// Returns 0 and sets r.overran on EOF.
+func (r *bitReader) readUE() uint32 {
+	leadingZeros := 0
+	for r.readBit() == 0 {
+		if r.overran {
+			return 0
+		}
+		leadingZeros++
+		if leadingZeros > 31 {
+			r.overran = true
+			return 0
+		}
+	}
+	if leadingZeros == 0 {
+		return 0
+	}
+	// Read leadingZeros more bits to form the value.
+	suffix := r.readBits(leadingZeros)
+	return (1 << leadingZeros) - 1 + suffix
+}
+
+// readSE reads a signed exp-golomb coded value.
+func (r *bitReader) readSE() int32 {
+	ue := r.readUE()
+	if ue == 0 {
+		return 0
+	}
+	if ue&1 == 0 {
+		return -int32(ue / 2)
+	}
+	return int32((ue + 1) / 2)
+}
+
+// skipScalingLists skips the scaling-list fields in an H.264 SPS (High profile).
+// Called only by parseH264Dimensions.
+func skipScalingLists(r *bitReader) {
+	for i := range 8 {
+		if r.readBit() != 0 {
+			size := 16
+			if i >= 6 {
+				size = 64
+			}
+			lastScale := int32(8)
+			nextScale := int32(8)
+			for range size {
+				if nextScale != 0 {
+					delta := r.readSE()
+					nextScale = (lastScale + delta + 256) % 256
+				}
+				lastScale = nextScale
+			}
+		}
+	}
+}

--- a/internal/timelapse/frame_extractor_test.go
+++ b/internal/timelapse/frame_extractor_test.go
@@ -302,7 +302,11 @@ func createTestMP4(t *testing.T, tmpDir, name string, isH265 bool, samples []tes
 	defer f.Close()
 
 	w := mp4.NewWriter(f)
-	ftypSize, err := writeFtyp(w)
+	brand := [4]byte{'a', 'v', 'c', '1'}
+	if isH265 {
+		brand = [4]byte{'h', 'v', 'c', '1'}
+	}
+	ftypSize, err := writeCodecFtyp(w, brand)
 	if err != nil {
 		t.Fatalf("write ftyp: %v", err)
 	}

--- a/internal/timelapse/h264_go_merge.go
+++ b/internal/timelapse/h264_go_merge.go
@@ -9,11 +9,8 @@ package timelapse
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -46,7 +43,7 @@ func (m *H264GoMerger) Tier() MergeTier {
 // outputPath with the given fps, and returns a MergeResult.
 func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, fps int) (*MergeResult, error) {
 	// List and sort frame files.
-	frames, err := listH264FrameFiles(framesDir)
+	frames, err := listCodecFrameFiles(framesDir, "h264")
 	if err != nil {
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err
 	}
@@ -154,13 +151,15 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// First pass: calculate moov size by writing to a buffer.
-	muxer := &h264Muxer{
-		frameCount:  len(frames),
-		sampleSizes: sampleSizes,
-		width:       width,
-		height:      height,
-		avcCData:    avcCData,
-		sampleDur:   sampleDuration,
+	muxer := &codecMuxer{
+		frameCount:        len(frames),
+		sampleSizes:       sampleSizes,
+		width:             width,
+		height:            height,
+		decoderConfigData: avcCData,
+		sampleDur:         sampleDuration,
+		sampleEntryType:   [4]byte{'a', 'v', 'c', '1'},
+		configBoxType:     [4]byte{'a', 'v', 'c', 'C'},
 	}
 
 	buf := &bytesWriter{}
@@ -188,7 +187,7 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	w := mp4.NewWriter(f)
 
 	// Write ftyp.
-	ftypSize, err := writeFtyp(w)
+	ftypSize, err := writeCodecFtyp(w, [4]byte{'a', 'v', 'c', '1'})
 	if err != nil {
 		return &MergeResult{Tier: TierGo, Error: err.Error()},
 			fmt.Errorf("write ftyp: %w", err)
@@ -213,7 +212,7 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// Write mdat box (strips SPS/PPS from samples — they are in avcC only).
-	if err := writeH264Mdat(w, frames, ctx); err != nil {
+	if err := writeCodecMdat(w, frames, ctx, isH264ParamSet); err != nil {
 		f.Close()
 		os.Remove(outputPath)
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err
@@ -229,391 +228,7 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}, nil
 }
 
-// --- H.264 MP4 Muxer ---
-
-// h264Muxer builds the moov box structure for an H.264 video track.
-type h264Muxer struct {
-	frameCount  int
-	sampleSizes []uint32
-	width       int
-	height      int
-	avcCData    []byte
-	sampleDur   time.Duration
-	chunkOffset int64
-}
-
-func (m *h264Muxer) writeMoov(w *mp4.Writer, chunkOffset int64) error {
-	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("moov")})
-	if err != nil {
-		return err
-	}
-	if err := m.writeMvhd(w); err != nil {
-		return err
-	}
-	if err := m.writeTrak(w, chunkOffset); err != nil {
-		return err
-	}
-	_, err = w.EndBox()
-	return err
-}
-
-func (m *h264Muxer) writeMvhd(w *mp4.Writer) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mvhd")})
-	if err != nil {
-		return err
-	}
-
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-
-	mvhd := &mp4.Mvhd{
-		Timescale:   1000,
-		DurationV0:  duration,
-		Rate:        0x00010000,
-		Volume:      0x0100,
-		NextTrackID: 2,
-		Matrix: [9]int32{
-			0x00010000, 0, 0,
-			0, 0x00010000, 0,
-			0, 0, 0x40000000,
-		},
-	}
-	if _, err := mp4.Marshal(w, mvhd, mp4.Context{}); err != nil {
-		return err
-	}
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h264Muxer) writeTrak(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trak")})
-	if err != nil {
-		return err
-	}
-
-	// tkhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tkhd")})
-	if err != nil {
-		return err
-	}
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-	tkhd := &mp4.Tkhd{
-		TrackID:    1,
-		DurationV0: duration,
-		Width:      uint32(m.width) << 16,
-		Height:     uint32(m.height) << 16,
-		Matrix: [9]int32{
-			0x00010000, 0, 0,
-			0, 0x00010000, 0,
-			0, 0, 0x40000000,
-		},
-	}
-	if _, err := mp4.Marshal(w, tkhd, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// mdia
-	if err := m.writeMdia(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h264Muxer) writeMdia(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdia")})
-	if err != nil {
-		return err
-	}
-
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-
-	// mdhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdhd")})
-	if err != nil {
-		return err
-	}
-	mdhd := &mp4.Mdhd{
-		Timescale:  1000,
-		DurationV0: duration,
-		Language:   [3]byte{0x15, 0xC0, 0x00},
-	}
-	if _, err := mp4.Marshal(w, mdhd, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// hdlr
-	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hdlr")})
-	if err != nil {
-		return err
-	}
-	hdlr := &mp4.Hdlr{
-		HandlerType: [4]byte{'v', 'i', 'd', 'e'},
-		Name:        "VideoHandler\x00",
-	}
-	if _, err := mp4.Marshal(w, hdlr, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi3
-
-	// minf > stbl
-	if err := m.writeMinf(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h264Muxer) writeMinf(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("minf")})
-	if err != nil {
-		return err
-	}
-
-	// vmhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("vmhd")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Vmhd{Graphicsmode: 0}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// dinf > dref > url
-	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dinf")})
-	if err != nil {
-		return err
-	}
-	bi4, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dref")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Dref{EntryCount: 1}, mp4.Context{}); err != nil {
-		return err
-	}
-	bi5, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("url ")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Url{Location: ""}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi5
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi4
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi3
-
-	// stbl
-	if err := m.writeStbl(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h264Muxer) writeStbl(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stbl")})
-	if err != nil {
-		return err
-	}
-
-	n := m.frameCount
-
-	// stsd > avc1 + avcC
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsd")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsd{EntryCount: 1}, mp4.Context{}); err != nil {
-		return err
-	}
-	if err := m.writeAVC1SampleEntry(w); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// stts
-	bi6, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stts")})
-	if err != nil {
-		return err
-	}
-	sampleDelta := uint32(m.sampleDur.Milliseconds())
-	sttsEntries := make([]mp4.SttsEntry, n)
-	for i := range sttsEntries {
-		sttsEntries[i] = mp4.SttsEntry{
-			SampleCount: 1,
-			SampleDelta: sampleDelta,
-		}
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stts{EntryCount: uint32(n), Entries: sttsEntries}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi6
-
-	// stsc
-	bi7, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsc")})
-	if err != nil {
-		return err
-	}
-	stscEntries := []mp4.StscEntry{
-		{FirstChunk: 1, SamplesPerChunk: uint32(n), SampleDescriptionIndex: 1},
-	}
-	if n == 0 {
-		stscEntries = nil
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsc{EntryCount: uint32(len(stscEntries)), Entries: stscEntries}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi7
-
-	// stsz
-	bi8, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsz")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsz{SampleSize: 0, SampleCount: uint32(n), EntrySize: m.sampleSizes}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi8
-
-	// stco
-	bi9, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stco")})
-	if err != nil {
-		return err
-	}
-	stco := &mp4.Stco{EntryCount: 0, ChunkOffset: nil}
-	if n > 0 {
-		stco.EntryCount = 1
-		stco.ChunkOffset = []uint32{uint32(chunkOffset)}
-	}
-	if _, err := mp4.Marshal(w, stco, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi9
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-// writeAVC1SampleEntry writes the avc1 sample entry with the avcC box inside stsd.
-func (m *h264Muxer) writeAVC1SampleEntry(w *mp4.Writer) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("avc1")})
-	if err != nil {
-		return err
-	}
-
-	avc1 := &mp4.VisualSampleEntry{
-		SampleEntry: mp4.SampleEntry{
-			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType("avc1")},
-			DataReferenceIndex: 1,
-		},
-		Width:           uint16(m.width),
-		Height:          uint16(m.height),
-		Horizresolution: 0x00480000,
-		Vertresolution:  0x00480000,
-		FrameCount:      1,
-		Depth:           0x0018,
-	}
-	if _, err := mp4.Marshal(w, avc1, mp4.Context{}); err != nil {
-		return err
-	}
-
-	// avcC box (raw decoder configuration data)
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("avcC")})
-	if err != nil {
-		return err
-	}
-	if _, err := w.Write(m.avcCData); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi
-	return nil
-}
-
 // --- Helpers ---
-
-// writeFtyp writes the ftyp box and returns its total size.
-func writeFtyp(w *mp4.Writer) (int64, error) {
-	start, _ := w.Seek(0, 1)
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("ftyp")})
-	if err != nil {
-		return 0, err
-	}
-
-	ftyp := &mp4.Ftyp{
-		MajorBrand:   [4]byte{'i', 's', 'o', 'm'},
-		MinorVersion: 0,
-		CompatibleBrands: []mp4.CompatibleBrandElem{
-			{CompatibleBrand: [4]byte{'i', 's', 'o', 'm'}},
-			{CompatibleBrand: [4]byte{'i', 's', 'o', '2'}},
-			{CompatibleBrand: [4]byte{'m', 'p', '4', '1'}},
-			{CompatibleBrand: [4]byte{'a', 'v', 'c', '1'}},
-		},
-	}
-	if _, err := mp4.Marshal(w, ftyp, mp4.Context{}); err != nil {
-		return 0, err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return 0, err
-	}
-	_ = bi
-
-	end, _ := w.Seek(0, 1)
-	return end - start, nil
-}
 
 // isH264ParamSet returns true if the NAL unit is a parameter set (SPS or PPS).
 // These must only appear in the avcC box, not in sample data.
@@ -623,76 +238,6 @@ func isH264ParamSet(nalu []byte) bool {
 	}
 	nalType := nalu[0] & 0x1F
 	return nalType == 7 || nalType == 8 // SPS, PPS
-}
-
-// writeH264Mdat writes the mdat box with H.264 frame data, stripping SPS/PPS
-// from each frame. Parameter sets belong in avcC only — including them in sample
-// data causes MEDIA_ERR_SRC_NOT_SUPPORTED in browsers.
-func writeH264Mdat(w *mp4.Writer, framePaths []string, ctx context.Context) error {
-	// First pass: compute total mdat payload size (excluding param sets).
-	var totalPayloadSize uint32
-	for _, path := range framePaths {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read frame %s: %w", path, err)
-		}
-		for _, nalu := range splitAnnexB(data) {
-			if isH264ParamSet(nalu) {
-				continue
-			}
-			totalPayloadSize += 4 + uint32(len(nalu))
-		}
-	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	mdatBoxSize := uint64(8 + totalPayloadSize)
-	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdat"), Size: mdatBoxSize})
-	if err != nil {
-		return fmt.Errorf("start mdat: %w", err)
-	}
-
-	// Write each frame as length-prefixed NALUs, skipping param sets.
-	for _, path := range framePaths {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read frame for mdat %s: %w", path, err)
-		}
-
-		for _, nalu := range splitAnnexB(data) {
-			if isH264ParamSet(nalu) {
-				continue
-			}
-			lenBytes := make([]byte, 4)
-			binary.BigEndian.PutUint32(lenBytes, uint32(len(nalu)))
-			if _, err := w.Write(lenBytes); err != nil {
-				return fmt.Errorf("write NALU length: %w", err)
-			}
-			if _, err := w.Write(nalu); err != nil {
-				return fmt.Errorf("write NALU data: %w", err)
-			}
-		}
-	}
-
-	if _, err := w.EndBox(); err != nil {
-		return fmt.Errorf("end mdat: %w", err)
-	}
-	return nil
 }
 
 // buildAvcC builds the AVCDecoderConfiguration record bytes from raw SPS and PPS
@@ -710,55 +255,6 @@ func buildAvcC(sps, pps []byte) []byte {
 		return nil
 	}
 	return buf.Bytes()
-}
-
-// splitAnnexB splits an Annex-B byte stream into individual raw NAL units,
-// stripping the 0x00000001 (or 0x000001) start codes.
-func splitAnnexB(data []byte) [][]byte {
-	var nalus [][]byte
-	start := 0
-	found := false
-
-	for i := 0; i < len(data)-3; i++ {
-		if data[i] == 0 && data[i+1] == 0 {
-			var codeLen int
-			if data[i+2] == 1 {
-				codeLen = 3
-			} else if i+3 < len(data) && data[i+2] == 0 && data[i+3] == 1 {
-				codeLen = 4
-			} else {
-				continue
-			}
-
-			if found {
-				// Extract NALU from start to current position.
-				nalu := data[start:i]
-				// Strip trailing zeros (emulation prevention or padding).
-				for len(nalu) > 0 && nalu[len(nalu)-1] == 0 {
-					nalu = nalu[:len(nalu)-1]
-				}
-				if len(nalu) > 0 {
-					nalus = append(nalus, nalu)
-				}
-			}
-			i += codeLen - 1
-			start = i + 1
-			found = true
-		}
-	}
-
-	// Handle the last NALU.
-	if start < len(data) {
-		nalu := data[start:]
-		for len(nalu) > 0 && nalu[len(nalu)-1] == 0 {
-			nalu = nalu[:len(nalu)-1]
-		}
-		if len(nalu) > 0 {
-			nalus = append(nalus, nalu)
-		}
-	}
-
-	return nalus
 }
 
 // parseH264Dimensions extracts width and height from a raw H.264 SPS NAL unit.
@@ -871,106 +367,3 @@ func parseH264Dimensions(sps []byte) (width, height int) {
 
 	return width, height
 }
-
-// --- Bit-level reader for H.264 SPS parsing ---
-
-type bitReader struct {
-	data    []byte
-	pos     int  // bit position (0-7 in current byte)
-	offset  int  // byte offset
-	overran bool // true if we read past the end of data
-}
-
-func (r *bitReader) readBit() uint8 {
-	if r.offset >= len(r.data) {
-		r.overran = true
-		return 0
-	}
-	bit := (r.data[r.offset] >> (7 - r.pos)) & 1
-	r.pos++
-	if r.pos >= 8 {
-		r.pos = 0
-		r.offset++
-	}
-	return bit
-}
-
-// readBits reads n bits as a uint32 (MSB first).
-func (r *bitReader) readBits(n int) uint32 {
-	var val uint32
-	for range n {
-		val = (val << 1) | uint32(r.readBit())
-	}
-	return val
-}
-
-// readUE reads an unsigned exp-golomb coded value.
-// Returns 0 and sets r.overran on EOF.
-func (r *bitReader) readUE() uint32 {
-	leadingZeros := 0
-	for r.readBit() == 0 {
-		if r.overran {
-			return 0
-		}
-		leadingZeros++
-		if leadingZeros > 31 {
-			r.overran = true
-			return 0
-		}
-	}
-	if leadingZeros == 0 {
-		return 0
-	}
-	// Read leadingZeros more bits to form the value.
-	suffix := r.readBits(leadingZeros)
-	return (1 << leadingZeros) - 1 + suffix
-}
-
-// readSE reads a signed exp-golomb coded value.
-func (r *bitReader) readSE() int32 {
-	ue := r.readUE()
-	if ue == 0 {
-		return 0
-	}
-	if ue&1 == 0 {
-		return -int32(ue / 2)
-	}
-	return int32((ue + 1) / 2)
-}
-
-// skipScalingLists skips scaling list fields in an SPS.
-func skipScalingLists(r *bitReader) {
-	for i := range 8 {
-		if r.readBit() != 0 {
-			size := 16
-			if i >= 6 {
-				size = 64
-			}
-			lastScale := int32(8)
-			nextScale := int32(8)
-			for range size {
-				if nextScale != 0 {
-					delta := r.readSE()
-					nextScale = (lastScale + delta + 256) % 256
-				}
-				lastScale = nextScale
-			}
-		}
-	}
-}
-
-// --- Frame listing ---
-
-// listH264FrameFiles returns a sorted list of .h264 frame files in the directory.
-func listH264FrameFiles(dir string) ([]string, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "frame_*.h264"))
-	if err != nil {
-		return nil, err
-	}
-	// Sort to ensure correct frame order.
-	sort.Strings(matches)
-	return matches, nil
-}
-
-// Ensure H264GoMerger satisfies the TimelapseMerger interface.
-var _ TimelapseMerger = (*H264GoMerger)(nil)

--- a/internal/timelapse/h264_go_merge_test.go
+++ b/internal/timelapse/h264_go_merge_test.go
@@ -888,7 +888,7 @@ func TestListH264FrameFiles(t *testing.T) {
 		}
 	}
 
-	result, err := listH264FrameFiles(tmpDir)
+	result, err := listCodecFrameFiles(tmpDir, "h264")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,7 +907,7 @@ func TestListH264FrameFiles(t *testing.T) {
 
 func TestListH264FrameFiles_EmptyDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	result, err := listH264FrameFiles(tmpDir)
+	result, err := listCodecFrameFiles(tmpDir, "h264")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/timelapse/h265_go_merge.go
+++ b/internal/timelapse/h265_go_merge.go
@@ -9,11 +9,8 @@ package timelapse
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
-	"path/filepath"
-	"sort"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -52,7 +49,7 @@ func (m *H265GoMerger) Tier() MergeTier {
 // outputPath with the given fps, and returns a MergeResult.
 func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, fps int) (*MergeResult, error) {
 	// List and sort frame files.
-	frames, err := listH265FrameFiles(framesDir)
+	frames, err := listCodecFrameFiles(framesDir, "h265")
 	if err != nil {
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err
 	}
@@ -168,13 +165,15 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// First pass: calculate moov size by writing to a buffer.
-	muxer := &h265Muxer{
-		frameCount:  len(frames),
-		sampleSizes: sampleSizes,
-		width:       width,
-		height:      height,
-		hvcCData:    hvcCData,
-		sampleDur:   sampleDuration,
+	muxer := &codecMuxer{
+		frameCount:        len(frames),
+		sampleSizes:       sampleSizes,
+		width:             width,
+		height:            height,
+		decoderConfigData: hvcCData,
+		sampleDur:         sampleDuration,
+		sampleEntryType:   [4]byte{'h', 'v', 'c', '1'},
+		configBoxType:     [4]byte{'h', 'v', 'c', 'C'},
 	}
 
 	buf := &bytesWriter{}
@@ -202,7 +201,7 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	w := mp4.NewWriter(f)
 
 	// Write ftyp.
-	ftypSize, err := writeH265Ftyp(w)
+	ftypSize, err := writeCodecFtyp(w, [4]byte{'h', 'v', 'c', '1'})
 	if err != nil {
 		return &MergeResult{Tier: TierGo, Error: err.Error()},
 			fmt.Errorf("write ftyp: %w", err)
@@ -227,7 +226,7 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// Write mdat box (strips VPS/SPS/PPS from samples — they are in hvcC only).
-	if err := writeH265Mdat(w, frames, ctx); err != nil {
+	if err := writeCodecMdat(w, frames, ctx, isH265ParamSet); err != nil {
 		f.Close()
 		os.Remove(outputPath)
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err
@@ -243,391 +242,7 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}, nil
 }
 
-// --- H.265 MP4 Muxer ---
-
-// h265Muxer builds the moov box structure for an H.265 video track.
-type h265Muxer struct {
-	frameCount  int
-	sampleSizes []uint32
-	width       int
-	height      int
-	hvcCData    []byte
-	sampleDur   time.Duration
-	chunkOffset int64
-}
-
-func (m *h265Muxer) writeMoov(w *mp4.Writer, chunkOffset int64) error {
-	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("moov")})
-	if err != nil {
-		return err
-	}
-	if err := m.writeMvhd(w); err != nil {
-		return err
-	}
-	if err := m.writeTrak(w, chunkOffset); err != nil {
-		return err
-	}
-	_, err = w.EndBox()
-	return err
-}
-
-func (m *h265Muxer) writeMvhd(w *mp4.Writer) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mvhd")})
-	if err != nil {
-		return err
-	}
-
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-
-	mvhd := &mp4.Mvhd{
-		Timescale:   1000,
-		DurationV0:  duration,
-		Rate:        0x00010000,
-		Volume:      0x0100,
-		NextTrackID: 2,
-		Matrix: [9]int32{
-			0x00010000, 0, 0,
-			0, 0x00010000, 0,
-			0, 0, 0x40000000,
-		},
-	}
-	if _, err := mp4.Marshal(w, mvhd, mp4.Context{}); err != nil {
-		return err
-	}
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h265Muxer) writeTrak(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trak")})
-	if err != nil {
-		return err
-	}
-
-	// tkhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tkhd")})
-	if err != nil {
-		return err
-	}
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-	tkhd := &mp4.Tkhd{
-		TrackID:    1,
-		DurationV0: duration,
-		Width:      uint32(m.width) << 16,
-		Height:     uint32(m.height) << 16,
-		Matrix: [9]int32{
-			0x00010000, 0, 0,
-			0, 0x00010000, 0,
-			0, 0, 0x40000000,
-		},
-	}
-	if _, err := mp4.Marshal(w, tkhd, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// mdia
-	if err := m.writeMdia(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h265Muxer) writeMdia(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdia")})
-	if err != nil {
-		return err
-	}
-
-	duration := uint32(m.frameCount) * uint32(m.sampleDur.Milliseconds())
-
-	// mdhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdhd")})
-	if err != nil {
-		return err
-	}
-	mdhd := &mp4.Mdhd{
-		Timescale:  1000,
-		DurationV0: duration,
-		Language:   [3]byte{0x15, 0xC0, 0x00},
-	}
-	if _, err := mp4.Marshal(w, mdhd, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// hdlr
-	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hdlr")})
-	if err != nil {
-		return err
-	}
-	hdlr := &mp4.Hdlr{
-		HandlerType: [4]byte{'v', 'i', 'd', 'e'},
-		Name:        "VideoHandler\x00",
-	}
-	if _, err := mp4.Marshal(w, hdlr, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi3
-
-	// minf > stbl
-	if err := m.writeMinf(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h265Muxer) writeMinf(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("minf")})
-	if err != nil {
-		return err
-	}
-
-	// vmhd
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("vmhd")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Vmhd{Graphicsmode: 0}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// dinf > dref > url
-	bi3, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dinf")})
-	if err != nil {
-		return err
-	}
-	bi4, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dref")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Dref{EntryCount: 1}, mp4.Context{}); err != nil {
-		return err
-	}
-	bi5, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("url ")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Url{Location: ""}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi5
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi4
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi3
-
-	// stbl
-	if err := m.writeStbl(w, chunkOffset); err != nil {
-		return err
-	}
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-func (m *h265Muxer) writeStbl(w *mp4.Writer, chunkOffset int64) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stbl")})
-	if err != nil {
-		return err
-	}
-
-	n := m.frameCount
-
-	// stsd > hvc1 + hvcC
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsd")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsd{EntryCount: 1}, mp4.Context{}); err != nil {
-		return err
-	}
-	if err := m.writeHvc1SampleEntry(w); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	// stts
-	bi6, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stts")})
-	if err != nil {
-		return err
-	}
-	sampleDelta := uint32(m.sampleDur.Milliseconds())
-	sttsEntries := make([]mp4.SttsEntry, n)
-	for i := range sttsEntries {
-		sttsEntries[i] = mp4.SttsEntry{
-			SampleCount: 1,
-			SampleDelta: sampleDelta,
-		}
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stts{EntryCount: uint32(n), Entries: sttsEntries}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi6
-
-	// stsc
-	bi7, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsc")})
-	if err != nil {
-		return err
-	}
-	stscEntries := []mp4.StscEntry{
-		{FirstChunk: 1, SamplesPerChunk: uint32(n), SampleDescriptionIndex: 1},
-	}
-	if n == 0 {
-		stscEntries = nil
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsc{EntryCount: uint32(len(stscEntries)), Entries: stscEntries}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi7
-
-	// stsz
-	bi8, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsz")})
-	if err != nil {
-		return err
-	}
-	if _, err := mp4.Marshal(w, &mp4.Stsz{SampleSize: 0, SampleCount: uint32(n), EntrySize: m.sampleSizes}, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi8
-
-	// stco
-	bi9, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stco")})
-	if err != nil {
-		return err
-	}
-	stco := &mp4.Stco{EntryCount: 0, ChunkOffset: nil}
-	if n > 0 {
-		stco.EntryCount = 1
-		stco.ChunkOffset = []uint32{uint32(chunkOffset)}
-	}
-	if _, err := mp4.Marshal(w, stco, mp4.Context{}); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi9
-
-	_, err = w.EndBox()
-	_ = bi
-	return err
-}
-
-// writeHvc1SampleEntry writes the hvc1 sample entry with the hvcC box inside stsd.
-func (m *h265Muxer) writeHvc1SampleEntry(w *mp4.Writer) error {
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hvc1")})
-	if err != nil {
-		return err
-	}
-
-	hvc1 := &mp4.VisualSampleEntry{
-		SampleEntry: mp4.SampleEntry{
-			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType("hvc1")},
-			DataReferenceIndex: 1,
-		},
-		Width:           uint16(m.width),
-		Height:          uint16(m.height),
-		Horizresolution: 0x00480000,
-		Vertresolution:  0x00480000,
-		FrameCount:      1,
-		Depth:           0x0018,
-	}
-	if _, err := mp4.Marshal(w, hvc1, mp4.Context{}); err != nil {
-		return err
-	}
-
-	// hvcC box (HEVC decoder configuration data)
-	bi2, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hvcC")})
-	if err != nil {
-		return err
-	}
-	if _, err := w.Write(m.hvcCData); err != nil {
-		return err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi2
-
-	if _, err := w.EndBox(); err != nil {
-		return err
-	}
-	_ = bi
-	return nil
-}
-
 // --- Helpers ---
-
-// writeH265Ftyp writes the ftyp box for an HEVC MP4 file and returns its total size.
-func writeH265Ftyp(w *mp4.Writer) (int64, error) {
-	start, _ := w.Seek(0, 1)
-	bi, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("ftyp")})
-	if err != nil {
-		return 0, err
-	}
-
-	ftyp := &mp4.Ftyp{
-		MajorBrand:   [4]byte{'i', 's', 'o', 'm'},
-		MinorVersion: 0,
-		CompatibleBrands: []mp4.CompatibleBrandElem{
-			{CompatibleBrand: [4]byte{'i', 's', 'o', 'm'}},
-			{CompatibleBrand: [4]byte{'i', 's', 'o', '2'}},
-			{CompatibleBrand: [4]byte{'m', 'p', '4', '1'}},
-			{CompatibleBrand: [4]byte{'h', 'v', 'c', '1'}},
-		},
-	}
-	if _, err := mp4.Marshal(w, ftyp, mp4.Context{}); err != nil {
-		return 0, err
-	}
-	if _, err := w.EndBox(); err != nil {
-		return 0, err
-	}
-	_ = bi
-
-	end, _ := w.Seek(0, 1)
-	return end - start, nil
-}
 
 // buildHvcC builds the HEVCDecoderConfigurationRecord bytes from raw VPS, SPS,
 // and PPS NAL units (without start codes). Format per ISO 14496-15.
@@ -667,76 +282,6 @@ func isH265ParamSet(nalu []byte) bool {
 	}
 	nalType := (nalu[0] >> 1) & 0x3F
 	return nalType == 32 || nalType == 33 || nalType == 34 // VPS, SPS, PPS
-}
-
-// writeH265Mdat writes the mdat box with H.265 frame data, stripping VPS/SPS/PPS
-// from each frame. Parameter sets belong in hvcC only — including them in sample
-// data causes MEDIA_ERR_SRC_NOT_SUPPORTED in browsers.
-func writeH265Mdat(w *mp4.Writer, framePaths []string, ctx context.Context) error {
-	// First pass: compute total mdat payload size (excluding param sets).
-	var totalPayloadSize uint32
-	for _, path := range framePaths {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read frame %s: %w", path, err)
-		}
-		for _, nalu := range splitAnnexB(data) {
-			if isH265ParamSet(nalu) {
-				continue
-			}
-			totalPayloadSize += 4 + uint32(len(nalu))
-		}
-	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	mdatBoxSize := uint64(8 + totalPayloadSize)
-	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdat"), Size: mdatBoxSize})
-	if err != nil {
-		return fmt.Errorf("start mdat: %w", err)
-	}
-
-	// Write each frame as length-prefixed NALUs, skipping param sets.
-	for _, path := range framePaths {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return fmt.Errorf("read frame for mdat %s: %w", path, err)
-		}
-
-		for _, nalu := range splitAnnexB(data) {
-			if isH265ParamSet(nalu) {
-				continue
-			}
-			lenBytes := make([]byte, 4)
-			binary.BigEndian.PutUint32(lenBytes, uint32(len(nalu)))
-			if _, err := w.Write(lenBytes); err != nil {
-				return fmt.Errorf("write NALU length: %w", err)
-			}
-			if _, err := w.Write(nalu); err != nil {
-				return fmt.Errorf("write NALU data: %w", err)
-			}
-		}
-	}
-
-	if _, err := w.EndBox(); err != nil {
-		return fmt.Errorf("end mdat: %w", err)
-	}
-	return nil
 }
 
 // --- SPS parsing for H.265 ---
@@ -863,36 +408,6 @@ func parseH265Dimensions(sps []byte) (width, height int) {
 	}
 
 	return width, height
-}
-
-// removeEmulationPrevention removes H.264/H.265 emulation prevention bytes
-// (0x00 0x00 0x03 → 0x00 0x00) from RBSP data.
-func removeEmulationPrevention(data []byte) []byte {
-	result := make([]byte, 0, len(data))
-	i := 0
-	for i < len(data) {
-		if i+2 < len(data) && data[i] == 0 && data[i+1] == 0 && data[i+2] == 3 {
-			result = append(result, 0, 0)
-			i += 3
-		} else {
-			result = append(result, data[i])
-			i++
-		}
-	}
-	return result
-}
-
-// --- Frame listing ---
-
-// listH265FrameFiles returns a sorted list of .h265 frame files in the directory.
-func listH265FrameFiles(dir string) ([]string, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "frame_*.h265"))
-	if err != nil {
-		return nil, err
-	}
-	// Sort to ensure correct frame order.
-	sort.Strings(matches)
-	return matches, nil
 }
 
 // Ensure H265GoMerger satisfies the TimelapseMerger interface.

--- a/internal/timelapse/h265_go_merge_test.go
+++ b/internal/timelapse/h265_go_merge_test.go
@@ -914,7 +914,7 @@ func TestListH265FrameFiles(t *testing.T) {
 		}
 	}
 
-	result, err := listH265FrameFiles(tmpDir)
+	result, err := listCodecFrameFiles(tmpDir, "h265")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -933,7 +933,7 @@ func TestListH265FrameFiles(t *testing.T) {
 
 func TestListH265FrameFiles_EmptyDir(t *testing.T) {
 	tmpDir := t.TempDir()
-	result, err := listH265FrameFiles(tmpDir)
+	result, err := listCodecFrameFiles(tmpDir, "h265")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## 背景(#236 阶段 2,接续 PR #267)

h264_go_merge.go (1003 LOC) 和 h265_go_merge.go (982 LOC) 中有大量**逐字节相同**的 box 骨架代码(`writeMoov`/`writeMvhd`/`writeTrak`/`writeMdia`/`writeMinf`/`writeStbl`) —— 唯一的真实差异是 sample-entry box(`avc1`+`avcC` vs `hvc1`+`hvcC`)和 ftyp brand。PR #92/#95 时代改一处要动两文件,典型的重复税。

## 修复

**新建 `internal/timelapse/codec_merge.go`**,把共享部分集中:

1. **`codecMuxer` 类型** —— 合并 h264Muxer/h265Muxer,公共字段 + `sampleEntryType`/`configBoxType` `[4]byte` 参数化 sample/config box 类型。单一 `writeSampleEntry` 方法服务两种 codec。
2. **box 骨架方法**(`writeMoov`/`writeMvhd`/`writeTrak`/`writeMdia`/`writeMinf`/`writeStbl`)—— 作为 `codecMuxer` 方法,逐字节相同(同样的 StartBox/Marshal/EndBox 序列、同样字段值)。
3. **`writeCodecFtyp(brand)`** —— 参数化 ftyp brand。
4. **`writeCodecMdat(w, frames, ctx, isParamSet)`** —— 参数化 param-set 谓词(唯一 codec 差异)。
5. **codec-agnostic 辅助函数集中** —— `splitAnnexB`/`bitReader`(+ 全部方法)/`removeEmulationPrevention`/`skipScalingLists` 之前散在两个文件(bitReader 定义在 h264 文件却被 h265 跨文件复用,脆弱),现在统一到 codec_merge.go。

## 结果

| 文件 | 之前 | 之后 |
|---|---|---|
| h264_go_merge.go | 1003 | **369** ✓ (#236 ≤400) |
| h265_go_merge.go | 982 | **414** (略超 400,h265 SPS 解析器本身比 h264 大) |
| codec_merge.go | — | 663 (共享基类 + 辅助) |
| **净变化** | | **−440 行** |

## 行为零变化

box 字节序列完全一致(同样的 StartBox/Marshal/EndBox 序列、同样字段值)。重构是纯结构性的 —— codecMuxer 持有的字段就是 h264Muxer/h265Muxer 的字段(只是 `avcCData`/`hvcCData` 合并为 `decoderConfigData`)。

## 测试

- timelapse 全套测试绿:`TestH264/H265GoMerger_*`、`TestBuildHvcC_*`(PR #92/#89 回归守卫)、`TestBuildAvcC`、`TestParse*Dimensions`、`TestSplitAnnexB`、`TestAutoDetectMerger_*Routing`、frame_extractor 测试
- `TestH265GoMerger_ValidOutputBoxStructure`(字节级检查 hvc1/hvcC 在输出中)绿 —— 验证参数化后 box 类型字节正确

## 验证

Docker VM `192.168.63.197`(go1.26 + gofumpt v0.11.0):
- ✅ `gofumpt -l` 全清
- ✅ `go build ./...`
- ✅ `go test -race ./internal/{timelapse,mp4util,muxer,merge}/...` 全绿(timelapse 33s)

## 后续

部署 + 浏览器测 timelapse 回放(H.264 + H.265 摄像头各生成一次 timelapse,确认可播放)。这是 #236 的最后一个 PR(阶段 1 已在 PR #267 合并)。

Closes #236