### PR TITLE
fix(timelapse): RollingMergeManager StartSegmentMerge/StopAll wg race [main CI 修复]

### DIFF
--- a/internal/timelapse/rolling.go
+++ b/internal/timelapse/rolling.go
@@ -59,6 +59,17 @@ type RollingMergeManager struct {
 	progressMu           sync.Mutex
 	progress             map[string]*progressEntry
 	progressCleanupDelay time.Duration
+	// stopped is set under r.mu by StopAll. Once set, StartSegmentMerge refuses
+	// to launch new merges — this is what makes the wg.Add/wg.Wait pair safe
+	// from the sync.WaitGroup "Add with positive delta must happen before Wait
+	// when counter is zero" rule. Without it, a StartSegmentMerge that races
+	// ahead of StopAll's Wait would call wg.Add(1) after Wait has drained the
+	// counter to zero (data race + potential "WaitGroup is reused before
+	// previous Wait has returned" panic). The flag is read AND the Add is done
+	// atomically under r.mu in StartSegmentMerge, and set under r.mu before the
+	// Wait in StopAll, so StopAll's clear-then-Wait cannot observe a zero
+	// counter while a racing Start is mid-Add.
+	stopped bool
 	// stopMu serializes concurrent StopAll calls. sync.WaitGroup forbids Add
 	// after its counter has gone to zero on a Wait, so two overlapping StopAll
 	// calls (one Wait drains wg to zero, a concurrent StartSegmentMerge does
@@ -95,6 +106,19 @@ func (r *RollingMergeManager) StartSegmentMerge(ctx context.Context, cameraID, s
 	ctx, cancel := context.WithCancel(ctx)
 
 	r.mu.Lock()
+	// Refuse to start a new merge after StopAll has begun tearing down. The
+	// stopped flag + the wg.Add below are under the same r.mu hold as StopAll's
+	// set-stopped+clear, so once StopAll has set stopped and moved on to Wait,
+	// no racing Start can sneak in a wg.Add(1) after the counter reaches zero
+	// (which would violate sync.WaitGroup's "no Add after Wait-at-zero" rule
+	// and trigger a data race / panic). This is the root cause of the
+	// TestRollingMergeManager_ConcurrentStopAllAndStart flake on main CI.
+	if r.stopped {
+		r.mu.Unlock()
+		cancel()
+		slog.Debug("rolling merge: refusing to start new merge after StopAll", "camera_id", cameraID)
+		return
+	}
 	// Cancel any existing merge for this camera before starting a new one.
 	if old, ok := r.active[cameraID]; ok {
 		slog.Warn("rolling merge: replacing active merge for camera", "camera_id", cameraID)
@@ -318,6 +342,10 @@ func (r *RollingMergeManager) StopAll() {
 	defer r.stopMu.Unlock()
 
 	r.mu.Lock()
+	// Set stopped BEFORE clearing + waiting. StartSegmentMerge checks this
+	// flag under the same r.mu, so once we release the lock here no racing
+	// Start can perform a wg.Add(1) after our Wait has drained the counter.
+	r.stopped = true
 	for _, entry := range r.active {
 		entry.cancel()
 	}


### PR DESCRIPTION
## 问题

main 分支 CI **稳定失败**:`TestRollingMergeManager_ConcurrentStopAllAndStart` race detected(`internal/timelapse`)。这是真实的并发 bug,不是测试 flake —— 已在 3 次不同 CI run 中复现(#271 第一次、#274 VM 验证、main push 31181753892)。

## 根因

`StartSegmentMerge` 的 `r.wg.Add(1)`(rolling.go:109)和 `StopAll` 的 `r.wg.Wait()`(rolling.go:330)会**并发执行**,违反 sync.WaitGroup 的 `no Add with positive delta after Wait-at-zero` 规则。

之前的 `stopMu` 只序列化了**多个 StopAll 调用之间的交叉**,没覆盖 **StopAll ↔ StartSegmentMerge** 的交叉。时序:

1. StopAll 在 r.mu 下 cancel+clear,释放 r.mu
2. StopAll 调 `r.wg.Wait()` —— 若此刻 counter 已归零,Wait 立即返回
3. 一个并发的 StartSegmentMerge 在 r.mu 下做 `r.wg.Add(1)` —— **Add 发生在 Wait 归零之后** → race detector 抓到,极端情况 panic `WaitGroup is reused before previous Wait has returned`

## 修复

加 `stopped` 标志(`r.mu` 下,与 `wg.Add` 同一锁持):
- `StopAll` 在 clear 前设 `stopped = true`
- `StartSegmentMerge` 在 r.mu 下检查 `stopped`,若已停则拒绝启动(不再 `wg.Add`)

这样 `StopAll` 的 Wait 释放后,不会有任何 racing Start 做 Add —— 所有 Start 要么在 StopAll 设 stopped 之前就完成了 Add(Wait 会等它们),要么在 StopAll 之后(被 stopped 拒绝)。

测试 `TestRollingMergeManager_ConcurrentStopAllAndStart` 本就不假设 Start 在 StopAll 后必须成功(注释写 "final state may have some active entries"),所以拒绝路径不破坏测试语义。

## 验证

Docker VM go1.26:
- ✅ `gofumpt -l` clean
- ✅ `go vet ./internal/timelapse/...`
- ✅ `go test -race -count=20 -run TestRollingMergeManager_ConcurrentStopAllAndStart` **全过**(修复前 1-2 次就 race)
- ✅ `go test -race ./internal/timelapse/...` 全套绿(33s)

## 影响

- 生产:App.Stop() 与并发的 segment-close 触发的 merge start 不再 race(之前是潜在的 panic/race 源)
- 部署价值:中(防御性修复,消除 main CI 红线)