### PR TITLE
fix(onvif): #266 过滤非 ONVIF WS-Discovery 应答者(Synology NAS 等)

### DIFF
--- a/internal/onvif/onvifgo.go
+++ b/internal/onvif/onvifgo.go
@@ -32,10 +32,54 @@ func MapDiscoveredDevice(d *discovery.Device) DiscoveredDevice {
 	}
 }
 
-// MapDiscoveredDevices converts a slice of onvif-go discovery.Device to project DiscoveredDevice.
+// isONVIFDevice reports whether a WS-Discovery ProbeMatch answerer is actually
+// an ONVIF network video device, as opposed to a generic WS-Discovery responder
+// (Synology NAS DSM on :5357/:5000, Windows machines, printers, scanners) that
+// answers ANY Probe regardless of its d:Types filter.
+//
+// Per ONVIF Core Spec, a real camera's ProbeMatch carries either:
+//   - Types containing "NetworkVideoTransmitter" (the ONVIF device type the
+//     NVR's Probe explicitly asks for — see wsDiscoveryProbe), or
+//   - a Scope beginning with "onvif://www.onvif.org/" (ONVIF scope namespace).
+//
+// Synology et al. advertise neither (their Types is "wsdiscovery:Device" or
+// empty, and their scopes are device-vendor-specific), so filtering on these
+// two signals drops them at the discovery boundary instead of letting them
+// flow into HandleDiscovered → enrich → enroll as forever-pending_activation
+// shells that can never connect (issue #266).
+//
+// The check is permissive on purpose: matching either signal keeps the device.
+// This avoids false-negative drops of marginal ONVIF implementations that
+// populate Scopes but leave Types empty (or vice versa).
+func isONVIFDevice(d *discovery.Device) bool {
+	for _, t := range d.Types {
+		// Type entries are QNames like "dp0:NetworkVideoTransmitter"; match on
+		// the local part so the prefix (dp0 / tns / etc.) doesn't matter.
+		if strings.Contains(t, "NetworkVideoTransmitter") {
+			return true
+		}
+	}
+	for _, s := range d.Scopes {
+		if strings.HasPrefix(s, "onvif://www.onvif.org/") {
+			return true
+		}
+	}
+	return false
+}
+
+// MapDiscoveredDevices converts a slice of onvif-go discovery.Device to project
+// DiscoveredDevice, dropping any that are not ONVIF devices (isONVIFDevice).
+// Non-ONVIF WS-Discovery responders (Synology NAS, printers, Windows) are
+// filtered here so they never reach HandleDiscovered/enroll (issue #266).
 func MapDiscoveredDevices(devices []*discovery.Device) []DiscoveredDevice {
 	result := make([]DiscoveredDevice, 0, len(devices))
 	for _, d := range devices {
+		if !isONVIFDevice(d) {
+			logger.Debug("dropping non-ONVIF WS-Discovery responder",
+				"endpoint", d.GetDeviceEndpoint(),
+				"types", d.Types, "scope_count", len(d.Scopes))
+			continue
+		}
 		result = append(result, MapDiscoveredDevice(d))
 	}
 	return result

--- a/internal/onvif/onvifgo_test.go
+++ b/internal/onvif/onvifgo_test.go
@@ -81,4 +81,90 @@ func TestMapDiscoveredDevices(t *testing.T) {
 		require.Equal(t, "Cam1", result[0].Name)
 		require.Equal(t, "Cam2", result[1].Name)
 	})
+
+	// TestMapDiscoveredDevices_DropsNonONVIF is the #266 regression guard:
+	// generic WS-Discovery responders (Synology NAS DSM, printers, Windows
+	// machines) answer the NVR's NetworkVideoTransmitter Probe with neither
+	// that Type nor any onvif:// scope. They must be filtered out at the
+	// discovery boundary so they never become pending_activation shells.
+	t.Run("drops non-ONVIF WS-Discovery responders (#266)", func(t *testing.T) {
+		t.Helper()
+		devices := []*discovery.Device{
+			// Real ONVIF camera — kept (Types has NetworkVideoTransmitter).
+			{
+				EndpointRef: "uuid:real-cam", XAddrs: []string{"http://cam/onvif/device_service"},
+				Types: []string{"dp0:NetworkVideoTransmitter"}, Scopes: []string{"onvif://www.onvif.org/name/Cam"},
+			},
+			// Synology NAS DSM — no NetworkVideoTransmitter type, no onvif:// scope → dropped.
+			{
+				EndpointRef: "uuid:synology", XAddrs: []string{"http://synologynas:5357/wsd/abc"},
+				Types: []string{"wsdiscovery:Device"}, Scopes: []string{"http://schemas.xmlsoap.org/ws/2006/02/devprof/devcat/Computers"},
+			},
+			// Generic responder, empty Types + empty Scopes → dropped.
+			{EndpointRef: "uuid:empty", XAddrs: []string{"http://maoplus:5000/wsd/def"}, Types: nil, Scopes: nil},
+			// Camera that only advertises via onvif:// scope (no Types) — kept.
+			{
+				EndpointRef: "uuid:scope-only", XAddrs: []string{"http://cam2/onvif"},
+				Types: nil, Scopes: []string{"onvif://www.onvif.org/name/Cam2", "onvif://www.onvif.org/hardware/H264"},
+			},
+		}
+
+		result := MapDiscoveredDevices(devices)
+
+		require.Len(t, result, 2, "only the two ONVIF devices (Types=NetworkVideoTransmitter, scope-only) should survive")
+		require.Equal(t, "uuid:real-cam", result[0].UUID)
+		require.Equal(t, "uuid:scope-only", result[1].UUID)
+	})
+}
+
+func TestIsONVIFDevice(t *testing.T) {
+	t.Helper()
+	tests := []struct {
+		name string
+		d    *discovery.Device
+		want bool
+	}{
+		{
+			name: "NetworkVideoTransmitter type (with prefix)",
+			d:    &discovery.Device{Types: []string{"dp0:NetworkVideoTransmitter"}},
+			want: true,
+		},
+		{
+			name: "NetworkVideoTransmitter type (bare)",
+			d:    &discovery.Device{Types: []string{"NetworkVideoTransmitter"}},
+			want: true,
+		},
+		{
+			name: "onvif:// scope only (no type)",
+			d:    &discovery.Device{Scopes: []string{"onvif://www.onvif.org/name/Cam", "onvif://www.onvif.org/hardware/X"}},
+			want: true,
+		},
+		{
+			name: "Synology NAS (wsdiscovery:Device, no onvif scope)",
+			d:    &discovery.Device{Types: []string{"wsdiscovery:Device"}, Scopes: []string{"http://schemas.xmlsoap.org/ws/2006/02/devprof/devcat/Computers"}},
+			want: false,
+		},
+		{
+			name: "printer (empty type, vendor scope)",
+			d:    &discovery.Device{Types: []string{""}, Scopes: []string{"http://vendor.example.com/printer"}},
+			want: false,
+		},
+		{
+			name: "completely empty (Windows machine)",
+			d:    &discovery.Device{},
+			want: false,
+		},
+		{
+			name: "false-positive guard: scope contains 'onvif' substring but not the namespace prefix",
+			d:    &discovery.Device{Scopes: []string{"http://example.com/not-onvif-device"}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isONVIFDevice(tt.d); got != tt.want {
+				t.Errorf("isONVIFDevice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## 问题

开启 `auto_discover` 后,Synology NAS / 打印机 / Windows 等非摄像头设备因为响应了 WS-Discovery Probe(它们不区分 Probe 的 `d:Types`,对所有 Probe 一律回 ProbeMatches)被误识别为 ONVIF 摄像头,落入 `pending_activation` 永远连不上,每个 discovery 周期刷 `auto-remediate skipped` 日志。

M5 实测抓到的 3 个误录入条目:

| endpoint | 实际来源 |
|---|---|
| `http://mickeybeehome:5000/wsd/<uuid>` | Synology DSM(:5000) |
| `http://synologynas:5357/wsd/<uuid>` | Synology NAS(:5357 SSDP/WS-Discovery) |
| `http://maoplus:5357/wsd/<uuid>` | 同一个 Synology discovery responder 的另一个主机名 |

## 根因

`MapDiscoveredDevices`(`internal/onvif/onvifgo.go`)把收到的 ProbeMatch 全部映射成 `DiscoveredDevice`,**没有校验对方回的 Types 是否真的是 NetworkVideoTransmitter 或 Scopes 是否含 `onvif://www.onvif.org/` 命名空间**。于是这类无差别应答者流入了 `HandleDiscovered → enrich → enroll`,最终因 `GetDeviceInformation` 连不上而落入 `pending_activation`。

## 修复

在 `MapDiscoveredDevices` 加 `isONVIFDevice` 过滤(**映射前丢弃**,最早拦截点):
- `Types` 含 `NetworkVideoTransmitter`(匹配 local part,不依赖 QName 前缀 `dp0:`/`tns:`),**或**
- `Scopes` 含 `onvif://www.onvif.org/` 前缀的项

任一命中才视为 ONVIF 设备。Synology(`wsdiscovery:Device`)、打印机(空/vendor scope)、Windows(全空)全被挡掉。**真摄像头一定满足其一**(ONVIF Core Spec 规定),不会误伤。

## 测试

| 测试 | 覆盖 |
|---|---|
| `TestMapDiscoveredDevices_DropsNonONVIF`(新) | 4 设备(真 cam + Synology + 空 + scope-only cam)→ 断言只留 2 个 ONVIF 设备 |
| `TestIsONVIFDevice`(新) | 7 用例:NetworkVideoTransmitter 带/不带前缀、onvif scope、Synology、printer、空、substring 假阳性 guard |

现有 `TestMapDiscoveredDevice`/`TestMapDiscoveredDevices` 测试用的 device 都带 `onvif://` scope,过滤后仍通过(无回归)。

## 验证

Docker VM go1.26 + gofumpt v0.11.0:
- ✅ `gofumpt -l` clean
- ✅ `go build ./...`
- ✅ `go test -race ./internal/onvif/...` 全绿(6.8s,含现有 discovery/client 全套测试)

## 影响

- **生产**:不再录入 Synology NAS 等假摄像头;现有误录入条目需用户手动 `DELETE /api/cameras/{id}`(本修复只阻止未来录入,issue 正文已说明)
- **部署价值**:中(减少日志噪音 + 阻止假 pending_activation 条目累积)
- 不影响真 ONVIF 摄像头(ONVIF Core Spec 保证它们带 NetworkVideoTransmitter Types 或 onvif:// scope)

Closes #266