### PR TITLE
fix(web): MergePanel cancel-merge dialog rendered on every recording detail (#277 regression)

### DIFF
--- a/web/src/routes/recordings/MergePanel.svelte
+++ b/web/src/routes/recordings/MergePanel.svelte
@@ -281,12 +281,13 @@
   onDestroy(() => teardown());
 </script>
 
-<ConfirmDialog
-  open={cancelMergeConfirm}
-  title={t('detail.cancelMerge')}
-  message={t('detail.cancelMergeConfirm')}
-  confirmText={t('detail.cancelMerge')}
-  variant="danger"
-  onconfirm={handleCancelMerge}
-  oncancel={() => (cancelMergeConfirm = false)}
-/>
+{#if cancelMergeConfirm}
+  <ConfirmDialog
+    title={t('detail.cancelMerge')}
+    message={t('detail.cancelMergeConfirm')}
+    confirmText={t('detail.cancelMerge')}
+    variant="danger"
+    onconfirm={handleCancelMerge}
+    oncancel={() => (cancelMergeConfirm = false)}
+  />
+{/if}


### PR DESCRIPTION
## Summary

Regression from #277: the "取消合并" (Cancel Merge) confirm dialog rendered on **every** recording detail page load, even for recordings with no merge in progress.

## Root cause

`ConfirmDialog.svelte` has no internal `{#if open}` guard — it always renders its dialog markup (only the `dialogEl` focus behavior keys off the `open` prop). The original `RecordingDetail.svelte` gated the dialog with `{#if cancelMergeConfirm}`. The #136 refactor moved this into `MergePanel.svelte` but dropped the `{#if}` wrapper, passing `open={cancelMergeConfirm}` instead — which has no effect on visibility.

## Fix

Restore the `{#if cancelMergeConfirm}` wrapper around `<ConfirmDialog>` in `MergePanel.svelte`, matching the original pattern.

```diff
-<ConfirmDialog
-  open={cancelMergeConfirm}
-  ...
-/>
+{#if cancelMergeConfirm}
+  <ConfirmDialog ... />
+{/if}
```

## Verification (browser-tested on M5)

After redeploying, reloaded `/#/recordings/:id` for several recordings:

| Path | Before fix | After fix |
|---|---|---|
| h265 merged recording | ❌ cancel-merge dialog on load | ✅ no dialog |
| timelapse cycler | ❌ dialog on load | ✅ no dialog; cycler plays 1/9 → 9/9 |
| mjpeg cycler | ❌ dialog on load | ✅ no dialog; JPEG cycler works |
| h265 `<video>` play/pause | — | ✅ plays (button → 暂停) |
| next-segment nav | — | ✅ recording ID switches, new segment loads |
| delete-confirm modal | — | ✅ opens on delete click (not immediate delete) |

Regression caught by the browser GUI test of the #136 refactor — the build/unit tests didn't catch it because `ConfirmDialog`'s always-render behavior isn't exercised by the existing component tests.
