### PR TITLE
fix(camera): handleActivateCamera 对已运行摄像头返回 409(幂等) + 前端软处理

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -808,6 +808,11 @@ func (h *Handler) handleActivateCamera(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case errors.As(err, new(*model.CameraNotFoundError)):
 			writeAPIError(w, http.StatusNotFound, err)
+		case errors.As(err, new(*model.CameraAlreadyRunningError)):
+			// Idempotent: the recorder auto-restored (e.g. on NVR restart) and raced
+			// with this request. Mirrors handleStartCamera's 409 — the camera is
+			// already in the desired state, not a server error.
+			writeAPIError(w, http.StatusConflict, err)
 		default:
 			logger.Error("failed to activate camera", "camera_id", id, "error", err, "path", r.URL.Path)
 			WriteError(w, http.StatusInternalServerError, "failed to activate camera")

--- a/internal/api/handlers_camera_test.go
+++ b/internal/api/handlers_camera_test.go
@@ -456,6 +456,36 @@ func TestStartCamera_NoManager(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 }
 
+// --- handleActivateCamera tests ---
+//
+// handleActivateCamera parses the JSON body before checking the manager, so
+// the InvalidBody branch (400) is reachable even with a nil manager. The
+// NoManager case mirrors TestStartCamera_NoManager: a valid (empty) body with
+// no manager wired up returns 503. The 409 (CameraAlreadyRunningError) and 404
+// (CameraNotFoundError) branches require a real CameraManager, which the test
+// harness does not inject (camMgr is a concrete *camera.CameraManager, not an
+// interface); they are covered instead by the higher-level camera-manager tests.
+
+func TestActivateCamera_InvalidBody(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/test-cam/activate", bytes.NewReader([]byte("not json")), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestActivateCamera_NoManager(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/test-cam/activate", nil, "", "")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
 // --- handleStopCamera tests ---
 
 func TestStopCamera_NoManager(t *testing.T) {

--- a/internal/api/handlers_camera_test.go
+++ b/internal/api/handlers_camera_test.go
@@ -482,7 +482,9 @@ func TestActivateCamera_NoManager(t *testing.T) {
 	defer db.Close()
 	h := TestHandler(db, store)
 
-	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/test-cam/activate", nil, "", "")
+	// A valid JSON body is required so the handler reaches the manager-nil
+	// check (an empty/nil body fails JSON decode with io.EOF → 400 first).
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/test-cam/activate", bytes.NewReader([]byte(`{}`)), "", "")
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 }
 

--- a/web/src/lib/components/CameraCard.svelte
+++ b/web/src/lib/components/CameraCard.svelte
@@ -390,7 +390,7 @@ let healthShowWarningIcon = $derived(
      {/if}
      <!-- Activate: supply credentials for a pending_activation camera (auto-discovered,
           credentials unknown). -->
-     {#if isPendingActivation && onactivate}
+     {#if isPendingActivation && camera.status !== 'recording' && onactivate}
         <button
           class="btn btn-ghost px-2 py-1 text-sm text-amber-400 hover:text-amber-300"
           onclick={() => (activateOpen = true)}

--- a/web/src/routes/Cameras.svelte
+++ b/web/src/routes/Cameras.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { listCameras, deleteCamera, startCamera, stopCamera, updateCamera, xiaomiDevices, listProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, listArchives, setArchiveRetention, deleteArchiveGroup, listArchiveRecordings, deleteArchiveRecording, getHealthStatus, getTranscodingStatus, getTranscodingSettings, getTranscodingCheck, getCameraRecordingStats, rediscoverCamera, activateCamera, getAuthHeader } from '$lib/api';
+  import { listCameras, deleteCamera, startCamera, stopCamera, updateCamera, xiaomiDevices, listProtocols, DEFAULT_PROTOCOLS, buildProtocolsMap, listArchives, setArchiveRetention, deleteArchiveGroup, listArchiveRecordings, deleteArchiveRecording, getHealthStatus, getTranscodingStatus, getTranscodingSettings, getTranscodingCheck, getCameraRecordingStats, rediscoverCamera, activateCamera, getAuthHeader, ApiRequestError } from '$lib/api';
   import type { Camera, XiaomiDevice, ProtocolInfo, ArchiveGroup, Recording, CameraHealth, HealthStatusResponse } from '$lib/api';
   import { t } from '$lib/i18n';
   import { showToast } from '$lib/toast';
@@ -401,6 +401,15 @@
       showToast(t('cameras.activateSuccess'), 'success');
       await loadCameras();
     } catch (e: any) {
+      // The recorder auto-restored (e.g. on NVR restart) and raced with this
+      // request — the camera is already in the desired state, so treat it as
+      // success rather than a scary red error. Backend returns 409 with
+      // code CAMERA_ALREADY_RUNNING (mirrors the /start endpoint).
+      if (e instanceof ApiRequestError && e.code === 'CAMERA_ALREADY_RUNNING') {
+        showToast(t('errors.CAMERA_ALREADY_RUNNING'), 'info');
+        await loadCameras();
+        return; // don't re-throw: close the dialog, status is already aligned
+      }
       showToast(friendlyError(e, 'cameras.activateFailed'), 'error');
       throw e; // re-throw so CameraCard keeps the dialog open on failure
     }


### PR DESCRIPTION
## 问题

NVR 重启后 recorder 会自动恢复录像中的摄像头。如果一个 `pending_activation` 摄像头在用户点"激活"之前已被 recorder 自恢复为 `recording`，`handleActivateCamera` 调用的 `ActivateCamera` 返回 `CameraAlreadyRunningError`，但该分支此前落入 `default` → 返回 **500**，前端弹红色"激活失败"。实际上摄像头已处于用户想要的状态——这是竞态，不是错误。

`handleStartCamera` 早已对 `CameraAlreadyRunningError` 返回 409；`handleActivateCamera` 缺同样的幂等处理。

## 改动

**后端** `internal/api/handlers_camera.go`
`handleActivateCamera` 增加 `CameraAlreadyRunningError → 409` 分支，对齐 `handleStartCamera`。

**前端**
- `Cameras.svelte` `handleActivateCamera`：捕获 `CAMERA_ALREADY_RUNNING`，弹 **info** 提示（非红色 error）并刷新列表，不 re-throw（关闭对话框，状态已对齐）。
- `CameraCard.svelte`：摄像头已 `recording` 时不渲染激活按钮（`isPendingActivation && status !== 'recording'`），避免用户看到一个点了必失败的按钮。

**测试** `handlers_camera_test.go`
新增 `TestActivateCamera_InvalidBody`(400) 与 `TestActivateCamera_NoManager`(503)，对齐现有 `TestStartCamera_NoManager` 风格。409/404 分支需真实 `CameraManager`（`camMgr` 是具体类型非接口，测试 harness 不注入），由更高层 camera-manager 测试覆盖。

i18n：`errors.CAMERA_ALREADY_RUNNING` 键已存在（en/zh）。

## 验证

`CGO_ENABLED=0 GOOS=linux go vet ./internal/api/` ✅ 干净
`CGO_ENABLED=0 GOOS=linux go test -c ./internal/api/` ✅ 编译通过