### PR TITLE
fix(test): CameraForm.test lucide mock 补 Copy 图标 (#297 后续)

### DIFF
--- a/web/src/__tests__/CameraForm.test.ts
+++ b/web/src/__tests__/CameraForm.test.ts
@@ -11,7 +11,7 @@ vi.mock('$lib/i18n', () => ({
 
 // --- Mock lucide-svelte icons ---
 vi.mock('lucide-svelte', () => {
-  const icons = ['Eye', 'EyeOff', 'PlugZap', 'Plus', 'Trash2', 'ArrowUpRight'];
+  const icons = ['Eye', 'EyeOff', 'PlugZap', 'Plus', 'Trash2', 'ArrowUpRight', 'Copy'];
   const mock: Record<string, () => HTMLElement> = {};
   for (const name of icons) {
     mock[name] = () => document.createElement('span');


### PR DESCRIPTION
PR #301 给 CameraForm 加了实时预览的 Copy 图标按钮（lucide-svelte），但 CameraForm.test.ts 的 lucide-svelte mock 漏了 Copy → `No "Copy" export is defined on the mock`，1 个 vitest 用例失败。

补上 Copy 即可。无功能改动，纯测试 mock 修复。