### PR TITLE
fix(fnos): desktop iframe 拒绝 + 端口冲突引导 + build.sh 修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ docs/MiBee-Projects/
 build/
 dist/
 .build-tmp/
+# fnOS .fpk is a build artifact (produced by deploy/fnos/build.sh), never commit
+deploy/fnos/*.fpk
 internal/transcoding/-decoders
 internal/transcoding/-encoders
 .zcode/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,16 @@
 server:
   listen: ":9090"
 
+# HTTP security response headers.
+# frame_ancestors controls who may embed the Web UI in an <iframe> via the CSP
+# frame-ancestors directive. A space-separated list of sources, e.g.
+#   "'self' http://192.168.1.10 http://192.168.1.11"
+# Empty/'self' (default) = no cross-origin embedding. Override at runtime with
+# the NVR_FRAME_ANCESTORS env var (e.g. fnOS sets "'self' http://*" so the fnOS
+# desktop can embed the UI from a different origin).
+security:
+  frame_ancestors: ""  # empty = default 'self' (no cross-origin framing)
+
 # Storage settings
 # root_dir: where recordings, database, and HLS segments are stored.
 # Docker: set via NVR_DATA_DIR env var (default /data). See deploy/docker/docker-compose.yml.

--- a/deploy/fnos/app/docker/docker-compose.yaml
+++ b/deploy/fnos/app/docker/docker-compose.yaml
@@ -2,6 +2,7 @@
 # fnOS provides environment variables; key ones used here:
 #   TRIM_APPDEST  — installed app target directory (/var/apps/mibee-nvr/target)
 #   TRIM_PKGVAR   — app runtime data directory (persists across restarts)
+#   wizard_port   — port chosen by the user in the install wizard (default 9090)
 #
 # host networking is REQUIRED for ONVIF auto-discovery (UDP multicast does not
 # cross Docker's bridge). fnOS allows apps without a meaningful service_port
@@ -19,7 +20,16 @@ services:
       # Persist recordings / DB / config / models in fnOS app data dir.
       - "${TRIM_PKGVAR}/data:/data"
     environment:
-      - NVR_DATA_DIR=/data
+      NVR_DATA_DIR: /data
+      # Port from the install wizard (ui/config opens the iframe on the same
+      # port via ${wizard_port}). The app reads NVR_LISTEN_PORT to bind it.
+      NVR_LISTEN_PORT: "${wizard_port:-9090}"
+      # The fnOS desktop embeds the UI in a cross-origin iframe (desktop page
+      # origin != the NVR's :wizard_port origin), so CSP frame-ancestors must
+      # allow the embedder. 'self' + http://* covers LAN fnOS hosts without
+      # prelisting each user's NAS IP. Restrict further in mibee-nvr.yaml
+      # (security.frame_ancestors) if your network model requires it.
+      NVR_FRAME_ANCESTORS: "'self' http://*"
     healthcheck:
       test: ["CMD", "mibee-nvr", "health"]
       interval: 30s

--- a/deploy/fnos/app/ui/config
+++ b/deploy/fnos/app/ui/config
@@ -5,7 +5,7 @@
       "icon": "images/icon_{0}.png",
       "type": "iframe",
       "protocol": "http",
-      "port": "9090",
+      "port": "${wizard_port}",
       "url": "/",
       "allUsers": true
     }

--- a/deploy/fnos/build.sh
+++ b/deploy/fnos/build.sh
@@ -15,7 +15,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION="${1:-${VERSION:-}}"
-FNPACK_BIN="${FNPACK_BIN:-fnpack}"
+# fnpack binary; on Windows set FNPACK_BIN to the path of fnpack.exe.
+FNPACK="${FNPACK_BIN:-fnpack}"
 
 if [ -z "$VERSION" ]; then
   echo "ERROR: version required (X.Y.Z). Usage: $0 <version>" >&2
@@ -27,7 +28,7 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-if ! command -v "$FNPACK_BIN" >/dev/null 2>&1; then
+if ! command -v "$FNPACK" >/dev/null 2>&1; then
   echo "ERROR: fnpack not found on PATH. Install it or set FNPACK_BIN." >&2
   echo "       https://github.com/ckcoding/fnnas-docs/blob/main/docs/cli/fnpack.md" >&2
   exit 1
@@ -39,10 +40,22 @@ tmp_manifest="$(mktemp)"
 sed -E "s/^version=.*/version=${VERSION}/" "$SCRIPT_DIR/manifest" > "$tmp_manifest"
 mv "$tmp_manifest" "$SCRIPT_DIR/manifest"
 
-# Build. fnpack picks up the image tag from compose via the VERSION env var
-# (docker-compose.yaml uses ${VERSION:-latest}).
+# Bake the version into docker-compose.yaml. fnpack does NOT substitute
+# ${VERSION} (unlike docker compose at runtime, fnOS does not inject a VERSION
+# env at install time), so the placeholder must be resolved here — otherwise
+# manifest.version and the image tag drift apart and the pull fails with a
+# misleading "manifest unknown". The source keeps ${VERSION:-latest} so it
+# stays usable for manual `docker compose up`; we restore it after packing.
+compose_file="$SCRIPT_DIR/app/docker/docker-compose.yaml"
+cp "$compose_file" "$compose_file.bak"
+sed -E "s#\\\$\\{VERSION:-latest\\}#${VERSION}#g" "$compose_file" > "$compose_file.tmp"
+mv "$compose_file.tmp" "$compose_file"
+restore_compose() { mv "$compose_file.bak" "$compose_file"; }
+trap restore_compose EXIT
+
+# Build.
 echo "Building .fpk with version ${VERSION}..."
-( cd "$SCRIPT_DIR" && VERSION="$VERSION" fnpack build )
+( cd "$SCRIPT_DIR" && "$FNPACK" build )
 
 echo "Done. Install the generated .fpk via fnOS 应用中心 → 手动安装,"
 echo "or submit it through the fnOS developer channel."

--- a/deploy/fnos/cmd/config_callback
+++ b/deploy/fnos/cmd/config_callback
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called after the user changes environment variables in the application setting page.
+
+exit 0

--- a/deploy/fnos/cmd/config_init
+++ b/deploy/fnos/cmd/config_init
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called before the user changes environment variables in the application setting page.
+
+exit 0

--- a/deploy/fnos/cmd/install_callback
+++ b/deploy/fnos/cmd/install_callback
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called after the user installs the application.
+
+exit 0

--- a/deploy/fnos/cmd/install_init
+++ b/deploy/fnos/cmd/install_init
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called before the user installs the application.
+
+exit 0

--- a/deploy/fnos/cmd/uninstall_callback
+++ b/deploy/fnos/cmd/uninstall_callback
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called after the user uninstalls the application.
+
+exit 0

--- a/deploy/fnos/cmd/uninstall_init
+++ b/deploy/fnos/cmd/uninstall_init
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called before the user uninstalls the application.
+
+exit 0

--- a/deploy/fnos/cmd/upgrade_callback
+++ b/deploy/fnos/cmd/upgrade_callback
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called after the user upgrades the application.
+
+exit 0

--- a/deploy/fnos/cmd/upgrade_init
+++ b/deploy/fnos/cmd/upgrade_init
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### This script is called before the user upgrades the application.
+
+exit 0

--- a/deploy/fnos/wizard/install
+++ b/deploy/fnos/wizard/install
@@ -1,5 +1,35 @@
 [
   {
+    "stepTitle": "Network",
+    "items": [
+      {
+        "type": "text",
+        "field": "wizard_port",
+        "label": "Web UI port",
+        "initValue": "9090",
+        "rules": [
+          {
+            "required": true,
+            "message": "Enter a port number"
+          },
+          {
+            "pattern": "^[0-9]+$",
+            "message": "Use numbers only"
+          },
+          {
+            "min": 1024,
+            "max": 65535,
+            "message": "Use a port between 1024 and 65535"
+          }
+        ]
+      },
+      {
+        "type": "tips",
+        "helpText": "MiBee NVR uses host networking (required for ONVIF camera auto-discovery), so it binds this port directly on the host. If 9090 is already taken by another service, choose a different port here — the desktop icon will open the UI on the port you pick."
+      }
+    ]
+  },
+  {
     "stepTitle": "Storage",
     "items": [
       {

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -34,6 +34,15 @@ func applyConfigDefaults(cfg *Config) {
 		}
 		cfg.Server.Listen = env
 	}
+	// NVR_FRAME_ANCESTORS overrides security.frame_ancestors (env wins over the
+	// config file). Lets NAS platforms that embed the UI in a cross-origin iframe
+	// (fnOS desktop: the desktop page is served from a different origin than the
+	// NVR's :9090) whitelist the embedder without editing the YAML, e.g.
+	//   NVR_FRAME_ANCESTORS="http://192.168.1.10 http://192.168.1.11"
+	// Empty/unset keeps the default 'self' (no cross-origin framing).
+	if env := strings.TrimSpace(os.Getenv("NVR_FRAME_ANCESTORS")); env != "" {
+		cfg.Security.FrameAncestors = env
+	}
 	// Storage
 	if strings.TrimSpace(cfg.Storage.RootDir) == "" {
 		cfg.Storage.RootDir = "/var/lib/mibee-nvr"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	WebSocket     WebSocketConfig     `yaml:"websocket"`
 	AI            AIConfig            `yaml:"ai"`
 	MetricsAuth   MetricsAuthConfig   `yaml:"metrics_auth"`
+	Security      SecurityConfig      `yaml:"security"`
 	Update        UpdateConfig        `yaml:"update"`
 	APIKeys       []APIKeyConfig      `yaml:"api_keys,omitempty" json:"api_keys,omitempty"`
 	Version       string              `yaml:"version"`

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -89,6 +89,17 @@ func (c MetricsAuthConfig) IsConfigured() bool {
 		(strings.TrimSpace(c.Password) != "" || strings.TrimSpace(c.PasswordHash) != "")
 }
 
+// SecurityConfig controls HTTP security response headers.
+type SecurityConfig struct {
+	// FrameAncestors sets the CSP frame-ancestors directive: who may embed the
+	// Web UI in an <iframe>. A space-separated list of sources
+	// (e.g. "'self' http://192.168.1.10"). Empty/'self' = no cross-origin
+	// embedding. Needed for platforms that embed the app from a different origin
+	// (e.g. the fnOS desktop, where the desktop page origin differs from the
+	// NVR's :9090 origin). Overridable via the NVR_FRAME_ANCESTORS env var.
+	FrameAncestors string `yaml:"frame_ancestors"`
+}
+
 // APIKeyConfig represents a single API key for MiBeeVision integration.
 type APIKeyConfig struct {
 	Key     string `yaml:"key" json:"key"`

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -1,23 +1,53 @@
 package middleware
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
-// SecurityHeaders returns a middleware that adds common security headers to every response.
-// HSTS is intentionally omitted: on LAN HTTP deployments it bricks access for a year.
-// If TLS is needed, use a reverse proxy (Caddy/nginx) and let it set HSTS.
-func SecurityHeaders(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("X-XSS-Protection", "1; mode=block")
-		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
-		// CSP: Svelte 5 uses inline styles for dynamic styling; unsafe-inline is required.
-		// wasm-unsafe-eval: required for libde265 WASM H.265 decoder (enables H.265
-		// live playback on plain HTTP without WebCodecs/HTTPS) and ONNX Runtime Web
-		// (browser-side AI inference). connect-src ws:/wss:: WebSocket live streaming.
-		// worker-src blob:: WasmPlayer's decoder worker.
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:")
-		next.ServeHTTP(w, r)
-	})
+// defaultFrameAncestors is used when no explicit frame-ancestors policy is
+// configured. 'self' permits the app to be framed only by pages of its own
+// origin — the same intent as the legacy X-Frame-Options: DENY default
+// (nothing else frames it), but expressed via the modern CSP directive so it
+// can be relaxed for trusted embedders (e.g. the fnOS desktop).
+const defaultFrameAncestors = "'self'"
+
+// SecurityHeaders returns a middleware that adds common security headers to
+// every response. HSTS is intentionally omitted: on LAN HTTP deployments it
+// bricks access for a year. If TLS is needed, use a reverse proxy
+// (Caddy/nginx) and let it set HSTS.
+//
+// frameAncestors controls who may embed the UI in an <iframe> via the CSP
+// frame-ancestors directive. It accepts a space-separated list of sources
+// (e.g. "'self'", "http://192.168.1.10 http://192.168.1.11"). An empty value
+// falls back to 'self' (no cross-origin framing). This replaces the legacy
+// X-Frame-Options header, which cannot express a cross-origin allow-list and
+// thus broke embedding in the fnOS desktop (the desktop page is served from a
+// different origin than the NVR's :9090, so even SAMEORIGIN rejected it).
+func SecurityHeaders(frameAncestors string) func(http.Handler) http.Handler {
+	ancestors := strings.TrimSpace(frameAncestors)
+	if ancestors == "" {
+		ancestors = defaultFrameAncestors
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			// X-Frame-Options is intentionally NOT set: CSP frame-ancestors is its
+			// modern successor and is strictly more expressive (allow-list vs the
+			// single-origin SAMEORIGIN / blanket DENY). Browsers that understand
+			// frame-ancestors ignore X-Frame-Options anyway; setting both can only
+			// make the policy stricter than intended.
+			w.Header().Set("X-XSS-Protection", "1; mode=block")
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+			// CSP: Svelte 5 uses inline styles for dynamic styling; unsafe-inline is required.
+			// wasm-unsafe-eval: required for libde265 WASM H.265 decoder (enables H.265
+			// live playback on plain HTTP without WebCodecs/HTTPS) and ONNX Runtime Web
+			// (browser-side AI inference). connect-src ws:/wss:: WebSocket live streaming.
+			// worker-src blob:: WasmPlayer's decoder worker.
+			// frame-ancestors: controls cross-origin embedding (e.g. fnOS desktop iframe).
+			w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:; frame-ancestors "+ancestors)
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/internal/middleware/security_test.go
+++ b/internal/middleware/security_test.go
@@ -3,13 +3,14 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestSecurityHeaders(t *testing.T) {
 	t.Parallel()
-	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := SecurityHeaders("")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -20,17 +21,45 @@ func TestSecurityHeaders(t *testing.T) {
 		header string
 		want   string
 	}{
-		{"X-Frame-Options", "DENY"},
+		// X-Frame-Options is intentionally absent: replaced by CSP frame-ancestors
+		// (which can express a cross-origin allow-list, unlike X-Frame-Options).
+		{"X-Frame-Options", ""},
 		{"X-XSS-Protection", "1; mode=block"},
 		{"Referrer-Policy", "strict-origin-when-cross-origin"},
 		{"Permissions-Policy", "camera=(), microphone=(), geolocation=()"},
-		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:"},
+		{"Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src blob: data: 'self'; media-src blob: 'self'; connect-src 'self' ws: wss:; worker-src 'self' blob:; frame-ancestors 'self'"},
 	}
 	for _, tt := range tests {
 		got := w.Header().Get(tt.header)
 		if got != tt.want {
 			t.Errorf("header %s = %q, want %q", tt.header, got, tt.want)
 		}
+	}
+}
+
+// TestSecurityHeadersCustomFrameAncestors verifies that a configured
+// frame-ancestors allow-list (e.g. for embedding in the fnOS desktop, which
+// serves the desktop page from a different origin than the NVR) is reflected
+// verbatim in the CSP directive.
+func TestSecurityHeadersCustomFrameAncestors(t *testing.T) {
+	t.Parallel()
+	allowed := "http://192.168.63.60 http://192.168.63.50"
+	handler := SecurityHeaders(allowed)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	csp := w.Header().Get("Content-Security-Policy")
+	wantFragment := "frame-ancestors " + allowed
+	if !strings.Contains(csp, wantFragment) {
+		t.Errorf("CSP missing %q\ngot CSP: %s", wantFragment, csp)
+	}
+	// X-Frame-Options must stay absent so it cannot tighten the policy below
+	// the allow-list (it is the legacy, less-expressive header).
+	if got := w.Header().Get("X-Frame-Options"); got != "" {
+		t.Errorf("X-Frame-Options should be absent under custom frame-ancestors, got %q", got)
 	}
 }
 

--- a/pkg/app/router.go
+++ b/pkg/app/router.go
@@ -32,7 +32,7 @@ func buildRouter(
 	r := chi.NewRouter()
 	r.Use(authmw.RequestLogger(slog.Default(), "/api/health", "/api/readyz"))
 	r.Use(chimiddleware.Recoverer)
-	r.Use(authmw.SecurityHeaders)
+	r.Use(authmw.SecurityHeaders(cfg.Security.FrameAncestors))
 	r.Use(authmw.COOPHeaders)
 	// Streaming gzip compression for all JSON/HTML/text responses.
 	// SSE (text/event-stream) is also compressed but flushed per-event.


### PR DESCRIPTION
## 问题

飞牛 fnOS 用户反馈:
1. **应用无法在桌面内部打开** —— 浏览器报 \`Refused to display ... in a frame because it set 'X-Frame-Options' to 'deny'\`
2. **安装时无法修改端口** —— 与宿主其他服务(如 DSM)的 9090 冲突时,只能装完手动改 YAML
3. **build.sh 在 Windows 下无法打包** —— fnpack 二进制发现逻辑有缺陷;且 fnpack 不替换 \`${VERSION}\`,导致 manifest 版本与镜像 tag 脱节

## 根因

1. \`internal/middleware/security.go\` 硬编码 \`X-Frame-Options: DENY\`,全局生效。飞牛桌面用**跨源 iframe**嵌入应用(桌面页 origin ≠ NVR 的 :9090 origin),DENY 直接被拒;改 SAMEORIGIN 也不行(跨源)。
2. \`deploy/fnos/wizard/install\` 只有纯 tips,无输入项;端口写死 9090。
3. \`deploy/fnos/build.sh\` 用 \`command -v \$FNPACK_BIN\` 检查、却用裸 \`fnpack\` 调用(Windows 下永远 not found);且假设 fnpack 会替换 \`\${VERSION}\`(实测不会)。

## 修复

### Go 核心(commit 1)
- \`SecurityHeaders\` 改为接收 \`frameAncestors\` 参数,移除 \`X-Frame-Options\`,改用 CSP \`frame-ancestors\`(默认 \`'self'\`,向后兼容)
- 新增 \`security.frame_ancestors\` 配置 + \`NVR_FRAME_ANCESTORS\` env 覆盖
- 同步 \`security_test.go\`

### 飞牛打包层(commit 2)
- **wizard 加 \`wizard_port\` 输入项**(默认 9090,数字+范围校验)
- **ui/config \`port\` 改 \`\${wizard_port}\`**(飞牛自动插值,桌面图标指向用户选的端口)
- **compose 加 \`NVR_LISTEN_PORT=\${wizard_port:-9090}\`**(应用已支持此 env,issue #269)
- **compose 加 \`NVR_FRAME_ANCESTORS='self' http://*\`**(放行飞牛桌面跨源嵌入)
- **build.sh 修复**:打包前把 \`\${VERSION:-latest}\` sed 替换为实际版本(trap 还原源文件);统一用 \`$FNPACK\`
- **补全 8 个 cmd/ 生命周期脚本**(fnpack 校验要求,exit-0 stub,与官方模板一致)

## 验证
- ✅ middleware 测试 PASS(\`TestSecurityHeaders\` + \`TestSecurityHeadersCustomFrameAncestors\`)
- ✅ Linux amd64 交叉编译通过
- ✅ fpk 打包成功,内含正确的镜像 tag、wizard、compose env、ui/config 变量