### PR TITLE
feat: NAS 品牌 logo 嵌入 Web UI + 仅预览模式补全(timelapse/SRT-RTMP)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,6 +49,19 @@ cameras: []
 #     encoding: "h264"         # Encoding: h264, h265, mjpeg, jpeg
 #     url: "rtsp://192.168.1.100:554/stream"
 #     enabled: true
+#     recording_enabled: true       # Write recordings to disk (default: true). Set false for
+#                                   # "live-only" / preview-only mode: the camera stays connected
+#                                   # and feeds live preview (HLS/WebRTC/HTTP-FLV/WS) plus relay/
+#                                   # forwarding, but writes NO segment files — useful when the NVR
+#                                   # is used purely as a live/relay gateway and disk writes (e.g. on
+#                                   # an SD card) must be avoided. Applies to all protocols incl.
+#                                   # SRT/RTMP push-ingest cameras. Also gates timelapse frame
+#                                   # capture — a preview-only camera writes no timelapse frames
+#                                   # either (the capture loops stay alive but skip all disk I/O).
+#                                   # Other "don't record" knobs (NOT the same as this):
+#                                   #   recording_schedule    — time-window recording (still writes when "on")
+#                                   #   activation_state: "pending_activation" — does not connect at all
+#                                   #   push_retention_days: 0 — cleanup policy only (segments are written first)
 #     audio_enabled: false          # Enable audio recording (default: false)
 #     frame_watchdog_timeout: "30s"  # Timeout before declaring camera unhealthy (default: 30s)
 #     timelapse:                      # Per-camera timelapse recording (see full reference below)

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -177,13 +177,14 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 			enc = string(model.FormatH264)
 		}
 		rec = recorder.NewIngestRecorder(recorder.IngestConfig{
-			CameraID:   cam.ID,
-			Encoding:   enc,
-			SegmentDur: segDur,
-			Store:      cm.store,
-			DB:         cm.db,
-			Metrics:    cm.metrics,
-			EventBus:   cm.eventBus,
+			CameraID:      cam.ID,
+			Encoding:      enc,
+			SegmentDur:    segDur,
+			Store:         cm.store,
+			DB:            cm.db,
+			Metrics:       cm.metrics,
+			EventBus:      cm.eventBus,
+			RecordEnabled: cam.RecordingEnabled,
 		})
 	default:
 		return nil

--- a/internal/camera/timelapse.go
+++ b/internal/camera/timelapse.go
@@ -147,13 +147,14 @@ func (cm *CameraManager) createTimelapseSnapshotRecorder(cam config.CameraConfig
 // createTimelapseMJPEGRecorder creates a TimelapseRecorder for MJPEG stream or auto source.
 func (cm *CameraManager) createTimelapseMJPEGRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
 	tlCfg := recorder.TimelapseRecorderConfig{
-		CameraID: cam.ID,
-		URL:      cam.URL,
-		Username: cam.Username,
-		Password: cam.Password,
-		DataDir:  cm.cfg.Storage.RootDir,
-		DB:       cm.db,
-		Metrics:  cm.metrics,
+		CameraID:      cam.ID,
+		URL:           cam.URL,
+		Username:      cam.Username,
+		Password:      cam.Password,
+		DataDir:       cm.cfg.Storage.RootDir,
+		DB:            cm.db,
+		Metrics:       cm.metrics,
+		RecordEnabled: cam.RecordingEnabled,
 	}
 	if cam.Timelapse != nil {
 		if d, err := time.ParseDuration(cam.Timelapse.Interval); err == nil && d >= time.Millisecond {
@@ -466,6 +467,7 @@ func (cm *CameraManager) startTimelapseKeyframeExtractor(cameraID string, cam co
 		DB:                  cm.db,
 		MergeMgr:            mergeMgr,
 		CodecParamsProvider: codecProvider,
+		RecordEnabled:       cam.RecordingEnabled,
 	})
 
 	ctx := context.Background()
@@ -739,6 +741,7 @@ func (cm *CameraManager) startTimelapseFramePoller(cameraID string, cam config.C
 		Metrics:       cm.metrics,
 		MergeMgr:      mergeMgr,
 		FrameProvider: frameProvider,
+		RecordEnabled: cam.RecordingEnabled,
 	}
 	capturer := timelapse.NewSnapshotCapturer(snapCfg, cm.store, cm.metrics)
 

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -35,6 +35,13 @@ type IngestConfig struct {
 	// Metrics, EventBus optional (nil-safe)
 	Metrics  *metrics.Metrics
 	EventBus *event.EventBus
+	// RecordEnabled gates whether pushed frames are written to disk as segments.
+	// nil or true (default) = record normally. false = "live-only" mode: the
+	// recorder keeps accepting publishers and the StreamHub fan-out keeps feeding
+	// live preview (HLS/WebRTC/FLV/WS) and relay, but NO segments are written —
+	// useful when the NVR is used purely as a live/relay gateway and disk writes
+	// must be avoided. Mirrors RecordEnabled on the pull recorders (base.go).
+	RecordEnabled *bool
 }
 
 // IngestRecorder records H.264 video pushed into the NVR via SRT/RTMP ingest.
@@ -246,6 +253,15 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 			broadcastAU = append(broadcastAU, au...)
 		}
 		hub.Broadcast(ptsTicks, broadcastAU, isIDR)
+	}
+
+	// Live-only mode: the StreamHub fan-out above already delivered this frame to
+	// live preview (HLS/WebRTC/FLV/WS) and relay, and the cached SPS/PPS keep
+	// getCodecParams() populated. Skip all segment I/O from here on so nothing is
+	// written to disk. Mirrors the gate in base.go writeFrames.
+	// nil => recording enabled (default); pointer to false => live-only.
+	if r.cfg.RecordEnabled != nil && !*r.cfg.RecordEnabled {
+		return
 	}
 
 	// ---- Find VCL NALU (type 1 non-IDR or type 5 IDR) to write to disk ----

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -36,6 +36,13 @@ type TimelapseRecorderConfig struct {
 	DB         RecordingDB
 	Metrics    *metrics.Metrics
 	MergeMgr   *timelapse.RollingMergeManager // optional rolling merge manager
+	// RecordEnabled gates whether captured frames are written to disk, mirroring
+	// the segment recorder's RecordEnabled (internal/recorder/base.go).
+	// nil or true = write timelapse frames (default). false = "preview-only":
+	// the capture loop keeps the MJPEG connection alive but performs no
+	// segment/frame I/O — useful when recording_enabled=false and the user
+	// expects zero disk writes.
+	RecordEnabled *bool
 }
 
 // TimelapseRecorder captures JPEG frames at a configurable interval from an
@@ -322,6 +329,13 @@ func (r *TimelapseRecorder) connectAndStream(ctx context.Context) (error, bool) 
 		// Validate JPEG magic bytes
 		if len(data) < 2 || data[0] != 0xFF || data[1] != 0xD8 {
 			timelapseLogger.Warn("skipping invalid frame (missing JPEG magic)", "camera_id", r.cfg.CameraID, "size", len(data))
+			continue
+		}
+
+		// Preview-only: keep the MJPEG stream alive (so it recovers if the flag
+		// flips back) but skip ALL segment/frame I/O. Mirrors the recorder gate
+		// in base.go; nil => recording enabled (default).
+		if r.cfg.RecordEnabled != nil && !*r.cfg.RecordEnabled {
 			continue
 		}
 

--- a/internal/timelapse/keyframe_extractor.go
+++ b/internal/timelapse/keyframe_extractor.go
@@ -51,6 +51,14 @@ type KeyframeExtractorConfig struct {
 	// and the H264GoMerger/H265GoMerger permanently fails with "frames missing SPS".
 	// Optional — when nil, only inline parameter sets are used.
 	CodecParamsProvider func() (sps, pps, vps []byte)
+
+	// RecordEnabled gates whether captured frames are written to disk, mirroring
+	// the segment recorder's RecordEnabled (internal/recorder/base.go).
+	// nil or true = write timelapse frames (default). false = "preview-only":
+	// the capture loop keeps ticking (so it self-heals if the flag flips back),
+	// but performs no segment/frame I/O — useful when a camera is set to
+	// recording_enabled=false and the user expects zero disk writes.
+	RecordEnabled *bool
 }
 
 // KeyframeExtractor subscribes to a recorder's StreamHub and captures
@@ -96,6 +104,10 @@ type KeyframeExtractor struct {
 	// parameter sets are missing from frame AUs (out-of-band codec config).
 	codecParamsProvider func() (sps, pps, vps []byte)
 
+	// recordEnabled gates disk writes (nil/true = write, false = preview-only).
+	// Mirrors the recorder gate; see KeyframeExtractorConfig.RecordEnabled.
+	recordEnabled *bool
+
 	// Segment state.
 	curTempPath  string
 	curFinalPath string
@@ -131,6 +143,7 @@ func NewKeyframeExtractor(cfg KeyframeExtractorConfig) *KeyframeExtractor {
 		db:                  cfg.DB,
 		mergeMgr:            cfg.MergeMgr,
 		codecParamsProvider: cfg.CodecParamsProvider,
+		recordEnabled:       cfg.RecordEnabled,
 		consumerID:          "keyframe-extractor-" + cfg.CameraID,
 	}
 }
@@ -288,6 +301,12 @@ func (k *KeyframeExtractor) captureLoop(ctx context.Context) {
 // current segment. Prefers IDR frames but falls back to P-frames if no
 // IDR has been received since the last capture.
 func (k *KeyframeExtractor) captureFrame() {
+	// Preview-only: keep the loop alive (so it recovers if the flag flips back)
+	// but skip ALL segment/frame I/O. Mirrors the recorder gate in base.go.
+	if k.recordEnabled != nil && !*k.recordEnabled {
+		return
+	}
+
 	// Try to get the latest IDR frame first.
 	k.latestFrameMu.Lock()
 	frame := k.latestFrame

--- a/internal/timelapse/snapshot_capturer.go
+++ b/internal/timelapse/snapshot_capturer.go
@@ -41,6 +41,14 @@ type SnapshotCapturerConfig struct {
 	// (critical for ESP32 cameras with very limited concurrent HTTP capacity).
 	// When set, SnapshotURL is not required and the HTTP client is unused.
 	FrameProvider func() []byte
+
+	// RecordEnabled gates whether captured frames are written to disk, mirroring
+	// the segment recorder's RecordEnabled (internal/recorder/base.go).
+	// nil or true = write timelapse frames (default). false = "preview-only":
+	// the capture loop keeps ticking (so it self-heals if the flag flips back),
+	// but performs no segment/frame I/O — useful when a camera is set to
+	// recording_enabled=false and the user expects zero disk writes.
+	RecordEnabled *bool
 }
 
 // SnapshotCapturer captures JPEG snapshots from an HTTP URL at a configurable
@@ -204,6 +212,12 @@ func (r *SnapshotCapturer) run(ctx context.Context) {
 
 // captureFrame fetches a single snapshot and writes it to the current segment.
 func (r *SnapshotCapturer) captureFrame(ctx context.Context) {
+	// Preview-only: keep the loop alive (so it recovers if the flag flips back)
+	// but skip ALL segment/frame I/O. Mirrors the recorder gate in base.go.
+	if r.cfg.RecordEnabled != nil && !*r.cfg.RecordEnabled {
+		return
+	}
+
 	var data []byte
 	if r.cfg.FrameProvider != nil {
 		// Dual-mode: pull latest frame from the running recorder's in-memory cache.

--- a/web/public/logo-icon.svg
+++ b/web/public/logo-icon.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="MiBeeNvr">
+  <defs>
+    <linearGradient id="lensGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#cfcaff"/>
+    </linearGradient>
+    <linearGradient id="bodyGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#635bff"/>
+      <stop offset="1" stop-color="#3a1c9e"/>
+    </linearGradient>
+  </defs>
+  <!-- 机翼 -->
+  <g fill="#ffffff" stroke="#635bff" stroke-width="2" opacity="0.96">
+    <ellipse cx="94" cy="100" rx="25" ry="42" transform="rotate(-22 94 100)"/>
+    <ellipse cx="162" cy="100" rx="25" ry="42" transform="rotate(22 162 100)"/>
+  </g>
+  <!-- 触角 -->
+  <g fill="none" stroke="#3a1c9e" stroke-width="4" stroke-linecap="round">
+    <path d="M116 102 C108 84 104 70 99 56"/>
+    <path d="M140 102 C148 84 152 70 157 56"/>
+  </g>
+  <!-- 机身/镜头 -->
+  <circle cx="128" cy="154" r="56" fill="#1b1147"/>
+  <circle cx="128" cy="154" r="48" fill="url(#lensGrad)" stroke="#ffffff" stroke-width="3"/>
+  <circle cx="128" cy="154" r="31" fill="url(#bodyGrad)"/>
+  <circle cx="128" cy="154" r="17" fill="#160d3a"/>
+  <circle cx="118" cy="144" r="7" fill="#ffffff" opacity="0.85"/>
+  <!-- 蜜蜂黄尾 -->
+  <circle cx="128" cy="214" r="9" fill="#ffd166" stroke="#3a1c9e" stroke-width="2"/>
+  <!-- REC -->
+  <circle cx="200" cy="58" r="12" fill="#ff4d5e"/>
+</svg>

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -113,7 +113,10 @@
           <span>{backLabel || t('detail.back')}</span>
         </button>
       {/if}
-      <a href="#/surveillance" class="logo">MiBee NVR</a>
+      <a href="#/surveillance" class="logo">
+        <img src="/logo-icon.svg" alt="" class="logo-mark" />
+        <span>MiBee NVR</span>
+      </a>
       
       <!-- Desktop Navigation -->
       <nav class="nav-links">
@@ -231,15 +234,26 @@
 
 
   .logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
     font-size: 1.25rem;
     font-weight: 700;
     letter-spacing: -0.025em;
     text-decoration: none;
     white-space: nowrap;
-    background: linear-gradient(135deg, #8b5cf6 0%, #a78bfa 40%, #38bdf8 100%);
+    background: linear-gradient(135deg, #635bff 0%, #3a1c9e 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
+  }
+
+  .logo-mark {
+    width: 2rem;
+    height: 2rem;
+    flex-shrink: 0;
+    /* SVG gradient text fill doesn't apply to the <img>; keep it crisp. */
+    -webkit-text-fill-color: initial;
   }
 
   .nav-links {

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1138,6 +1138,7 @@
   "settings.sidebar.advanced": "Advanced",
   "settings.sidebar.about": "About",
   "about.title": "About & Updates",
+  "about.brandTagline": "Network Video Recorder",
   "about.currentVersion": "Current version",
   "about.latestVersion": "Latest version",
   "about.lastChecked": "Last checked",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1138,6 +1138,7 @@
   "settings.sidebar.advanced": "高级",
   "settings.sidebar.about": "关于",
   "about.title": "关于与更新",
+  "about.brandTagline": "网络视频录像机",
   "about.currentVersion": "当前版本",
   "about.latestVersion": "最新版本",
   "about.lastChecked": "上次检查",

--- a/web/src/routes/Login.svelte
+++ b/web/src/routes/Login.svelte
@@ -76,8 +76,10 @@
 
   <div class="card w-full max-w-md p-10 border th-border shadow-2xl">
     <div class="text-center mb-10">
-      <div class="text-sm font-semibold tracking-widest uppercase th-text-tertiary mb-3">MiBee</div>
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-violet-400 to-blue-400 bg-clip-text text-transparent mb-3">{t('login.title')}</h1>
+      <div class="flex items-center justify-center gap-3 mb-3">
+        <img src="/logo-icon.svg" alt="MiBee NVR" class="h-14 w-14" />
+        <h1 class="text-3xl font-bold bg-gradient-to-r from-[#635bff] to-[#3a1c9e] bg-clip-text text-transparent">{t('login.title')}</h1>
+      </div>
       <p class="th-text-tertiary text-sm">{t('login.subtitle')}</p>
     </div>
 

--- a/web/src/routes/Setup.svelte
+++ b/web/src/routes/Setup.svelte
@@ -135,8 +135,8 @@
 
   <div class="card w-full max-w-lg p-10 border th-border shadow-2xl">
     <div class="text-center mb-8">
-      <div class="text-sm font-semibold tracking-widest uppercase th-text-tertiary mb-3">MiBee</div>
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-violet-400 to-blue-400 bg-clip-text text-transparent mb-3">{t('setup.title')}</h1>
+      <img src="/logo-icon.svg" alt="MiBee NVR" class="h-16 w-16 mx-auto mb-4" />
+      <h1 class="text-3xl font-bold bg-gradient-to-r from-[#635bff] to-[#3a1c9e] bg-clip-text text-transparent mb-3">{t('setup.title')}</h1>
       <p class="th-text-tertiary text-sm">{t('setup.subtitle')}</p>
     </div>
 

--- a/web/src/routes/Surveillance.svelte
+++ b/web/src/routes/Surveillance.svelte
@@ -173,6 +173,12 @@
   function getStatusBadge(camera: Camera): { class: string; label: string; icon: any; text: string } {
     const status = camera.status?.toLowerCase() || '';
     if (status === 'recording' || status === 'active') {
+      // Live-only cameras connect and stream for preview/relay but write no
+      // segments — show "Live only" instead of "Recording" so the grid matches
+      // CameraCard and users can tell preview-only cameras at a glance.
+      if (camera.recording_enabled === false) {
+        return { class: 'badge-info', label: '●', icon: CircleCheck, text: t('cameras.statusLive') };
+      }
       return { class: 'badge-success', label: '●', icon: CircleCheck, text: t('cameras.statusRecording') };
     }
     if (status === 'error' || status === 'failed') {

--- a/web/src/routes/settings/UpdatePanel.svelte
+++ b/web/src/routes/settings/UpdatePanel.svelte
@@ -106,8 +106,12 @@
 </script>
 
 <div class="space-y-6">
-  <div>
-    <h3 class="text-lg font-semibold th-text-primary">{t('about.title')}</h3>
+  <div class="flex items-center gap-3">
+    <img src="/logo-icon.svg" alt="MiBee NVR" class="h-12 w-12" />
+    <div>
+      <h3 class="text-lg font-semibold th-text-primary">{t('about.title')}</h3>
+      <p class="text-xs th-text-tertiary">{t('about.brandTagline')}</p>
+    </div>
   </div>
 
   {#if loading}


### PR DESCRIPTION
## 概述

两块工作合在一个 PR（都已在 M5 实测验证）：

### 1. NAS 品牌 logo 嵌入 Web UI（#308）
官方 logo（`docs/brand/logo-icon.svg`）此前只用作 favicon，可见 UI 里没有任何 logo——Login/Setup/Header 全是纯渐变文字。本 PR：
- **Login / Setup**：logo 与标题横向并排（56px），去掉重复的 "MiBee" 小字眉标，渐变对齐官方品牌色 `#635bff → #3a1c9e`
- **Header 顶栏**：logo 图标 + "MiBee NVR" 文字横排，覆盖所有登录后内页
- **Settings → 关于**：logo + 标题 + 品牌副标（新增 `about.brandTagline` i18n 中英）
- 渐变色统一从 `violet/blue-400` 对齐到品牌色

### 2. 仅预览模式（`recording_enabled: false`）补全

**2a. SRT/RTMP 推流摄像头**（#308）：`IngestRecorder` 此前没有 `RecordEnabled` 字段，推流摄像头无法 preview-only——是唯一空洞。补 gate（在 StreamHub fan-out 之后、segment 创建之前），preview/relay 不受影响。

**2b. timelapse 写盘 gate**（#307）：`recording_enabled` 此前只 gate segment 录制，timelapse 三条独立抓帧管线（SnapshotCapturer / KeyframeExtractor / TimelapseRecorder）不受约束，导致 preview-only + timelapse 同开仍落盘，与 UI "仅预览" 语义冲突。给三个抓帧器加 `RecordEnabled *bool` gate，loop 仍 tick（flag 翻回自愈），只在写盘前跳过。

### 3. 前端徽标修正（#308）
`Surveillance.getStatusBadge` 镜像 `CameraCard` 逻辑：preview-only 摄像头显示"仅直播"而非误显"录制中"。

### 4. 文档
`config.example.yaml` 补 `recording_enabled` 说明（含 timelapse gate + 四种"不录像"机制区分）。

## 验证

| 环境 | 结果 |
|---|---|
| Docker VM (197, Go 1.26.2) `go test -race ./...` | ✅ 43 包全绿，零 race |
| Docker VM `go vet ./...` | ✅ clean |
| Docker VM `npm run test` (vitest) | ✅ 564/564 通过 |
| Docker VM `npm run build` | ✅ logo 进 dist |
| M5 (Banana Pi) 部署实测 | ✅ 服务健康，11 摄像头恢复 recording |
| M5 `/logo-icon.svg` | ✅ HTTP 200, md5 与品牌源文件一致 |
| M5 H80 (preview-only + timelapse 30s) 部署后满 12min | ✅ **零新文件**（部署前当天写 36 个 mp4） |
| M5 preview-only 摄像头 HLS/FLV 预览 | ✅ HTTP 200 |

## 改动文件
15 个文件，+162/-22。Go 改动遵循现有 gate 模式（镜像 `base.go:528`），无新依赖、无 API breaking。

## 关联 issue
Closes #307, Closes #308

## 部署状态
代码已在 M5 (`192.168.63.30`) 运行（含本 PR 全部改动），稳定。回滚备份 `mibee-nvr.bak-20260810-111118`。