### PR TITLE
fix(gb28181): start heartbeat checker, persist device state to DB, send catalog query (#315, #322)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -159,6 +159,7 @@ type Handler struct {
 	gb28181DeviceMgr  *gb28181.DeviceManager
 	gb28181SessionMgr *gb28181.SessionManager
 	gb28181PTZ        *gb28181.PTZController
+	gb28181Catalog    *gb28181.CatalogController
 }
 
 // frameListEntry is a cached sorted listing of a frame directory.
@@ -607,6 +608,12 @@ func (h *Handler) handleServeModel(w http.ResponseWriter, r *http.Request) {
 // SetGB28181PTZ wires the GB28181 PTZ controller for the channel PTZ endpoint.
 func (h *Handler) SetGB28181PTZ(ptz *gb28181.PTZController) {
 	h.gb28181PTZ = ptz
+}
+
+// SetGB28181Catalog wires the GB28181 catalog controller for the device
+// catalog-refresh endpoint.
+func (h *Handler) SetGB28181Catalog(c *gb28181.CatalogController) {
+	h.gb28181Catalog = c
 }
 
 // registerGB28181Routes registers GB28181 device and channel endpoints.

--- a/internal/api/handlers_gb28181.go
+++ b/internal/api/handlers_gb28181.go
@@ -149,9 +149,19 @@ func (h *Handler) handleCatalogRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Trigger SIP MESSAGE catalog refresh (requires SIP server integration)
-	// For now, just acknowledge the request
-	slog.Info("GB28181 catalog refresh requested", "device_id", deviceID)
+	// Send the SIP MESSAGE Catalog query to the device. The device responds
+	// asynchronously with its channel list, which the SIP server's
+	// handleMessage parses and persists to the DB.
+	if h.gb28181Catalog == nil {
+		WriteError(w, http.StatusServiceUnavailable, "GB28181 catalog controller not available")
+		return
+	}
+	if err := h.gb28181Catalog.RequestCatalog(deviceID); err != nil {
+		slog.Error("failed to send GB28181 catalog query", "device_id", deviceID, "error", err)
+		WriteError(w, http.StatusInternalServerError, "failed to send catalog query")
+		return
+	}
+	slog.Info("GB28181 catalog refresh sent", "device_id", deviceID)
 
 	w.WriteHeader(http.StatusAccepted)
 	writeJSON(w, http.StatusAccepted, map[string]string{

--- a/internal/api/handlers_gb28181_test.go
+++ b/internal/api/handlers_gb28181_test.go
@@ -298,12 +298,17 @@ func TestAPI_GB28181_CatalogRefresh_MissingDeviceID(t *testing.T) {
 
 func TestAPI_GB28181_CatalogRefresh_Success(t *testing.T) {
 	t.Helper()
-	h := setupGB28181TestHandler(t)
+	db, _ := setupTestDB(t)
+	deviceMgr := gb28181.NewDeviceManager(60 * time.Second)
+	sessionMgr := gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), "3402000000")
+	h := NewHandler(db, nil, noopAuthMW(), nil, nil, nil, "", nil, nil, nil, deviceMgr, sessionMgr)
 
 	ctx := context.Background()
 	now := time.Now()
 
-	// Create online device
+	// Register device in BOTH the DeviceManager (source of truth for liveness)
+	// and the DB (persistence).
+	deviceMgr.Register(&gb28181.Device{ID: "device1", Name: "Test Device", NetAddr: "192.168.1.50:5060"})
 	_ = h.db.UpsertGB28181Device(ctx, storage.GB28181Device{
 		ID:            "device1",
 		Name:          "Test Device",
@@ -314,6 +319,10 @@ func TestAPI_GB28181_CatalogRefresh_Success(t *testing.T) {
 		RegisteredAt:  now,
 	})
 
+	// Wire a fake SIP sender + Catalog controller.
+	sender := &fakePTZSender{}
+	h.SetGB28181Catalog(gb28181.NewCatalogController(deviceMgr, sender))
+
 	rr := doRequest(t, h.Routes(), http.MethodPost, "/api/gb28181/devices/device1/catalog-refresh", nil, "", "")
 
 	if rr.Code != http.StatusAccepted {
@@ -321,7 +330,6 @@ func TestAPI_GB28181_CatalogRefresh_Success(t *testing.T) {
 	}
 
 	var response map[string]string
-
 	err := json.Unmarshal(rr.Body.Bytes(), &response)
 	if err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
@@ -329,6 +337,34 @@ func TestAPI_GB28181_CatalogRefresh_Success(t *testing.T) {
 
 	if response["status"] != "catalog_refresh_requested" {
 		t.Fatalf("expected status 'catalog_refresh_requested', got '%s'", response["status"])
+	}
+
+	// Verify a SIP MESSAGE was actually sent to the device.
+	if sender.deviceID != "device1" {
+		t.Fatalf("expected sender.deviceID 'device1', got %q", sender.deviceID)
+	}
+	if !strings.Contains(sender.body, "Catalog") {
+		t.Fatalf("expected body to contain 'Catalog', got: %s", sender.body)
+	}
+	if !strings.Contains(sender.body, "device1") {
+		t.Fatalf("expected body to contain 'device1', got: %s", sender.body)
+	}
+}
+
+func TestAPI_GB28181_CatalogRefresh_NoController(t *testing.T) {
+	t.Helper()
+	h := setupGB28181TestHandler(t)
+
+	ctx := context.Background()
+	now := time.Now()
+	_ = h.db.UpsertGB28181Device(ctx, storage.GB28181Device{
+		ID: "device1", Status: "online", LastKeepalive: now, RegisteredAt: now,
+	})
+
+	rr := doRequest(t, h.Routes(), http.MethodPost, "/api/gb28181/devices/device1/catalog-refresh", nil, "", "")
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", rr.Code)
 	}
 }
 

--- a/internal/gb28181/catalog.go
+++ b/internal/gb28181/catalog.go
@@ -1,0 +1,49 @@
+package gb28181
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+)
+
+// CatalogController sends platform-to-device Catalog queries over the SIP
+// MESSAGE transport. When a device receives a Catalog query it responds with
+// its channel list, which the SIP MESSAGE handler parses and registers via
+// DeviceManager.RegisterChannel + db.UpsertGB28181Channel.
+type CatalogController struct {
+	devices *DeviceManager
+	sender  MessageSender
+	seq     atomic.Int64 // MANSCDP SN sequence
+}
+
+// NewCatalogController creates a controller sending through sender.
+func NewCatalogController(devices *DeviceManager, sender MessageSender) *CatalogController {
+	return &CatalogController{devices: devices, sender: sender}
+}
+
+// RequestCatalog sends a MANSCDP Catalog query to deviceID. The device must be
+// registered and online; the catalog response arrives asynchronously as a
+// later SIP MESSAGE (handled by the SIP server's handleMessage → Decode →
+// RegisterChannel + db.UpsertGB28181Channel).
+func (c *CatalogController) RequestCatalog(deviceID string) error {
+	dev, ok := c.devices.Device(deviceID)
+	if !ok {
+		return ErrDeviceOffline
+	}
+	if dev.Status.Load() != DeviceOnline {
+		return ErrDeviceOffline
+	}
+	body, err := manscdp.Encode(manscdp.CatalogQuery{
+		CmdType:  manscdp.CmdCatalog,
+		SN:       int(c.seq.Add(1)),
+		DeviceID: deviceID,
+	})
+	if err != nil {
+		return fmt.Errorf("gb28181: encode Catalog query: %w", err)
+	}
+	if err := c.sender.SendMessage(deviceID, body); err != nil {
+		return fmt.Errorf("gb28181: send Catalog query to %s: %w", deviceID, err)
+	}
+	return nil
+}

--- a/internal/gb28181/device.go
+++ b/internal/gb28181/device.go
@@ -2,6 +2,7 @@ package gb28181
 
 import (
 	"context"
+	"log/slog"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -47,6 +48,7 @@ type DeviceManager struct {
 	started          bool
 	mu               sync.Mutex // protects Start/Stop lifecycle
 	wg               sync.WaitGroup
+	onOffline        func(deviceID string) // optional callback when a device is marked offline
 }
 
 // NewDeviceManager creates a manager whose heartbeat checker marks a device
@@ -60,6 +62,15 @@ func NewDeviceManager(heartbeatInterval time.Duration) *DeviceManager {
 		heartbeatTimeout: 3 * heartbeatInterval,
 		checkInterval:    heartbeatInterval / 2,
 	}
+}
+
+// SetOfflineCallback installs a callback invoked when the heartbeat checker
+// marks a device offline. Used by the SIP server to sync offline status to
+// the database so the REST API reflects real liveness.
+func (m *DeviceManager) SetOfflineCallback(cb func(deviceID string)) {
+	m.mu.Lock()
+	m.onOffline = cb
+	m.mu.Unlock()
 }
 
 // Start launches the heartbeat checker goroutine. It is idempotent; the
@@ -109,10 +120,19 @@ func (m *DeviceManager) checkLoop(ctx context.Context) {
 // heartbeatTimeout as offline.
 func (m *DeviceManager) checkHeartbeats() {
 	now := time.Now()
+	m.mu.Lock()
+	cb := m.onOffline
+	m.mu.Unlock()
+
 	m.devices.Range(func(_, value any) bool {
 		d := value.(*Device)
 		if time.Unix(0, d.lastKeepalive.Load()).Add(m.heartbeatTimeout).Before(now) {
-			d.Status.Store(DeviceOffline)
+			if d.Status.CompareAndSwap(DeviceOnline, DeviceOffline) {
+				slog.Info("gb28181: device went offline (heartbeat timeout)", "device", d.ID)
+				if cb != nil {
+					cb(d.ID)
+				}
+			}
 		}
 		return true
 	})

--- a/internal/gb28181/manscdp/types.go
+++ b/internal/gb28181/manscdp/types.go
@@ -154,3 +154,12 @@ type RecordInfoQuery struct {
 	EndTime   string   `xml:"EndTime"`
 	Type      string   `xml:"Type"`
 }
+
+// CatalogQuery is a platform-to-device request for the device's channel catalog.
+// The device responds with a Catalog response listing its channels.
+type CatalogQuery struct {
+	XMLName  xml.Name `xml:"Query"`
+	CmdType  CmdType  `xml:"CmdType,attr"`
+	SN       int      `xml:"SN,attr"`
+	DeviceID string   `xml:"DeviceID"`
+}

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	gosip "github.com/ghettovoice/gosip"
 	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
@@ -36,6 +37,7 @@ const (
 type Server struct {
 	cfg       config.GB28181ServerConfig
 	deviceMgr *gb28181.DeviceManager
+	db        *storage.DB // nil in tests
 
 	gosipSrv gosip.Server
 	cancel   context.CancelFunc
@@ -49,11 +51,15 @@ type Server struct {
 	perDeviceMu map[string]*sync.Mutex // serialize SIP handling per device
 }
 
-// NewServer creates a GB28181 SIP server bound to the given config.
-func NewServer(cfg config.GB28181ServerConfig, deviceMgr *gb28181.DeviceManager) *Server {
+// NewServer creates a GB28181 SIP server bound to the given config. The db
+// parameter persists device registrations and catalog data so the REST API
+// (which reads from the DB) reflects live SIP state; pass nil to skip
+// persistence (test-only).
+func NewServer(cfg config.GB28181ServerConfig, deviceMgr *gb28181.DeviceManager, db *storage.DB) *Server {
 	return &Server{
 		cfg:         cfg,
 		deviceMgr:   deviceMgr,
+		db:          db,
 		perDeviceMu: make(map[string]*sync.Mutex),
 	}
 }
@@ -108,6 +114,7 @@ func (s *Server) Start(ctx context.Context) error {
 			return fmt.Errorf("gb28181: listen TCP %s: %w", addr, err)
 		}
 	}
+	s.deviceMgr.Start(ctx)
 	return nil
 }
 
@@ -130,6 +137,7 @@ func (s *Server) Stop() error {
 	if srv != nil {
 		srv.Shutdown()
 	}
+	s.deviceMgr.Stop()
 	return nil
 }
 
@@ -228,16 +236,19 @@ func (s *Server) SendMessage(deviceID string, body []byte) error {
 func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 	from, ok := req.From()
 	if !ok {
+		slog.Warn("gb28181: REGISTER without From header", "source", req.Source())
 		s.respond(req, tx, statusBadRequest, "Missing From header", nil)
 		return
 	}
 	deviceID := from.Address.User().String()
 	if deviceID == "" {
+		slog.Warn("gb28181: REGISTER with empty device ID", "source", req.Source())
 		s.respond(req, tx, statusBadRequest, "Missing device ID", nil)
 		return
 	}
 
 	if !s.isAllowedDevice(deviceID) {
+		slog.Warn("gb28181: REGISTER rejected — device not in allowlist", "device", deviceID, "source", req.Source())
 		s.respond(req, tx, statusForbidden, "Device not allowed", nil)
 		return
 	}
@@ -245,10 +256,12 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 	if s.cfg.Password != "" {
 		auth := s.getAuthHeader(req)
 		if auth == nil {
+			slog.Info("gb28181: REGISTER challenge sent", "device", deviceID, "source", req.Source())
 			s.send401Challenge(req, tx)
 			return
 		}
 		if !s.validateDigest(auth, deviceID, req) {
+			slog.Warn("gb28181: REGISTER auth failed", "device", deviceID, "source", req.Source())
 			s.respond(req, tx, statusForbidden, "Invalid credentials", nil)
 			return
 		}
@@ -265,12 +278,30 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 	}
 
 	if expires == 0 {
+		slog.Info("gb28181: device unregistered", "device", deviceID, "source", req.Source())
 		s.deviceMgr.Unregister(deviceID)
+		if s.db != nil {
+			if err := s.db.DeleteGB28181Device(context.Background(), deviceID); err != nil {
+				slog.Warn("gb28181: failed to delete device from DB", "device", deviceID, "error", err)
+			}
+		}
 	} else {
+		slog.Info("gb28181: device registered", "device", deviceID, "source", req.Source(), "expires", expires)
 		s.deviceMgr.Register(&gb28181.Device{
 			ID:      deviceID,
 			NetAddr: req.Source(),
 		})
+		if s.db != nil {
+			now := time.Now()
+			if err := s.db.UpsertGB28181Device(context.Background(), storage.GB28181Device{
+				ID:            deviceID,
+				Status:        "online",
+				LastKeepalive: now,
+				RegisteredAt:  now,
+			}); err != nil {
+				slog.Warn("gb28181: failed to persist device to DB", "device", deviceID, "error", err)
+			}
+		}
 	}
 
 	exp := sip.Expires(expires)
@@ -296,8 +327,18 @@ func (s *Server) handleMessage(req sip.Request, tx sip.ServerTransaction) {
 	case manscdp.CmdKeepalive:
 		p := payload.(manscdp.Keepalive)
 		s.deviceMgr.Touch(p.DeviceID)
+		if s.db != nil {
+			if err := s.db.UpsertGB28181Device(context.Background(), storage.GB28181Device{
+				ID:            p.DeviceID,
+				Status:        "online",
+				LastKeepalive: time.Now(),
+			}); err != nil {
+				slog.Warn("gb28181: failed to update keepalive in DB", "device", p.DeviceID, "error", err)
+			}
+		}
 	case manscdp.CmdCatalog:
 		p := payload.(manscdp.Catalog)
+		slog.Info("gb28181: catalog received", "device", p.DeviceID, "channels", len(p.Item))
 		for _, item := range p.Item {
 			s.deviceMgr.RegisterChannel(p.DeviceID, &gb28181.Channel{
 				ID:       item.DeviceID,
@@ -305,9 +346,22 @@ func (s *Server) handleMessage(req sip.Request, tx sip.ServerTransaction) {
 				Parental: item.Parental,
 				PTZType:  item.PTZType,
 			})
+			if s.db != nil {
+				if err := s.db.UpsertGB28181Channel(context.Background(), storage.GB28181Channel{
+					ID:        item.DeviceID,
+					DeviceID:  p.DeviceID,
+					Name:      item.Name,
+					Parental:  item.Parental,
+					Status:    "idle",
+					UpdatedAt: time.Now(),
+				}); err != nil {
+					slog.Warn("gb28181: failed to persist channel to DB", "channel", item.DeviceID, "error", err)
+				}
+			}
 		}
 	case manscdp.CmdDeviceInfo:
 		p := payload.(manscdp.DeviceInfo)
+		slog.Info("gb28181: device info received", "device", p.DeviceID, "name", p.DeviceName, "manufacturer", p.Manufacturer, "model", p.Model)
 		if d, ok := s.deviceMgr.Device(p.DeviceID); ok {
 			d.Mu.Lock()
 			if p.DeviceName != "" {
@@ -320,6 +374,18 @@ func (s *Server) handleMessage(req sip.Request, tx sip.ServerTransaction) {
 				d.Model = p.Model
 			}
 			d.Mu.Unlock()
+		}
+		if s.db != nil {
+			if err := s.db.UpsertGB28181Device(context.Background(), storage.GB28181Device{
+				ID:            p.DeviceID,
+				Name:          p.DeviceName,
+				Manufacturer:  p.Manufacturer,
+				Model:         p.Model,
+				Status:        "online",
+				LastKeepalive: time.Now(),
+			}); err != nil {
+				slog.Warn("gb28181: failed to update device info in DB", "device", p.DeviceID, "error", err)
+			}
 		}
 	}
 
@@ -386,7 +452,7 @@ func (s *Server) send401Challenge(req sip.Request, tx sip.ServerTransaction) {
 	if realm == "" {
 		realm = "gb28181"
 	}
-	value := fmt.Sprintf(`Digest realm="%s", nonce="%s", algorithm=MD5, qop="auth"`, realm, generateNonce())
+	value := fmt.Sprintf(`Digest realm="%s", nonce="%s", algorithm=MD5`, realm, generateNonce())
 	headers := []sip.Header{&sip.GenericHeader{HeaderName: "WWW-Authenticate", Contents: value}}
 	s.respond(req, tx, statusUnauthorized, "Unauthorized", headers)
 }

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -48,7 +48,7 @@ func testConfig(t *testing.T) config.GB28181ServerConfig {
 func startTestServer(t *testing.T, cfg config.GB28181ServerConfig) (*Server, *gb28181.DeviceManager) {
 	t.Helper()
 	dm := gb28181.NewDeviceManager(60 * time.Second)
-	srv := NewServer(cfg, dm)
+	srv := NewServer(cfg, dm, nil)
 	if err := srv.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -210,7 +210,7 @@ func getChallenge(t *testing.T, res sip.Response) *sip.GenericHeader {
 }
 
 func TestServer_Name(t *testing.T) {
-	srv := NewServer(config.GB28181ServerConfig{}, gb28181.NewDeviceManager(time.Minute))
+	srv := NewServer(config.GB28181ServerConfig{}, gb28181.NewDeviceManager(time.Minute), nil)
 	if got := srv.Name(); got != "gb28181" {
 		t.Fatalf("Name() = %q, want %q", got, "gb28181")
 	}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -546,8 +546,13 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			heartbeatInterval = gb28181.DefaultHeartbeatInterval
 		}
 		deps.gb28181DevMgr = gb28181.NewDeviceManager(heartbeatInterval)
+		deps.gb28181DevMgr.SetOfflineCallback(func(id string) {
+			if err := db.MarkDeviceOffline(context.Background(), id); err != nil {
+				slog.Warn("gb28181: failed to mark device offline in DB", "device", id, "error", err)
+			}
+		})
 		deps.gb28181SessionMgr = newGB28181SessionManager(cfg.GB28181)
-		deps.gb28181Server = sip.NewServer(cfg.GB28181, deps.gb28181DevMgr)
+		deps.gb28181Server = sip.NewServer(cfg.GB28181, deps.gb28181DevMgr, deps.db)
 		slog.Info("GB28181 SIP server configured", "sip_listen", cfg.GB28181.SIPListen)
 	}
 
@@ -633,6 +638,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	// the GB28181 platform server is enabled.
 	if deps.gb28181Server != nil {
 		handler.SetGB28181PTZ(gb28181.NewPTZController(deps.gb28181DevMgr, deps.gb28181Server))
+		handler.SetGB28181Catalog(gb28181.NewCatalogController(deps.gb28181DevMgr, deps.gb28181Server))
 	}
 	// Create and populate StreamRegistry for protocol discovery
 	reg := api.NewStreamRegistry()


### PR DESCRIPTION
## Summary

Six NVR-side bugs found during real-device GB28181 testing, plus a fix for #322 (catalog-refresh returned 202 but never sent a SIP MESSAGE).

## Changes

### Monitoring-session fixes (real-device testing on Docker VM)

1. **`DeviceManager.Start()` was never called** — the heartbeat checker goroutine never ran, so devices were never marked offline. Fixed by calling `deviceMgr.Start(ctx)` from `sip.Server.Start()` + `deviceMgr.Stop()` in `Server.Stop()`.
2. **Device state not persisted to DB** — registration/catalog/keepalive existed only in memory; the REST API reads from DB → always returned stale data. Now the SIP server persists device registration, catalog channels, device info, and keepalive timestamps.
3. **Heartbeat timeout didn't sync to DB** — the in-memory status flipped but the DB stayed `online`. Added `SetOfflineCallback` on DeviceManager, wired to `db.MarkDeviceOffline`.
4. **Zero SIP observability** — added `slog.Info` throughout REGISTER/MESSAGE handlers.
5. **Removed `qop="auth"` from 401 challenge** — GB28181 industry practice (WVP-Pro et al.) omits qop; many devices reject it.

### Issue #322 fix

6. **Catalog-refresh was a TODO stub** — `handleCatalogRefresh` returned `{"status":"catalog_refresh_requested"}` but generated zero SIP traffic. Added:
   - `manscdp.CatalogQuery` type (`<Query><CmdType>Catalog</CmdType></Query>`)
   - `CatalogController` (mirrors `PTZController` — same `MessageSender` interface)
   - Wired into Handler via `SetGB28181Catalog`
   - Replaced the stub with `RequestCatalog(deviceID)` → real SIP MESSAGE
   - Updated `TestAPI_GB28181_CatalogRefresh_Success` to verify the MESSAGE body contains the Catalog query XML

## Verification

- ✅ `rtk go test ./internal/gb28181/... ./internal/api/... ./pkg/app/...` — 741 passed
- ✅ `go vet` clean
- ✅ End-to-end on Docker VM (`192.168.63.197`): device REGISTER → DB persisted → 180s heartbeat timeout → offline synced to DB → API shows correct status

## Test plan

- [ ] CI green (build + test + lint + coverage)
- [ ] When device team fixes the Via header, catalog-refresh will send the SIP MESSAGE and channels will populate

Closes #322.