### PR TITLE
fix(gb28181): INVITE implementation, auto-channel, XML format, SSRC, localIP

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -160,6 +160,7 @@ type Handler struct {
 	gb28181SessionMgr *gb28181.SessionManager
 	gb28181PTZ        *gb28181.PTZController
 	gb28181Catalog    *gb28181.CatalogController
+	gb28181Inviter    GB28181InviteSender
 }
 
 // frameListEntry is a cached sorted listing of a frame directory.
@@ -614,6 +615,17 @@ func (h *Handler) SetGB28181PTZ(ptz *gb28181.PTZController) {
 // catalog-refresh endpoint.
 func (h *Handler) SetGB28181Catalog(c *gb28181.CatalogController) {
 	h.gb28181Catalog = c
+}
+
+// GB28181InviteSender sends a SIP INVITE to start a media session on a channel.
+// Implemented by the SIP server; declared here to avoid importing sip in Handler.
+type GB28181InviteSender interface {
+	InviteChannel(deviceID, channelID string) error
+}
+
+// SetGB28181Inviter wires the SIP server for the channel INVITE endpoint.
+func (h *Handler) SetGB28181Inviter(s GB28181InviteSender) {
+	h.gb28181Inviter = s
 }
 
 // registerGB28181Routes registers GB28181 device and channel endpoints.

--- a/internal/api/handlers_gb28181.go
+++ b/internal/api/handlers_gb28181.go
@@ -212,13 +212,19 @@ func (h *Handler) handleInviteChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The actual INVITE is handled by the SIP server
-	// This endpoint just validates and acknowledges the request
+	// Send the SIP INVITE via the SIP server's InviteChannel method.
+	if h.gb28181Inviter == nil {
+		WriteError(w, http.StatusServiceUnavailable, "GB28181 invite not available")
+		return
+	}
 	slog.Info("GB28181 channel invite requested", "device_id", deviceID, "channel_id", channelID)
-
-	w.WriteHeader(http.StatusAccepted)
+	if err := h.gb28181Inviter.InviteChannel(deviceID, channelID); err != nil {
+		slog.Error("failed to send GB28181 INVITE", "channel_id", channelID, "error", err)
+		WriteError(w, http.StatusInternalServerError, "failed to send INVITE")
+		return
+	}
 	writeJSON(w, http.StatusAccepted, map[string]string{
-		"status":     "invite_requested",
+		"status":     "invite_sent",
 		"device_id":  deviceID,
 		"channel_id": channelID,
 	})

--- a/internal/gb28181/catalog.go
+++ b/internal/gb28181/catalog.go
@@ -3,8 +3,6 @@ package gb28181
 import (
 	"fmt"
 	"sync/atomic"
-
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
 )
 
 // CatalogController sends platform-to-device Catalog queries over the SIP
@@ -34,14 +32,12 @@ func (c *CatalogController) RequestCatalog(deviceID string) error {
 	if dev.Status.Load() != DeviceOnline {
 		return ErrDeviceOffline
 	}
-	body, err := manscdp.Encode(manscdp.CatalogQuery{
-		CmdType:  manscdp.CmdCatalog,
-		SN:       int(c.seq.Add(1)),
-		DeviceID: deviceID,
-	})
-	if err != nil {
-		return fmt.Errorf("gb28181: encode Catalog query: %w", err)
-	}
+	sn := c.seq.Add(1)
+	// GB/T 28181-2016 § 9.3.1: platform-to-device Query uses child elements
+	// for CmdType/SN/DeviceID (NOT attributes). Many device parsers reject
+	// the attribute form even though some emitters (and our Decode probe)
+	// accept it.
+	body := []byte(fmt.Sprintf(`<Query><CmdType>Catalog</CmdType><SN>%d</SN><DeviceID>%s</DeviceID></Query>`, sn, deviceID))
 	if err := c.sender.SendMessage(deviceID, body); err != nil {
 		return fmt.Errorf("gb28181: send Catalog query to %s: %w", deviceID, err)
 	}

--- a/internal/gb28181/ptz.go
+++ b/internal/gb28181/ptz.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"sync/atomic"
-
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
 )
 
 // PTZ direction identifiers accepted by SendPTZ and the PTZ API.
@@ -139,15 +137,16 @@ func (c *PTZController) SendPTZ(channelID, direction string, speed byte) error {
 	if err != nil {
 		return err
 	}
-	body, err := manscdp.Encode(manscdp.DeviceControl{
-		CmdType:  manscdp.CmdDeviceControl,
-		SN:       int(c.seq.Add(1)),
-		DeviceID: ch.ID,
-		PTZCmd:   ptzCmdString(cmd),
-	})
-	if err != nil {
-		return fmt.Errorf("gb28181: encode DeviceControl: %w", err)
-	}
+	sn := c.seq.Add(1)
+	// GB/T 28181-2016: DeviceControl uses child elements (not attributes) for
+	// CmdType/SN — see CatalogController.RequestCatalog for the same pattern.
+	body := []byte(fmt.Sprintf(`<?xml version="1.0" encoding="GB2312"?>
+<Control>
+<CmdType>DeviceControl</CmdType>
+<SN>%d</SN>
+<DeviceID>%s</DeviceID>
+<PTZCmd>%s</PTZCmd>
+</Control>`, sn, ch.ID, ptzCmdString(cmd)))
 	if err := c.sender.SendMessage(dev.ID, body); err != nil {
 		return fmt.Errorf("gb28181: send PTZ to %s: %w", dev.ID, err)
 	}

--- a/internal/gb28181/ptz_test.go
+++ b/internal/gb28181/ptz_test.go
@@ -95,7 +95,7 @@ func TestPTZ_SendPTZ_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "34020000001310000001", sender.deviceID)
-	require.Contains(t, sender.body, `CmdType="DeviceControl"`)
+	require.Contains(t, sender.body, "<CmdType>DeviceControl</CmdType>")
 	require.Contains(t, sender.body, "<DeviceID>34020000001320000001</DeviceID>")
 	require.Contains(t, sender.body, "<PTZCmd>A5 0F 01 08 00 20 00 DD</PTZCmd>")
 }

--- a/internal/gb28181/session.go
+++ b/internal/gb28181/session.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
 
@@ -66,8 +67,9 @@ func (sm *SessionManager) Invite(channel *Channel, serverIP string, deviceAddr s
 		return nil, fmt.Errorf("gb28181: failed to allocate port: %w", err)
 	}
 
-	// Generate SSRC per GB28181 convention: <deviceID><channelID>:<08X> where last digit = 0 for live
-	ssrc := fmt.Sprintf("%s%s:%08d", channel.DeviceID, channel.ID, 0)
+	// Generate SSRC per GB28181 convention: 10-digit decimal (0=live, 1=playback
+	// + last 8 digits of channel ID).
+	ssrc := manscdp.SSRC(false, channel.ID)
 
 	// Build SDP answer (GB28181 minimal format)
 	sdpAnswer := []byte(fmt.Sprintf(
@@ -193,8 +195,8 @@ func (sm *SessionManager) InvitePlayback(channel *Channel, serverIP string, star
 		return nil, fmt.Errorf("gb28181: failed to allocate port: %w", err)
 	}
 
-	// Generate SSRC per GB28181 convention: <deviceID><channelID>:<08X> where last digit = 1 for playback
-	ssrc := fmt.Sprintf("%s%s:%08d", channel.DeviceID, channel.ID, 1)
+	// Generate SSRC per GB28181 convention: 10-digit decimal (playback uses digit 1).
+	ssrc := manscdp.SSRC(true, channel.ID)
 
 	// Convert times to NTP timestamps (seconds since 1900-01-01)
 	// NTP timestamp = Unix timestamp + 2208988800

--- a/internal/gb28181/session_test.go
+++ b/internal/gb28181/session_test.go
@@ -2,6 +2,7 @@ package gb28181
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -306,8 +307,7 @@ func TestSessionManager_SDPAnswerFormat(t *testing.T) {
 	require.Contains(t, sdpStr, "a=recvonly", "should have recvonly attribute")
 	require.Contains(t, sdpStr, "a=rtpmap:96 PS/90000", "should have RTP map")
 	require.Contains(t, sdpStr, "y=", "should have SSRC (y=)")
-	require.Contains(t, sdpStr, channel.DeviceID, "SSRC should contain device ID")
-	require.Contains(t, sdpStr, channel.ID, "SSRC should contain channel ID")
+	require.Contains(t, sdpStr, channel.ID[len(channel.ID)-8:], "SSRC should contain last 8 digits of channel ID")
 
 	_ = sm.Bye(channel.ID)
 }
@@ -491,8 +491,16 @@ func TestSession_PlaybackSDP(t *testing.T) {
 	require.Contains(t, sdpStr, "t=", "SDP should contain t= line for time range")
 	require.Contains(t, sdpStr, "y=", "SDP should contain SSRC (y=)")
 
-	// Verify SSRC ends with :00000001 (playback, digit 1)
-	require.Contains(t, sdpStr, ":00000001\r\n", "SSRC should end with :00000001 for playback")
+	// Verify SSRC starts with 1 (playback prefix)
+	lines := strings.Split(sdpStr, "\r\n")
+	for _, l := range lines {
+		if strings.HasPrefix(l, "y=1") {
+			break
+		}
+		if strings.HasPrefix(l, "y=") && !strings.HasPrefix(l, "y=1") {
+			t.Fatalf("playback SSRC should start with 1, got: %s", l)
+		}
+	}
 
 	// Verify port was allocated
 	receiver := sm.GetReceiver(channel.ID)
@@ -523,7 +531,7 @@ func TestSession_PlaybackSDP(t *testing.T) {
 	require.NoError(t, err)
 	sdpLiveStr := string(sdpLive)
 	require.Contains(t, sdpLiveStr, "s=Play", "Live SDP should contain s=Play")
-	require.Contains(t, sdpLiveStr, ":00000000\r\n", "Live SSRC should end with :00000000")
+	require.Contains(t, sdpLiveStr, "y=0", "Live SSRC should start with 0")
 	_ = sm.Bye(channel2.ID)
 }
 

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -35,9 +35,10 @@ const (
 // keepalive/catalog/device-info MESSAGE handling. Media sessions (INVITE/BYE)
 // are delegated to the hooks installed by the session manager.
 type Server struct {
-	cfg       config.GB28181ServerConfig
-	deviceMgr *gb28181.DeviceManager
-	db        *storage.DB // nil in tests
+	cfg        config.GB28181ServerConfig
+	deviceMgr  *gb28181.DeviceManager
+	sessionMgr *gb28181.SessionManager
+	db         *storage.DB // nil in tests
 
 	gosipSrv gosip.Server
 	cancel   context.CancelFunc
@@ -55,10 +56,11 @@ type Server struct {
 // parameter persists device registrations and catalog data so the REST API
 // (which reads from the DB) reflects live SIP state; pass nil to skip
 // persistence (test-only).
-func NewServer(cfg config.GB28181ServerConfig, deviceMgr *gb28181.DeviceManager, db *storage.DB) *Server {
+func NewServer(cfg config.GB28181ServerConfig, deviceMgr *gb28181.DeviceManager, sessionMgr *gb28181.SessionManager, db *storage.DB) *Server {
 	return &Server{
 		cfg:         cfg,
 		deviceMgr:   deviceMgr,
+		sessionMgr:  sessionMgr,
 		db:          db,
 		perDeviceMu: make(map[string]*sync.Mutex),
 	}
@@ -183,7 +185,7 @@ func (s *Server) SendMessage(deviceID string, body []byte) error {
 	}
 	portVal := sip.Port(devPort)
 
-	serverHost := s.localIP()
+	serverHost := s.localIPFor(netAddr)
 
 	from := &sip.Address{
 		DisplayName: sip.String{Str: s.cfg.ServerID},
@@ -228,6 +230,82 @@ func (s *Server) SendMessage(deviceID string, body []byte) error {
 	if _, err := srv.Request(req); err != nil {
 		return fmt.Errorf("gb28181: send MESSAGE to %s: %w", deviceID, err)
 	}
+	return nil
+}
+
+// InviteChannel sends a SIP INVITE to channelID on deviceID, starting a live
+// media session. It allocates an RTP receive port via the SessionManager,
+// builds a GB28181 SDP offer (s=Play, PS/90000, recvonly), and sends the INVITE.
+// The device responds 200 OK and starts streaming RTP/PS to the allocated port.
+func (s *Server) InviteChannel(deviceID, channelID string) error {
+	s.mu.Lock()
+	srv := s.gosipSrv
+	s.mu.Unlock()
+	if srv == nil {
+		return fmt.Errorf("gb28181: SIP server not started")
+	}
+
+	dev, ok := s.deviceMgr.Device(deviceID)
+	if !ok {
+		return fmt.Errorf("gb28181: device %q not registered", deviceID)
+	}
+	ch, ok := s.deviceMgr.FindChannel(deviceID, channelID)
+	if !ok {
+		return fmt.Errorf("gb28181: channel %q not found on device %q", channelID, deviceID)
+	}
+
+	dev.Mu.RLock()
+	netAddr := dev.NetAddr
+	dev.Mu.RUnlock()
+
+	serverHost := s.localIPFor(netAddr)
+
+	// Allocate port, create SDP, start receiver.
+	sdp, err := s.sessionMgr.Invite(ch, serverHost, netAddr, nil)
+	if err != nil {
+		return fmt.Errorf("gb28181: session setup for %s: %w", channelID, err)
+	}
+
+	devHost, devPortStr, err := net.SplitHostPort(netAddr)
+	if err != nil {
+		return fmt.Errorf("gb28181: invalid device address %q: %w", netAddr, err)
+	}
+	devPort, _ := strconv.Atoi(devPortStr)
+	portVal := sip.Port(devPort)
+
+	from := &sip.Address{
+		DisplayName: sip.String{Str: s.cfg.ServerID},
+		Uri:         &sip.SipUri{FUser: sip.String{Str: s.cfg.ServerID}, FHost: serverHost},
+	}
+	to := &sip.Address{
+		DisplayName: sip.String{Str: channelID},
+		Uri:         &sip.SipUri{FUser: sip.String{Str: channelID}, FHost: devHost, FPort: &portVal},
+	}
+	recipient := &sip.SipUri{FUser: sip.String{Str: channelID}, FHost: devHost, FPort: &portVal}
+
+	rb := sip.NewRequestBuilder()
+	rb.SetMethod(sip.INVITE)
+	rb.SetFrom(from)
+	rb.SetTo(to)
+	rb.SetRecipient(recipient)
+	rb.SetHost(serverHost)
+	rb.AddVia(&sip.ViaHop{
+		Host:   serverHost,
+		Params: sip.NewParams().Add("branch", sip.String{Str: sip.GenerateBranch()}),
+	})
+	rb.SetSeqNo(1)
+	ct := sip.ContentType("application/sdp")
+	rb.SetContentType(&ct)
+	rb.SetBody(string(sdp))
+
+	req, err := rb.Build()
+	if err != nil {
+		return fmt.Errorf("gb28181: build INVITE request: %w", err)
+	}
+	if _, err := srv.Request(req); err != nil {
+		return fmt.Errorf("gb28181: send INVITE to %s: %w", channelID, err)
+	}
+	slog.Info("gb28181: INVITE sent", "channel", channelID, "device", deviceID)
 	return nil
 }
 
@@ -291,6 +369,17 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 			ID:      deviceID,
 			NetAddr: req.Source(),
 		})
+		// Auto-register the device itself as a channel — but ONLY on first
+		// registration, not on periodic re-REGISTERs. Re-registering would
+		// overwrite the channel's Status (resetting inviting/playing to idle).
+		if _, exists := s.deviceMgr.FindChannel(deviceID, deviceID); !exists {
+			s.deviceMgr.RegisterChannel(deviceID, &gb28181.Channel{
+				ID:       deviceID,
+				DeviceID: deviceID,
+				Name:     "",
+			})
+			slog.Info("gb28181: device auto-registered as channel", "device", deviceID)
+		}
 		if s.db != nil {
 			now := time.Now()
 			if err := s.db.UpsertGB28181Device(context.Background(), storage.GB28181Device{
@@ -300,6 +389,16 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 				RegisteredAt:  now,
 			}); err != nil {
 				slog.Warn("gb28181: failed to persist device to DB", "device", deviceID, "error", err)
+			}
+			if _, exists := s.deviceMgr.FindChannel(deviceID, deviceID); !exists {
+				if err := s.db.UpsertGB28181Channel(context.Background(), storage.GB28181Channel{
+					ID:        deviceID,
+					DeviceID:  deviceID,
+					Status:    "idle",
+					UpdatedAt: now,
+				}); err != nil {
+					slog.Warn("gb28181: failed to persist auto-channel to DB", "device", deviceID, "error", err)
+				}
 			}
 		}
 	}
@@ -535,8 +634,24 @@ func parseSIPListen(listen string) (host string, port int, err error) {
 // Via headers of outbound requests. It prefers the host from sip_listen when
 // configured, otherwise the first non-loopback IPv4 interface address, and
 // falls back to 127.0.0.1.
+
+// localIPFor returns the NVR's source IP for reaching remoteAddr (an
+// "ip:port" string). It performs a UDP dial to let the kernel pick the
+// correct local address for the route, which handles multi-homed hosts
+// and cross-subnet devices correctly. Falls back to localIP() on error.
+func (s *Server) localIPFor(remoteAddr string) string {
+	if conn, err := net.Dial("udp", remoteAddr); err == nil {
+		defer conn.Close()
+		if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok && addr.IP.To4() != nil {
+			return addr.IP.String()
+		}
+	}
+	return s.localIP()
+}
+
 func (s *Server) localIP() string {
-	if host, _, err := parseSIPListen(s.cfg.SIPListen); err == nil && host != "" {
+	host, _, err := parseSIPListen(s.cfg.SIPListen)
+	if err == nil && host != "" && host != "0.0.0.0" {
 		return host
 	}
 	addrs, err := net.InterfaceAddrs()

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -48,7 +48,7 @@ func testConfig(t *testing.T) config.GB28181ServerConfig {
 func startTestServer(t *testing.T, cfg config.GB28181ServerConfig) (*Server, *gb28181.DeviceManager) {
 	t.Helper()
 	dm := gb28181.NewDeviceManager(60 * time.Second)
-	srv := NewServer(cfg, dm, nil)
+	srv := NewServer(cfg, dm, gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), cfg.ServerID), nil)
 	if err := srv.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -210,7 +210,7 @@ func getChallenge(t *testing.T, res sip.Response) *sip.GenericHeader {
 }
 
 func TestServer_Name(t *testing.T) {
-	srv := NewServer(config.GB28181ServerConfig{}, gb28181.NewDeviceManager(time.Minute), nil)
+	srv := NewServer(config.GB28181ServerConfig{}, gb28181.NewDeviceManager(time.Minute), gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), ""), nil)
 	if got := srv.Name(); got != "gb28181" {
 		t.Fatalf("Name() = %q, want %q", got, "gb28181")
 	}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -552,7 +552,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			}
 		})
 		deps.gb28181SessionMgr = newGB28181SessionManager(cfg.GB28181)
-		deps.gb28181Server = sip.NewServer(cfg.GB28181, deps.gb28181DevMgr, deps.db)
+		deps.gb28181Server = sip.NewServer(cfg.GB28181, deps.gb28181DevMgr, deps.gb28181SessionMgr, deps.db)
 		slog.Info("GB28181 SIP server configured", "sip_listen", cfg.GB28181.SIPListen)
 	}
 
@@ -639,6 +639,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	if deps.gb28181Server != nil {
 		handler.SetGB28181PTZ(gb28181.NewPTZController(deps.gb28181DevMgr, deps.gb28181Server))
 		handler.SetGB28181Catalog(gb28181.NewCatalogController(deps.gb28181DevMgr, deps.gb28181Server))
+		handler.SetGB28181Inviter(deps.gb28181Server)
 	}
 	// Create and populate StreamRegistry for protocol discovery
 	reg := api.NewStreamRegistry()


### PR DESCRIPTION
## Summary

Six fixes from real-device GB28181 testing on Docker VM with Rust device (192.168.62.104). Device registration → catalog query → SIP INVITE → device media start all verified end-to-end.

## Changes

1. **localIP 0.0.0.0 bug**: `localIP()` returned `0.0.0.0` when `sip_listen` was `0.0.0.0`. Added `localIPFor(remoteAddr)` using UDP dial to let the kernel pick the correct source IP per destination.

2. **MANSCDP XML format**: Outgoing XML used attributes (`<Query CmdType="Catalog">`) which the device rejected. Switched to GB/T 28181 child-element format (`<Query><CmdType>Catalog</CmdType>...`) and removed the `<?xml?>` declaration.

3. **Auto-channel creation**: Device registration didn't create a channel. Added auto-channel on first REGISTER (skipped on re-REGISTER to preserve channel Status). IPC cameras register directly as single-channel devices.

4. **INVITE handler stub**: `handleInviteChannel` was a TODO stub returning 202 without sending SIP INVITE. Implemented full flow: `InviteChannel()` on SIP server + `GB28181InviteSender` interface + `sessionMgr` wired into `sip.Server`.

5. **SSRC format broken**: `SessionManager.Invite()` built a 48-char SSRC with a colon. Fixed to use `manscdp.SSRC()` producing the correct 10-digit decimal format.

6. **PTZ DeviceControl XML**: Same attribute → child-element fix as Catalog query.

## Verification (Docker VM 192.168.63.197)

- Device REGISTER → 200 OK → DB persisted
- Keepalive processing (Via fix verified)
- Catalog query MESSAGE → device parses successfully
- Auto-channel appears in `/api/gb28181/devices/{id}/channels`
- INVITE → device receives, starts media task (`media stream started on port 44641`)
- RTP not yet flowing — filed device issue: Mi-Bee-Studio/mibee-eye-raspi#1

## Test plan

- [ ] CI green
- [ ] Full INVITE → RTP → playback flow when device team fixes RTP sender