### PR TITLE
fix(gb28181): expose gb28181 config in settings API + fix auto-channel DB write

### DIFF
--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -400,6 +400,19 @@ func (h *Handler) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		"server": map[string]any{
 			"listen": h.config.Server.Listen,
 		},
+		"gb28181": map[string]any{
+			"enabled":            h.config.GB28181.Enabled,
+			"sip_listen":         h.config.GB28181.SIPListen,
+			"server_id":          h.config.GB28181.ServerID,
+			"realm":              h.config.GB28181.Realm,
+			"password":           h.config.GB28181.Password,
+			"port_range":         h.config.GB28181.PortRange,
+			"allowed_device_ids": h.config.GB28181.AllowedDeviceIDs,
+			"heartbeat_interval": h.config.GB28181.HeartbeatInterval,
+			"catalog_interval":   h.config.GB28181.CatalogInterval,
+			"tcp_mode":           h.config.GB28181.TCPMode,
+			"tcp_framing":        h.config.GB28181.TCPFraming,
+		},
 	})
 }
 
@@ -454,6 +467,19 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		Server   *struct {
 			Listen *string `json:"listen"`
 		} `json:"server"`
+		GB28181 *struct {
+			Enabled           *bool     `json:"enabled"`
+			SIPListen         *string   `json:"sip_listen"`
+			ServerID          *string   `json:"server_id"`
+			Realm             *string   `json:"realm"`
+			Password          *string   `json:"password"`
+			PortRange         *string   `json:"port_range"`
+			AllowedDeviceIDs  *[]string `json:"allowed_device_ids"`
+			HeartbeatInterval *string   `json:"heartbeat_interval"`
+			CatalogInterval   *string   `json:"catalog_interval"`
+			TCPMode           *bool     `json:"tcp_mode"`
+			TCPFraming        *string   `json:"tcp_framing"`
+		} `json:"gb28181"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -530,6 +556,48 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.config.Server.Listen = fmt.Sprintf(":%d", port)
+	}
+
+	// Update GB28181 settings
+	if body.GB28181 != nil {
+		if body.GB28181.Enabled != nil {
+			h.config.GB28181.Enabled = *body.GB28181.Enabled
+		}
+		if body.GB28181.SIPListen != nil {
+			h.config.GB28181.SIPListen = *body.GB28181.SIPListen
+		}
+		if body.GB28181.ServerID != nil {
+			h.config.GB28181.ServerID = *body.GB28181.ServerID
+		}
+		if body.GB28181.Realm != nil {
+			h.config.GB28181.Realm = *body.GB28181.Realm
+		}
+		if body.GB28181.Password != nil {
+			h.config.GB28181.Password = *body.GB28181.Password
+		}
+		if body.GB28181.PortRange != nil {
+			h.config.GB28181.PortRange = *body.GB28181.PortRange
+		}
+		if body.GB28181.AllowedDeviceIDs != nil {
+			h.config.GB28181.AllowedDeviceIDs = *body.GB28181.AllowedDeviceIDs
+		}
+		if body.GB28181.HeartbeatInterval != nil {
+			h.config.GB28181.HeartbeatInterval = *body.GB28181.HeartbeatInterval
+		}
+		if body.GB28181.CatalogInterval != nil {
+			h.config.GB28181.CatalogInterval = *body.GB28181.CatalogInterval
+		}
+		if body.GB28181.TCPMode != nil {
+			h.config.GB28181.TCPMode = *body.GB28181.TCPMode
+		}
+		if body.GB28181.TCPFraming != nil {
+			h.config.GB28181.TCPFraming = *body.GB28181.TCPFraming
+		}
+		// Validate the updated config (catches invalid server_id, sip_listen, etc.)
+		if err := config.Validate(h.config); err != nil {
+			WriteError(w, http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	// Persist config to disk

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -372,7 +372,10 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		// Auto-register the device itself as a channel — but ONLY on first
 		// registration, not on periodic re-REGISTERs. Re-registering would
 		// overwrite the channel's Status (resetting inviting/playing to idle).
-		if _, exists := s.deviceMgr.FindChannel(deviceID, deviceID); !exists {
+		// Capture once: was this a first-time registration?
+		// Used for both in-memory + DB auto-channel creation.
+		_, channelExists := s.deviceMgr.FindChannel(deviceID, deviceID)
+		if !channelExists {
 			s.deviceMgr.RegisterChannel(deviceID, &gb28181.Channel{
 				ID:       deviceID,
 				DeviceID: deviceID,
@@ -390,7 +393,7 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 			}); err != nil {
 				slog.Warn("gb28181: failed to persist device to DB", "device", deviceID, "error", err)
 			}
-			if _, exists := s.deviceMgr.FindChannel(deviceID, deviceID); !exists {
+			if !channelExists {
 				if err := s.db.UpsertGB28181Channel(context.Background(), storage.GB28181Channel{
 					ID:        deviceID,
 					DeviceID:  deviceID,


### PR DESCRIPTION
## Problem

Two bugs found during Docker VM real-device testing:

1. **`/api/settings` did not include a `gb28181` block** — the frontend's `gb28181Enabled` store stayed `false`, hiding the "GB28181 Devices" nav item and making it impossible for users to find any GB28181 UI.

2. **Auto-channel was registered in memory but never persisted to DB** — the `FindChannel` guard ran AFTER `RegisterChannel`, so the second check found the channel (already in memory) and skipped the DB write. The API reads channels from DB, so `/api/gb28181/devices/{id}/channels` always returned empty.

## Fix

1. Added `gb28181` block to both `handleGetSettings` (expose all fields) and `handleUpdateSettings` (apply changes + `config.Validate` on save).
2. Captured `channelExists` once before either the in-memory registration or the DB write, so both use the same initial check.

## Verification (Docker VM 192.168.63.197)

- `/api/settings` returns full `gb28181` block ✅
- "GB28181 Devices" nav item appears in frontend ✅
- GB28181 Devices page shows 2 registered devices + channels ✅
- Settings → GB28181 panel shows all config fields populated ✅
- Channels API returns 1 channel (was 0 before fix) ✅

## Test plan

- [ ] CI green