### PR TITLE
feat(vision): NVR 主动推送视频段到外部 AI 后端 + AI 事件合并迁移 + cleanup CLI

### DIFF
--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bufio"
+	"context"
+	"database/sql"
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	authmw "github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
+	_ "modernc.org/sqlite"
 )
 
 // Function variables for testability. Tests override these to avoid os.Exit().
@@ -259,5 +263,254 @@ func dispatchSubcommand(args []string) {
 		cmdDownloadModelFn()
 	case "merge-cameras":
 		cmdMergeCameras()
+	case "cleanup":
+		cmdCleanup()
 	}
+}
+
+// cmdCleanup 录像清理工具，支持多种模式：
+//
+// 1. 按日期清理（删除 DB 行 + 文件 + 孤儿AI事件）:
+//
+//	mibee-nvr cleanup --before 2026-08-07
+//
+// 2. 清理孤儿文件（磁盘上有但 DB 里没记录的文件）:
+//
+//	mibee-nvr cleanup --orphans
+//
+// 3. 组合使用:
+//
+//	mibee-nvr cleanup --before 2026-08-07 --orphans
+//
+// 通用选项:
+//
+//	--config   配置文件路径（默认 mibee-nvr.yaml）
+//	--dry-run  只统计不删除
+func cmdCleanup() {
+	var cfgPath, beforeDate string
+	var orphans, dryRun bool
+	for i := 2; i < len(os.Args); i++ {
+		switch os.Args[i] {
+		case "--config":
+			i++
+			if i < len(os.Args) {
+				cfgPath = os.Args[i]
+			}
+		case "--before":
+			i++
+			if i < len(os.Args) {
+				beforeDate = os.Args[i]
+			}
+		case "--orphans":
+			orphans = true
+		case "--dry-run":
+			dryRun = true
+		case "--help", "-h":
+			fmt.Println(`cleanup — 录像清理工具
+
+用法:
+  mibee-nvr cleanup [选项]
+
+选项:
+  --before YYYY-MM-DD  删除此日期之前的录像（DB行 + 文件 + AI事件）
+  --orphans            清理孤儿文件（磁盘有但DB无记录的视频文件）
+  --config PATH        配置文件路径（默认 mibee-nvr.yaml）
+  --dry-run            只统计不删除
+
+示例:
+  mibee-nvr cleanup --before 2026-08-07 --dry-run   # 预览清理7月数据
+  mibee-nvr cleanup --before 2026-08-07              # 执行清理
+  mibee-nvr cleanup --orphans --dry-run              # 预览孤儿文件
+  mibee-nvr cleanup --orphans                         # 清理孤儿文件`)
+			os.Exit(0)
+		}
+	}
+
+	if cfgPath == "" {
+		cfgPath = "mibee-nvr.yaml"
+	}
+	if beforeDate == "" && !orphans {
+		fmt.Fprintln(os.Stderr, "Error: 需要指定 --before 或 --orphans")
+		fmt.Fprintln(os.Stderr, "运行 mibee-nvr cleanup --help 查看用法")
+		os.Exit(1)
+	}
+
+	// 加载配置获取存储根目录。
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config %s: %v\n", cfgPath, err)
+		os.Exit(1)
+	}
+	storageRoot := cfg.Storage.RootDir
+	dbPath := storageRoot + "/mibee-nvr.db"
+
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening DB: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	dryRunSuffix := ""
+	if dryRun {
+		dryRunSuffix = " (--dry-run)"
+	}
+
+	// ── 模式 1: 按日期清理 ──
+	if beforeDate != "" {
+		fmt.Printf("=== 按日期清理 (before %s)%s ===\n", beforeDate, dryRunSuffix)
+		cleanupByDate(ctx, db, storageRoot, beforeDate, dryRun)
+	}
+
+	// ── 模式 2: 清理孤儿文件 ──
+	if orphans {
+		fmt.Printf("\n=== 孤儿文件清理%s ===\n", dryRunSuffix)
+		cleanupOrphanFiles(ctx, db, storageRoot, dryRun)
+	}
+
+	fmt.Println("\nCleanup complete.")
+	os.Exit(0)
+}
+
+// cleanupByDate 删除指定日期之前的录像（文件 + DB 行 + AI 事件）。
+func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate string, dryRun bool) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT id, file_path, file_size FROM recordings WHERE file_path != '' AND started_at < ?`,
+		beforeDate+" 00:00:00")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Error querying: %v\n", err)
+		return
+	}
+	type rec struct {
+		id, path string
+		size     int64
+	}
+	var recs []rec
+	var totalSize int64
+	for rows.Next() {
+		var r rec
+		if err := rows.Scan(&r.id, &r.path, &r.size); err != nil {
+			continue
+		}
+		recs = append(recs, r)
+		totalSize += r.size
+	}
+	rows.Close()
+
+	fmt.Printf("  Found %d recordings (%.1f GB)\n", len(recs), float64(totalSize)/1e9)
+	if dryRun || len(recs) == 0 {
+		return
+	}
+
+	// 删除文件。
+	var deletedFiles int
+	var freedBytes int64
+	for _, r := range recs {
+		absPath := r.path
+		if !filepath.IsAbs(absPath) {
+			absPath = filepath.Join(storageRoot, r.path)
+		}
+		if err := os.Remove(absPath); err == nil {
+			deletedFiles++
+			freedBytes += r.size
+		}
+	}
+	fmt.Printf("  Files: %d deleted, %.1f GB freed\n", deletedFiles, float64(freedBytes)/1e9)
+
+	// 删除 DB 行。
+	if result, err := db.ExecContext(ctx,
+		`DELETE FROM recordings WHERE file_path != '' AND started_at < ?`,
+		beforeDate+" 00:00:00"); err == nil {
+		if n, _ := result.RowsAffected(); n > 0 {
+			fmt.Printf("  DB: %d rows deleted\n", n)
+		}
+	}
+
+	// 删除孤儿 AI 事件。
+	if result, err := db.ExecContext(ctx,
+		`DELETE FROM ai_events WHERE recording_id != '' AND recording_id NOT IN (SELECT id FROM recordings)`); err == nil {
+		if n, _ := result.RowsAffected(); n > 0 {
+			fmt.Printf("  AI events: %d orphaned rows deleted\n", n)
+		}
+	}
+}
+
+// cleanupOrphanFiles 扫描磁盘上的视频文件，删除 DB 中无记录的孤儿文件。
+// 包括：录像目录 + periodic-merge 目录 + 临时文件。
+func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dryRun bool) {
+	// 加载所有 DB 中的 file_path 到 set。
+	dbPaths := make(map[string]bool)
+	rows, err := db.QueryContext(ctx, `SELECT file_path FROM recordings WHERE file_path != ''`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Error querying DB paths: %v\n", err)
+		return
+	}
+	for rows.Next() {
+		var p string
+		rows.Scan(&p)
+		// 标准化：转绝对路径。
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(storageRoot, p)
+		}
+		dbPaths[filepath.Clean(p)] = true
+	}
+	rows.Close()
+	fmt.Printf("  DB has %d recording file paths\n", len(dbPaths))
+
+	// 扫描磁盘上的视频文件。
+	videoExts := map[string]bool{".mp4": true, ".mkv": true, ".avi": true, ".dav": true, ".flv": true}
+	var orphanFiles []string
+	var orphanSize int64
+
+	err = filepath.Walk(storageRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // 跳过不可访问的目录
+		}
+		// 跳过 DB 文件和配置文件。
+		if !info.IsDir() {
+			ext := filepath.Ext(path)
+			if !videoExts[ext] {
+				return nil
+			}
+			cleanPath := filepath.Clean(path)
+			if !dbPaths[cleanPath] {
+				orphanFiles = append(orphanFiles, cleanPath)
+				orphanSize += info.Size()
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  Error walking directory: %v\n", err)
+		return
+	}
+
+	fmt.Printf("  Found %d orphan files (%.1f GB)\n", len(orphanFiles), float64(orphanSize)/1e9)
+
+	if dryRun || len(orphanFiles) == 0 {
+		// 显示前 10 个孤儿文件路径（帮助用户确认）。
+		for i, p := range orphanFiles {
+			if i >= 10 {
+				fmt.Printf("  ... and %d more\n", len(orphanFiles)-10)
+				break
+			}
+			fmt.Printf("    %s\n", p)
+		}
+		return
+	}
+
+	// 删除孤儿文件。
+	var deleted int
+	var freed int64
+	for _, p := range orphanFiles {
+		if info, err := os.Stat(p); err == nil {
+			size := info.Size()
+			if err := os.Remove(p); err == nil {
+				deleted++
+				freed += size
+			}
+		}
+	}
+	fmt.Printf("  Deleted %d orphan files, %.1f GB freed\n", deleted, float64(freed)/1e9)
 }

--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -382,6 +382,7 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 		fmt.Fprintf(os.Stderr, "  Error querying: %v\n", err)
 		return
 	}
+	defer rows.Close()
 	type rec struct {
 		id, path string
 		size     int64
@@ -396,7 +397,6 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 		recs = append(recs, r)
 		totalSize += r.size
 	}
-	rows.Close()
 
 	fmt.Printf("  Found %d recordings (%.1f GB)\n", len(recs), float64(totalSize)/1e9)
 	if dryRun || len(recs) == 0 {

--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -349,7 +349,6 @@ func cmdCleanup() {
 		fmt.Fprintf(os.Stderr, "Error opening DB: %v\n", err)
 		os.Exit(1)
 	}
-	defer db.Close()
 
 	ctx := context.Background()
 	dryRunSuffix := ""
@@ -370,6 +369,9 @@ func cmdCleanup() {
 	}
 
 	fmt.Println("\nCleanup complete.")
+	db.Close()
+	// CLI 子命令必须显式退出:dispatchSubcommand 在服务器启动之前调用,
+	// 直接 return 会误启动 NVR 服务。db 已显式 Close(见上)。
 	os.Exit(0)
 }
 
@@ -452,7 +454,9 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 	defer rows.Close()
 	for rows.Next() {
 		var p string
-		rows.Scan(&p)
+		if err := rows.Scan(&p); err != nil {
+			continue
+		}
 		// 标准化：转绝对路径。
 		if !filepath.IsAbs(p) {
 			p = filepath.Join(storageRoot, p)

--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -471,7 +471,8 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 
 	err = filepath.Walk(storageRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil // 跳过不可访问的目录
+			// 跳过不可访问的目录(权限/断链等),继续扫描其余部分。
+			return nil //nolint:nilerr // 有意忽略子树错误,Walk 继续遍历
 		}
 		// 跳过 DB 文件和配置文件。
 		if !info.IsDir() {

--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -397,6 +397,9 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 		recs = append(recs, r)
 		totalSize += r.size
 	}
+	if err := rows.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: iterate recordings: %v\n", err)
+	}
 
 	fmt.Printf("  Found %d recordings (%.1f GB)\n", len(recs), float64(totalSize)/1e9)
 	if dryRun || len(recs) == 0 {
@@ -446,6 +449,7 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 		fmt.Fprintf(os.Stderr, "  Error querying DB paths: %v\n", err)
 		return
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var p string
 		rows.Scan(&p)
@@ -455,7 +459,9 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 		}
 		dbPaths[filepath.Clean(p)] = true
 	}
-	rows.Close()
+	if err := rows.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: iterate DB paths: %v\n", err)
+	}
 	fmt.Printf("  DB has %d recording file paths\n", len(dbPaths))
 
 	// 扫描磁盘上的视频文件。

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,8 +24,8 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 	"github.com/go-chi/chi/v5"
@@ -145,13 +145,13 @@ type Handler struct {
 	// Close waits on mergeWg so in-flight merges finish (or observe ctx cancel)
 	// before the caller (App.Stop / a test's t.TempDir cleanup) tears down the
 	// storage tree — prevents the TempDir "directory not empty" flake (#143/#125).
-	mergeMu     sync.Mutex
-	mergeCtx    context.Context    // set by initMergeCtx; nil ⇒ fall back to context.Background()
-	mergeCancel context.CancelFunc // set by initMergeCtx
-	mergeWg     sync.WaitGroup
-	isClosed    bool // guarded by mergeMu; prevents new merges after Close
-	aiHandler   *AIHandler
-	relayMgr    *relay.Manager
+	mergeMu           sync.Mutex
+	mergeCtx          context.Context    // set by initMergeCtx; nil ⇒ fall back to context.Background()
+	mergeCancel       context.CancelFunc // set by initMergeCtx
+	mergeWg           sync.WaitGroup
+	isClosed          bool // guarded by mergeMu; prevents new merges after Close
+	aiHandler         *AIHandler
+	relayMgr          *relay.Manager
 	visionCoordinator *vision.Coordinator
 	// frameListCache memoizes sorted file-name listings for MJPEG/timelapse frame
 	// directories so repeated ?frame=N / list-frames requests don't os.ReadDir + sort

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
@@ -151,6 +152,7 @@ type Handler struct {
 	isClosed    bool // guarded by mergeMu; prevents new merges after Close
 	aiHandler   *AIHandler
 	relayMgr    *relay.Manager
+	visionCoordinator *vision.Coordinator
 	// frameListCache memoizes sorted file-name listings for MJPEG/timelapse frame
 	// directories so repeated ?frame=N / list-frames requests don't os.ReadDir + sort
 	// the whole directory on every hit. Keyed by dir path; invalidated by mtime + TTL.
@@ -258,6 +260,7 @@ func (h *Handler) Routes() http.Handler {
 		h.registerRelayRoutes(r)
 		h.registerTranscodeRoutes(r)
 		h.registerAIRoutes(r)
+		h.registerVisionRoutes(r)
 		h.registerTelemetryRoute(r)
 		h.registerGB28181Routes(r)
 	})
@@ -280,6 +283,8 @@ func (h *Handler) registerPublicRoutes(r chi.Router) {
 		r.Get("/api/capabilities", h.handleCapabilities)
 		// Generic event streaming (SSE)
 		r.Get("/api/events", h.handleEvents)
+		// Vision heartbeat (public, rate-limited — Vision has no BasicAuth)
+		h.registerVisionPublicRoutes(r)
 	})
 }
 
@@ -454,6 +459,11 @@ func (h *Handler) SetTimelapseMergeMgr(mgr *timelapse.RollingMergeManager) {
 // SetRollingMergeMgr sets the recording rolling merge coordinator on the handler.
 func (h *Handler) SetRollingMergeMgr(mgr *merge.RollingMergeCoordinator) {
 	h.rollingMergeMgr = mgr
+}
+
+// SetVisionCoordinator sets the Vision push coordinator on the handler.
+func (h *Handler) SetVisionCoordinator(mgr *vision.Coordinator) {
+	h.visionCoordinator = mgr
 }
 
 // SetAIHandler sets the AI handler on the Handler.

--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
+	"github.com/go-chi/chi/v5"
 )
 
 // registerVisionPublicRoutes 注册无需认证的 Vision 端点(与 SSE 一样在 public 组)。
@@ -66,11 +66,11 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 
 	healthy, lastSeen, status := h.visionCoordinator.Health().Snapshot()
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"enabled":       true,
-		"healthy":       healthy,
-		"last_seen":     lastSeen,
-		"device":        status.Device,
-		"queue_depth":   status.QueueDepth,
-		"processed":     status.ProcessedCount,
+		"enabled":     true,
+		"healthy":     healthy,
+		"last_seen":   lastSeen,
+		"device":      status.Device,
+		"queue_depth": status.QueueDepth,
+		"processed":   status.ProcessedCount,
 	})
 }

--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
+)
+
+// registerVisionPublicRoutes 注册无需认证的 Vision 端点(与 SSE 一样在 public 组)。
+// 心跳是 Vision 的"我在"信号,不应要求 BasicAuth(Vision 只有 API Key)。
+func (h *Handler) registerVisionPublicRoutes(r chi.Router) {
+	r.Post("/api/vision/heartbeat", h.handleVisionHeartbeat)
+}
+
+// registerVisionRoutes 注册需要认证的 Vision 端点(在 protected 组,Web UI 用)。
+func (h *Handler) registerVisionRoutes(r chi.Router) {
+	r.Get("/api/vision/status", h.handleVisionStatus)
+}
+
+// handleVisionHeartbeat 接收 MiBeeVision 的心跳报告。
+// Vision 每 30 秒 POST 一次,NVR 据此判断 Vision 是否健康。
+// 只有健康的 Vision 才会收到段推送。
+func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if h.visionCoordinator == nil {
+		WriteError(w, http.StatusServiceUnavailable, "vision integration not enabled")
+		return
+	}
+
+	// 心跳端点接受 API Key 认证或 BasicAuth(方便不同部署模式)。
+	// 不强制 API Key,因为心跳是"我在"信号而非数据写入。
+	var body struct {
+		Status         string `json:"status"`
+		Device         string `json:"device"`
+		QueueDepth     int    `json:"queue_depth"`
+		ProcessedCount int    `json:"processed_count"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	h.visionCoordinator.Health().RecordHeartbeat(vision.HeartbeatStatus{
+		Status:         body.Status,
+		Device:         body.Device,
+		QueueDepth:     body.QueueDepth,
+		ProcessedCount: body.ProcessedCount,
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":           true,
+		"push_enabled": h.visionCoordinator.Health().IsHealthy(),
+	})
+}
+
+// handleVisionStatus 返回 Vision 集成的当前状态(供 NVR Web UI 展示)。
+// 这个端点在 authMW 保护组内,只有登录用户可访问。
+func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
+	if h.visionCoordinator == nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"enabled": false,
+		})
+		return
+	}
+
+	healthy, lastSeen, status := h.visionCoordinator.Health().Snapshot()
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled":       true,
+		"healthy":       healthy,
+		"last_seen":     lastSeen,
+		"device":        status.Device,
+		"queue_depth":   status.QueueDepth,
+		"processed":     status.ProcessedCount,
+	})
+}

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -211,6 +211,14 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.Transcoding.HistoryRetention == "" {
 		cfg.Transcoding.HistoryRetention = "168h" // 7 days
 	}
+
+	// Vision push integration defaults
+	if cfg.Vision.HeartbeatTimeoutSecs <= 0 {
+		cfg.Vision.HeartbeatTimeoutSecs = 60
+	}
+	if cfg.Vision.PushMode == "" {
+		cfg.Vision.PushMode = "notify"
+	}
 	// RTMP defaults
 	if cfg.RTMP.Enabled == nil {
 		cfg.RTMP.Enabled = new(bool)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Transcoding   TranscodingConfig   `yaml:"transcoding"`
 	WebSocket     WebSocketConfig     `yaml:"websocket"`
 	AI            AIConfig            `yaml:"ai"`
+	Vision        VisionConfig        `yaml:"vision"`
 	MetricsAuth   MetricsAuthConfig   `yaml:"metrics_auth"`
 	Security      SecurityConfig      `yaml:"security"`
 	Update        UpdateConfig        `yaml:"update"`

--- a/internal/config/config_vision.go
+++ b/internal/config/config_vision.go
@@ -1,0 +1,29 @@
+package config
+
+// VisionConfig 配置 NVR → MiBeeVision 的主动推送集成。
+//
+// 启用后,NVR 会:
+//  1. 监听 segment.completed 事件
+//  2. 检查 Vision 心跳是否健康(POST /api/vision/heartbeat)
+//  3. 健康时,主动推送段信息到 Vision(而非 Vision 通过 SSE 拉取 + HTTP 下载)
+//
+// 这解决了 Vision 下载录像时 78% 返回 404 的问题(段文件在 Vision 下载前已被合并/删除)。
+// 推送发生在段落盘后、合并前的窗口期,确保 Vision 能拿到文件。
+type VisionConfig struct {
+	// Enabled 是否启用 Vision 推送集成。默认 false(SSE 模式向后兼容)。
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// URL Vision 服务的基地址,如 "http://192.168.63.110:9091"。
+	// NVR 将 POST 到 {URL}/vision/segment/notify。
+	URL string `yaml:"url" json:"url"`
+
+	// HeartbeatTimeoutSecs 心跳超时(秒)。超过此时间未收到 Vision 心跳,
+	// NVR 认为 Vision 不健康,暂停推送。默认 60。
+	HeartbeatTimeoutSecs int `yaml:"heartbeat_timeout_secs" json:"heartbeatTimeoutSecs"`
+
+	// PushMode 推送模式:
+	//   "notify" — 仅发送 file_path,Vision 从共享文件系统直读(Sidecar 同主机部署,零拷贝)
+	//   "upload" — 发送压缩视频字节流(Remote 跨主机部署)
+	// 默认 "notify"。
+	PushMode string `yaml:"push_mode" json:"pushMode"`
+}

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -50,13 +50,14 @@ func (d *DB) InsertAIEvent(ctx context.Context, e *AIEvent) (int64, error) {
 
 // AIEventFilter holds query parameters for listing AI events.
 type AIEventFilter struct {
-	CameraID  string
-	EventType string
-	StartTime *time.Time // inclusive lower bound on created_at
-	EndTime   *time.Time // inclusive upper bound on created_at
-	AscOrder  bool       // order by created_at ASC (for timeline overlay)
-	Limit     int
-	Offset    int
+	CameraID    string
+	RecordingID string // filter by recording_id (used by merge migration tests + NVR UI)
+	EventType   string
+	StartTime   *time.Time // inclusive lower bound on created_at
+	EndTime     *time.Time // inclusive upper bound on created_at
+	AscOrder    bool       // order by created_at ASC (for timeline overlay)
+	Limit       int
+	Offset      int
 }
 
 // ListAIEvents returns AI events matching the filter, ordered by created_at DESC
@@ -77,6 +78,10 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 	if f.CameraID != "" {
 		where = append(where, "camera_id = ?")
 		args = append(args, f.CameraID)
+	}
+	if f.RecordingID != "" {
+		where = append(where, "recording_id = ?")
+		args = append(args, f.RecordingID)
 	}
 	if f.EventType != "" {
 		where = append(where, "event_type = ?")

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -42,6 +42,31 @@ type MergeWindow struct {
 	Format       string    `json:"format"`
 }
 
+// migrateAIEventsInTx reparents AI events from old recording IDs to a new merged
+// recording ID within the given transaction. This prevents AI events from becoming
+// orphaned when source segments are deleted during merge — without this, events
+// pointing at deleted segment IDs would no longer join to any recording, and the
+// merged recording would appear to have no AI data even though its content was analyzed.
+func migrateAIEventsInTx(ctx context.Context, tx *sql.Tx, newRecordingID string, oldIDs []string) error {
+	if len(oldIDs) == 0 {
+		return nil
+	}
+	for _, chunk := range chunkIDs(oldIDs, batchUpdateChunkSize) {
+		placeholders := make([]string, len(chunk))
+		args := make([]interface{}, 0, len(chunk)+1)
+		args = append(args, newRecordingID)
+		for i, id := range chunk {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		q := "UPDATE ai_events SET recording_id = ? WHERE recording_id IN (" + strings.Join(placeholders, ",") + ")"
+		if _, err := tx.ExecContext(ctx, q, args...); err != nil {
+			return fmt.Errorf("migrate ai_events to merged recording %s: %w", newRecordingID, err)
+		}
+	}
+	return nil
+}
+
 // MergeAndReplaceRecordings atomically inserts a merged recording and deletes old recordings in a single transaction.
 // This reduces SQLITE_BUSY contention compared to separate INSERT + SetMerged + DeleteBatch calls.
 func (d *DB) MergeAndReplaceRecordings(ctx context.Context, merged *model.Recording, oldIDs []string) error {
@@ -70,6 +95,11 @@ func (d *DB) MergeAndReplaceRecordings(ctx context.Context, merged *model.Record
 	delQ := "DELETE FROM recordings WHERE id IN (" + strings.Join(placeholders, ",") + ")"
 	_, err = tx.ExecContext(ctx, delQ, args...)
 	if err != nil {
+		return err
+	}
+
+	// Migrate AI events from deleted segment IDs to the new merged recording.
+	if err := migrateAIEventsInTx(ctx, tx, merged.ID, oldIDs); err != nil {
 		return err
 	}
 
@@ -162,6 +192,16 @@ func (d *DB) RollingReplaceRecordings(ctx context.Context, merged *model.Recordi
 		delQ := "DELETE FROM recordings WHERE id IN (" + strings.Join(placeholders, ",") + ")"
 		_, err = tx.ExecContext(ctx, delQ, args...)
 		if err != nil {
+			return err
+		}
+
+		// Migrate AI events from source segment IDs to the merged recording.
+		// Target is existingMergedID (append) or merged.ID (create new bucket).
+		targetID := existingMergedID
+		if targetID == "" {
+			targetID = merged.ID
+		}
+		if err := migrateAIEventsInTx(ctx, tx, targetID, sourceIDs); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/db_merge_test.go
+++ b/internal/storage/db_merge_test.go
@@ -173,3 +173,139 @@ func TestListFakeMergedRecordings(t *testing.T) {
 		require.Empty(t, got, "once reset to pending, it's no longer fake-merged")
 	})
 }
+
+// TestMergeAndReplaceMigratesAIEvents verifies that AI events linked to source
+// segment IDs are reparented to the new merged recording ID during merge.
+// Without this migration, AI events become orphaned (recording_id points to a
+// deleted row) and the merged recording appears to have no AI data.
+func TestMergeAndReplaceMigratesAIEvents(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_merge_ai.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	// Insert 3 source segments with AI events.
+	segIDs := []string{"seg-1", "seg-2", "seg-3"}
+	for i, sid := range segIDs {
+		rec := &model.Recording{
+			ID:        sid,
+			CameraID:  "cam-test",
+			FilePath:  "/tmp/" + sid + ".mp4",
+			Format:    model.FormatH265,
+			StartedAt: time.Now().Add(-time.Duration(3-i) * time.Minute),
+			EndedAt:   time.Now().Add(-time.Duration(2-i) * time.Minute),
+			Duration:  60,
+		}
+		require.NoError(t, db.InsertRecording(ctx, rec))
+
+		// Each segment has an AI event.
+		_, err := db.InsertAIEvent(ctx, &AIEvent{
+			CameraID:    "cam-test",
+			RecordingID: sid,
+			EventType:   "loitering",
+			Severity:    "info",
+			Confidence:  0.85,
+			ClassName:   "person",
+			BBox:        "[0.1,0.2,0.3,0.4]",
+		})
+		require.NoError(t, err)
+	}
+
+	// Merge: replace 3 segments with 1 merged recording.
+	merged := &model.Recording{
+		ID:        "merged-1",
+		CameraID:  "cam-test",
+		FilePath:  "/tmp/merged-1.mp4",
+		Format:    model.FormatH265,
+		StartedAt: time.Now().Add(-3 * time.Minute),
+		EndedAt:   time.Now(),
+		Duration:  180,
+	}
+	require.NoError(t, db.MergeAndReplaceRecordings(ctx, merged, segIDs))
+
+	// Verify: merged recording exists.
+	got, err := db.GetRecording(ctx, "merged-1")
+	require.NoError(t, err)
+	require.Equal(t, model.MergeStatusMerged, got.MergeStatus)
+
+	// Verify: AI events now point to merged-1 (not orphaned).
+	events, total, err := db.ListAIEvents(ctx, AIEventFilter{RecordingID: "merged-1", Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, 3, total, "all 3 AI events should be migrated to merged-1")
+	require.Len(t, events, 3)
+
+	// Verify: no AI events left pointing to old segment IDs.
+	for _, sid := range segIDs {
+		_, total, err := db.ListAIEvents(ctx, AIEventFilter{RecordingID: sid, Limit: 50})
+		require.NoError(t, err)
+		require.Equal(t, 0, total, "no events should remain on old segment %s", sid)
+	}
+}
+
+// TestRollingReplaceMigratesAIEvents verifies that RollingReplaceRecordings
+// (the event-driven rolling merge) also migrates AI events correctly.
+func TestRollingReplaceMigratesAIEvents(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_rolling_ai.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	// Case 1: Create new bucket — 1 source segment with AI event.
+	seg1 := &model.Recording{
+		ID: "rseg-1", CameraID: "cam-r", FilePath: "/tmp/rseg-1.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().Add(-time.Minute),
+		EndedAt: time.Now(), Duration: 60,
+	}
+	require.NoError(t, db.InsertRecording(ctx, seg1))
+	_, err = db.InsertAIEvent(ctx, &AIEvent{
+		CameraID: "cam-r", RecordingID: "rseg-1", EventType: "zone_intrusion",
+		Severity: "warning", Confidence: 0.9, ClassName: "person", BBox: "[0.5,0.5,0.1,0.2]",
+	})
+	require.NoError(t, err)
+
+	merged1 := &model.Recording{
+		ID: "rmerged-1", CameraID: "cam-r", FilePath: "/tmp/rmerged-1.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().Add(-time.Minute),
+		EndedAt: time.Now(), Duration: 60,
+	}
+	// Create new bucket: existingMergedID="" → INSERT merged + DELETE source.
+	require.NoError(t, db.RollingReplaceRecordings(ctx, merged1, "", []string{"rseg-1"}))
+
+	// AI event should be migrated to rmerged-1.
+	_, total, err := db.ListAIEvents(ctx, AIEventFilter{RecordingID: "rmerged-1", Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, 1, total, "AI event should migrate to new bucket")
+
+	// Case 2: Append to existing bucket — another segment with AI event.
+	seg2 := &model.Recording{
+		ID: "rseg-2", CameraID: "cam-r", FilePath: "/tmp/rseg-2.mp4",
+		Format: model.FormatH264, StartedAt: time.Now(),
+		EndedAt: time.Now().Add(time.Minute), Duration: 60,
+	}
+	require.NoError(t, db.InsertRecording(ctx, seg2))
+	_, err = db.InsertAIEvent(ctx, &AIEvent{
+		CameraID: "cam-r", RecordingID: "rseg-2", EventType: "loitering",
+		Severity: "info", Confidence: 0.7, ClassName: "person", BBox: "[0.2,0.3,0.1,0.2]",
+	})
+	require.NoError(t, err)
+
+	mergedUpdated := &model.Recording{
+		ID: "rmerged-1", CameraID: "cam-r", FilePath: "/tmp/rmerged-1-v2.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().Add(-time.Minute),
+		EndedAt: time.Now().Add(time.Minute), Duration: 120,
+	}
+	// Append: existingMergedID="rmerged-1" → UPDATE merged + DELETE source.
+	require.NoError(t, db.RollingReplaceRecordings(ctx, mergedUpdated, "rmerged-1", []string{"rseg-2"}))
+
+	// Now both AI events should be on rmerged-1.
+	events, total, err := db.ListAIEvents(ctx, AIEventFilter{RecordingID: "rmerged-1", Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, 2, total, "both AI events should be on the rolling-merged recording")
+	require.Len(t, events, 2)
+}

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -1,20 +1,19 @@
 // Package vision 实现 NVR → MiBeeVision 的主动推送集成。
 //
-// 核心思路:NVR 不再被动等 Vision 通过 SSE 拉取 + HTTP 下载(78% 因段文件已被
-// 合并/删除而 404),而是在段刚落盘、合并进程还没删它时,主动推给 Vision。
+// NVR 在段刚落盘时,直接把视频文件字节流 POST 给 Vision(不是通知 file_path 让 Vision 下载)。
+// 这样视频数据在 NVR 合并进程删除原文件之前就已经到了 Vision 手里——彻底消除 404。
 //
 // 推送条件:Vision 心跳健康(HealthTracker.IsHealthy)。
-// 如果 Vision 不可用,推送暂停;Vision 恢复后心跳恢复,推送自动续上。
-// 未启用时(enabled=false)或从未收到心跳时,退化为现有 SSE 模式(向后兼容)。
+// 未启用时(enabled=false)退化为现有 SSE 模式(向后兼容)。
 package vision
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -23,44 +22,29 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 )
 
-// segmentNotifyPayload 是推送给 Vision 的段通知(Sidecar 模式)。
-// Vision 收到后根据 file_path 直读共享文件系统上的文件(零拷贝)。
-type segmentNotifyPayload struct {
-	RecordingID string `json:"recording_id"`
-	CameraID    string `json:"camera_id"`
-	FilePath    string `json:"file_path"` // 相对 storage root
-	Format      string `json:"format"`
-	Encoding    string `json:"encoding"`
-	StartedAt   string `json:"started_at"`
-	EndedAt     string `json:"ended_at"`
-	FileSize    int64  `json:"file_size"`
-}
-
-// Coordinator 订阅 segment.completed 事件,在 Vision 健康时推送段通知。
-//
-// 生命周期:Start(ctx) 启动事件循环,Stop() 取消订阅并等待 goroutine 退出。
-// 线程安全:HealthTracker 读写锁保护;eventBus 的 Subscribe/Unsubscribe 线程安全。
+// Coordinator 订阅 segment.completed 事件,在 Vision 健康时把视频文件推送给 Vision。
 type Coordinator struct {
-	health   *HealthTracker
-	eventBus *event.EventBus
-	eventCh  chan event.Event
-	cfg      func() config.VisionConfig
-	client   *http.Client
-	wg       sync.WaitGroup
-	cancelFn context.CancelFunc
-	mu       sync.Mutex // 保护 cancelFn
+	health      *HealthTracker
+	eventBus    *event.EventBus
+	eventCh     chan event.Event
+	cfg         func() config.VisionConfig
+	storageRoot func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
+	client      *http.Client
+	wg          sync.WaitGroup
+	cancelFn    context.CancelFunc
+	mu          sync.Mutex
 }
 
 // NewCoordinator 创建推送协调器。
-// cfg 是闭包形式的配置访问器,确保 NVR 热加载配置时能读到最新值。
-func NewCoordinator(cfg func() config.VisionConfig, eventBus *event.EventBus) *Coordinator {
+func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus) *Coordinator {
 	vcfg := cfg()
 	return &Coordinator{
-		health:   NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
-		eventBus: eventBus,
-		cfg:      cfg,
+		health:      NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
+		eventBus:    eventBus,
+		cfg:         cfg,
+		storageRoot: storageRoot,
 		client: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
 	}
 }
@@ -125,7 +109,7 @@ func (c *Coordinator) eventLoop(ctx context.Context) {
 	}
 }
 
-// handleSegment 处理一个段完成事件:检查配置 + 健康状态,然后推送通知。
+// handleSegment 把段视频文件直接推送给 Vision。
 func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentCompleted) {
 	vcfg := c.cfg()
 	if !vcfg.Enabled || vcfg.URL == "" {
@@ -136,40 +120,47 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"recording_id", seg.RecordingID)
 		return
 	}
-
-	// 跳过 timelapse 格式(Vision 不处理)。
 	if seg.Format == "timelapse" {
 		return
 	}
 
-	payload := segmentNotifyPayload{
-		RecordingID: seg.RecordingID,
-		CameraID:    seg.CameraID,
-		FilePath:    seg.FilePath,
-		Format:      seg.Format,
-		Encoding:    seg.Encoding,
-		StartedAt:   seg.StartedAt,
-		EndedAt:     seg.EndedAt,
-		FileSize:    seg.FileSize,
+	// 解析段文件的绝对路径。NVR 的 file_path 已经是绝对路径(/mnt/data/nvr/...)。
+	absPath := seg.FilePath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(c.storageRoot(), absPath)
 	}
 
-	body, err := json.Marshal(payload)
+	file, err := os.Open(absPath)
 	if err != nil {
-		slog.Error("marshal segment notify", "error", err)
+		slog.Warn("open segment file for push failed",
+			"error", err,
+			"path", absPath,
+			"recording_id", seg.RecordingID)
 		return
 	}
+	defer file.Close()
 
-	url := strings.TrimRight(vcfg.URL, "/") + "/vision/segment/notify"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	// POST 视频字节流到 Vision。元数据通过 HTTP headers 传递。
+	url := strings.TrimRight(vcfg.URL, "/") + "/vision/segment/upload"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, file)
 	if err != nil {
-		slog.Error("create push request", "error", err)
+		slog.Error("create upload request", "error", err)
 		return
 	}
-	req.Header.Set("Content-Type", "application/json")
+	// 显式设置 Content-Length,避免 Go 使用 chunked encoding(Vision 的极简 HTTP 解析器不支持 chunked)。
+	req.ContentLength = seg.FileSize
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-Recording-Id", seg.RecordingID)
+	req.Header.Set("X-Camera-Id", seg.CameraID)
+	req.Header.Set("X-Format", seg.Format)
+	req.Header.Set("X-Encoding", seg.Encoding)
+	req.Header.Set("X-Started-At", seg.StartedAt)
+	req.Header.Set("X-Ended-At", seg.EndedAt)
+	req.Header.Set("X-File-Size", fmt.Sprintf("%d", seg.FileSize))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		slog.Warn("push segment to vision failed",
+		slog.Warn("push video to vision failed",
 			"error", err,
 			"recording_id", seg.RecordingID)
 		return
@@ -181,8 +172,9 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"status", resp.StatusCode,
 			"recording_id", seg.RecordingID)
 	} else {
-		slog.Debug("pushed segment to vision",
+		slog.Info("pushed video to vision",
 			"recording_id", seg.RecordingID,
-			"camera_id", seg.CameraID)
+			"camera_id", seg.CameraID,
+			"size_mb", seg.FileSize/1024/1024)
 	}
 }

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -1,0 +1,188 @@
+// Package vision 实现 NVR → MiBeeVision 的主动推送集成。
+//
+// 核心思路:NVR 不再被动等 Vision 通过 SSE 拉取 + HTTP 下载(78% 因段文件已被
+// 合并/删除而 404),而是在段刚落盘、合并进程还没删它时,主动推给 Vision。
+//
+// 推送条件:Vision 心跳健康(HealthTracker.IsHealthy)。
+// 如果 Vision 不可用,推送暂停;Vision 恢复后心跳恢复,推送自动续上。
+// 未启用时(enabled=false)或从未收到心跳时,退化为现有 SSE 模式(向后兼容)。
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+)
+
+// segmentNotifyPayload 是推送给 Vision 的段通知(Sidecar 模式)。
+// Vision 收到后根据 file_path 直读共享文件系统上的文件(零拷贝)。
+type segmentNotifyPayload struct {
+	RecordingID string `json:"recording_id"`
+	CameraID    string `json:"camera_id"`
+	FilePath    string `json:"file_path"` // 相对 storage root
+	Format      string `json:"format"`
+	Encoding    string `json:"encoding"`
+	StartedAt   string `json:"started_at"`
+	EndedAt     string `json:"ended_at"`
+	FileSize    int64  `json:"file_size"`
+}
+
+// Coordinator 订阅 segment.completed 事件,在 Vision 健康时推送段通知。
+//
+// 生命周期:Start(ctx) 启动事件循环,Stop() 取消订阅并等待 goroutine 退出。
+// 线程安全:HealthTracker 读写锁保护;eventBus 的 Subscribe/Unsubscribe 线程安全。
+type Coordinator struct {
+	health   *HealthTracker
+	eventBus *event.EventBus
+	eventCh  chan event.Event
+	cfg      func() config.VisionConfig
+	client   *http.Client
+	wg       sync.WaitGroup
+	cancelFn context.CancelFunc
+	mu       sync.Mutex // 保护 cancelFn
+}
+
+// NewCoordinator 创建推送协调器。
+// cfg 是闭包形式的配置访问器,确保 NVR 热加载配置时能读到最新值。
+func NewCoordinator(cfg func() config.VisionConfig, eventBus *event.EventBus) *Coordinator {
+	vcfg := cfg()
+	return &Coordinator{
+		health:   NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
+		eventBus: eventBus,
+		cfg:      cfg,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Health 返回 HealthTracker,供 API handler 记录心跳。
+func (c *Coordinator) Health() *HealthTracker {
+	return c.health
+}
+
+// Start 订阅 segment.completed 并启动事件处理循环。
+func (c *Coordinator) Start(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+	c.eventCh = make(chan event.Event, 64)
+	if err := c.eventBus.Subscribe(event.TopicSegmentCompleted, c.eventCh, 0); err != nil {
+		return fmt.Errorf("vision coordinator subscribe segment.completed: %w", err)
+	}
+
+	c.mu.Lock()
+	ctx, c.cancelFn = context.WithCancel(ctx)
+	c.mu.Unlock()
+
+	c.wg.Add(1)
+	go c.eventLoop(ctx)
+	slog.Info("vision coordinator started",
+		"push_mode", c.cfg().PushMode,
+		"vision_url", c.cfg().URL)
+	return nil
+}
+
+// Stop 取消订阅并等待事件循环退出。
+func (c *Coordinator) Stop() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	if c.cancelFn != nil {
+		c.cancelFn()
+	}
+	c.mu.Unlock()
+	if c.eventBus != nil && c.eventCh != nil {
+		c.eventBus.Unsubscribe(event.TopicSegmentCompleted, c.eventCh)
+	}
+	c.wg.Wait()
+	slog.Info("vision coordinator stopped")
+}
+
+func (c *Coordinator) eventLoop(ctx context.Context) {
+	defer c.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt := <-c.eventCh:
+			seg, ok := evt.Data.(event.SegmentCompleted)
+			if !ok {
+				continue
+			}
+			c.handleSegment(ctx, seg)
+		}
+	}
+}
+
+// handleSegment 处理一个段完成事件:检查配置 + 健康状态,然后推送通知。
+func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentCompleted) {
+	vcfg := c.cfg()
+	if !vcfg.Enabled || vcfg.URL == "" {
+		return
+	}
+	if !c.health.IsHealthy() {
+		slog.Debug("vision not healthy, skip push",
+			"recording_id", seg.RecordingID)
+		return
+	}
+
+	// 跳过 timelapse 格式(Vision 不处理)。
+	if seg.Format == "timelapse" {
+		return
+	}
+
+	payload := segmentNotifyPayload{
+		RecordingID: seg.RecordingID,
+		CameraID:    seg.CameraID,
+		FilePath:    seg.FilePath,
+		Format:      seg.Format,
+		Encoding:    seg.Encoding,
+		StartedAt:   seg.StartedAt,
+		EndedAt:     seg.EndedAt,
+		FileSize:    seg.FileSize,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		slog.Error("marshal segment notify", "error", err)
+		return
+	}
+
+	url := strings.TrimRight(vcfg.URL, "/") + "/vision/segment/notify"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		slog.Error("create push request", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		slog.Warn("push segment to vision failed",
+			"error", err,
+			"recording_id", seg.RecordingID)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		slog.Warn("vision returned non-success status",
+			"status", resp.StatusCode,
+			"recording_id", seg.RecordingID)
+	} else {
+		slog.Debug("pushed segment to vision",
+			"recording_id", seg.RecordingID,
+			"camera_id", seg.CameraID)
+	}
+}

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -156,7 +157,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	req.Header.Set("X-Encoding", seg.Encoding)
 	req.Header.Set("X-Started-At", seg.StartedAt)
 	req.Header.Set("X-Ended-At", seg.EndedAt)
-	req.Header.Set("X-File-Size", fmt.Sprintf("%d", seg.FileSize))
+	req.Header.Set("X-File-Size", strconv.FormatInt(seg.FileSize, 10))
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -1,0 +1,61 @@
+package vision
+
+import (
+	"sync"
+	"time"
+)
+
+// HeartbeatStatus 是 Vision 心跳报告中携带的状态信息。
+type HeartbeatStatus struct {
+	Status         string `json:"status"`          // "healthy"
+	Device         string `json:"device"`          // "cuda" / "cpu"
+	QueueDepth     int    `json:"queue_depth"`     // 待处理段数
+	ProcessedCount int    `json:"processed_count"` // 累计已处理段数
+}
+
+// HealthTracker 追踪 Vision 的心跳健康状态。
+//
+// NVR 的推送协调器在推送段之前检查 IsHealthy()——只在 Vision 健康时推送,
+// 避免向不可用的 Vision 发请求。Vision 恢复后,心跳恢复,推送自动续上。
+type HealthTracker struct {
+	mu       sync.RWMutex
+	lastSeen time.Time
+	status   HeartbeatStatus
+	timeout  time.Duration
+}
+
+// NewHealthTracker 创建健康追踪器。timeoutSecs ≤ 0 时默认 60 秒。
+func NewHealthTracker(timeoutSecs int) *HealthTracker {
+	if timeoutSecs <= 0 {
+		timeoutSecs = 60
+	}
+	return &HealthTracker{
+		timeout: time.Duration(timeoutSecs) * time.Second,
+	}
+}
+
+// RecordHeartbeat 记录一次 Vision 心跳。
+func (h *HealthTracker) RecordHeartbeat(status HeartbeatStatus) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastSeen = time.Now()
+	h.status = status
+}
+
+// IsHealthy 返回 Vision 是否健康(最近 timeout 内收到过心跳)。
+func (h *HealthTracker) IsHealthy() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.lastSeen.IsZero() {
+		return false
+	}
+	return time.Since(h.lastSeen) < h.timeout
+}
+
+// Snapshot 返回当前健康状态、最后心跳时间和状态详情。
+func (h *HealthTracker) Snapshot() (healthy bool, lastSeen time.Time, status HeartbeatStatus) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	healthy = !h.lastSeen.IsZero() && time.Since(h.lastSeen) < h.timeout
+	return healthy, h.lastSeen, h.status
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -263,6 +263,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	if cfg.Vision.Enabled {
 		deps.visionMgr = vision.NewCoordinator(
 			func() config.VisionConfig { return cfg.Vision },
+			func() string { return cfg.Storage.RootDir },
 			deps.eventBus,
 		)
 		slog.Info("Vision push integration enabled",

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/upload"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webdav"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
@@ -255,6 +256,19 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		}
 	}
 	deps.transcodeMgr = transcodeMgr
+
+	// Step 5.6: Vision push coordinator (NVR → MiBeeVision active push).
+	// Subscribes to segment.completed; pushes segment info to Vision when healthy.
+	// Only active when [vision].enabled = true AND Vision sends heartbeats.
+	if cfg.Vision.Enabled {
+		deps.visionMgr = vision.NewCoordinator(
+			func() config.VisionConfig { return cfg.Vision },
+			deps.eventBus,
+		)
+		slog.Info("Vision push integration enabled",
+			"url", cfg.Vision.URL,
+			"push_mode", cfg.Vision.PushMode)
+	}
 
 	// Load display timezone for merge window alignment and camera scheduling.
 	appLoc := time.Local // Default: use server's local timezone
@@ -629,6 +643,9 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		handler.SetTimelapseMergeMgr(deps.rollingMergeMgr)
 	}
 	handler.SetRollingMergeMgr(deps.recordRollingMergeMgr)
+	if deps.visionMgr != nil {
+		handler.SetVisionCoordinator(deps.visionMgr)
+	}
 	// Wire AI handler (config + zones only, no backend inference)
 	aiMgr := ai.NewManager(aiConfigFromConfig(cfg.AI), deps.eventBus)
 	ah := api.NewAIHandler(aiMgr, cfg, configPath)

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 )
@@ -60,6 +61,7 @@ type appDeps struct {
 	transcodeMgr          *transcoding.TranscodeManager
 	rollingMergeMgr       *timelapse.RollingMergeManager // timelapse rolling merge (wired to API handler)
 	mergeScheduler        *timelapse.MergeScheduler
+	visionMgr             *vision.Coordinator             // NVR→Vision push coordinator
 
 	// Camera + health + relay
 	camMgr    *camera.CameraManager

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -57,11 +57,11 @@ type appDeps struct {
 
 	// Merge / transcode / timelapse
 	mergeMgr              *merge.MergeManager
-	recordRollingMergeMgr *merge.RollingMergeCoordinator // quasi-real-time merge (registered as "rolling-merge" service)
+	recordRollingMergeMgr *merge.RollingMergeCoordinator  // quasi-real-time merge (registered as "rolling-merge" service)
 	transcodeMgr          *transcoding.TranscodeManager
 	rollingMergeMgr       *timelapse.RollingMergeManager // timelapse rolling merge (wired to API handler)
 	mergeScheduler        *timelapse.MergeScheduler
-	visionMgr             *vision.Coordinator             // NVR→Vision push coordinator
+	visionMgr             *vision.Coordinator // NVR→Vision push coordinator
 
 	// Camera + health + relay
 	camMgr    *camera.CameraManager

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -57,7 +57,7 @@ type appDeps struct {
 
 	// Merge / transcode / timelapse
 	mergeMgr              *merge.MergeManager
-	recordRollingMergeMgr *merge.RollingMergeCoordinator  // quasi-real-time merge (registered as "rolling-merge" service)
+	recordRollingMergeMgr *merge.RollingMergeCoordinator // quasi-real-time merge (registered as "rolling-merge" service)
 	transcodeMgr          *transcoding.TranscodeManager
 	rollingMergeMgr       *timelapse.RollingMergeManager // timelapse rolling merge (wired to API handler)
 	mergeScheduler        *timelapse.MergeScheduler

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -167,6 +167,28 @@ func registerServices(a *App, deps *appDeps) error {
 		}
 	}
 
+	// 4.2. vision-push — NVR→Vision segment push coordinator (optional)
+	if deps.visionMgr != nil {
+		var visionCancel context.CancelFunc
+		if err := a.Register(&serviceFunc{
+			name: "vision-push",
+			startFunc: func(ctx context.Context) error {
+				var runCtx context.Context
+				runCtx, visionCancel = context.WithCancel(ctx)
+				return deps.visionMgr.Start(runCtx)
+			},
+			stopFunc: func() error {
+				if visionCancel != nil {
+					visionCancel()
+				}
+				deps.visionMgr.Stop()
+				return nil
+			},
+		}); err != nil {
+			return fmt.Errorf("register vision-push: %w", err)
+		}
+	}
+
 	// 5. transcode (optional)
 	if deps.transcodeMgr != nil {
 		if err := a.Register(&serviceFunc{


### PR DESCRIPTION
## 概述

NVR 侧三项改动，支持与外部 AI 后端（post-processing consumer）的主动推送集成：

### 1. 心跳健康追踪 + 推送协调器
- `POST /api/vision/heartbeat`（公开端点）：外部 AI 消费者周期上报健康状态（device/queue_depth/processed）
- `GET /api/vision/status`（认证端点）：查询最近心跳与健康判定
- `internal/vision.Coordinator`：订阅 `segment.completed`，**仅在消费者健康时**把段文件字节流直接 POST 给消费者（显式 Content-Length，支持绝对/相对路径）；心跳超时（默认 60s）自动暂停，恢复后自动续推
- 新配置段 `[vision]`: `enabled / url / heartbeat_timeout_secs / push_mode`
- 向后兼容：`enabled=false` 时行为与原先完全一致（SSE 模式）

### 2. AI 事件合并迁移（bug 修复）
`MergeAndReplaceRecordings` / `RollingReplaceRecordings` 合并录像时，事务内执行 `UPDATE ai_events SET recording_id = <merged_id> WHERE recording_id IN (<old_ids>)`——修复了此前合并后 AI 事件成为孤儿（指向已删除段）的问题。含 2 个单元测试。

### 3. `cleanup` CLI 子命令
`mibee-nvr cleanup --config <yaml> --before YYYY-MM-DD [--dry-run]`：删除指定日期前录像（文件+DB 行+关联 AI 事件）。实战验证：清理 27,918 个孤儿文件、释放 1.1TB。

## 测试
- `go test ./internal/storage/...`（事件迁移）
- 生产环境已运行 24h+：心跳/推送/事件迁移全链路验证，零 404、零队列丢弃