### PR TITLE
feat(playback): 录像连续播放 Phase 2 — 按需 fMP4 分片器 + 全天 VOD HLS 时间轴 (#321)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vod"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 	"github.com/go-chi/chi/v5"
@@ -164,6 +165,10 @@ type Handler struct {
 	gb28181Catalog    *gb28181.CatalogController
 	gb28181Inviter    GB28181InviteSender
 	gb28181Bye        GB28181ByeSender
+	// vodMgr serves the on-demand HLS VOD fragmenter for recording playback
+	// (#321 Phase 2). Self-contained (owns its segment cache) — constructed
+	// here rather than threaded through NewHandler's positional params.
+	vodMgr *vod.Manager
 }
 
 // frameListEntry is a cached sorted listing of a frame directory.
@@ -179,7 +184,7 @@ type frameListEntry struct {
 const frameListCacheTTL = 500 * time.Millisecond
 
 func NewHandler(db *storage.DB, store *storage.Manager, authMW func(http.Handler) http.Handler, cfg *config.Config, camMgr *camera.CameraManager, hlsMgr *hls.Manager, configPath string, mergeMgr *merge.MergeManager, cloudProxy CloudAuthProxy, mergeScheduler *timelapse.MergeScheduler, gb28181DeviceMgr *gb28181.DeviceManager, gb28181SessionMgr *gb28181.SessionManager) *Handler {
-	return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler, gb28181DeviceMgr: gb28181DeviceMgr, gb28181SessionMgr: gb28181SessionMgr}
+	return &Handler{db: db, store: store, authMW: authMW, config: cfg, camMgr: camMgr, hlsMgr: hlsMgr, configPath: configPath, snapshots: make(map[string]*snapshotCache), frameListCache: make(map[string]*frameListEntry), mergeMgr: mergeMgr, cloudProxy: cloudProxy, mergeScheduler: mergeScheduler, gb28181DeviceMgr: gb28181DeviceMgr, gb28181SessionMgr: gb28181SessionMgr, vodMgr: vod.NewManager()}
 }
 
 // startMergeGoroutine launches fn on a tracked background goroutine using the
@@ -300,6 +305,11 @@ func (h *Handler) registerAnonymousRoutes(r chi.Router) {
 	r.Get("/api/recordings/{id}/merged", h.handleMergedRecording)      // Public for timelapse video playback
 	r.Head("/api/recordings/{id}/merged", h.handleMergedRecording)     // HEAD for browser <video> probe
 	r.Get("/models/{filename}", h.handleServeModel)                    // Public for browser-side AI model loading
+	// VOD HLS recording playback (#321) — same exposure class as /download:
+	// hls.js requests these same-origin without auth headers, and they serve
+	// the same media bytes /download already exposes.
+	r.Get("/api/cameras/{cameraID}/playback/playlist.m3u8", h.handlePlaybackPlaylist)
+	r.Get("/api/cameras/{cameraID}/playback/{recordingID}/{segName}", h.handlePlaybackSegment)
 }
 
 // --- Helpers ---

--- a/internal/api/handlers_vod.go
+++ b/internal/api/handlers_vod.go
@@ -142,14 +142,16 @@ func (h *Handler) handlePlaybackSegment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Re-derive the fragment plan and locate the requested fragment. The plan
-	// is deterministic, so this both validates the range and reproduces the
-	// exact audio alignment/timing the playlist was generated with.
+	// Look up the cached fragment plan and locate the requested fragment.
 	var frag *vod.Fragment
-	for _, f := range vod.PlanFragments(info, h.vodMgr.TargetSec()) {
-		if f.First == first && f.End == end {
-			ff := f
-			frag = &ff
+	frags, _, err := h.vodMgr.Fragments(*rec)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "plan fragments: "+err.Error())
+		return
+	}
+	for i := range frags {
+		if frags[i].First == first && frags[i].End == end {
+			frag = &frags[i]
 			break
 		}
 	}

--- a/internal/api/handlers_vod.go
+++ b/internal/api/handlers_vod.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"encoding/binary"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vod"
+)
+
+// VOD HLS playback endpoints (#321 Phase 2). Same exposure class as
+// /api/recordings/{id}/download: public (anonymous) because <video>/hls.js
+// request them same-origin without auth headers, and the bytes they serve are
+// the same media the download route already exposes.
+//
+//	GET /api/cameras/{cameraID}/playback/playlist.m3u8?start=&end=
+//	GET /api/cameras/{cameraID}/playback/{recordingID}/init.mp4
+//	GET /api/cameras/{cameraID}/playback/{recordingID}/f{first}-{end}.m4s
+
+// maxVodSpan limits the playlist window. One day is the UI's unit; two days
+// headroom for timezone edges without unbounded parse work.
+const maxVodSpan = 48 * time.Hour
+
+var vodSegmentName = regexp.MustCompile(`^f(\d+)-(\d+)\.m4s$`)
+
+// handlePlaybackPlaylist renders the VOD M3U8 for a camera + time range.
+func (h *Handler) handlePlaybackPlaylist(w http.ResponseWriter, r *http.Request) {
+	cameraID := chi.URLParam(r, "cameraID")
+	q := r.URL.Query()
+	startStr, endStr := q.Get("start"), q.Get("end")
+	if startStr == "" || endStr == "" {
+		WriteError(w, http.StatusBadRequest, "start and end (RFC3339) are required")
+		return
+	}
+	start, err := time.Parse(time.RFC3339, startStr)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid start: "+err.Error())
+		return
+	}
+	end, err := time.Parse(time.RFC3339, endStr)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid end: "+err.Error())
+		return
+	}
+	if !end.After(start) {
+		WriteError(w, http.StatusBadRequest, "end must be after start")
+		return
+	}
+	if end.Sub(start) > maxVodSpan {
+		WriteError(w, http.StatusBadRequest, "range exceeds 48h")
+		return
+	}
+
+	recs, err := h.db.ListRecordings(r.Context(), model.RecordingFilter{
+		CameraID:  cameraID,
+		StartTime: start,
+		EndTime:   end,
+		Formats:   []model.Format{model.FormatH264, model.FormatH265},
+		Limit:     200,
+		SortBy:    "started_at",
+		SortOrder: "asc",
+	})
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "list recordings: "+err.Error())
+		return
+	}
+	if len(recs) == 0 {
+		WriteError(w, http.StatusNotFound, "no video recordings in range")
+		return
+	}
+
+	playlist, count, err := h.vodMgr.BuildPlaylist(cameraID, recs)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "build playlist: "+err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+	// Fragments/init are immutable per recording ID, but the playlist itself
+	// shifts as rolling merges replace recordings — keep it revalidatable.
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Vod-Recordings", strconv.Itoa(count))
+	_, _ = w.Write([]byte(playlist))
+}
+
+// handlePlaybackSegment serves a recording's init segment (init.mp4) or one
+// media fragment (f{first}-{end}.m4s, half-open sample range).
+func (h *Handler) handlePlaybackSegment(w http.ResponseWriter, r *http.Request) {
+	cameraID := chi.URLParam(r, "cameraID")
+	recordingID := chi.URLParam(r, "recordingID")
+	segName := chi.URLParam(r, "segName")
+
+	rec, err := h.db.GetRecording(r.Context(), recordingID)
+	if err != nil || rec == nil {
+		WriteError(w, http.StatusNotFound, "recording not found")
+		return
+	}
+	if rec.CameraID != cameraID {
+		WriteError(w, http.StatusNotFound, "recording not found")
+		return
+	}
+	if rec.Format != model.FormatH264 && rec.Format != model.FormatH265 {
+		WriteError(w, http.StatusNotFound, "recording is not video-playable")
+		return
+	}
+
+	info, err := h.vodMgr.GetInfo(*rec)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "parse recording: "+err.Error())
+		return
+	}
+
+	if segName == "init.mp4" {
+		initSeg, err := vod.BuildInitSegment(info, vod.IncludeAudio(info))
+		if err != nil {
+			WriteError(w, http.StatusInternalServerError, "build init segment: "+err.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "video/mp4")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		w.Header().Set("Content-Length", strconv.Itoa(len(initSeg)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(initSeg)
+		return
+	}
+
+	m := vodSegmentName.FindStringSubmatch(segName)
+	if m == nil {
+		WriteError(w, http.StatusNotFound, "unknown segment")
+		return
+	}
+	first, err1 := strconv.Atoi(m[1])
+	end, err2 := strconv.Atoi(m[2])
+	if err1 != nil || err2 != nil {
+		WriteError(w, http.StatusBadRequest, "bad segment range")
+		return
+	}
+
+	// Re-derive the fragment plan and locate the requested fragment. The plan
+	// is deterministic, so this both validates the range and reproduces the
+	// exact audio alignment/timing the playlist was generated with.
+	var frag *vod.Fragment
+	for _, f := range vod.PlanFragments(info, h.vodMgr.TargetSec()) {
+		if f.First == first && f.End == end {
+			ff := f
+			frag = &ff
+			break
+		}
+	}
+	if frag == nil {
+		WriteError(w, http.StatusNotFound, "segment not in current playlist (playlist may be stale)")
+		return
+	}
+
+	data, err := vod.BuildFragment(info, *frag, uint32(frag.First), vod.IncludeAudio(info))
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "build fragment: "+err.Error())
+		return
+	}
+
+	src, err := os.Open(info.FilePath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "open recording file: "+err.Error())
+		return
+	}
+	defer src.Close()
+
+	w.Header().Set("Content-Type", "video/mp4")
+	// A fragment for a given recording ID + sample range is immutable.
+	w.Header().Set("Cache-Control", "public, max-age=86400, immutable")
+	w.Header().Set("Content-Length", strconv.FormatInt(data.TotalBytes, 10))
+	w.WriteHeader(http.StatusOK)
+
+	if _, err := w.Write(data.Moof); err != nil {
+		return
+	}
+	mdatBytes := data.TotalBytes - int64(len(data.Moof)) - 8
+	var mdatHeader [8]byte
+	binary.BigEndian.PutUint32(mdatHeader[0:4], uint32(mdatBytes+8))
+	copy(mdatHeader[4:8], "mdat")
+	if _, err := w.Write(mdatHeader[:]); err != nil {
+		return
+	}
+
+	buf := make([]byte, 1<<20)
+	for _, ranges := range [][]vod.ByteRange{data.VideoRanges, data.AudioRanges} {
+		for _, br := range ranges {
+			if _, err := io.CopyBuffer(w, io.NewSectionReader(src, br.Offset, br.Size), buf); err != nil {
+				return // client went away mid-stream
+			}
+		}
+	}
+}

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -150,9 +150,12 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		videoTrack.width, videoTrack.height = uint16(w), uint16(h)
 	}
 	// Populate placeholder samples so the size calculation includes per-sample tables.
+	// Keyframes marked true on EVERY placeholder sample: the real pass writes
+	// fewer-or-equal stss entries, so the reserved moov always fits.
 	videoTrack.samples = make([]mergedSample, totalVideoSamples)
 	for i := range videoTrack.samples {
 		videoTrack.samples[i].duration = 33 // placeholder
+		videoTrack.samples[i].isKeyFrame = true
 	}
 	// Build audio track placeholder for size calculation.
 	var audioTrack *mergeTrack
@@ -744,6 +747,32 @@ func writeMergeStbl(w *mp4.Writer, tr *mergeTrack, chunkOffset int64) error {
 		return err
 	}
 	_ = bi8
+
+	// stss — sync sample table (1-indexed). Lets parsers (VOD fragmenter, other
+	// players) find keyframes without probing media bytes. Written whenever any
+	// keyframe exists — including the all-sync case — so the SIZE-estimation
+	// pass (which marks every placeholder sample as a keyframe = worst case)
+	// never under-reserves the moov.
+	var syncSamples []uint32
+	for i, s := range samples {
+		if s.isKeyFrame {
+			syncSamples = append(syncSamples, uint32(i+1))
+		}
+	}
+	if len(syncSamples) > 0 {
+		biSS, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stss")})
+		if err != nil {
+			return err
+		}
+		stss := &mp4.Stss{EntryCount: uint32(len(syncSamples)), SampleNumber: syncSamples}
+		if _, err := mp4.Marshal(w, stss, mp4.Context{}); err != nil {
+			return err
+		}
+		if _, err := w.EndBox(); err != nil {
+			return err
+		}
+		_ = biSS
+	}
 
 	// stco or co64 — single chunk at chunkOffset.
 	if uint64(chunkOffset) > math.MaxUint32 {

--- a/internal/merge/parser.go
+++ b/internal/merge/parser.go
@@ -24,6 +24,11 @@ type SegmentInfo struct {
 	MdatSize      int64 // total mdat box size including header
 	Samples       []SampleEntry
 	FilePath      string // source file path for data reading
+	// KeyframesFromStss reports that Samples' IsKeyFrame flags were populated
+	// from the file's sync-sample table (complete + exact). False means the
+	// flags were NOT probed (ParseSegmentNoProbe on an stss-less file) and the
+	// caller must derive keyframes itself.
+	KeyframesFromStss bool
 
 	// Audio track fields (populated when segment contains audio).
 	HasAudio         bool
@@ -66,11 +71,27 @@ type trackAccum struct {
 	stscEntries []mp4.StscEntry
 	stcoOffsets []uint32
 	co64Offsets []uint64
+	stssSamples []uint32 // sync-sample numbers (1-indexed), when present
 }
 
 // ParseSegment reads an MP4 file and extracts codec config, sample tables,
-// and mdat location. Uses file seeking — does not load the entire file.
+// and mdat location, including per-sample keyframe flags (from stss when the
+// file has one, else by probing each sample's first NAL header byte).
+// Uses file seeking — does not load the entire file.
 func ParseSegment(filePath string) (*SegmentInfo, error) {
+	return parseSegment(filePath, true)
+}
+
+// ParseSegmentNoProbe is ParseSegment WITHOUT the byte-probing keyframe pass:
+// IsKeyFrame is only filled when the file carries a sync-sample table (stss).
+// For stss-less files the caller owns keyframe detection (e.g. the VOD
+// fragmenter probes lazily at candidate cut points instead of scanning the
+// whole media data — a full probe pass costs minutes on slow spinning disks).
+func ParseSegmentNoProbe(filePath string) (*SegmentInfo, error) {
+	return parseSegment(filePath, false)
+}
+
+func parseSegment(filePath string, probeKeyframes bool) (*SegmentInfo, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("open: %w", err)
@@ -184,6 +205,9 @@ func ParseSegment(filePath string) (*SegmentInfo, error) {
 		case *mp4.Stsc:
 			current.stscEntries = b.Entries
 
+		case *mp4.Stss:
+			current.stssSamples = b.SampleNumber
+
 		case *mp4.Stco:
 			current.stcoOffsets = b.ChunkOffset
 
@@ -263,9 +287,19 @@ func ParseSegment(filePath string) (*SegmentInfo, error) {
 		return nil, fmt.Errorf("build video samples: %w", err)
 	}
 
-	// Detect keyframes in video samples.
-	if err := detectKeyframes(f, videoSamples, videoTrack.codec); err != nil {
-		return nil, fmt.Errorf("detect keyframes: %w", err)
+	// Detect keyframes in video samples. A sync-sample table (stss) is the
+	// fast path — no media bytes need to be read. Without stss, byte-probe
+	// each sample's first NAL header (sequential windowed reads) — skippable
+	// via ParseSegmentNoProbe for callers with their own lazy strategy.
+	keyframesFromStss := len(videoTrack.stssSamples) > 0
+	if keyframesFromStss {
+		if err := markKeyframesFromStss(videoSamples, videoTrack.stssSamples); err != nil {
+			return nil, fmt.Errorf("mark keyframes from stss: %w", err)
+		}
+	} else if probeKeyframes {
+		if err := detectKeyframes(f, videoSamples, videoTrack.codec); err != nil {
+			return nil, fmt.Errorf("detect keyframes: %w", err)
+		}
 	}
 
 	// Validate per-sample bounds.
@@ -296,17 +330,18 @@ func ParseSegment(filePath string) (*SegmentInfo, error) {
 	}
 
 	info := &SegmentInfo{
-		Codec:         videoTrack.codec,
-		SPS:           videoTrack.sps,
-		PPS:           videoTrack.pps,
-		VPS:           videoTrack.vps,
-		Timescale:     videoTrack.timescale,
-		SampleCount:   len(videoSamples),
-		TotalDuration: totalDur,
-		MdatOffset:    mdatOffset,
-		MdatSize:      mdatSize,
-		Samples:       videoSamples,
-		FilePath:      filePath,
+		Codec:            videoTrack.codec,
+		SPS:              videoTrack.sps,
+		PPS:              videoTrack.pps,
+		VPS:              videoTrack.vps,
+		Timescale:        videoTrack.timescale,
+		SampleCount:      len(videoSamples),
+		TotalDuration:    totalDur,
+		MdatOffset:       mdatOffset,
+		MdatSize:         mdatSize,
+		Samples:          videoSamples,
+		FilePath:         filePath,
+		KeyframesFromStss: keyframesFromStss,
 	}
 
 	// Build audio sample entries if audio track present.
@@ -558,40 +593,76 @@ func buildSampleEntries(
 	return samples, nil
 }
 
-// detectKeyframes reads the first few bytes of each sample's NAL data
-// to determine if it's a keyframe (IDR for H.264, IRAP for H.265).
+// markKeyframesFromStss sets IsKeyFrame from a sync-sample table (1-indexed
+// sample numbers). Out-of-range entries are an error — a corrupt stss must not
+// silently produce a wrong keyframe map.
+func markKeyframesFromStss(samples []SampleEntry, stssSamples []uint32) error {
+	n := uint32(len(samples))
+	for _, num := range stssSamples {
+		if num < 1 || num > n {
+			return fmt.Errorf("stss entry %d out of range (1..%d)", num, n)
+		}
+		samples[num-1].IsKeyFrame = true
+	}
+	return nil
+}
+
+// detectKeyframes reads the first bytes of each sample's NAL data to determine
+// if it's a keyframe (IDR for H.264, IRAP for H.265).
+//
+// Samples are laid out in ascending file-offset order (per-track chunk layout),
+// so the probe walks the media data sequentially in large windows instead of
+// issuing one tiny ReadAt per sample. A 1-hour recording has ~90k samples —
+// per-sample 6-byte reads cost ~13 CPU-seconds in syscall overhead alone on
+// ARM (verified on the Banana Pi: a 9-file day kept the process in D-state for
+// minutes); windowed 1MB reads cut the syscall count ~200x with identical
+// results.
 func detectKeyframes(f *os.File, samples []SampleEntry, codec string) error {
 	if len(samples) == 0 || codec == "" {
 		return nil
 	}
 
-	// 4-byte NAL length prefix + up to 2 bytes NAL header (H.265 has 2-byte header).
-	buf := make([]byte, 6)
+	const window = 1 << 20
+	buf := make([]byte, window)
+	var winStart, winEnd int64 // file range currently buffered in buf
 
-	for i := range samples {
-		if samples[i].Size < 5 {
-			continue
+	var readErr error
+	probe := func(i int) {
+		s := &samples[i]
+		if s.Size < 5 {
+			return
 		}
-
-		n, err := f.ReadAt(buf, samples[i].Offset)
-		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
-			return fmt.Errorf("read sample %d at offset %d: %w", i, samples[i].Offset, err)
+		off := s.Offset
+		if off < winStart || off+6 > winEnd {
+			n, err := f.ReadAt(buf, off)
+			if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				readErr = fmt.Errorf("read sample %d at offset %d: %w", i, off, err)
+				return
+			}
+			winStart, winEnd = off, off+int64(n)
 		}
-		if n < 5 {
-			continue
+		if off+6 > winEnd {
+			return // short read at EOF — skip this sample
 		}
-
-		// buf[0:4] = NAL length prefix (big-endian).
-		// buf[4] = first byte of NAL unit (for both H.264 and H.265).
+		pos := off - winStart
+		// buf[pos:pos+4] = NAL length prefix (big-endian).
+		// buf[pos+4] = first byte of NAL unit (for both H.264 and H.265).
 		switch codec {
 		case "h264":
-			nalType := buf[4] & 0x1F
-			samples[i].IsKeyFrame = (nalType == 5) || (nalType == 7) || (nalType == 8) // IDR, SPS, or PPS
+			nalType := buf[pos+4] & 0x1F
+			s.IsKeyFrame = (nalType == 5) || (nalType == 7) || (nalType == 8) // IDR, SPS, or PPS
 		case "h265":
 			// H.265 NAL header: forbidden_zero_bit(1) + nal_unit_type(6) + nuh_layer_id(6) + nuh_temporal_id_plus1(3).
 			// Type is in bits 1-6 of the first NAL header byte.
-			nalType := (uint16(buf[4]) >> 1) & 0x3F
-			samples[i].IsKeyFrame = (nalType >= 16 && nalType <= 21) // IRAP: BLA/IDR/CRA
+			nalType := (uint16(buf[pos+4]) >> 1) & 0x3F
+			s.IsKeyFrame = (nalType >= 16 && nalType <= 21) // IRAP: BLA/IDR/CRA
+		}
+	}
+
+	for i := range samples {
+		probe(i)
+		if readErr != nil {
+			return readErr
 		}
 	}
 

--- a/internal/merge/parser.go
+++ b/internal/merge/parser.go
@@ -330,17 +330,17 @@ func parseSegment(filePath string, probeKeyframes bool) (*SegmentInfo, error) {
 	}
 
 	info := &SegmentInfo{
-		Codec:            videoTrack.codec,
-		SPS:              videoTrack.sps,
-		PPS:              videoTrack.pps,
-		VPS:              videoTrack.vps,
-		Timescale:        videoTrack.timescale,
-		SampleCount:      len(videoSamples),
-		TotalDuration:    totalDur,
-		MdatOffset:       mdatOffset,
-		MdatSize:         mdatSize,
-		Samples:          videoSamples,
-		FilePath:         filePath,
+		Codec:             videoTrack.codec,
+		SPS:               videoTrack.sps,
+		PPS:               videoTrack.pps,
+		VPS:               videoTrack.vps,
+		Timescale:         videoTrack.timescale,
+		SampleCount:       len(videoSamples),
+		TotalDuration:     totalDur,
+		MdatOffset:        mdatOffset,
+		MdatSize:          mdatSize,
+		Samples:           videoSamples,
+		FilePath:          filePath,
 		KeyframesFromStss: keyframesFromStss,
 	}
 

--- a/internal/merge/sps_export.go
+++ b/internal/merge/sps_export.go
@@ -1,0 +1,12 @@
+package merge
+
+// SPSResolution parses pixel dimensions from raw SPS bytes. Exported for the
+// VOD fragmenter (init-segment stsd/tkhd need width/height); codec is "h264"
+// or "h265". Thin adapter over the unexported parsers per the repo's adapter
+// convention — existing signatures stay untouched.
+func SPSResolution(codec string, sps []byte) (width, height int, err error) {
+	if codec == "h265" {
+		return parseHEVCSPSResolution(sps)
+	}
+	return parseSPSResolution(sps)
+}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786723453195';
+const CACHE_VERSION = 'mibee-nvr-1786759423308';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786759423308';
+const CACHE_VERSION = '__SW_CACHE_VERSION__';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/internal/vod/cache.go
+++ b/internal/vod/cache.go
@@ -1,0 +1,150 @@
+// Package vod turns recorded MP4 files into a time-addressable HLS VOD
+// stream WITHOUT materializing anything on disk: an on-demand fMP4
+// fragmenter that serves per-recording init segments + keyframe-aligned
+// media fragments, plus the day-level M3U8 playlist that stitches every
+// recording of a camera into one seekable timeline (#321 Phase 2).
+//
+// Design constraints (RPi-class host):
+//   - Sample tables are parsed once per recording and cached (LRU, keyed by
+//     recording ID, invalidated by path/size/mtime). Fragment requests are
+//     then pure box-writing + bounded file copies.
+//   - The media data (mdat) is NEVER fully loaded: fragments reference the
+//     source file's sample byte ranges and stream them through a 1MB buffer.
+//   - Video is the timeline master. Audio is included per fragment only when
+//     the codec is MSE-friendly (AAC/Opus); G.711 is dropped because Chrome's
+//     MediaSource does not accept ulaw/alaw sample entries.
+package vod
+
+import (
+	"container/list"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+var logger = slog.Default().With("component", "vod")
+
+// segmentCache caches parsed sample tables per recording. Parsing a 1-hour
+// recording (~90k samples + per-sample keyframe probes) costs 100–300ms; the
+// day playlist needs every recording parsed once and every fragment request
+// re-uses the same tables, so the cache is what makes this cheap.
+type segmentCache struct {
+	mu      sync.Mutex
+	max     int
+	ll      *list.List // front = most recently used
+	entries map[string]*list.Element
+
+	sf singleflight.Group // collapses concurrent parses of the same recording
+}
+
+type cacheItem struct {
+	rec  model.Recording // snapshot for stat validation
+	info *merge.SegmentInfo
+}
+
+func newSegmentCache(maxEntries int) *segmentCache {
+	if maxEntries < 1 {
+		maxEntries = 1
+	}
+	return &segmentCache{
+		max:     maxEntries,
+		ll:      list.New(),
+		entries: make(map[string]*list.Element),
+	}
+}
+
+// Get returns the parsed SegmentInfo for a recording, parsing (and caching)
+// on miss. Concurrent Gets for the same recording collapse into one parse.
+// The returned pointer is shared — callers MUST NOT mutate it.
+func (c *segmentCache) Get(rec model.Recording) (*merge.SegmentInfo, error) {
+	if rec.FilePath == "" {
+		return nil, fmt.Errorf("recording %s has no file path", rec.ID)
+	}
+
+	c.mu.Lock()
+	if el, ok := c.entries[rec.ID]; ok {
+		item := el.Value.(*cacheItem)
+		if sameFileState(item.rec, rec) {
+			c.ll.MoveToFront(el)
+			c.mu.Unlock()
+			return item.info, nil
+		}
+		// File changed underneath (rolling merge replaced it) — drop the entry.
+		c.ll.Remove(el)
+		delete(c.entries, rec.ID)
+	}
+	c.mu.Unlock()
+
+	v, err, _ := c.sf.Do(rec.ID, func() (any, error) {
+		return parseAndStore(c, rec)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*merge.SegmentInfo), nil
+}
+
+func parseAndStore(c *segmentCache, rec model.Recording) (*merge.SegmentInfo, error) {
+	// Re-check under the key: another goroutine may have stored a fresh entry
+	// between our lock release and the singleflight start.
+	c.mu.Lock()
+	if el, ok := c.entries[rec.ID]; ok {
+		item := el.Value.(*cacheItem)
+		if sameFileState(item.rec, rec) {
+			c.ll.MoveToFront(el)
+			c.mu.Unlock()
+			return item.info, nil
+		}
+		c.ll.Remove(el)
+		delete(c.entries, rec.ID)
+	}
+	c.mu.Unlock()
+
+	info, err := merge.ParseSegment(rec.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", rec.FilePath, err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.entries[rec.ID]; ok { // lost a race with another store
+		item := el.Value.(*cacheItem)
+		if sameFileState(item.rec, rec) {
+			c.ll.MoveToFront(el)
+			return item.info, nil
+		}
+		c.ll.Remove(el)
+		delete(c.entries, rec.ID)
+	}
+	el := c.ll.PushFront(&cacheItem{rec: rec, info: info})
+	c.entries[rec.ID] = el
+	for c.ll.Len() > c.max {
+		oldest := c.ll.Back()
+		if oldest == nil {
+			break
+		}
+		c.ll.Remove(oldest)
+		delete(c.entries, oldest.Value.(*cacheItem).rec.ID)
+	}
+	return info, nil
+}
+
+// sameFileState compares the identity fields used for cache validation.
+func sameFileState(a, b model.Recording) bool {
+	return a.FilePath == b.FilePath && a.FileSize == b.FileSize && a.StartedAt.Equal(b.StartedAt)
+}
+
+// statRecording refreshes file size from disk so cache validation also
+// catches appends to the same path (recordings being actively written are
+// normally excluded by the caller's time filter, this is defense in depth).
+func statRecording(rec *model.Recording) {
+	if fi, err := os.Stat(rec.FilePath); err == nil {
+		rec.FileSize = fi.Size()
+	}
+}

--- a/internal/vod/cache.go
+++ b/internal/vod/cache.go
@@ -106,7 +106,7 @@ func parseAndStore(c *segmentCache, rec model.Recording) (*merge.SegmentInfo, er
 	}
 	c.mu.Unlock()
 
-	info, err := merge.ParseSegment(rec.FilePath)
+	info, err := merge.ParseSegmentNoProbe(rec.FilePath)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", rec.FilePath, err)
 	}

--- a/internal/vod/fragment.go
+++ b/internal/vod/fragment.go
@@ -1,0 +1,334 @@
+package vod
+
+import (
+	"fmt"
+
+	"github.com/abema/go-mp4"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+)
+
+// TargetFragmentDur is the target HLS fragment duration. Fragments always
+// START on a keyframe (recordings are IDR-started by design), so actual
+// durations vary with the camera's GOP length — a fragment is cut at the
+// first keyframe at or after this target.
+const TargetFragmentDur = 6 // seconds
+
+// trun flag bits (ISO/IEC 14496-12 §8.8.8).
+const (
+	trunDataOffsetPresent    = 0x000001
+	trunSampleDurationPresent = 0x000100
+	trunSampleSizePresent     = 0x000200
+	trunSampleFlagsPresent    = 0x000400
+)
+
+// sample flag bits: bit(4..5) sample_depends_on, bit(20) sample_is_non_sync_sample.
+//   keyframe: sample_depends_on=2 (no dependency), sync sample
+//   other:    sample_depends_on=1 (depends on others), non-sync
+const (
+	sampleFlagsKeyframe = 0x02000000
+	sampleFlagsOther    = 0x01010000
+)
+
+// Fragment describes one HLS media segment: a keyframe-aligned video sample
+// range plus the audio samples that overlap it in time. Ranges are half-open
+// [First,End).
+type Fragment struct {
+	First, End int // video sample indices
+	AudioFirst, AudioEnd int // audio sample indices
+
+	StartUnits    uint64 // cumulative video timescale units at First
+	DurationUnits uint64 // total video timescale units in this fragment
+}
+
+// DurationSec returns the fragment duration in (video-timescale) seconds.
+func (f Fragment) DurationSec(timescale uint32) float64 {
+	if timescale == 0 {
+		return 0
+	}
+	return float64(f.DurationUnits) / float64(timescale)
+}
+
+// PlanFragments cuts a recording into keyframe-aligned fragments of ~target
+// seconds. The first fragment starts at sample 0 (recordings begin with an
+// IDR); subsequent fragments start at the first keyframe whose accumulated
+// duration reaches the target. Audio sample ranges are aligned by overlap
+// with each video fragment's time span.
+func PlanFragments(info *merge.SegmentInfo, targetSec float64) []Fragment {
+	n := info.SampleCount
+	if n == 0 || len(info.Samples) == 0 {
+		return nil
+	}
+	ts := float64(info.Timescale)
+	var frags []Fragment
+
+	start := 0
+	var startUnits uint64
+	for start < n {
+		var units uint64
+		end := -1
+		for i := start; i < n; i++ {
+			// Cut BEFORE the keyframe sample i so the fragment covers
+			// [start, i) — sample i's duration belongs to the NEXT fragment.
+			if i > start && info.Samples[i].IsKeyFrame && float64(units)/ts >= targetSec {
+				end = i
+				break
+			}
+			units += uint64(info.Samples[i].Duration)
+		}
+		if end < 0 {
+			end = n // tail fragment
+		}
+		frags = append(frags, Fragment{
+			First: start, End: end,
+			StartUnits:    startUnits,
+			DurationUnits: units,
+		})
+		startUnits += units
+		start = end
+	}
+
+	// Align audio ranges by time overlap.
+	if info.HasAudio && len(info.AudioSamples) > 0 {
+		ats := float64(info.AudioTimescale)
+		var audioUnits uint64
+		ai := 0
+		for k := range frags {
+			fStartSec := float64(frags[k].StartUnits) / ts
+			fEndSec := fStartSec + float64(frags[k].DurationUnits)/ts
+			first := ai
+			for ai < len(info.AudioSamples) {
+				sampleStartSec := float64(audioUnits) / ats
+				if sampleStartSec >= fEndSec {
+					break // belongs to a later fragment
+				}
+				audioUnits += uint64(info.AudioSamples[ai].Duration)
+				ai++
+				_ = sampleStartSec
+			}
+			frags[k].AudioFirst, frags[k].AudioEnd = first, ai
+		}
+	}
+	return frags
+}
+
+// ByteRange is a contiguous byte region of the source MP4 file.
+type ByteRange struct {
+	Offset int64
+	Size   int64
+}
+
+// coalesceRanges merges adjacent sample byte ranges so the mdat streamer does
+// one copy per contiguous run instead of one per sample. Samples within one
+// source chunk are contiguous; chunk breaks (e.g. audio/video interleave)
+// split the runs.
+func coalesceRanges(samples []merge.SampleEntry, first, end int) []ByteRange {
+	if first >= end || first < 0 || end > len(samples) {
+		return nil
+	}
+	ranges := make([]ByteRange, 0, end-first)
+	cur := ByteRange{Offset: samples[first].Offset, Size: int64(samples[first].Size)}
+	for i := first + 1; i < end; i++ {
+		s := samples[i]
+		if cur.Offset+cur.Size == s.Offset {
+			cur.Size += int64(s.Size)
+		} else {
+			ranges = append(ranges, cur)
+			cur = ByteRange{Offset: s.Offset, Size: int64(s.Size)}
+		}
+	}
+	return append(ranges, cur)
+}
+
+// seekableBuffer is an in-memory io.WriteSeeker for mp4.Writer, which seeks
+// BACK to patch box sizes on EndBox — so seeks must not truncate (in-place
+// overwrite semantics, same as internal/merge's bytesWriter).
+type seekableBuffer struct {
+	buf []byte
+	pos int
+}
+
+func (b *seekableBuffer) Write(p []byte) (int, error) {
+	end := b.pos + len(p)
+	if end > len(b.buf) {
+		grown := make([]byte, end)
+		copy(grown, b.buf)
+		b.buf = grown
+	}
+	copy(b.buf[b.pos:], p)
+	b.pos = end
+	return len(p), nil
+}
+
+func (b *seekableBuffer) Seek(offset int64, whence int) (int64, error) {
+	var pos int64
+	switch whence {
+	case 0:
+		pos = offset
+	case 1:
+		pos = int64(b.pos) + offset
+	case 2:
+		pos = int64(len(b.buf)) + offset
+	}
+	if pos < 0 {
+		return 0, fmt.Errorf("seekableBuffer: negative offset %d", pos)
+	}
+	b.pos = int(pos)
+	return pos, nil
+}
+
+func (b *seekableBuffer) Bytes() []byte { return b.buf }
+
+// FragmentData is the assembled response for one media segment: the moof box
+// bytes followed by the mdat header + sample payload (streamed by the caller
+// from ByteRanges of the source file).
+type FragmentData struct {
+	Moof        []byte
+	VideoRanges []ByteRange
+	AudioRanges []ByteRange
+	TotalBytes  int64 // moof + mdat header + all range bytes (for Content-Length)
+}
+
+// BuildFragment assembles the moof for one fragment. data_offset fields need
+// the final moof size, which itself does not depend on their VALUES — so the
+// box tree is serialized twice (measure, then fill).
+func BuildFragment(info *merge.SegmentInfo, frag Fragment, sequenceNumber uint32, includeAudio bool) (*FragmentData, error) {
+	if frag.First < 0 || frag.End > info.SampleCount || frag.First >= frag.End {
+		return nil, fmt.Errorf("fragment sample range [%d,%d) out of bounds (0,%d)", frag.First, frag.End, info.SampleCount)
+	}
+
+	videoRanges := coalesceRanges(info.Samples, frag.First, frag.End)
+	var videoBytes int64
+	for _, r := range videoRanges {
+		videoBytes += r.Size
+	}
+
+	includeAudio = includeAudio && info.HasAudio && frag.AudioEnd > frag.AudioFirst
+	var audioRanges []ByteRange
+	var audioBytes int64
+	var audioStartUnits uint64
+	if includeAudio {
+		audioRanges = coalesceRanges(info.AudioSamples, frag.AudioFirst, frag.AudioEnd)
+		for _, r := range audioRanges {
+			audioBytes += r.Size
+		}
+		for i := 0; i < frag.AudioFirst; i++ {
+			audioStartUnits += uint64(info.AudioSamples[i].Duration)
+		}
+	}
+
+	build := func(videoOffset, audioOffset int32) ([]byte, error) {
+		buf := &seekableBuffer{}
+		w := mp4.NewWriter(buf)
+		if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("moof")}); err != nil {
+			return nil, err
+		}
+		// mfhd
+		if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mfhd")}); err != nil {
+			return nil, err
+		}
+		if _, err := mp4.Marshal(w, &mp4.Mfhd{SequenceNumber: sequenceNumber}, mp4.Context{}); err != nil {
+			return nil, err
+		}
+		if _, err := w.EndBox(); err != nil {
+			return nil, err
+		}
+		// video traf
+		if err := writeTraf(w, 1, frag.StartUnits, info.Samples[frag.First:frag.End], videoOffset, true); err != nil {
+			return nil, fmt.Errorf("video traf: %w", err)
+		}
+		if includeAudio {
+			if err := writeTraf(w, 2, audioStartUnits, info.AudioSamples[frag.AudioFirst:frag.AudioEnd], audioOffset, false); err != nil {
+				return nil, fmt.Errorf("audio traf: %w", err)
+			}
+		}
+		if _, err := w.EndBox(); err != nil { // moof
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
+	// Pass 1: measure with zero offsets; pass 2: fill real offsets.
+	moof, err := build(0, 0)
+	if err != nil {
+		return nil, err
+	}
+	moofSize := int32(len(moof))
+	moof, err = build(moofSize+8, moofSize+8+int32(videoBytes))
+	if err != nil {
+		return nil, err
+	}
+	if int32(len(moof)) != moofSize {
+		return nil, fmt.Errorf("moof size changed between passes: %d vs %d", len(moof), moofSize)
+	}
+
+	return &FragmentData{
+		Moof:        moof,
+		VideoRanges: videoRanges,
+		AudioRanges: audioRanges,
+		TotalBytes:  int64(len(moof)) + 8 + videoBytes + audioBytes,
+	}, nil
+}
+
+// writeTraf writes one track fragment: tfhd (default-base-is-moof), tfdt
+// (v1, 64-bit base decode time), trun (per-sample duration/size/flags +
+// data offset). Keyframe flags mark sync samples for the video track.
+func writeTraf(w *mp4.Writer, trackID uint32, baseUnits uint64, samples []merge.SampleEntry, dataOffset int32, video bool) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("traf")}); err != nil {
+		return err
+	}
+	// tfhd
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tfhd")}); err != nil {
+		return err
+	}
+	tfhd := &mp4.Tfhd{TrackID: trackID}
+	tfhd.SetFlags(mp4.TfhdDefaultBaseIsMoof)
+	if _, err := mp4.Marshal(w, tfhd, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	// tfdt (version 1 = 64-bit)
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tfdt")}); err != nil {
+		return err
+	}
+	tfdt := &mp4.Tfdt{BaseMediaDecodeTimeV1: baseUnits}
+	tfdt.SetVersion(1)
+	if _, err := mp4.Marshal(w, tfdt, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	// trun
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trun")}); err != nil {
+		return err
+	}
+	entries := make([]mp4.TrunEntry, len(samples))
+	for i, s := range samples {
+		flag := uint32(sampleFlagsOther)
+		if !video || s.IsKeyFrame {
+			flag = sampleFlagsKeyframe
+		}
+		entries[i] = mp4.TrunEntry{
+			SampleDuration: s.Duration,
+			SampleSize:     s.Size,
+			SampleFlags:    flag,
+		}
+	}
+	trun := &mp4.Trun{
+		SampleCount: uint32(len(samples)),
+		DataOffset:  dataOffset,
+		Entries:     entries,
+	}
+	trun.SetFlags(trunDataOffsetPresent | trunSampleDurationPresent | trunSampleSizePresent | trunSampleFlagsPresent)
+	if _, err := mp4.Marshal(w, trun, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox() // traf
+	return err
+}

--- a/internal/vod/fragment.go
+++ b/internal/vod/fragment.go
@@ -16,15 +16,16 @@ const TargetFragmentDur = 6 // seconds
 
 // trun flag bits (ISO/IEC 14496-12 §8.8.8).
 const (
-	trunDataOffsetPresent    = 0x000001
+	trunDataOffsetPresent     = 0x000001
 	trunSampleDurationPresent = 0x000100
 	trunSampleSizePresent     = 0x000200
 	trunSampleFlagsPresent    = 0x000400
 )
 
 // sample flag bits: bit(4..5) sample_depends_on, bit(20) sample_is_non_sync_sample.
-//   keyframe: sample_depends_on=2 (no dependency), sync sample
-//   other:    sample_depends_on=1 (depends on others), non-sync
+//
+//	keyframe: sample_depends_on=2 (no dependency), sync sample
+//	other:    sample_depends_on=1 (depends on others), non-sync
 const (
 	sampleFlagsKeyframe = 0x02000000
 	sampleFlagsOther    = 0x01010000
@@ -34,7 +35,7 @@ const (
 // range plus the audio samples that overlap it in time. Ranges are half-open
 // [First,End).
 type Fragment struct {
-	First, End int // video sample indices
+	First, End           int // video sample indices
 	AudioFirst, AudioEnd int // audio sample indices
 
 	StartUnits    uint64 // cumulative video timescale units at First
@@ -107,7 +108,7 @@ func PlanFragments(info *merge.SegmentInfo, targetSec float64, oracle keyframeOr
 		ai := 0
 		for k := range frags {
 			fStartSec := float64(frags[k].StartUnits) / ts
-			fEndSec := fStartSec + float64(frags[k].DurationUnits) / ts
+			fEndSec := fStartSec + float64(frags[k].DurationUnits)/ts
 			first := ai
 			for ai < len(info.AudioSamples) {
 				sampleStartSec := float64(audioUnits) / ats
@@ -223,7 +224,7 @@ func BuildFragment(info *merge.SegmentInfo, frag Fragment, sequenceNumber uint32
 		for _, r := range audioRanges {
 			audioBytes += r.Size
 		}
-		for i := 0; i < frag.AudioFirst; i++ {
+		for i := range frag.AudioFirst {
 			audioStartUnits += uint64(info.AudioSamples[i].Duration)
 		}
 	}

--- a/internal/vod/fragment.go
+++ b/internal/vod/fragment.go
@@ -51,10 +51,11 @@ func (f Fragment) DurationSec(timescale uint32) float64 {
 
 // PlanFragments cuts a recording into keyframe-aligned fragments of ~target
 // seconds. The first fragment starts at sample 0 (recordings begin with an
-// IDR); subsequent fragments start at the first keyframe whose accumulated
-// duration reaches the target. Audio sample ranges are aligned by overlap
-// with each video fragment's time span.
-func PlanFragments(info *merge.SegmentInfo, targetSec float64) []Fragment {
+// IDR); subsequent fragments start at the first keyframe at/after the target
+// duration, as reported by the oracle (exact via stss, stride-probed
+// otherwise). Audio sample ranges are aligned by overlap with each video
+// fragment's time span.
+func PlanFragments(info *merge.SegmentInfo, targetSec float64, oracle keyframeOracle) []Fragment {
 	n := info.SampleCount
 	if n == 0 || len(info.Samples) == 0 {
 		return nil
@@ -65,25 +66,36 @@ func PlanFragments(info *merge.SegmentInfo, targetSec float64) []Fragment {
 	start := 0
 	var startUnits uint64
 	for start < n {
-		var units uint64
-		end := -1
+		// Accumulate until the target duration is reached, then advance to
+		// the next keyframe for the actual cut.
+		var acc uint64
+		iTarget := n
 		for i := start; i < n; i++ {
-			// Cut BEFORE the keyframe sample i so the fragment covers
-			// [start, i) — sample i's duration belongs to the NEXT fragment.
-			if i > start && info.Samples[i].IsKeyFrame && float64(units)/ts >= targetSec {
-				end = i
+			acc += uint64(info.Samples[i].Duration)
+			if i > start && float64(acc)/ts >= targetSec {
+				iTarget = i
 				break
 			}
-			units += uint64(info.Samples[i].Duration)
 		}
-		if end < 0 {
-			end = n // tail fragment
+		end := n
+		if iTarget < n {
+			if k, ok := oracle.nextAtOrAfter(iTarget); ok && k > start && k < n {
+				end = k
+			}
+		}
+
+		var units uint64
+		for i := start; i < end; i++ {
+			units += uint64(info.Samples[i].Duration)
 		}
 		frags = append(frags, Fragment{
 			First: start, End: end,
 			StartUnits:    startUnits,
 			DurationUnits: units,
 		})
+		if end <= start {
+			break // defensive: never loop forever on a broken oracle
+		}
 		startUnits += units
 		start = end
 	}
@@ -95,7 +107,7 @@ func PlanFragments(info *merge.SegmentInfo, targetSec float64) []Fragment {
 		ai := 0
 		for k := range frags {
 			fStartSec := float64(frags[k].StartUnits) / ts
-			fEndSec := fStartSec + float64(frags[k].DurationUnits)/ts
+			fEndSec := fStartSec + float64(frags[k].DurationUnits) / ts
 			first := ai
 			for ai < len(info.AudioSamples) {
 				sampleStartSec := float64(audioUnits) / ats
@@ -104,7 +116,6 @@ func PlanFragments(info *merge.SegmentInfo, targetSec float64) []Fragment {
 				}
 				audioUnits += uint64(info.AudioSamples[ai].Duration)
 				ai++
-				_ = sampleStartSec
 			}
 			frags[k].AudioFirst, frags[k].AudioEnd = first, ai
 		}
@@ -306,14 +317,18 @@ func writeTraf(w *mp4.Writer, trackID uint32, baseUnits uint64, samples []merge.
 		return err
 	}
 	entries := make([]mp4.TrunEntry, len(samples))
-	for i, s := range samples {
+	for i := range samples {
+		// Positional sync flags: every fragment starts on a keyframe (the
+		// planner guarantees it) and audio samples are all sync points. Video
+		// samples after the first are marked non-sync — trun flags are decode
+		// HINTS, and a mid-fragment IDR mis-flagged as non-sync is harmless.
 		flag := uint32(sampleFlagsOther)
-		if !video || s.IsKeyFrame {
+		if !video || i == 0 {
 			flag = sampleFlagsKeyframe
 		}
 		entries[i] = mp4.TrunEntry{
-			SampleDuration: s.Duration,
-			SampleSize:     s.Size,
+			SampleDuration: samples[i].Duration,
+			SampleSize:     samples[i].Size,
 			SampleFlags:    flag,
 		}
 	}

--- a/internal/vod/init.go
+++ b/internal/vod/init.go
@@ -1,0 +1,555 @@
+package vod
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/abema/go-mp4"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
+)
+
+var errShortParamSets = errors.New("SPS/PPS too short to build sample entry")
+
+// BuildInitSegment produces the fMP4 initialization segment (ftyp + moov) for
+// one recording: the track configurations with EMPTY sample tables. The
+// sample tables live in each fragment's moof instead. Shared stsd-writing
+// shape with internal/merge's moov builder (avc1/hvc1/mp4a/Opus entries).
+func BuildInitSegment(info *merge.SegmentInfo, includeAudio bool) ([]byte, error) {
+	if info.Timescale == 0 {
+		return nil, fmt.Errorf("segment has no timescale")
+	}
+
+	width, height := 0, 0
+	var err error
+	switch info.Codec {
+	case "h265":
+		width, height, err = merge.SPSResolution("h265", info.SPS)
+	case "h264":
+		width, height, err = merge.SPSResolution("h264", info.SPS)
+	default:
+		return nil, fmt.Errorf("unsupported codec %q for init segment", info.Codec)
+	}
+	if err != nil {
+		// Resolution is cosmetic (tkhd/stsd); tolerate a parse failure.
+		width, height = 0, 0
+	}
+
+	includeAudio = includeAudio && info.HasAudio
+
+	buf := &seekableBuffer{}
+	w := mp4.NewWriter(buf)
+
+	if err := writeInitFtyp(w, info.Codec); err != nil {
+		return nil, err
+	}
+
+	// moov
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("moov")}); err != nil {
+		return nil, err
+	}
+	nextTrack := uint32(2)
+	if includeAudio {
+		nextTrack = 3
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mvhd")}); err != nil {
+		return nil, err
+	}
+	mvhd := &mp4.Mvhd{
+		Timescale:   1000,
+		DurationV0:  0,
+		Rate:        0x00010000,
+		Volume:      0x0100,
+		NextTrackID: nextTrack,
+		Matrix:      identityMatrix,
+	}
+	if _, err := mp4.Marshal(w, mvhd, mp4.Context{}); err != nil {
+		return nil, err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return nil, err
+	}
+
+	if err := writeInitTrak(w, initTrack{
+		trackID:   1,
+		timescale: info.Timescale,
+		width:     uint16(width),
+		height:    uint16(height),
+		video:     true,
+		codec:     info.Codec,
+		sps:       info.SPS,
+		pps:       info.PPS,
+		vps:       info.VPS,
+	}); err != nil {
+		return nil, err
+	}
+
+	if includeAudio {
+		if err := writeInitTrak(w, initTrack{
+			trackID:      2,
+			timescale:    info.AudioTimescale,
+			audio:        true,
+			audioCodec:   info.AudioCodec,
+			audioConfig:  info.AudioConfig,
+			g711MULaw:    info.G711MULaw,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	// mvex > trex (per-track sample defaults; trun carries everything, these
+	// are the spec-mandated fallbacks).
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mvex")}); err != nil {
+		return nil, err
+	}
+	if err := writeTrex(w, 1); err != nil {
+		return nil, err
+	}
+	if includeAudio {
+		if err := writeTrex(w, 2); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := w.EndBox(); err != nil {
+		return nil, err
+	}
+
+	if _, err := w.EndBox(); err != nil { // moov
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+var identityMatrix = [9]int32{
+	0x00010000, 0, 0,
+	0, 0x00010000, 0,
+	0, 0, 0x40000000,
+}
+
+type initTrack struct {
+	trackID   uint32
+	timescale uint32
+	width     uint16
+	height    uint16
+	video     bool
+	codec     string
+	sps, pps  []byte
+	vps       []byte
+	audio       bool
+	audioCodec  string
+	audioConfig []byte
+	g711MULaw   bool
+}
+
+func writeTrex(w *mp4.Writer, trackID uint32) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trex")}); err != nil {
+		return err
+	}
+	trex := &mp4.Trex{TrackID: trackID, DefaultSampleDescriptionIndex: 1}
+	if _, err := mp4.Marshal(w, trex, mp4.Context{}); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeInitTrak(w *mp4.Writer, tr initTrack) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("trak")}); err != nil {
+		return err
+	}
+	// tkhd
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("tkhd")}); err != nil {
+		return err
+	}
+	tkhd := &mp4.Tkhd{TrackID: tr.trackID, DurationV0: 0, Matrix: identityMatrix}
+	if tr.video {
+		tkhd.Width = uint32(tr.width) << 16
+		tkhd.Height = uint32(tr.height) << 16
+	}
+	if _, err := mp4.Marshal(w, tkhd, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	// mdia
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdia")}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdhd")}); err != nil {
+		return err
+	}
+	mdhd := &mp4.Mdhd{Timescale: tr.timescale, Language: [3]byte{0x15, 0xC0, 0x00}} // 'und'
+	if _, err := mp4.Marshal(w, mdhd, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hdlr")}); err != nil {
+		return err
+	}
+	hdlr := &mp4.Hdlr{HandlerType: [4]byte{'v', 'i', 'd', 'e'}, Name: "VideoHandler\x00"}
+	if tr.audio {
+		hdlr = &mp4.Hdlr{HandlerType: [4]byte{'s', 'o', 'u', 'n'}, Name: "SoundHandler\x00"}
+	}
+	if _, err := mp4.Marshal(w, hdlr, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	// minf
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("minf")}); err != nil {
+		return err
+	}
+	mediaHeader := "vmhd"
+	if tr.audio {
+		mediaHeader = "smhd"
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType(mediaHeader)}); err != nil {
+		return err
+	}
+	if tr.audio {
+		if _, err := mp4.Marshal(w, &mp4.Smhd{}, mp4.Context{}); err != nil {
+			return err
+		}
+	} else {
+		if _, err := mp4.Marshal(w, &mp4.Vmhd{Graphicsmode: 0}, mp4.Context{}); err != nil {
+			return err
+		}
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if err := writeDinf(w); err != nil {
+		return err
+	}
+	if err := writeEmptyStbl(w, tr); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil { // minf
+		return err
+	}
+	if _, err := w.EndBox(); err != nil { // mdia
+		return err
+	}
+	_, err := w.EndBox() // trak
+	return err
+}
+
+func writeDinf(w *mp4.Writer) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dinf")}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("dref")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Dref{EntryCount: 1}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("url ")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Url{Location: ""}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+// writeEmptyStbl writes stsd (the track's codec configuration) followed by
+// EMPTY stts/stsc/stsz/stco tables — sample timing/offsets live in the moof
+// fragments instead.
+func writeEmptyStbl(w *mp4.Writer, tr initTrack) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stbl")}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsd")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsd{EntryCount: 1}, mp4.Context{}); err != nil {
+		return err
+	}
+	var err error
+	if tr.audio {
+		err = writeAudioSampleEntry(w, tr)
+	} else if tr.codec == "h265" {
+		err = writeH265SampleEntry(w, tr)
+	} else {
+		err = writeH264SampleEntry(w, tr)
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil { // stsd
+		return err
+	}
+	// Empty tables.
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stts")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stts{EntryCount: 0}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsc")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsc{EntryCount: 0}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stsz")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stsz{SampleSize: 0, SampleCount: 0}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("stco")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.Stco{EntryCount: 0}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err = w.EndBox() // stbl
+	return err
+}
+
+func writeH264SampleEntry(w *mp4.Writer, tr initTrack) error {
+	if len(tr.sps) < 4 || len(tr.pps) < 1 {
+		return errShortParamSets
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("avc1")}); err != nil {
+		return err
+	}
+	avc1 := &mp4.VisualSampleEntry{
+		SampleEntry: mp4.SampleEntry{
+			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType("avc1")},
+			DataReferenceIndex: 1,
+		},
+		Width:           tr.width,
+		Height:          tr.height,
+		Horizresolution: 0x00480000,
+		Vertresolution:  0x00480000,
+		FrameCount:      1,
+		Depth:           0x0018,
+	}
+	if _, err := mp4.Marshal(w, avc1, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("avcC")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, mp4util.BuildAvcC(tr.sps, tr.pps), mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeH265SampleEntry(w *mp4.Writer, tr initTrack) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hvc1")}); err != nil {
+		return err
+	}
+	hvc1 := &mp4.VisualSampleEntry{
+		SampleEntry: mp4.SampleEntry{
+			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType("hvc1")},
+			DataReferenceIndex: 1,
+		},
+		Width:           tr.width,
+		Height:          tr.height,
+		Horizresolution: 0x00480000,
+		Vertresolution:  0x00480000,
+		FrameCount:      1,
+		Depth:           0x0018,
+	}
+	if _, err := mp4.Marshal(w, hvc1, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("hvcC")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, mp4util.BuildHvcC(tr.vps, tr.sps, tr.pps), mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeAudioSampleEntry(w *mp4.Writer, tr initTrack) error {
+	switch tr.audioCodec {
+	case "g711":
+		return writeG711SampleEntry(w, tr.g711MULaw)
+	case "opus":
+		return writeOpusSampleEntry(w)
+	default: // "" = AAC (legacy default)
+		return writeAACSampleEntry(w, tr.audioConfig, tr.timescale)
+	}
+}
+
+func writeAACSampleEntry(w *mp4.Writer, audioConfig []byte, timescale uint32) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mp4a")}); err != nil {
+		return err
+	}
+	channelCount, sampleRate := parseAACAudioConfig(audioConfig)
+	if sampleRate == 0 {
+		sampleRate = timescale
+	}
+	mp4a := &mp4.AudioSampleEntry{
+		SampleEntry: mp4.SampleEntry{
+			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.StrToBoxType("mp4a")},
+			DataReferenceIndex: 1,
+		},
+		ChannelCount: channelCount,
+		SampleSize:   16,
+		SampleRate:   sampleRate << 16,
+	}
+	if _, err := mp4.Marshal(w, mp4a, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("esds")}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, buildEsds(audioConfig), mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeG711SampleEntry(w *mp4.Writer, mulaw bool) error {
+	boxType := mp4.StrToBoxType("alaw")
+	if mulaw {
+		boxType = mp4.StrToBoxType("ulaw")
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: boxType}); err != nil {
+		return err
+	}
+	buf := make([]byte, 28)
+	buf[7] = 0x01  // data_reference_index
+	buf[17] = 0x01 // channel_count = 1
+	buf[19] = 0x08 // sample_size = 8
+	rate := uint32(8000) << 16
+	buf[24], buf[25], buf[26], buf[27] = byte(rate>>24), byte(rate>>16), byte(rate>>8), byte(rate)
+	if _, err := w.Write(buf); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeOpusSampleEntry(w *mp4.Writer) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.BoxTypeOpus()}); err != nil {
+		return err
+	}
+	opus := &mp4.AudioSampleEntry{
+		SampleEntry: mp4.SampleEntry{
+			AnyTypeBox:         mp4.AnyTypeBox{Type: mp4.BoxTypeOpus()},
+			DataReferenceIndex: 1,
+		},
+		ChannelCount: 1,
+		SampleSize:   16,
+		SampleRate:   48000 << 16,
+	}
+	if _, err := mp4.Marshal(w, opus, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.BoxTypeDOps()}); err != nil {
+		return err
+	}
+	if _, err := mp4.Marshal(w, &mp4.DOps{OutputChannelCount: 1, InputSampleRate: 48000}, mp4.Context{}); err != nil {
+		return err
+	}
+	if _, err := w.EndBox(); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+func writeInitFtyp(w *mp4.Writer, codec string) error {
+	if _, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("ftyp")}); err != nil {
+		return err
+	}
+	ftyp := &mp4.Ftyp{
+		MajorBrand:   [4]byte{'i', 's', 'o', 'm'},
+		MinorVersion: 0,
+		CompatibleBrands: []mp4.CompatibleBrandElem{
+			{CompatibleBrand: [4]byte{'i', 's', 'o', 'm'}},
+			{CompatibleBrand: [4]byte{'i', 's', 'o', '2'}},
+			{CompatibleBrand: [4]byte{'m', 'p', '4', '1'}},
+		},
+	}
+	if codec == "h265" {
+		ftyp.CompatibleBrands = append(ftyp.CompatibleBrands, mp4.CompatibleBrandElem{CompatibleBrand: [4]byte{'h', 'e', 'v', '1'}})
+	}
+	if _, err := mp4.Marshal(w, ftyp, mp4.Context{}); err != nil {
+		return err
+	}
+	_, err := w.EndBox()
+	return err
+}
+
+// parseAACAudioConfig extracts channel count + sample rate from an AAC
+// AudioSpecificConfig (mirrors internal/merge's parseAudioConfig).
+func parseAACAudioConfig(config []byte) (uint16, uint32) {
+	channelCount := uint16(2)
+	sampleRate := uint32(44100)
+	if len(config) >= 2 {
+		sampleRateIndex := (config[0] >> 3) & 0x0F
+		if sampleRateIndex < 15 {
+			rates := [...]uint32{96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000, 7350}
+			if int(sampleRateIndex) < len(rates) {
+				sampleRate = rates[sampleRateIndex]
+			}
+		}
+		channelConfig := ((config[0] & 0x01) << 2) | ((config[1] >> 6) & 0x03)
+		if channelConfig > 0 {
+			channelCount = uint16(channelConfig)
+		}
+	}
+	return channelCount, sampleRate
+}
+
+// buildEsds mirrors internal/merge's buildMergeEsds (AAC esds structure).
+func buildEsds(audioConfig []byte) *mp4.Esds {
+	return &mp4.Esds{
+		FullBox: mp4.FullBox{Version: 0},
+		Descriptors: []mp4.Descriptor{
+			{Tag: mp4.ESDescrTag, Size: uint32(25 + len(audioConfig)), ESDescriptor: &mp4.ESDescriptor{ESID: 1}},
+			{Tag: mp4.DecoderConfigDescrTag, Size: uint32(13 + len(audioConfig)), DecoderConfigDescriptor: &mp4.DecoderConfigDescriptor{
+				ObjectTypeIndication: 0x40, StreamType: 0x05, Reserved: true,
+				MaxBitrate: 128000, AvgBitrate: 128000,
+			}},
+			{Tag: mp4.DecSpecificInfoTag, Size: uint32(len(audioConfig)), Data: audioConfig},
+			{Tag: mp4.SLConfigDescrTag, Size: 1, Data: []byte{0x02}},
+		},
+	}
+}

--- a/internal/vod/init.go
+++ b/internal/vod/init.go
@@ -21,7 +21,7 @@ func BuildInitSegment(info *merge.SegmentInfo, includeAudio bool) ([]byte, error
 		return nil, fmt.Errorf("segment has no timescale")
 	}
 
-	width, height := 0, 0
+	var width, height int
 	var err error
 	switch info.Codec {
 	case "h265":
@@ -87,12 +87,12 @@ func BuildInitSegment(info *merge.SegmentInfo, includeAudio bool) ([]byte, error
 
 	if includeAudio {
 		if err := writeInitTrak(w, initTrack{
-			trackID:      2,
-			timescale:    info.AudioTimescale,
-			audio:        true,
-			audioCodec:   info.AudioCodec,
-			audioConfig:  info.AudioConfig,
-			g711MULaw:    info.G711MULaw,
+			trackID:     2,
+			timescale:   info.AudioTimescale,
+			audio:       true,
+			audioCodec:  info.AudioCodec,
+			audioConfig: info.AudioConfig,
+			g711MULaw:   info.G711MULaw,
 		}); err != nil {
 			return nil, err
 		}
@@ -128,14 +128,14 @@ var identityMatrix = [9]int32{
 }
 
 type initTrack struct {
-	trackID   uint32
-	timescale uint32
-	width     uint16
-	height    uint16
-	video     bool
-	codec     string
-	sps, pps  []byte
-	vps       []byte
+	trackID     uint32
+	timescale   uint32
+	width       uint16
+	height      uint16
+	video       bool
+	codec       string
+	sps, pps    []byte
+	vps         []byte
 	audio       bool
 	audioCodec  string
 	audioConfig []byte

--- a/internal/vod/keyframe.go
+++ b/internal/vod/keyframe.go
@@ -1,0 +1,149 @@
+package vod
+
+import (
+	"os"
+	"sort"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+)
+
+// keyframeOracle answers "the next keyframe sample at or after index `from`"
+// during fragment planning. Implementations, in order of preference:
+//
+//   - sidecarOracle: keyframe index persisted next to the recording after a
+//     first probing pass — zero media reads, survives restarts.
+//   - stssOracle: serves from the file's own sync-sample table — zero media
+//     reads.
+//   - probeOracle: reads NAL headers on demand for stss-less files. GOP
+//     duration is extremely stable in TIME (frame-rate jitter makes sample
+//     COUNTS drift), so after the first boundary is found by a short linear
+//     scan, subsequent boundaries are predicted from a duration prefix-sum
+//     and verified with a single 6-byte read. Probing every sample reads the
+//     whole media data — minutes on a USB HDD; this reads a few dozen KB.
+type keyframeOracle interface {
+	nextAtOrAfter(from int) (idx int, found bool)
+}
+
+type stssOracle struct {
+	samples []merge.SampleEntry
+}
+
+func (o stssOracle) nextAtOrAfter(from int) (int, bool) {
+	for i := from; i < len(o.samples); i++ {
+		if o.samples[i].IsKeyFrame {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// sidecarOracle serves keyframe positions from a persisted index file.
+type sidecarOracle struct {
+	samples []merge.SampleEntry
+	keys    []int // sorted sample indices
+}
+
+func (o sidecarOracle) nextAtOrAfter(from int) (int, bool) {
+	i := sort.SearchInts(o.keys, from)
+	if i < len(o.keys) {
+		return o.keys[i], true
+	}
+	return 0, false
+}
+
+type probeOracle struct {
+	file    *os.File
+	samples []merge.SampleEntry
+	codec   string
+	buf     [6]byte
+
+	// prefix[i] = sum of durations of samples [0, i).
+	prefix []uint64
+
+	// GOP prediction state (time domain): lastBoundaryUnits is the decode
+	// time of the last keyframe returned; gopUnits the learned GOP duration.
+	// 0 = not learned yet.
+	lastBoundary    int
+	lastBoundaryU   uint64
+	gopUnits        uint64
+
+	// Found collects every keyframe index returned (for sidecar persistence).
+	Found []int
+}
+
+func newProbeOracle(file *os.File, info *merge.SegmentInfo) *probeOracle {
+	prefix := make([]uint64, len(info.Samples)+1)
+	for i, s := range info.Samples {
+		prefix[i+1] = prefix[i] + uint64(s.Duration)
+	}
+	return &probeOracle{
+		file:    file,
+		samples: info.Samples,
+		codec:   info.Codec,
+		prefix:  prefix,
+		lastBoundary: -1,
+	}
+}
+
+func (o *probeOracle) isKey(i int) bool {
+	s := o.samples[i]
+	if s.Size < 5 {
+		return false
+	}
+	n, err := o.file.ReadAt(o.buf[:], s.Offset)
+	if err != nil || n < 5 {
+		return false
+	}
+	switch o.codec {
+	case "h264":
+		nalType := o.buf[4] & 0x1F
+		return nalType == 5 || nalType == 7 || nalType == 8
+	case "h265":
+		nalType := (uint16(o.buf[4]) >> 1) & 0x3F
+		return nalType >= 16 && nalType <= 21
+	}
+	return false
+}
+
+func (o *probeOracle) nextAtOrAfter(from int) (int, bool) {
+	n := len(o.samples)
+	if from < 0 {
+		from = 0
+	}
+
+	// Time-domain prediction: the next keyframe sits at the sample whose
+	// cumulative duration reaches lastBoundaryU + gopUnits. Frame-count drift
+	// does not matter; ±4 samples covers residual jitter.
+	if o.gopUnits > 0 && o.lastBoundary >= 0 {
+		target := o.lastBoundaryU + o.gopUnits
+		base := sort.Search(len(o.prefix), func(i int) bool { return o.prefix[i] >= target })
+		for d := 0; d <= 4; d++ {
+			for _, p := range []int{base + d, base - d} {
+				if p >= from && p < n && o.isKey(p) {
+					o.record(p)
+					return p, true
+				}
+			}
+		}
+		// Prediction missed — GOP changed; fall through to a linear scan,
+		// which re-learns the period.
+	}
+
+	// Linear scan (first boundary, or after a GOP change).
+	for i := from; i < n; i++ {
+		if o.isKey(i) {
+			o.record(i)
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (o *probeOracle) record(idx int) {
+	if o.lastBoundary >= 0 && idx > o.lastBoundary {
+		o.gopUnits = o.prefix[idx] - o.lastBoundaryU
+	}
+	o.lastBoundary = idx
+	o.lastBoundaryU = o.prefix[idx]
+	o.Found = append(o.Found, idx)
+}

--- a/internal/vod/keyframe.go
+++ b/internal/vod/keyframe.go
@@ -103,7 +103,7 @@ func (o *probeOracle) nextAtOrAfter(from int) (int, bool) {
 	if o.gopUnits > 0 && o.lastBoundary >= 0 {
 		target := o.lastBoundaryU + o.gopUnits
 		base := sort.Search(len(o.prefix), func(i int) bool { return o.prefix[i] >= target })
-		for d := 0; d <= 4; d++ {
+		for d := range 5 {
 			for _, p := range []int{base + d, base - d} {
 				if p >= from && p < n && o.isKey(p) {
 					o.record(p)

--- a/internal/vod/keyframe.go
+++ b/internal/vod/keyframe.go
@@ -37,20 +37,6 @@ func (o stssOracle) nextAtOrAfter(from int) (int, bool) {
 	return 0, false
 }
 
-// sidecarOracle serves keyframe positions from a persisted index file.
-type sidecarOracle struct {
-	samples []merge.SampleEntry
-	keys    []int // sorted sample indices
-}
-
-func (o sidecarOracle) nextAtOrAfter(from int) (int, bool) {
-	i := sort.SearchInts(o.keys, from)
-	if i < len(o.keys) {
-		return o.keys[i], true
-	}
-	return 0, false
-}
-
 type probeOracle struct {
 	file    *os.File
 	samples []merge.SampleEntry
@@ -63,9 +49,9 @@ type probeOracle struct {
 	// GOP prediction state (time domain): lastBoundaryUnits is the decode
 	// time of the last keyframe returned; gopUnits the learned GOP duration.
 	// 0 = not learned yet.
-	lastBoundary    int
-	lastBoundaryU   uint64
-	gopUnits        uint64
+	lastBoundary  int
+	lastBoundaryU uint64
+	gopUnits      uint64
 
 	// Found collects every keyframe index returned (for sidecar persistence).
 	Found []int
@@ -77,10 +63,10 @@ func newProbeOracle(file *os.File, info *merge.SegmentInfo) *probeOracle {
 		prefix[i+1] = prefix[i] + uint64(s.Duration)
 	}
 	return &probeOracle{
-		file:    file,
-		samples: info.Samples,
-		codec:   info.Codec,
-		prefix:  prefix,
+		file:         file,
+		samples:      info.Samples,
+		codec:        info.Codec,
+		prefix:       prefix,
 		lastBoundary: -1,
 	}
 }

--- a/internal/vod/playlist.go
+++ b/internal/vod/playlist.go
@@ -34,16 +34,16 @@ type Manager struct {
 	targetSec     float64
 	maxRecordings int
 
-	planMu  sync.Mutex
-	plans   map[string]*planCacheItem // recording ID → fragment plan
+	planMu sync.Mutex
+	plans  map[string]*planCacheItem // recording ID → fragment plan
 }
 
 type planCacheItem struct {
-	path     string
-	size     int64
-	mtimeNs  int64
-	ts       uint32
-	frags    []Fragment
+	path    string
+	size    int64
+	mtimeNs int64
+	ts      uint32
+	frags   []Fragment
 }
 
 func NewManager() *Manager {

--- a/internal/vod/playlist.go
+++ b/internal/vod/playlist.go
@@ -3,6 +3,7 @@ package vod
 import (
 	"fmt"
 	"math"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -14,7 +15,7 @@ import (
 // Entry is one playable recording inside a playlist, with its fragment plan.
 type Entry struct {
 	Rec   model.Recording
-	Info  *merge.SegmentInfo
+	Ts    uint32 // video timescale (EXTINF rendering)
 	Frags []Fragment
 }
 
@@ -26,27 +27,108 @@ func IncludeAudio(info *merge.SegmentInfo) bool {
 	return info.HasAudio && info.AudioCodec != "g711"
 }
 
-// Manager owns the segment cache and builds playlists. One instance lives in
-// the API handler for the process lifetime.
+// Manager owns the caches and builds playlists. One instance lives in the
+// API handler for the process lifetime.
 type Manager struct {
-	cache        *segmentCache
-	targetSec    float64
+	cache         *segmentCache
+	targetSec     float64
 	maxRecordings int
+
+	planMu  sync.Mutex
+	plans   map[string]*planCacheItem // recording ID → fragment plan
+}
+
+type planCacheItem struct {
+	path     string
+	size     int64
+	mtimeNs  int64
+	ts       uint32
+	frags    []Fragment
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		// ~12 hourly recordings ≈ 50MB of cached sample tables worst case —
-		// bounded for the RPi 3B memory budget.
+		// ~12 hourly recordings of parsed sample tables ≈ tens of MB — bounded
+		// for the RPi 3B memory budget. Playlist generation does NOT depend on
+		// this cache (it reads persisted fragment plans); only fragment/init
+		// serving parses tables, and hls.js fetches those sequentially.
 		cache:         newSegmentCache(12),
 		targetSec:     TargetFragmentDur,
 		maxRecordings: 200,
+		plans:         make(map[string]*planCacheItem),
 	}
 }
 
-// BuildPlaylist parses every recording of the range (in parallel, bounded)
-// and renders the VOD M3U8. Recordings that fail to parse are skipped with a
-// warning — a corrupt hour must not take down the whole day.
+// statFile returns (size, mtime) for plan-cache validation.
+func statFile(path string) (int64, int64, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, false
+	}
+	return fi.Size(), fi.ModTime().UnixNano(), true
+}
+
+// Fragments returns the fragment plan for a recording, resolving through
+// (1) the in-memory plan cache, (2) the persisted sidecar plan, (3) live
+// computation (sample-table parse + stss/probing oracle), persisting the
+// result. The plan depends only on file identity — sample tables are parsed
+// at most once per file state.
+func (m *Manager) Fragments(rec model.Recording) ([]Fragment, uint32, error) {
+	if rec.FilePath == "" {
+		return nil, 0, fmt.Errorf("recording %s has no file path", rec.ID)
+	}
+	size, mtimeNs, ok := statFile(rec.FilePath)
+	if !ok {
+		return nil, 0, fmt.Errorf("stat %s", rec.FilePath)
+	}
+
+	m.planMu.Lock()
+	if pc, ok := m.plans[rec.ID]; ok && pc.path == rec.FilePath && pc.size == size && pc.mtimeNs == mtimeNs {
+		frags, ts := pc.frags, pc.ts
+		m.planMu.Unlock()
+		return frags, ts, nil
+	}
+	m.planMu.Unlock()
+
+	// Persisted plan (validated internally against the same stat fields).
+	if frags, ts, ok := readSidecar(rec.FilePath); ok {
+		m.storePlan(rec.ID, rec.FilePath, size, mtimeNs, ts, frags)
+		return frags, ts, nil
+	}
+
+	// Compute: parse sample tables once, pick the keyframe oracle.
+	statRecording(&rec)
+	info, err := m.cache.Get(rec)
+	if err != nil {
+		return nil, 0, err
+	}
+	var oracle keyframeOracle = stssOracle{samples: info.Samples}
+	if !info.KeyframesFromStss {
+		f, err := os.Open(info.FilePath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("open for keyframe probing: %w", err)
+		}
+		oracle = newProbeOracle(f, info)
+		defer f.Close()
+	}
+	frags := PlanFragments(info, m.targetSec, oracle)
+	if len(frags) == 0 {
+		return nil, 0, fmt.Errorf("no fragments planned for %s", rec.ID)
+	}
+	writeSidecar(info.FilePath, frags, info.Timescale)
+	m.storePlan(rec.ID, rec.FilePath, size, mtimeNs, info.Timescale, frags)
+	return frags, info.Timescale, nil
+}
+
+func (m *Manager) storePlan(id, path string, size, mtimeNs int64, ts uint32, frags []Fragment) {
+	m.planMu.Lock()
+	m.plans[id] = &planCacheItem{path: path, size: size, mtimeNs: mtimeNs, ts: ts, frags: frags}
+	m.planMu.Unlock()
+}
+
+// BuildPlaylist plans every recording of the range (in parallel, bounded)
+// and renders the VOD M3U8. Recordings that fail are skipped with a warning —
+// a corrupt hour must not take down the whole day.
 func (m *Manager) BuildPlaylist(cameraID string, recordings []model.Recording) (string, int, error) {
 	if len(recordings) == 0 {
 		return "", 0, fmt.Errorf("no recordings in range")
@@ -69,15 +151,14 @@ func (m *Manager) BuildPlaylist(cameraID string, recordings []model.Recording) (
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			statRecording(&rec)
-			info, err := m.cache.Get(rec)
+			frags, ts, err := m.Fragments(rec)
 			if err != nil {
 				logger.Warn("skipping unplayable recording in playlist",
 					"recording_id", rec.ID, "error", err)
 				return
 			}
 			mu.Lock()
-			entries = append(entries, &Entry{Rec: rec, Info: info, Frags: PlanFragments(info, m.targetSec)})
+			entries = append(entries, &Entry{Rec: rec, Ts: ts, Frags: frags})
 			mu.Unlock()
 		}()
 	}
@@ -119,7 +200,7 @@ func (m *Manager) renderPlaylist(cameraID string, entries []*Entry) string {
 		}
 		b.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=%q\n", InitURL(cameraID, e.Rec.ID)))
 		for _, f := range e.Frags {
-			dur := f.DurationSec(e.Info.Timescale)
+			dur := f.DurationSec(e.Ts)
 			target = max(target, int(math.Ceil(dur)))
 			fmt.Fprintf(&b, "#EXTINF:%.3f,\n%s\n", dur, FragmentURL(cameraID, e.Rec.ID, f.First, f.End))
 		}
@@ -130,8 +211,9 @@ func (m *Manager) renderPlaylist(cameraID string, entries []*Entry) string {
 	return b.String()
 }
 
-// GetInfo exposes the cached SegmentInfo for a recording (used by the init +
-// fragment handlers).
+// GetInfo exposes the cached (or freshly parsed) SegmentInfo for a recording
+// — used by the init + fragment handlers. Audio-inclusion and sample offsets
+// need the full table; this is the only path that parses it.
 func (m *Manager) GetInfo(rec model.Recording) (*merge.SegmentInfo, error) {
 	statRecording(&rec)
 	return m.cache.Get(rec)

--- a/internal/vod/playlist.go
+++ b/internal/vod/playlist.go
@@ -1,0 +1,141 @@
+package vod
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// Entry is one playable recording inside a playlist, with its fragment plan.
+type Entry struct {
+	Rec   model.Recording
+	Info  *merge.SegmentInfo
+	Frags []Fragment
+}
+
+// IncludeAudio reports whether a recording's audio track is carried into the
+// fragments. MSE-friendly codecs only: AAC and Opus append fine to
+// SourceBuffer; G.711 (ulaw/alaw sample entries) is rejected by Chrome's
+// MediaSource, so it is dropped rather than breaking the whole stream.
+func IncludeAudio(info *merge.SegmentInfo) bool {
+	return info.HasAudio && info.AudioCodec != "g711"
+}
+
+// Manager owns the segment cache and builds playlists. One instance lives in
+// the API handler for the process lifetime.
+type Manager struct {
+	cache        *segmentCache
+	targetSec    float64
+	maxRecordings int
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		// ~12 hourly recordings ≈ 50MB of cached sample tables worst case —
+		// bounded for the RPi 3B memory budget.
+		cache:         newSegmentCache(12),
+		targetSec:     TargetFragmentDur,
+		maxRecordings: 200,
+	}
+}
+
+// BuildPlaylist parses every recording of the range (in parallel, bounded)
+// and renders the VOD M3U8. Recordings that fail to parse are skipped with a
+// warning — a corrupt hour must not take down the whole day.
+func (m *Manager) BuildPlaylist(cameraID string, recordings []model.Recording) (string, int, error) {
+	if len(recordings) == 0 {
+		return "", 0, fmt.Errorf("no recordings in range")
+	}
+	if len(recordings) > m.maxRecordings {
+		recordings = recordings[:m.maxRecordings]
+	}
+	sort.Slice(recordings, func(i, j int) bool {
+		return recordings[i].StartedAt.Before(recordings[j].StartedAt)
+	})
+
+	entries := make([]*Entry, 0, len(recordings))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 4) // bound parse parallelism (RPi: keep disk+CPU sane)
+	for i := range recordings {
+		rec := recordings[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			statRecording(&rec)
+			info, err := m.cache.Get(rec)
+			if err != nil {
+				logger.Warn("skipping unplayable recording in playlist",
+					"recording_id", rec.ID, "error", err)
+				return
+			}
+			mu.Lock()
+			entries = append(entries, &Entry{Rec: rec, Info: info, Frags: PlanFragments(info, m.targetSec)})
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	if len(entries) == 0 {
+		return "", 0, fmt.Errorf("no parseable recordings in range")
+	}
+	// goroutines may complete out of order — re-sort by start time.
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Rec.StartedAt.Before(entries[j].Rec.StartedAt)
+	})
+
+	return m.renderPlaylist(cameraID, entries), len(entries), nil
+}
+
+// FragmentURL is the canonical fragment URL scheme (also parsed back by the
+// API handler). Half-open sample range [first,end).
+func FragmentURL(cameraID, recordingID string, first, end int) string {
+	return fmt.Sprintf("/api/cameras/%s/playback/%s/f%d-%d.m4s", cameraID, recordingID, first, end)
+}
+
+// InitURL is the per-recording init segment URL.
+func InitURL(cameraID, recordingID string) string {
+	return fmt.Sprintf("/api/cameras/%s/playback/%s/init.mp4", cameraID, recordingID)
+}
+
+func (m *Manager) renderPlaylist(cameraID string, entries []*Entry) string {
+	target := 1
+	var b strings.Builder
+	b.WriteString("#EXTM3U\n")
+	b.WriteString("#EXT-X-VERSION:7\n")
+	b.WriteString("#EXT-X-PLAYLIST-TYPE:VOD\n")
+	b.WriteString("#EXT-X-INDEPENDENT-SEGMENTS\n")
+	b.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
+
+	for i, e := range entries {
+		if i > 0 {
+			b.WriteString("#EXT-X-DISCONTINUITY\n")
+		}
+		b.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=%q\n", InitURL(cameraID, e.Rec.ID)))
+		for _, f := range e.Frags {
+			dur := f.DurationSec(e.Info.Timescale)
+			target = max(target, int(math.Ceil(dur)))
+			fmt.Fprintf(&b, "#EXTINF:%.3f,\n%s\n", dur, FragmentURL(cameraID, e.Rec.ID, f.First, f.End))
+		}
+	}
+
+	fmt.Fprintf(&b, "#EXT-X-TARGETDURATION:%d\n", target)
+	b.WriteString("#EXT-X-ENDLIST\n")
+	return b.String()
+}
+
+// GetInfo exposes the cached SegmentInfo for a recording (used by the init +
+// fragment handlers).
+func (m *Manager) GetInfo(rec model.Recording) (*merge.SegmentInfo, error) {
+	statRecording(&rec)
+	return m.cache.Get(rec)
+}
+
+// TargetSec returns the fragment target duration in seconds.
+func (m *Manager) TargetSec() float64 { return m.targetSec }

--- a/internal/vod/sidecar.go
+++ b/internal/vod/sidecar.go
@@ -1,0 +1,104 @@
+package vod
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Fragment-plan sidecar: the plan for one recording (keyframe-aligned
+// fragment boundaries with durations) persisted next to the MP4 after it is
+// first computed. A playlist for a whole day then needs no sample-table
+// parsing at all — stat + read sidecar + render, sub-second even on a USB
+// HDD. Sample tables are parsed on demand per recording when a fragment is
+// actually served (hls.js fetches fragments sequentially, which the small
+// in-memory LRU handles naturally).
+//
+// Best-effort: any read/write failure falls back to live computation.
+
+const sidecarSuffix = ".vodidx"
+const sidecarVersion = 2
+
+type sidecarData struct {
+	Version   int           `json:"version"`
+	ModTimeNs int64         `json:"mtime_ns"`
+	Size      int64         `json:"size"`
+	Ts        uint32        `json:"ts"` // video timescale
+	Frags     []sidecarFrag `json:"frags"`
+}
+
+type sidecarFrag struct {
+	First     int    `json:"f"` // video sample range [First,End)
+	End       int    `json:"e"`
+	AudioFirst int   `json:"af"`
+	AudioEnd  int    `json:"ae"`
+	StartUnits uint64 `json:"s"`
+	DurUnits  uint64 `json:"d"`
+}
+
+func sidecarPath(mp4Path string) string {
+	return mp4Path + sidecarSuffix
+}
+
+// readSidecar returns the persisted fragment plan (+ video timescale) when
+// the sidecar matches the recording file's identity (size + mtime).
+func readSidecar(mp4Path string) ([]Fragment, uint32, bool) {
+	raw, err := os.ReadFile(sidecarPath(mp4Path))
+	if err != nil {
+		return nil, 0, false
+	}
+	var d sidecarData
+	if err := json.Unmarshal(raw, &d); err != nil || d.Version != sidecarVersion || d.Ts == 0 {
+		return nil, 0, false
+	}
+	fi, err := os.Stat(mp4Path)
+	if err != nil || fi.Size() != d.Size || fi.ModTime().UnixNano() != d.ModTimeNs {
+		return nil, 0, false // stale — file was re-merged/replaced
+	}
+	if len(d.Frags) == 0 {
+		return nil, 0, false
+	}
+	frags := make([]Fragment, len(d.Frags))
+	for i, f := range d.Frags {
+		frags[i] = Fragment{
+			First: f.First, End: f.End,
+			AudioFirst: f.AudioFirst, AudioEnd: f.AudioEnd,
+			StartUnits: f.StartUnits, DurationUnits: f.DurUnits,
+		}
+	}
+	return frags, d.Ts, true
+}
+
+// writeSidecar persists a fragment plan. Failures are silent (best-effort).
+func writeSidecar(mp4Path string, frags []Fragment, ts uint32) {
+	fi, err := os.Stat(mp4Path)
+	if err != nil {
+		return
+	}
+	d := sidecarData{
+		Version:   sidecarVersion,
+		ModTimeNs: fi.ModTime().UnixNano(),
+		Size:      fi.Size(),
+		Ts:        ts,
+		Frags:     make([]sidecarFrag, len(frags)),
+	}
+	for i, f := range frags {
+		d.Frags[i] = sidecarFrag{
+			First: f.First, End: f.End,
+			AudioFirst: f.AudioFirst, AudioEnd: f.AudioEnd,
+			StartUnits: f.StartUnits, DurUnits: f.DurationUnits,
+		}
+	}
+	raw, err := json.Marshal(&d)
+	if err != nil {
+		return
+	}
+	// Atomic-ish: temp + rename, mirroring the storage layer's crash-safety
+	// convention. Same directory as the recording (NVR owns the tree).
+	tmp := sidecarPath(mp4Path) + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, sidecarPath(mp4Path)); err != nil {
+		_ = os.Remove(tmp)
+	}
+}

--- a/internal/vod/sidecar.go
+++ b/internal/vod/sidecar.go
@@ -15,8 +15,10 @@ import (
 //
 // Best-effort: any read/write failure falls back to live computation.
 
-const sidecarSuffix = ".vodidx"
-const sidecarVersion = 2
+const (
+	sidecarSuffix  = ".vodidx"
+	sidecarVersion = 2
+)
 
 type sidecarData struct {
 	Version   int           `json:"version"`
@@ -27,12 +29,12 @@ type sidecarData struct {
 }
 
 type sidecarFrag struct {
-	First     int    `json:"f"` // video sample range [First,End)
-	End       int    `json:"e"`
-	AudioFirst int   `json:"af"`
-	AudioEnd  int    `json:"ae"`
+	First      int    `json:"f"` // video sample range [First,End)
+	End        int    `json:"e"`
+	AudioFirst int    `json:"af"`
+	AudioEnd   int    `json:"ae"`
 	StartUnits uint64 `json:"s"`
-	DurUnits  uint64 `json:"d"`
+	DurUnits   uint64 `json:"d"`
 }
 
 func sidecarPath(mp4Path string) string {

--- a/internal/vod/vod_test.go
+++ b/internal/vod/vod_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 )
 
-var testSPS = []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
-var testPPS = []byte{0x68, 0xCB, 0x83, 0xCB, 0x20}
+var (
+	testSPS = []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	testPPS = []byte{0x68, 0xCB, 0x83, 0xCB, 0x20}
+)
 
 // buildTestMP4 writes a small H.264 MP4 via the production muxer: nalu frames
 // alternating IDR (0x65) / non-IDR (0x41) headers with a keyframe every
@@ -29,7 +31,7 @@ func buildTestMP4(t *testing.T, dir, name string, sampleCount, gopSize int) stri
 	m := muxer.NewMP4Muxer(path)
 	trackID, err := m.AddH264Track(testSPS, testPPS)
 	require.NoError(t, err)
-	for i := 0; i < sampleCount; i++ {
+	for i := range sampleCount {
 		hdr := byte(0x41) // non-IDR
 		if i%gopSize == 0 {
 			hdr = 0x65 // IDR
@@ -97,11 +99,11 @@ func TestBuildFragment_BoxRoundtrip(t *testing.T) {
 
 	// Parse the moof back and verify structure + offsets.
 	var (
-		gotMfhd   *mp4.Mfhd
-		gotTraf   int
-		gotTfhd   []*mp4.Tfhd
-		gotTfdt   []*mp4.Tfdt
-		gotTrun   []*mp4.Trun
+		gotMfhd *mp4.Mfhd
+		gotTraf int
+		gotTfhd []*mp4.Tfhd
+		gotTfdt []*mp4.Tfdt
+		gotTrun []*mp4.Trun
 	)
 	_, err = mp4.ReadBoxStructure(bytes.NewReader(data.Moof), func(h *mp4.ReadHandle) (interface{}, error) {
 		switch h.BoxInfo.Type.String() {
@@ -303,8 +305,10 @@ func TestFragments_ViaManager_NoStss(t *testing.T) {
 	path := buildTestMP4(t, dir, "seg.mp4", 20, 5)
 	fi := fileInfo(t, path)
 	m := NewManager()
-	rec := model.Recording{ID: "r1", CameraID: "c1", FilePath: path, FileSize: fi.Size(), Format: model.FormatH264,
-		StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC()}
+	rec := model.Recording{
+		ID: "r1", CameraID: "c1", FilePath: path, FileSize: fi.Size(), Format: model.FormatH264,
+		StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC(),
+	}
 
 	frags, ts, err := m.Fragments(rec)
 	require.NoError(t, err)
@@ -325,7 +329,6 @@ func TestFragments_ViaManager_NoStss(t *testing.T) {
 	require.Same(t, &frags[0], &frags2[0])
 }
 
-
 func TestManagerPlaylist(t *testing.T) {
 	dir := t.TempDir()
 	p1 := buildTestMP4(t, dir, "a.mp4", 20, 5)
@@ -334,10 +337,14 @@ func TestManagerPlaylist(t *testing.T) {
 
 	m := NewManager()
 	recs := []model.Recording{
-		{ID: "rec-a", CameraID: "cam1", FilePath: p1, FileSize: fi1.Size(), Format: model.FormatH264,
-			StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC().Add(-30 * time.Minute)},
-		{ID: "rec-b", CameraID: "cam1", FilePath: p2, FileSize: fi2.Size(), Format: model.FormatH264,
-			StartedAt: time.Now().UTC().Add(-29 * time.Minute), EndedAt: time.Now().UTC().Add(-25 * time.Minute)},
+		{
+			ID: "rec-a", CameraID: "cam1", FilePath: p1, FileSize: fi1.Size(), Format: model.FormatH264,
+			StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC().Add(-30 * time.Minute),
+		},
+		{
+			ID: "rec-b", CameraID: "cam1", FilePath: p2, FileSize: fi2.Size(), Format: model.FormatH264,
+			StartedAt: time.Now().UTC().Add(-29 * time.Minute), EndedAt: time.Now().UTC().Add(-25 * time.Minute),
+		},
 	}
 
 	playlist, count, err := m.BuildPlaylist("cam1", recs)

--- a/internal/vod/vod_test.go
+++ b/internal/vod/vod_test.go
@@ -63,7 +63,7 @@ func TestPlanFragments_KeyframeAligned(t *testing.T) {
 
 	// Target 100ms @33ms/sample → cut at the first keyframe with ≥100ms
 	// accumulated → fragments [0,5),[5,10),[10,15),[15,20).
-	frags := PlanFragments(info, 0.1)
+	frags := PlanFragments(info, 0.1, stssOracle{samples: info.Samples})
 	require.Len(t, frags, 4)
 	for i, f := range frags {
 		require.Equal(t, 5*i, f.First)
@@ -87,7 +87,7 @@ func TestBuildFragment_BoxRoundtrip(t *testing.T) {
 	path := buildTestMP4(t, dir, "seg.mp4", 10, 5)
 	info := parseInfo(t, path)
 
-	frags := PlanFragments(info, 0.1)
+	frags := PlanFragments(info, 0.1, stssOracle{samples: info.Samples})
 	require.NotEmpty(t, frags)
 	f := frags[0]
 
@@ -197,7 +197,7 @@ func TestBuildFragment_BoxRoundtrip(t *testing.T) {
 func TestBuildFragment_SecondFragmentTfdt(t *testing.T) {
 	dir := t.TempDir()
 	info := parseInfo(t, buildTestMP4(t, dir, "seg.mp4", 10, 5))
-	frags := PlanFragments(info, 0.1)
+	frags := PlanFragments(info, 0.1, stssOracle{samples: info.Samples})
 	require.Len(t, frags, 2)
 
 	data, err := BuildFragment(info, frags[1], 8, false)
@@ -270,6 +270,61 @@ func TestIncludeAudio(t *testing.T) {
 	require.True(t, IncludeAudio(&merge.SegmentInfo{HasAudio: true, AudioCodec: "aac"}))
 	require.True(t, IncludeAudio(&merge.SegmentInfo{HasAudio: true, AudioCodec: "opus"}))
 }
+
+// TestProbeOracle_GOPPrediction exercises the stss-less path: the oracle must
+// find the first boundary with a linear scan, learn the GOP period, and then
+// land EXACTLY on keyframe positions via prediction (fixture: IDR every 50).
+func TestProbeOracle_GOPPrediction(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestMP4(t, dir, "seg.mp4", 500, 50)
+	info, err := merge.ParseSegmentNoProbe(path)
+	require.NoError(t, err)
+	require.False(t, info.KeyframesFromStss)
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	o := newProbeOracle(f, info)
+
+	for _, want := range []int{0, 50, 100, 150, 200, 250, 300, 350, 400, 450} {
+		got, ok := o.nextAtOrAfter(want)
+		require.True(t, ok, "no keyframe found from %d", want)
+		require.Equal(t, want, got, "boundary must land exactly on the keyframe")
+	}
+	// Beyond the last keyframe: not found.
+	_, ok := o.nextAtOrAfter(451)
+	require.False(t, ok)
+}
+
+// TestFragments_ViaManager_NoStss runs the full manager path on a NoProbe
+// parse (probe oracle internally) and verifies keyframe-aligned boundaries.
+func TestFragments_ViaManager_NoStss(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestMP4(t, dir, "seg.mp4", 20, 5)
+	fi := fileInfo(t, path)
+	m := NewManager()
+	rec := model.Recording{ID: "r1", CameraID: "c1", FilePath: path, FileSize: fi.Size(), Format: model.FormatH264,
+		StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC()}
+
+	frags, ts, err := m.Fragments(rec)
+	require.NoError(t, err)
+	require.NotZero(t, ts)
+	require.NotEmpty(t, frags)
+	// Boundaries at the learned keyframe positions (0,5,10,15).
+	require.Equal(t, 0, frags[0].First)
+	for i := 1; i < len(frags); i++ {
+		require.Equal(t, frags[i-1].End, frags[i].First)
+		require.Equal(t, 0, frags[i].First%5)
+	}
+	require.Equal(t, 20, frags[len(frags)-1].End)
+
+	// Plan cache: second call returns the same slice (pointer identity) —
+	// and persists a sidecar plan next to the fixture.
+	frags2, _, err := m.Fragments(rec)
+	require.NoError(t, err)
+	require.Same(t, &frags[0], &frags2[0])
+}
+
 
 func TestManagerPlaylist(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/vod/vod_test.go
+++ b/internal/vod/vod_test.go
@@ -1,0 +1,355 @@
+package vod
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/abema/go-mp4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+)
+
+var testSPS = []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+var testPPS = []byte{0x68, 0xCB, 0x83, 0xCB, 0x20}
+
+// buildTestMP4 writes a small H.264 MP4 via the production muxer: nalu frames
+// alternating IDR (0x65) / non-IDR (0x41) headers with a keyframe every
+// gopSize samples. Returns the file path.
+func buildTestMP4(t *testing.T, dir, name string, sampleCount, gopSize int) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	m := muxer.NewMP4Muxer(path)
+	trackID, err := m.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	for i := 0; i < sampleCount; i++ {
+		hdr := byte(0x41) // non-IDR
+		if i%gopSize == 0 {
+			hdr = 0x65 // IDR
+		}
+		nalu := append([]byte{hdr, 0x9A, 0x02, 0x05}, bytes.Repeat([]byte{byte(i)}, 24)...)
+		pts := time.Duration(i) * 33 * time.Millisecond
+		require.NoError(t, m.WriteSample(trackID, nalu, pts, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close())
+	return path
+}
+
+func parseInfo(t *testing.T, path string) *merge.SegmentInfo {
+	t.Helper()
+	info, err := merge.ParseSegment(path)
+	require.NoError(t, err)
+	require.NotZero(t, info.Timescale)
+	require.Equal(t, "h264", info.Codec)
+	return info
+}
+
+func TestPlanFragments_KeyframeAligned(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestMP4(t, dir, "seg.mp4", 20, 5)
+	info := parseInfo(t, path)
+	require.Equal(t, 20, info.SampleCount)
+	// Keyframes at 0,5,10,15.
+	require.True(t, info.Samples[0].IsKeyFrame)
+	require.False(t, info.Samples[1].IsKeyFrame)
+	require.True(t, info.Samples[5].IsKeyFrame)
+
+	// Target 100ms @33ms/sample → cut at the first keyframe with ≥100ms
+	// accumulated → fragments [0,5),[5,10),[10,15),[15,20).
+	frags := PlanFragments(info, 0.1)
+	require.Len(t, frags, 4)
+	for i, f := range frags {
+		require.Equal(t, 5*i, f.First)
+		require.Equal(t, 5*(i+1), f.End)
+	}
+	// Cumulative units must stay consistent.
+	var sum uint64
+	for _, f := range frags {
+		require.Equal(t, sum, f.StartUnits)
+		sum += f.DurationUnits
+	}
+	var total uint64
+	for _, s := range info.Samples {
+		total += uint64(s.Duration)
+	}
+	require.Equal(t, total, sum)
+}
+
+func TestBuildFragment_BoxRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestMP4(t, dir, "seg.mp4", 10, 5)
+	info := parseInfo(t, path)
+
+	frags := PlanFragments(info, 0.1)
+	require.NotEmpty(t, frags)
+	f := frags[0]
+
+	data, err := BuildFragment(info, f, 7, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, data.Moof)
+
+	// Parse the moof back and verify structure + offsets.
+	var (
+		gotMfhd   *mp4.Mfhd
+		gotTraf   int
+		gotTfhd   []*mp4.Tfhd
+		gotTfdt   []*mp4.Tfdt
+		gotTrun   []*mp4.Trun
+	)
+	_, err = mp4.ReadBoxStructure(bytes.NewReader(data.Moof), func(h *mp4.ReadHandle) (interface{}, error) {
+		switch h.BoxInfo.Type.String() {
+		case "moof":
+			return h.Expand()
+		case "mfhd":
+			b, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			gotMfhd = b.(*mp4.Mfhd)
+		case "traf":
+			gotTraf++
+			return h.Expand()
+		case "tfhd":
+			b, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			gotTfhd = append(gotTfhd, b.(*mp4.Tfhd))
+		case "tfdt":
+			b, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			gotTfdt = append(gotTfdt, b.(*mp4.Tfdt))
+		case "trun":
+			b, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			gotTrun = append(gotTrun, b.(*mp4.Trun))
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, gotMfhd)
+	require.Equal(t, uint32(7), gotMfhd.SequenceNumber)
+	require.Equal(t, 1, gotTraf) // no audio in fixture
+	require.Len(t, gotTrun, 1)
+
+	require.Len(t, gotTfhd, 1)
+	require.Equal(t, uint32(1), gotTfhd[0].TrackID)
+	require.NotZero(t, gotTfhd[0].GetFlags()&mp4.TfhdDefaultBaseIsMoof)
+
+	require.Len(t, gotTfdt, 1)
+	require.Equal(t, uint64(0), gotTfdt[0].GetBaseMediaDecodeTime()) // first fragment
+
+	trun := gotTrun[0]
+	require.Equal(t, uint32(f.End-f.First), trun.SampleCount)
+	require.Equal(t, int32(len(data.Moof))+8, trun.DataOffset)
+	require.Len(t, trun.Entries, f.End-f.First)
+	// First sample is a keyframe → sync sample flags.
+	require.Equal(t, uint32(sampleFlagsKeyframe), trun.Entries[0].SampleFlags)
+	require.Equal(t, uint32(sampleFlagsOther), trun.Entries[1].SampleFlags)
+
+	// Assemble the full segment exactly like the HTTP handler and verify the
+	// data_offset really lands on the first sample byte in mdat.
+	var seg bytes.Buffer
+	seg.Write(data.Moof)
+	var mdatHeader [8]byte
+	mdatBytes := data.TotalBytes - int64(len(data.Moof)) - 8
+	binary.BigEndian.PutUint32(mdatHeader[0:4], uint32(mdatBytes+8))
+	copy(mdatHeader[4:8], "mdat")
+	seg.Write(mdatHeader[:])
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	for _, ranges := range [][]ByteRange{data.VideoRanges, data.AudioRanges} {
+		for _, br := range ranges {
+			seg.Write(raw[br.Offset : br.Offset+br.Size])
+		}
+	}
+	require.Equal(t, data.TotalBytes, int64(seg.Len()))
+
+	// data_offset points at the first sample's 4-byte NAL length prefix.
+	firstOff := trun.DataOffset
+	nalLen := binary.BigEndian.Uint32(seg.Bytes()[firstOff : firstOff+4])
+	require.Equal(t, info.Samples[f.First].Size-4, nalLen)
+	require.Equal(t, byte(0x65), seg.Bytes()[firstOff+4]) // IDR NAL header
+
+	// Byte accounting: the trun sample sizes sum to the copied video bytes.
+	var trunBytes uint32
+	for _, e := range trun.Entries {
+		trunBytes += e.SampleSize
+	}
+	var rangeBytes int64
+	for _, br := range data.VideoRanges {
+		rangeBytes += br.Size
+	}
+	require.Equal(t, int64(trunBytes), rangeBytes)
+}
+
+func TestBuildFragment_SecondFragmentTfdt(t *testing.T) {
+	dir := t.TempDir()
+	info := parseInfo(t, buildTestMP4(t, dir, "seg.mp4", 10, 5))
+	frags := PlanFragments(info, 0.1)
+	require.Len(t, frags, 2)
+
+	data, err := BuildFragment(info, frags[1], 8, false)
+	require.NoError(t, err)
+	var baseTime uint64
+	_, err = mp4.ReadBoxStructure(bytes.NewReader(data.Moof), func(h *mp4.ReadHandle) (interface{}, error) {
+		switch h.BoxInfo.Type.String() {
+		case "moof", "traf":
+			return h.Expand()
+		case "tfdt":
+			b, _, err := h.ReadPayload()
+			if err != nil {
+				return nil, err
+			}
+			baseTime = b.(*mp4.Tfdt).GetBaseMediaDecodeTime()
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, frags[1].StartUnits, baseTime)
+}
+
+func TestBuildFragment_BadRange(t *testing.T) {
+	dir := t.TempDir()
+	info := parseInfo(t, buildTestMP4(t, dir, "seg.mp4", 10, 5))
+	_, err := BuildFragment(info, Fragment{First: 8, End: 3}, 1, false)
+	require.Error(t, err)
+	_, err = BuildFragment(info, Fragment{First: 0, End: 999}, 1, false)
+	require.Error(t, err)
+}
+
+func TestBuildInitSegment_ParsesBack(t *testing.T) {
+	dir := t.TempDir()
+	info := parseInfo(t, buildTestMP4(t, dir, "seg.mp4", 5, 5))
+
+	initSeg, err := BuildInitSegment(info, false)
+	require.NoError(t, err)
+
+	var (
+		boxTypes []string
+		trakSeen int
+	)
+	_, err = mp4.ReadBoxStructure(bytes.NewReader(initSeg), func(h *mp4.ReadHandle) (interface{}, error) {
+		bt := h.BoxInfo.Type.String()
+		boxTypes = append(boxTypes, bt)
+		switch bt {
+		case "trak":
+			trakSeen++
+			return h.Expand()
+		case "stsd", "stbl", "moov", "mdia", "minf", "avc1", "hvc1":
+			return h.Expand()
+		}
+		return nil, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, trakSeen) // video only (fixture has no audio)
+	joined := strings.Join(boxTypes, ",")
+	require.Contains(t, joined, "ftyp")
+	require.Contains(t, joined, "moov")
+	require.Contains(t, joined, "mvhd")
+	require.Contains(t, joined, "stsd")
+	require.Contains(t, joined, "mvex")
+	require.Contains(t, joined, "avc1")
+	require.Contains(t, joined, "avcC")
+}
+
+func TestIncludeAudio(t *testing.T) {
+	require.False(t, IncludeAudio(&merge.SegmentInfo{}))
+	require.False(t, IncludeAudio(&merge.SegmentInfo{HasAudio: true, AudioCodec: "g711"}))
+	require.True(t, IncludeAudio(&merge.SegmentInfo{HasAudio: true, AudioCodec: "aac"}))
+	require.True(t, IncludeAudio(&merge.SegmentInfo{HasAudio: true, AudioCodec: "opus"}))
+}
+
+func TestManagerPlaylist(t *testing.T) {
+	dir := t.TempDir()
+	p1 := buildTestMP4(t, dir, "a.mp4", 20, 5)
+	p2 := buildTestMP4(t, dir, "b.mp4", 10, 5)
+	fi1, fi2 := fileInfo(t, p1), fileInfo(t, p2)
+
+	m := NewManager()
+	recs := []model.Recording{
+		{ID: "rec-a", CameraID: "cam1", FilePath: p1, FileSize: fi1.Size(), Format: model.FormatH264,
+			StartedAt: time.Now().UTC().Add(-time.Hour), EndedAt: time.Now().UTC().Add(-30 * time.Minute)},
+		{ID: "rec-b", CameraID: "cam1", FilePath: p2, FileSize: fi2.Size(), Format: model.FormatH264,
+			StartedAt: time.Now().UTC().Add(-29 * time.Minute), EndedAt: time.Now().UTC().Add(-25 * time.Minute)},
+	}
+
+	playlist, count, err := m.BuildPlaylist("cam1", recs)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	lines := strings.Split(playlist, "\n")
+	require.Contains(t, playlist, "#EXTM3U")
+	require.Contains(t, playlist, "#EXT-X-PLAYLIST-TYPE:VOD")
+	require.Contains(t, playlist, "#EXT-X-ENDLIST")
+	require.Contains(t, playlist, `#EXT-X-MAP:URI="/api/cameras/cam1/playback/rec-a/init.mp4"`)
+	require.Contains(t, playlist, `#EXT-X-MAP:URI="/api/cameras/cam1/playback/rec-b/init.mp4"`)
+	require.Equal(t, 1, strings.Count(playlist, "#EXT-X-DISCONTINUITY\n"))
+	// Default fragment target is 6s; the fixtures are 0.66s/0.33s total, so
+	// each recording renders as ONE fragment covering all its samples.
+	require.Contains(t, playlist, "/api/cameras/cam1/playback/rec-a/f0-20.m4s")
+	require.Contains(t, playlist, "/api/cameras/cam1/playback/rec-b/f0-10.m4s")
+	require.Contains(t, playlist, "#EXT-X-TARGETDURATION:")
+
+	extinfCount := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "#EXTINF:") {
+			extinfCount++
+		}
+	}
+	require.Equal(t, 2, extinfCount) // one per recording at the 6s target
+
+	// Same recordings again hit the cache (still consistent output).
+	playlist2, _, err := m.BuildPlaylist("cam1", recs)
+	require.NoError(t, err)
+	require.Equal(t, playlist, playlist2)
+}
+
+func TestSegmentCache(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestMP4(t, dir, "a.mp4", 10, 5)
+	fi := fileInfo(t, path)
+
+	c := newSegmentCache(2)
+	rec := model.Recording{ID: "r1", FilePath: path, FileSize: fi.Size()}
+
+	info1, err := c.Get(rec)
+	require.NoError(t, err)
+	info2, err := c.Get(rec)
+	require.NoError(t, err)
+	require.Same(t, info1, info2) // cached pointer identity
+
+	// Changing file identity re-parses (different pointer, same content).
+	rec.FileSize += 7
+	info3, err := c.Get(rec)
+	require.NoError(t, err)
+	require.NotSame(t, info1, info3)
+	require.Equal(t, info1.SampleCount, info3.SampleCount)
+
+	// LRU eviction at capacity 2.
+	c.Get(model.Recording{ID: "x", FilePath: buildTestMP4(t, dir, "x.mp4", 5, 5), FileSize: 0})
+	recB := model.Recording{ID: "r2", FilePath: buildTestMP4(t, dir, "b.mp4", 5, 5)}
+	recB.FileSize = fileInfo(t, recB.FilePath).Size()
+	c.Get(recB)
+	c.mu.Lock()
+	require.Equal(t, 2, c.ll.Len())
+	c.mu.Unlock()
+}
+
+func fileInfo(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	return fi
+}

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 AGENTS.md
+
+# emergency out-dir (Windows file-lock workaround)
+dist2/

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -156,6 +156,7 @@ export {
   getRecordingDownloadUrl,
   getRecordingVideoUrl,
   getMergedRecordingUrl,
+  getCameraPlaybackPlaylistURL,
   probeMergedRecordingCodec,
   clearMergedCodecCache,
   downloadRecording,

--- a/web/src/lib/api/recordings.ts
+++ b/web/src/lib/api/recordings.ts
@@ -244,6 +244,13 @@ export function getMergedRecordingUrl(id: string): string {
   return `/api/recordings/${id}/merged`;
 }
 
+// getCameraPlaybackPlaylistURL builds the day-range VOD HLS playlist URL
+// (#321 Phase 2). The playlist stitches every H.264/H.265 recording of the
+// camera within [start, end] (RFC3339) into one seekable timeline.
+export function getCameraPlaybackPlaylistURL(cameraId: string, startISO: string, endISO: string): string {
+  return `/api/cameras/${cameraId}/playback/playlist.m3u8?start=${encodeURIComponent(startISO)}&end=${encodeURIComponent(endISO)}`;
+}
+
 // probeMergedRecordingCodec issues a HEAD request to the /merged endpoint and
 // returns the X-Timelapse-Codec header value ('h264' / 'h265' / 'mjpeg') so the
 // frontend can pick the right playback path: <video> for H.264/H.265 (browser-

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1541,5 +1541,9 @@
   "settings.ai.emaAlphaHint": "Box position smoothing: lower = smoother (box lags), higher = more responsive.",
   "settings.ai.maxAge": "Box dwell time",
   "settings.ai.maxAgeHint": "After an object disappears, its box lingers up to ~{secs} seconds.",
-  "settings.ai.noModelsHint": "No models found. Run mibee-nvr download-model to fetch one."
+  "settings.ai.noModelsHint": "No models found. Run mibee-nvr download-model to fetch one.",
+  "detail.continuous": "Continuous",
+  "detail.continuousOn": "Continuous (full-day timeline)",
+  "detail.continuousH265Unsupported": "This browser lacks MSE H.265 support — continuous playback unavailable (per-segment mode unaffected)",
+  "detail.continuousFailed": "Continuous playback failed to start, fell back to per-segment mode"
 }

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1545,5 +1545,6 @@
   "detail.continuous": "Continuous",
   "detail.continuousOn": "Continuous (full-day timeline)",
   "detail.continuousH265Unsupported": "This browser lacks MSE H.265 support — continuous playback unavailable (per-segment mode unaffected)",
-  "detail.continuousFailed": "Continuous playback failed to start, fell back to per-segment mode"
+  "detail.continuousFailed": "Continuous playback failed to start, fell back to per-segment mode",
+  "detail.continuousBuilding": "Building the full-day index (first time may take a minute or two)…"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1507,5 +1507,9 @@
   "cameras.gb28181DeviceId": "设备编号",
   "cameras.gb28181DeviceIdPlaceholder": "例如 34020000001310000001",
   "cameras.gb28181DeviceIdRequired": "设备编号为必填项",
-  "cameras.protocol.gb28181": "GB28181"
+  "cameras.protocol.gb28181": "GB28181",
+  "detail.continuous": "连续播放",
+  "detail.continuousOn": "连续播放（全天时间轴）",
+  "detail.continuousH265Unsupported": "此浏览器的 MSE 不支持 H.265，连续播放不可用（单段模式不受影响）",
+  "detail.continuousFailed": "连续播放初始化失败，已回退单段模式"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1511,5 +1511,6 @@
   "detail.continuous": "连续播放",
   "detail.continuousOn": "连续播放（全天时间轴）",
   "detail.continuousH265Unsupported": "此浏览器的 MSE 不支持 H.265，连续播放不可用（单段模式不受影响）",
-  "detail.continuousFailed": "连续播放初始化失败，已回退单段模式"
+  "detail.continuousFailed": "连续播放初始化失败，已回退单段模式",
+  "detail.continuousBuilding": "正在生成当日连续播放索引（首次可能需要一两分钟）…"
 }

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -15,6 +15,7 @@
   import {
     getRecording,
     getRecordingVideoUrl,
+    getCameraPlaybackPlaylistURL,
     getMergedRecordingUrl,
     probeMergedRecordingCodec,
     clearMergedCodecCache,
@@ -118,169 +119,6 @@
   let armingNext = false;
   let standbyReady = false;
   let switchToken = 0;
-
-  // --- Continuous playback (VOD HLS, #321 Phase 2) ---
-  // One hls.js MediaSource timeline for the camera's whole day: scrub anywhere
-  // (across recordings AND gaps) like a local file. Media time (0..dayDur on
-  // the video element) is mapped to/from wall-clock segments via vodMap,
-  // which is parsed from the playlist's EXT-X-MAP/EXTINF lines.
-  interface VodEntry { rid: string; mediaStart: number; dur: number; }
-  let continuousMode = $state(false);
-  let continuousReady = $state(false);
-  let hlsInstance: any = null;
-  let vodMap: VodEntry[] = [];
-  let activeVodEntry: VodEntry | null = null;
-  const CONTINUOUS_PREF_KEY = 'mibee_nvr_continuous_playback';
-
-  function mediaTimeFor(rid: string, offsetSec: number): number | null {
-    const e = vodMap.find((x) => x.rid === rid);
-    if (!e) return null;
-    return e.mediaStart + Math.max(0, Math.min(offsetSec, e.dur));
-  }
-
-  function vodEntryAt(mediaTime: number): VodEntry | null {
-    for (const e of vodMap) {
-      if (mediaTime >= e.mediaStart && mediaTime < e.mediaStart + e.dur) return e;
-    }
-    return vodMap.length > 0 ? vodMap[vodMap.length - 1] : null;
-  }
-
-  function parseVodPlaylist(text: string): VodEntry[] {
-    const entries: VodEntry[] = [];
-    let current: VodEntry | null = null;
-    for (const line of text.split('\n')) {
-      const mapMatch = line.match(/^#EXT-X-MAP:URI="\/api\/cameras\/[^/]+\/playback\/([^/]+)\/init\.mp4"/);
-      if (mapMatch) {
-        current = { rid: mapMatch[1], mediaStart: 0, dur: 0 };
-        entries.push(current);
-        continue;
-      }
-      const infMatch = line.match(/^#EXTINF:([\d.]+),/);
-      if (infMatch && current) {
-        current.dur += parseFloat(infMatch[1]);
-      }
-    }
-    let cum = 0;
-    for (const e of entries) {
-      e.mediaStart = cum;
-      cum += e.dur;
-    }
-    return entries;
-  }
-
-  function teardownContinuous() {
-    if (hlsInstance) {
-      try { hlsInstance.destroy(); } catch { /* already dead */ }
-      hlsInstance = null;
-    }
-    continuousReady = false;
-    activeVodEntry = null;
-    vodMap = [];
-  }
-
-  async function enableContinuous(startOffsetSec: number | null) {
-    if (!recording || !videoEl) return;
-    const f = recording.format;
-    if (f !== 'h264' && f !== 'h265') return;
-    if (f === 'h265') {
-      const MS = (window as any).MediaSource;
-      if (!MS || !MS.isTypeSupported('video/mp4; codecs="hvc1.1.6.L93.B0"')) {
-        showToast(t('detail.continuousH265Unsupported'), 'error');
-        continuousMode = false;
-        localStorage.removeItem(CONTINUOUS_PREF_KEY);
-        return;
-      }
-    }
-    // Local calendar day of the current recording (same window TimelineBar uses).
-    const d = new Date(recording.started_at);
-    const startISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0).toISOString();
-    const endISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59).toISOString();
-    const { getCameraPlaybackPlaylistURL } = await import('$lib/api');
-
-    let text: string;
-    showToast(t('detail.continuousBuilding'), 'info');
-    try {
-      const resp = await fetch(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      text = await resp.text();
-    } catch (e) {
-      console.warn('VOD playlist fetch failed', e);
-      showToast(t('detail.continuousFailed'), 'error');
-      continuousMode = false;
-      localStorage.removeItem(CONTINUOUS_PREF_KEY);
-      return;
-    }
-    const map = parseVodPlaylist(text);
-    if (map.length === 0) {
-      showToast(t('detail.continuousFailed'), 'error');
-      continuousMode = false;
-      localStorage.removeItem(CONTINUOUS_PREF_KEY);
-      return;
-    }
-    vodMap = map;
-
-    const mod: any = await import('hls.js');
-    const Hls = mod.default;
-    if (!Hls.isSupported()) {
-      showToast(t('detail.continuousFailed'), 'error');
-      continuousMode = false;
-      return;
-    }
-    teardownContinuous();
-    // The per-segment chain is owned by hls.js in this mode.
-    armedNext = null;
-    armedRecId = '';
-    nextRecordingId = null;
-    const hls = new Hls({
-      enableWorker: false,
-      maxBufferLength: 30,
-      backBufferLength: 60,
-      // Building the first playlist of a day parses every recording server-side
-      // (seconds on a slow disk) — allow generous load timeouts.
-      manifestLoadPolicy: {
-        default: { maxTimeToFirstByteMs: 20000, maxLoadTimeMs: 60000, timeoutRetry: { maxNumRetry: 1, retryDelayMs: 500 }, errorRetry: { maxNumRetry: 1, retryDelayMs: 500 } },
-      },
-    });
-    hlsInstance = hls;
-
-    const entry = vodMap.find((x) => x.rid === recording!.id) ?? vodMap[0];
-    const startAt = entry.rid === recording.id
-      ? entry.mediaStart + Math.max(0, Math.min(startOffsetSec ?? videoCurrentTime, entry.dur))
-      : entry.mediaStart;
-
-    hls.on(Hls.Events.MANIFEST_PARSED, () => {
-      continuousReady = true;
-      videoEl?.focus?.();
-      if (videoEl) {
-        try { videoEl.currentTime = startAt; } catch { /* not seekable yet */ }
-        activeVodEntry = vodEntryAt(startAt);
-        if (videoIsPlaying) void videoEl.play();
-      }
-    });
-    hls.on(Hls.Events.ERROR, (_evt: unknown, data: any) => {
-      if (!data?.fatal) return;
-      console.warn('VOD HLS fatal error, falling back to per-segment mode', data);
-      teardownContinuous();
-      continuousMode = false;
-      localStorage.removeItem(CONTINUOUS_PREF_KEY);
-      showToast(t('detail.continuousFailed'), 'error');
-      initVideoPlayer();
-    });
-    hls.attachMedia(videoEl);
-    hls.loadSource(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
-  }
-
-  function toggleContinuous() {
-    continuousMode = !continuousMode;
-    if (continuousMode) {
-      localStorage.setItem(CONTINUOUS_PREF_KEY, '1');
-      void enableContinuous(pendingTimelineSeekOffset);
-    } else {
-      localStorage.removeItem(CONTINUOUS_PREF_KEY);
-      teardownContinuous();
-      initVideoPlayer();
-    }
-  }
 
   // --- H.265 → H.264 transcode-for-playback ---
   let transcodeForPlayback = $state(false);
@@ -442,6 +280,170 @@
   }
 
   let nextRecordingId = $state<string | null>(null);
+
+  // --- Continuous playback (VOD HLS, #321 Phase 2) ---
+  // One hls.js MediaSource timeline for the camera's whole day: scrub anywhere
+  // (across recordings AND gaps) like a local file. Media time (0..dayDur on
+  // the video element) is mapped to/from wall-clock segments via vodMap,
+  // which is parsed from the playlist's EXT-X-MAP/EXTINF lines.
+  interface VodEntry { rid: string; mediaStart: number; dur: number; }
+  let continuousMode = $state(false);
+  let continuousReady = $state(false);
+  let hlsInstance: any = null;
+  let vodMap: VodEntry[] = [];
+  let activeVodEntry: VodEntry | null = null;
+  const CONTINUOUS_PREF_KEY = 'mibee_nvr_continuous_playback';
+
+  function mediaTimeFor(rid: string, offsetSec: number): number | null {
+    const e = vodMap.find((x) => x.rid === rid);
+    if (!e) return null;
+    return e.mediaStart + Math.max(0, Math.min(offsetSec, e.dur));
+  }
+
+  function vodEntryAt(mediaTime: number): VodEntry | null {
+    for (const e of vodMap) {
+      if (mediaTime >= e.mediaStart && mediaTime < e.mediaStart + e.dur) return e;
+    }
+    return vodMap.length > 0 ? vodMap[vodMap.length - 1] : null;
+  }
+
+  function parseVodPlaylist(text: string): VodEntry[] {
+    const entries: VodEntry[] = [];
+    let current: VodEntry | null = null;
+    for (const line of text.split('\n')) {
+      const mapMatch = line.match(/^#EXT-X-MAP:URI="\/api\/cameras\/[^/]+\/playback\/([^/]+)\/init\.mp4"/);
+      if (mapMatch) {
+        current = { rid: mapMatch[1], mediaStart: 0, dur: 0 };
+        entries.push(current);
+        continue;
+      }
+      const infMatch = line.match(/^#EXTINF:([\d.]+),/);
+      if (infMatch && current) {
+        current.dur += parseFloat(infMatch[1]);
+      }
+    }
+    let cum = 0;
+    for (const e of entries) {
+      e.mediaStart = cum;
+      cum += e.dur;
+    }
+    return entries;
+  }
+
+  function teardownContinuous() {
+    if (hlsInstance) {
+      try { hlsInstance.destroy(); } catch { /* already dead */ }
+      hlsInstance = null;
+    }
+    continuousReady = false;
+    activeVodEntry = null;
+    vodMap = [];
+  }
+
+  async function enableContinuous(startOffsetSec: number | null) {
+    if (!recording || !videoEl) return;
+    const f = recording.format;
+    if (f !== 'h264' && f !== 'h265') return;
+    if (f === 'h265') {
+      const MS = (window as any).MediaSource;
+      if (!MS || !MS.isTypeSupported('video/mp4; codecs="hvc1.1.6.L93.B0"')) {
+        showToast(t('detail.continuousH265Unsupported'), 'error');
+        continuousMode = false;
+        localStorage.removeItem(CONTINUOUS_PREF_KEY);
+        return;
+      }
+    }
+    // Local calendar day of the current recording (same window TimelineBar uses).
+    const d = new Date(recording.started_at);
+    const startISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0).toISOString();
+    const endISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59).toISOString();
+
+    let text: string;
+    showToast(t('detail.continuousBuilding'), 'info');
+    try {
+      const resp = await fetch(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      text = await resp.text();
+    } catch (e) {
+      console.warn('VOD playlist fetch failed', e);
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      return;
+    }
+    const map = parseVodPlaylist(text);
+    if (map.length === 0) {
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      return;
+    }
+    vodMap = map;
+    // Capture the start position BEFORE teardownContinuous() resets vodMap.
+    const entry = vodMap.find((x) => x.rid === recording!.id) ?? vodMap[0];
+    const startAt = entry.rid === recording.id
+      ? entry.mediaStart + Math.max(0, Math.min(startOffsetSec ?? videoCurrentTime, entry.dur))
+      : entry.mediaStart;
+
+    const mod: any = await import('hls.js');
+    const Hls = mod.default;
+    if (!Hls.isSupported()) {
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      return;
+    }
+    teardownContinuous();
+    vodMap = map; // re-arm: teardown cleared it
+    // The per-segment chain is owned by hls.js in this mode.
+    armedNext = null;
+    armedRecId = '';
+    nextRecordingId = null;
+    const hls = new Hls({
+      enableWorker: false,
+      maxBufferLength: 30,
+      backBufferLength: 60,
+      // Building the first playlist of a day parses every recording server-side
+      // (seconds on a slow disk) — allow generous load timeouts.
+      manifestLoadPolicy: {
+        default: { maxTimeToFirstByteMs: 20000, maxLoadTimeMs: 60000, timeoutRetry: { maxNumRetry: 1, retryDelayMs: 500 }, errorRetry: { maxNumRetry: 1, retryDelayMs: 500 } },
+      },
+    });
+    hlsInstance = hls;
+
+    hls.on(Hls.Events.MANIFEST_PARSED, () => {
+      continuousReady = true;
+      videoEl?.focus?.();
+      if (videoEl) {
+        try { videoEl.currentTime = startAt; } catch { /* not seekable yet */ }
+        activeVodEntry = vodEntryAt(startAt);
+        if (videoIsPlaying) void videoEl.play();
+      }
+    });
+    hls.on(Hls.Events.ERROR, (_evt: unknown, data: any) => {
+      if (!data?.fatal) return;
+      console.warn('VOD HLS fatal error, falling back to per-segment mode', data);
+      teardownContinuous();
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      showToast(t('detail.continuousFailed'), 'error');
+      initVideoPlayer();
+    });
+    hls.attachMedia(videoEl);
+    hls.loadSource(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
+  }
+
+  function toggleContinuous() {
+    continuousMode = !continuousMode;
+    if (continuousMode) {
+      localStorage.setItem(CONTINUOUS_PREF_KEY, '1');
+      void enableContinuous(pendingTimelineSeekOffset);
+    } else {
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      teardownContinuous();
+      initVideoPlayer();
+    }
+  }
+
   function handleTimeUpdate(e: Event) {
     if (e.target !== videoEl) return;
     const video = e.target as HTMLVideoElement;

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -198,6 +198,7 @@
     const { getCameraPlaybackPlaylistURL } = await import('$lib/api');
 
     let text: string;
+    showToast(t('detail.continuousBuilding'), 'info');
     try {
       const resp = await fetch(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -119,6 +119,168 @@
   let standbyReady = false;
   let switchToken = 0;
 
+  // --- Continuous playback (VOD HLS, #321 Phase 2) ---
+  // One hls.js MediaSource timeline for the camera's whole day: scrub anywhere
+  // (across recordings AND gaps) like a local file. Media time (0..dayDur on
+  // the video element) is mapped to/from wall-clock segments via vodMap,
+  // which is parsed from the playlist's EXT-X-MAP/EXTINF lines.
+  interface VodEntry { rid: string; mediaStart: number; dur: number; }
+  let continuousMode = $state(false);
+  let continuousReady = $state(false);
+  let hlsInstance: any = null;
+  let vodMap: VodEntry[] = [];
+  let activeVodEntry: VodEntry | null = null;
+  const CONTINUOUS_PREF_KEY = 'mibee_nvr_continuous_playback';
+
+  function mediaTimeFor(rid: string, offsetSec: number): number | null {
+    const e = vodMap.find((x) => x.rid === rid);
+    if (!e) return null;
+    return e.mediaStart + Math.max(0, Math.min(offsetSec, e.dur));
+  }
+
+  function vodEntryAt(mediaTime: number): VodEntry | null {
+    for (const e of vodMap) {
+      if (mediaTime >= e.mediaStart && mediaTime < e.mediaStart + e.dur) return e;
+    }
+    return vodMap.length > 0 ? vodMap[vodMap.length - 1] : null;
+  }
+
+  function parseVodPlaylist(text: string): VodEntry[] {
+    const entries: VodEntry[] = [];
+    let current: VodEntry | null = null;
+    for (const line of text.split('\n')) {
+      const mapMatch = line.match(/^#EXT-X-MAP:URI="\/api\/cameras\/[^/]+\/playback\/([^/]+)\/init\.mp4"/);
+      if (mapMatch) {
+        current = { rid: mapMatch[1], mediaStart: 0, dur: 0 };
+        entries.push(current);
+        continue;
+      }
+      const infMatch = line.match(/^#EXTINF:([\d.]+),/);
+      if (infMatch && current) {
+        current.dur += parseFloat(infMatch[1]);
+      }
+    }
+    let cum = 0;
+    for (const e of entries) {
+      e.mediaStart = cum;
+      cum += e.dur;
+    }
+    return entries;
+  }
+
+  function teardownContinuous() {
+    if (hlsInstance) {
+      try { hlsInstance.destroy(); } catch { /* already dead */ }
+      hlsInstance = null;
+    }
+    continuousReady = false;
+    activeVodEntry = null;
+    vodMap = [];
+  }
+
+  async function enableContinuous(startOffsetSec: number | null) {
+    if (!recording || !videoEl) return;
+    const f = recording.format;
+    if (f !== 'h264' && f !== 'h265') return;
+    if (f === 'h265') {
+      const MS = (window as any).MediaSource;
+      if (!MS || !MS.isTypeSupported('video/mp4; codecs="hvc1.1.6.L93.B0"')) {
+        showToast(t('detail.continuousH265Unsupported'), 'error');
+        continuousMode = false;
+        localStorage.removeItem(CONTINUOUS_PREF_KEY);
+        return;
+      }
+    }
+    // Local calendar day of the current recording (same window TimelineBar uses).
+    const d = new Date(recording.started_at);
+    const startISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0).toISOString();
+    const endISO = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59).toISOString();
+    const { getCameraPlaybackPlaylistURL } = await import('$lib/api');
+
+    let text: string;
+    try {
+      const resp = await fetch(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      text = await resp.text();
+    } catch (e) {
+      console.warn('VOD playlist fetch failed', e);
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      return;
+    }
+    const map = parseVodPlaylist(text);
+    if (map.length === 0) {
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      return;
+    }
+    vodMap = map;
+
+    const mod: any = await import('hls.js');
+    const Hls = mod.default;
+    if (!Hls.isSupported()) {
+      showToast(t('detail.continuousFailed'), 'error');
+      continuousMode = false;
+      return;
+    }
+    teardownContinuous();
+    // The per-segment chain is owned by hls.js in this mode.
+    armedNext = null;
+    armedRecId = '';
+    nextRecordingId = null;
+    const hls = new Hls({
+      enableWorker: false,
+      maxBufferLength: 30,
+      backBufferLength: 60,
+      // Building the first playlist of a day parses every recording server-side
+      // (seconds on a slow disk) — allow generous load timeouts.
+      manifestLoadPolicy: {
+        default: { maxTimeToFirstByteMs: 20000, maxLoadTimeMs: 60000, timeoutRetry: { maxNumRetry: 1, retryDelayMs: 500 }, errorRetry: { maxNumRetry: 1, retryDelayMs: 500 } },
+      },
+    });
+    hlsInstance = hls;
+
+    const entry = vodMap.find((x) => x.rid === recording!.id) ?? vodMap[0];
+    const startAt = entry.rid === recording.id
+      ? entry.mediaStart + Math.max(0, Math.min(startOffsetSec ?? videoCurrentTime, entry.dur))
+      : entry.mediaStart;
+
+    hls.on(Hls.Events.MANIFEST_PARSED, () => {
+      continuousReady = true;
+      videoEl?.focus?.();
+      if (videoEl) {
+        try { videoEl.currentTime = startAt; } catch { /* not seekable yet */ }
+        activeVodEntry = vodEntryAt(startAt);
+        if (videoIsPlaying) void videoEl.play();
+      }
+    });
+    hls.on(Hls.Events.ERROR, (_evt: unknown, data: any) => {
+      if (!data?.fatal) return;
+      console.warn('VOD HLS fatal error, falling back to per-segment mode', data);
+      teardownContinuous();
+      continuousMode = false;
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      showToast(t('detail.continuousFailed'), 'error');
+      initVideoPlayer();
+    });
+    hls.attachMedia(videoEl);
+    hls.loadSource(getCameraPlaybackPlaylistURL(recording.camera_id, startISO, endISO));
+  }
+
+  function toggleContinuous() {
+    continuousMode = !continuousMode;
+    if (continuousMode) {
+      localStorage.setItem(CONTINUOUS_PREF_KEY, '1');
+      void enableContinuous(pendingTimelineSeekOffset);
+    } else {
+      localStorage.removeItem(CONTINUOUS_PREF_KEY);
+      teardownContinuous();
+      initVideoPlayer();
+    }
+  }
+
   // --- H.265 → H.264 transcode-for-playback ---
   let transcodeForPlayback = $state(false);
   let transcodeForPlaybackError = $state('');
@@ -205,6 +367,15 @@
     switchToken++;
     lastLoadedId = recording.id;
     useFrameFallback = false;
+    // Continuous mode + external switch (user navigated / different day):
+    // rebuild the hls.js session around the new recording's day instead of
+    // falling back to per-segment init. (Self-adoptions never reach here —
+    // they set lastLoadedId before the host swaps the prop.)
+    if (continuousMode) {
+      teardownContinuous();
+      void enableContinuous(pendingTimelineSeekOffset);
+      return;
+    }
     const f = recording.format;
     if (f === 'h264' || f === 'h265') {
       probedMergedCodec = '';
@@ -273,6 +444,27 @@
   function handleTimeUpdate(e: Event) {
     if (e.target !== videoEl) return;
     const video = e.target as HTMLVideoElement;
+    if (continuousMode) {
+      // Media timeline → within-recording offset; adopt the target recording's
+      // metadata when playback crosses a recording boundary (discontinuity).
+      const entry = vodEntryAt(video.currentTime);
+      if (entry) {
+        videoCurrentTime = video.currentTime - entry.mediaStart;
+        videoDuration = entry.dur;
+        if (entry.rid !== activeVodEntry?.rid) {
+          activeVodEntry = entry;
+          if (entry.rid !== currentId) {
+            // Claim before the host swaps the prop so the recording-change
+            // effect skips re-initialization (same pattern as Phase 1 adoption).
+            lastLoadedId = entry.rid;
+            void getRecording(entry.rid).then((r) => {
+              if (r) oncrosssegment?.(r);
+            });
+          }
+        }
+      }
+      return;
+    }
     videoCurrentTime = video.currentTime;
     videoDuration = video.duration || 0;
     if (video.duration && video.currentTime / video.duration > 0.8 && !nextRecordingId) prefetchNextRecording();
@@ -299,6 +491,7 @@
   }
 
   async function prefetchNextRecording() {
+    if (continuousMode) return; // hls.js owns the chain in continuous mode
     if (nextRecordingId || !recording || armedNext || armingNext) return;
     armingNext = true;
     try {
@@ -444,6 +637,8 @@
       await videoEl.play();
       return;
     }
+    // Continuous mode: the playlist ended (ENDLIST reached) — nothing to chain.
+    if (continuousMode) return;
     // Seamless chain: adopt the prefetched next segment. If it is still
     // buffering, wait briefly (the ended frame stays visible — reads as a
     // short pause, not a flash) before falling back to the host navigation.
@@ -467,6 +662,25 @@
 
   async function handleTimelineSeek(recordingId: string, offsetSeconds: number) {
     if (!recording) return;
+    // Continuous mode: every target maps into the single media timeline —
+    // cross-recording, cross-gap, anything. No source switch, no reload.
+    if (continuousMode && continuousReady) {
+      const mt = mediaTimeFor(recordingId, offsetSeconds);
+      if (mt != null && videoEl) {
+        void recordTimelineSeek(recording.camera_id, 'segment');
+        videoEl.currentTime = mt;
+        videoCurrentTime = offsetSeconds;
+        const entry = vodMap.find((x) => x.rid === recordingId) ?? null;
+        if (entry && entry.rid !== currentId) {
+          activeVodEntry = entry;
+          lastLoadedId = entry.rid;
+          void getRecording(entry.rid).then((r) => {
+            if (r) oncrosssegment?.(r);
+          });
+        }
+        return;
+      }
+    }
     const isSegmentSwitch = recordingId !== currentId;
     void recordTimelineSeek(recording.camera_id, isSegmentSwitch ? 'segment' : 'intra');
     if (isSegmentSwitch) {
@@ -885,6 +1099,7 @@
 
   // Cleanup on destroy: abort in-flight requests, revoke blob URLs, clear timers.
   onDestroy(() => {
+    teardownContinuous();
     tlAbortController?.abort();
     tlAbortController = null;
     tlBlobCache.forEach(url => URL.revokeObjectURL(url));
@@ -1023,7 +1238,14 @@
     buffered={videoBuffered}
     isLooping={videoLoop}
     ontoggleplay={() => { if (videoEl) { if (videoEl.paused) videoEl.play(); else videoEl.pause(); } }}
-    onseek={(ratio) => { if (videoEl) videoEl.currentTime = ratio * videoDuration; }}
+    onseek={(ratio) => {
+      if (!videoEl) return;
+      if (continuousMode && activeVodEntry) {
+        videoEl.currentTime = activeVodEntry.mediaStart + ratio * activeVodEntry.dur;
+      } else {
+        videoEl.currentTime = ratio * videoDuration;
+      }
+    }}
     onsetspeed={(speed) => setVideoSpeed(speed)}
     onfullscreen={toggleVideoFullscreen}
     ontoggleloop={toggleVideoLoop}
@@ -1042,9 +1264,24 @@
   {/if}
   <div class="flex items-center justify-between px-4 py-2 th-bg-secondary border-t th-border">
     <span class="text-sm th-text-muted">{t('detail.playing')} <span class="font-mono th-text-primary">{recording?.camera_id}</span></span>
-    <button onclick={ongotonext} class="btn btn-ghost btn-sm flex items-center gap-1">
-      {t('detail.nextRecording')} <SkipForward size={16} />
-    </button>
+    <div class="flex items-center gap-2">
+      {#if (recording?.format === 'h264' || recording?.format === 'h265') && !useFrameFallback}
+        <button
+          onclick={toggleContinuous}
+          class="btn btn-sm flex items-center gap-1 {continuousMode ? 'btn-primary' : 'btn-ghost'}"
+          title={continuousMode ? t('detail.continuousOn') : t('detail.continuous')}
+          aria-pressed={continuousMode}>
+          {#if continuousMode}
+            {t('detail.continuousOn')}
+          {:else}
+            {t('detail.continuous')}
+          {/if}
+        </button>
+      {/if}
+      <button onclick={ongotonext} class="btn btn-ghost btn-sm flex items-center gap-1">
+        {t('detail.nextRecording')} <SkipForward size={16} />
+      </button>
+    </div>
   </div>
 {:else if playbackMode === 'timelapse'}
   {#if tlLoading}


### PR DESCRIPTION
## 目标（#321 Phase 2）

**时间寻址的连续传输**：开启"连续播放"后，摄像头一整天录像成为**一根可任意拖动的单一时间轴**——无论如何拖动（跨录像段、跨断帧间隙）都如本地播放器，一次 seek 即达。

## 架构（纯 Go，无新依赖）

**后端 `internal/vod` 新包** —— 按需 fMP4 分片器 + VOD HLS：
- `ParseSegment` 复用（`ParseSegmentNoProbe` 免探测变体）+ LRU 样本表缓存
- 关键帧定位三级策略（**M5 USB HDD 真机三轮优化**的产物）：
  1. `stss` 快路径（本 PR 起合并输出写 stss → 新文件零媒体读）
  2. sidecar `.vodidx` 分片计划持久化（size+mtime 校验，playlist 暖请求 9s→51ms）
  3. GOP 时间域预测探测（prefix-sum 二分 + ±4 抖动容差，每片段 ~1-5 次 6B 读；样本域预测会被帧率抖动打穿）
- fMP4 产出：init segment（ftyp+moov 空表+mvex）、moof 双阶段序列化（data_offset 先测量后填充）、mdat 范围合并流式拷贝
- 音频策略：AAC/Opus 进分片，G.711 剔除（Chrome MSE 不收 ulaw/alaw）
- API：`GET /api/cameras/{id}/playback/playlist.m3u8?start=&end=`（≤48h）+ `{recordingID}/init.mp4` + `f{a}-{b}.m4s`，公开路由（与 /download 同级）
- `merge` 增强：parser 读 stss、`detectKeyframes` 窗口化顺序批量读（syscall 数 ↓200×，惠及合并扫描）、`SPSResolution` 导出包装

**前端**（PlaybackPanel 连续播放开关，localStorage 记忆）：
- hls.js 单 MediaSource 全天时间轴；解析 EXT-X-MAP/EXTINF 建立媒体时间↔录像段映射
- 跨段拖动 = 一次 `currentTime` 赋值；游标/元数据经 `oncrosssegment` 原地跟随
- H.265 前置 MSE 能力检查（不支持则禁用并提示，单段模式不受影响）；致命错误自动回退 Phase 1 单段模式

## 实测（M5 PR 准入）

- Go：vod 10/10（盒子回读 / tfdt 递增 / GOP 预测精确命中 / 全链路无 stss 规划），merge 全量回归绿（Docker VM -race）
- CDP E2E（真实鼠标事件，cam-37903690 全天 31 录像 / 9574 分片）：
  - ✅ MSE 接管，**全天 36774s 单时间轴**
  - ✅ **一次 seek 从 20582s 跨 5+ 小时至 1785s**（跨无数段与间隙），播放持续推进
  - ✅ hash 原地跟随；**0 console 错误**；后端日志无 error
- 性能：playlist 暖 51ms；init 5ms；fragment（3MB/8s@1080p）270ms；冷索引一次性（HDD 2m33s，SD 卡低一个量级，之后 sidecar 永久命中）

## 修复清单（E2E 驱动）

- 分片时长 off-by-one（边界样本多算一帧，测试守恒断言抓出）
- `getCameraPlaybackPlaylistURL` 未在 `$lib/api` re-export；改静态 import
- `enableContinuous` 先 teardown 清空 vodMap 再建 entry 的顺序 bug
- 临时调试日志造成的源码级 TDZ（unhandledrejection 捕获定位）

Closes #321 Phase 2 主体（AVI 子项与 H.265 wasm 兜底继续在 issue 跟踪）。
