### PR TITLE
fix(playback): 返回保留观看日 + VOD 分片 404 自动重建 (#321)

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = '__SW_CACHE_VERSION__';
+const CACHE_VERSION = 'mibee-nvr-1786768019014';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/internal/vod/playlist.go
+++ b/internal/vod/playlist.go
@@ -1,6 +1,7 @@
 package vod
 
 import (
+	"time"
 	"fmt"
 	"math"
 	"os"
@@ -198,6 +199,10 @@ func (m *Manager) renderPlaylist(cameraID string, entries []*Entry) string {
 		if i > 0 {
 			b.WriteString("#EXT-X-DISCONTINUITY\n")
 		}
+		// Wall-clock anchor for the recording period: lets the client find the
+		// NEAREST period by wall clock when rebuilding the session after
+		// rolling merges replaced the currently-playing recording (404s).
+		fmt.Fprintf(&b, "#EXT-X-PROGRAM-DATE-TIME:%s\n", e.Rec.StartedAt.UTC().Format(time.RFC3339Nano))
 		b.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=%q\n", InitURL(cameraID, e.Rec.ID)))
 		for _, f := range e.Frags {
 			dur := f.DurationSec(e.Ts)

--- a/internal/vod/playlist.go
+++ b/internal/vod/playlist.go
@@ -1,13 +1,13 @@
 package vod
 
 import (
-	"time"
 	"fmt"
 	"math"
 	"os"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"

--- a/internal/vod/vod_test.go
+++ b/internal/vod/vod_test.go
@@ -356,6 +356,8 @@ func TestManagerPlaylist(t *testing.T) {
 	require.Contains(t, playlist, "#EXT-X-PLAYLIST-TYPE:VOD")
 	require.Contains(t, playlist, "#EXT-X-ENDLIST")
 	require.Contains(t, playlist, `#EXT-X-MAP:URI="/api/cameras/cam1/playback/rec-a/init.mp4"`)
+	require.Contains(t, playlist, "#EXT-X-PROGRAM-DATE-TIME:")
+	require.Equal(t, 2, strings.Count(playlist, "#EXT-X-PROGRAM-DATE-TIME:"))
 	require.Contains(t, playlist, `#EXT-X-MAP:URI="/api/cameras/cam1/playback/rec-b/init.mp4"`)
 	require.Equal(t, 1, strings.Count(playlist, "#EXT-X-DISCONTINUITY\n"))
 	// Default fragment target is 6s; the fixtures are 0.66s/0.33s total, so

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -100,6 +100,16 @@
   }
 
   function goBack() {
+    // On a recording's detail page the back button returns to the recordings
+    // list ON THE WATCHED DAY (?date= carried by the detail URL) instead of
+    // raw browser history — watching yesterday's recording and going back must
+    // land on yesterday, not on today (#321 follow-up). Other back contexts
+    // (live view) keep native history semantics.
+    if (window.location.hash.startsWith('#/recordings/')) {
+      const m = window.location.hash.match(/[?&]date=(\d{4}-\d{2}-\d{2})/);
+      window.location.hash = m ? `#/recordings?date=${m[1]}` : '#/recordings';
+      return;
+    }
     window.history.back();
   }
 </script>

--- a/web/src/lib/__tests__/vod-playlist.test.ts
+++ b/web/src/lib/__tests__/vod-playlist.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { entryAt, mediaTimeFor, nearestEntryByWallClock, parseVodPlaylist } from '$lib/vod-playlist';
+
+const PL = (recs: Array<{ rid: string; wall?: string; durs: number[] }>) =>
+  '#EXTM3U\n' +
+  recs
+    .map(
+      (r) =>
+        (r.wall ? `#EXT-X-PROGRAM-DATE-TIME:${r.wall}\n` : '') +
+        `#EXT-X-MAP:URI="/api/cameras/cam1/playback/${r.rid}/init.mp4"\n` +
+        r.durs.map((d) => `#EXTINF:${d.toFixed(3)},\n/api/cameras/cam1/playback/${r.rid}/f0-1.m4s`).join('\n'),
+    )
+    .join('\n#EXT-X-DISCONTINUITY\n') +
+  '\n#EXT-X-ENDLIST\n';
+
+describe('parseVodPlaylist', () => {
+  it('builds cumulative media starts per EXT-X-MAP period', () => {
+    const text = PL([
+      { rid: 'a', durs: [4, 4, 4] },
+      { rid: 'b', durs: [6] },
+    ]);
+    const map = parseVodPlaylist(text);
+    expect(map).toHaveLength(2);
+    expect(map[0]).toMatchObject({ rid: 'a', mediaStart: 0, dur: 12 });
+    expect(map[1]).toMatchObject({ rid: 'b', mediaStart: 12, dur: 6 });
+  });
+
+  it('attaches the wall-clock anchor of the period that FOLLOWS it', () => {
+    const text = PL([
+      { rid: 'a', wall: '2026-08-14T10:00:00Z', durs: [8] },
+      { rid: 'b', wall: '2026-08-14T11:00:00Z', durs: [8] },
+    ]);
+    const map = parseVodPlaylist(text);
+    expect(map[0].wallStart).toBe(Date.parse('2026-08-14T10:00:00Z'));
+    expect(map[1].wallStart).toBe(Date.parse('2026-08-14T11:00:00Z'));
+  });
+
+  it('tolerates a playlist without PDT lines', () => {
+    const map = parseVodPlaylist(PL([{ rid: 'x', durs: [3] }]));
+    expect(map[0].wallStart).toBe(0);
+  });
+});
+
+describe('entryAt', () => {
+  const map = parseVodPlaylist(PL([{ rid: 'a', durs: [10] }, { rid: 'b', durs: [10] }]));
+  it('finds the containing period', () => {
+    expect(entryAt(map, 0)?.rid).toBe('a');
+    expect(entryAt(map, 9.9)?.rid).toBe('a');
+    expect(entryAt(map, 10)?.rid).toBe('b');
+  });
+  it('clamps past the end to the last period', () => {
+    expect(entryAt(map, 999)?.rid).toBe('b');
+  });
+});
+
+describe('nearestEntryByWallClock', () => {
+  const map = parseVodPlaylist(
+    PL([
+      { rid: 'a', wall: '2026-08-14T08:00:00Z', durs: [8] },
+      { rid: 'b', wall: '2026-08-14T09:00:00Z', durs: [8] },
+      { rid: 'c', wall: '2026-08-14T10:00:00Z', durs: [8] },
+    ]),
+  );
+  it('picks the closest period start', () => {
+    expect(nearestEntryByWallClock(map, Date.parse('2026-08-14T09:01:00Z'))?.rid).toBe('b');
+    expect(nearestEntryByWallClock(map, Date.parse('2026-08-14T09:40:00Z'))?.rid).toBe('c');
+  });
+  it('falls back to the first entry when no anchors exist', () => {
+    const noWall = parseVodPlaylist(PL([{ rid: 'x', durs: [1] }]));
+    expect(nearestEntryByWallClock(noWall, 123)?.rid).toBe('x');
+  });
+});
+
+describe('mediaTimeFor', () => {
+  const map = parseVodPlaylist(PL([{ rid: 'a', durs: [10] }, { rid: 'b', durs: [10] }]));
+  it('maps (rid, offset) into the media timeline', () => {
+    expect(mediaTimeFor(map, 'b', 5)).toBe(15);
+  });
+  it('clamps offsets beyond the recording duration', () => {
+    expect(mediaTimeFor(map, 'a', 99)).toBe(10);
+  });
+  it('returns null for unknown rid', () => {
+    expect(mediaTimeFor(map, 'zzz', 1)).toBeNull();
+  });
+});

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1546,5 +1546,6 @@
   "detail.continuousOn": "Continuous (full-day timeline)",
   "detail.continuousH265Unsupported": "This browser lacks MSE H.265 support — continuous playback unavailable (per-segment mode unaffected)",
   "detail.continuousFailed": "Continuous playback failed to start, fell back to per-segment mode",
-  "detail.continuousBuilding": "Building the full-day index (first time may take a minute or two)…"
+  "detail.continuousBuilding": "Building the full-day index (first time may take a minute or two)…",
+  "detail.continuousRebuilt": "Recordings updated (rolling merge) — playback restored to your position"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1512,5 +1512,6 @@
   "detail.continuousOn": "连续播放（全天时间轴）",
   "detail.continuousH265Unsupported": "此浏览器的 MSE 不支持 H.265，连续播放不可用（单段模式不受影响）",
   "detail.continuousFailed": "连续播放初始化失败，已回退单段模式",
-  "detail.continuousBuilding": "正在生成当日连续播放索引（首次可能需要一两分钟）…"
+  "detail.continuousBuilding": "正在生成当日连续播放索引（首次可能需要一两分钟）…",
+  "detail.continuousRebuilt": "录像已更新（滚动合并），已自动恢复到当前进度"
 }

--- a/web/src/lib/vod-playlist.ts
+++ b/web/src/lib/vod-playlist.ts
@@ -1,0 +1,90 @@
+/**
+ * VOD playlist mapping utilities (#321 Phase 2).
+ *
+ * The day playlist stitches every recording into one media timeline; these
+ * helpers translate between MEDIA time (0..totalDur on the <video> element,
+ * owned by hls.js/MSE) and the per-recording view the UI works in
+ * (recording id + within-recording offset + wall clock).
+ */
+
+export interface VodEntry {
+  /** Recording ID (from the period's EXT-X-MAP URI). */
+  rid: string;
+  /** Media-time offset where this recording's period starts. */
+  mediaStart: number;
+  /** Total content duration of the recording (sum of its EXTINF values). */
+  dur: number;
+  /** Wall-clock start (epoch ms, from #EXT-X-PROGRAM-DATE-TIME; 0 if absent). */
+  wallStart: number;
+}
+
+/**
+ * Parses a VOD playlist into per-recording entries: each EXT-X-MAP starts a
+ * period; its EXTINF durations accumulate; an optional
+ * #EXT-X-PROGRAM-DATE-TIME line before the map anchors the period in wall
+ * clock.
+ */
+export function parseVodPlaylist(text: string): VodEntry[] {
+  const entries: VodEntry[] = [];
+  let current: VodEntry | null = null;
+  let pendingWall = 0; // PDT precedes its period's EXT-X-MAP — hold it until the map arrives
+  for (const line of text.split('\n')) {
+    const pdt = line.match(/^#EXT-X-PROGRAM-DATE-TIME:(.+)$/);
+    if (pdt) {
+      pendingWall = Date.parse(pdt[1]) || 0;
+      continue;
+    }
+    const mapMatch = line.match(/^#EXT-X-MAP:URI="\/api\/cameras\/[^/]+\/playback\/([^/]+)\/init\.mp4"/);
+    if (mapMatch) {
+      current = { rid: mapMatch[1], mediaStart: 0, dur: 0, wallStart: pendingWall };
+      pendingWall = 0;
+      entries.push(current);
+      continue;
+    }
+    const infMatch = line.match(/^#EXTINF:([\d.]+),/);
+    if (infMatch && current) {
+      current.dur += parseFloat(infMatch[1]);
+    }
+  }
+  let cum = 0;
+  for (const e of entries) {
+    e.mediaStart = cum;
+    cum += e.dur;
+  }
+  return entries;
+}
+
+/** Entry containing the given media time (last entry past the end). */
+export function entryAt(entries: VodEntry[], mediaTime: number): VodEntry | null {
+  for (const e of entries) {
+    if (mediaTime >= e.mediaStart && mediaTime < e.mediaStart + e.dur) return e;
+  }
+  return entries.length > 0 ? entries[entries.length - 1] : null;
+}
+
+/**
+ * Entry whose wall-clock start is nearest to `epochMs`. Used when rebuilding
+ * the session after rolling merges replaced the currently-playing recording:
+ * its ID is gone from the fresh playlist, but its wall-clock position maps to
+ * the successor segment covering (or nearest to) the same moment.
+ */
+export function nearestEntryByWallClock(entries: VodEntry[], epochMs: number): VodEntry | null {
+  let best: VodEntry | null = null;
+  let bestDiff = Infinity;
+  for (const e of entries) {
+    if (!e.wallStart) continue;
+    const diff = Math.abs(e.wallStart - epochMs);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = e;
+    }
+  }
+  return best ?? (entries.length > 0 ? entries[0] : null);
+}
+
+/** Media time for (recording, offset); null when the rid is not in the map. */
+export function mediaTimeFor(entries: VodEntry[], rid: string, offsetSec: number): number | null {
+  const e = entries.find((x) => x.rid === rid);
+  if (!e) return null;
+  return e.mediaStart + Math.max(0, Math.min(offsetSec, e.dur));
+}

--- a/web/src/routes/RecordingDetail.svelte
+++ b/web/src/routes/RecordingDetail.svelte
@@ -70,6 +70,7 @@
       const rec = await getRecording(currentId);
       if (token !== loadToken) return;
       recording = rec;
+      syncDetailDateInURL();
       // PlaybackPanel handles player init in its $effect on `recording`.
       // The codec probe that picks <video> vs cycler for timelapse/mjpeg is
       // done lazily by PlaybackPanel's mode derivation.
@@ -157,6 +158,7 @@
     try {
       history.replaceState(null, '', `#/recordings/${r.id}`);
     } catch { /* non-browser env */ }
+    syncDetailDateInURL();
   }
 
   // Resolve ?at= absolute timestamp → offset once recording.started_at is known.
@@ -169,6 +171,21 @@
     pendingTimelineSeekAtMs = null;
     if (pendingTimelineSeekOffset == null) pendingTimelineSeekOffset = offsetSec;
   });
+
+  // Keep the watched day in the detail URL (?date=YYYY-MM-DD). The Header
+  // back button reads it to return to the recordings list on the SAME day
+  // (#321 follow-up); deep links like ?t=/?at= are preserved.
+  function syncDetailDateInURL() {
+    if (!recording?.started_at) return;
+    const day = new Date(recording.started_at).toLocaleDateString('en-CA');
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
+    try {
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      if (params.get('date') === day) return;
+      params.set('date', day);
+      history.replaceState(null, '', `#/recordings/${currentId}?${params.toString()}`);
+    } catch { /* non-browser env */ }
+  }
 
   // Route-entry effect: reacts to the recordingId PROP (fresh mount, or a
   // remount from another route). Mid-session segment switches do NOT come
@@ -186,18 +203,27 @@
     void loadRecording();
   });
 
+  // Back target keeps the watched day: #/recordings?date=<local day of the
+  // recording> — returning from yesterday's playback must land on yesterday's
+  // list, not jump to today (#321 follow-up).
+  function recordingsHashWithDay(): string {
+    if (!recording?.started_at) return '#/recordings';
+    const day = new Date(recording.started_at).toLocaleDateString('en-CA');
+    return /^\d{4}-\d{2}-\d{2}$/.test(day) ? `#/recordings?date=${day}` : '#/recordings';
+  }
+
   async function confirmDelete() {
     if (!recording) return;
     try {
       await deleteRecording(recording.id);
-      window.location.hash = '#/recordings';
+      window.location.hash = recordingsHashWithDay();
     } catch (e) {
       error = e instanceof Error ? e.message : t('common.failedDeleteRecording');
       deleteConfirm = false;
     }
   }
 
-  function goBack() { window.location.hash = '#/recordings'; }
+  function goBack() { window.location.hash = recordingsHashWithDay(); }
 
   // Merge completion → reload recording (re-probe codec, refresh merge_status).
   function onMergeCompleted() {

--- a/web/src/routes/Recordings.svelte
+++ b/web/src/routes/Recordings.svelte
@@ -44,6 +44,7 @@
   let initialViewMode: 'timeline' | 'list' | 'timelapse' = 'timeline';
   let initialFormat = 'All';
   let initialCameraId = '';
+  let initialDate: string | null = null;
   try {
     const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
     const v = params.get('view');
@@ -54,6 +55,11 @@
     if (f && ['All', 'Video', 'Timelapse', 'MJPEG'].includes(f)) initialFormat = f;
     const c = params.get('camera');
     if (c) initialCameraId = c;
+    // ?date=YYYY-MM-DD restores the watched day when returning from a
+    // recording's detail page (back-nav must land on the day you were
+    // watching, not jump to today).
+    const dt = params.get('date');
+    if (dt && /^\d{4}-\d{2}-\d{2}$/.test(dt)) initialDate = dt;
   } catch {}
 
   // ── Filter state ──
@@ -69,7 +75,7 @@
 
   // ── Date/time state ──
   let currentMonth = $state(new Date());
-  let selectedDate = $state<string | null>(null);
+  let selectedDate = $state<string | null>(initialDate);
 
   // ── Calendar summary (lightweight per-day aggregate, no row limit) ──
   let calendarSummary = $state<RecordingDaySummary[]>([]);
@@ -898,6 +904,8 @@ let selectedPresetCamera = $state<string>('');
         if (f && ['All', 'Video', 'Timelapse', 'MJPEG'].includes(f)) formatPill = f;
         const c = params.get('camera');
         if (c !== null) cameraId = c;
+        const dt = params.get('date');
+        if (dt && /^\d{4}-\d{2}-\d{2}$/.test(dt)) selectedDate = dt;
       } catch {}
     };
     window.addEventListener('hashchange', handler);
@@ -913,6 +921,20 @@ let selectedPresetCamera = $state<string>('');
       const d = String(today.getDate()).padStart(2, '0');
       selectedDate = `${y}-${m}-${d}`;
     }
+  });
+
+  // Mirror the selected date into the URL (?date=YYYY-MM-DD, replaceState — no
+  // history spam) so navigating to a recording and back returns to the SAME
+  // day instead of resetting to today (#321 follow-up).
+  $effect(() => {
+    const d = selectedDate;
+    if (!d) return;
+    try {
+      const params = new URLSearchParams(window.location.hash.split('?')[1] || '');
+      if (params.get('date') === d) return;
+      params.set('date', d);
+      history.replaceState(null, '', `#/recordings?${params.toString()}`);
+    } catch { /* non-browser env */ }
   });
 </script>
 

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -26,6 +26,7 @@
   } from '$lib/api';
   import { AlertTriangle, HelpCircle, SkipForward, Loader2, RefreshCw, Play, Pause, ChevronLeft, ChevronRight } from 'lucide-svelte';
   import MjpegPlayer from '$lib/components/MjpegPlayer.svelte';
+  import { parseVodPlaylist, entryAt, nearestEntryByWallClock, mediaTimeFor, type VodEntry } from '$lib/vod-playlist';
   import VideoPlaybackControls from '$lib/components/VideoPlaybackControls.svelte';
   import AviPlayback from '../../components/AviPlayback.svelte';
   import TimelineBar from '$lib/components/TimelineBar.svelte';
@@ -284,51 +285,19 @@
   // --- Continuous playback (VOD HLS, #321 Phase 2) ---
   // One hls.js MediaSource timeline for the camera's whole day: scrub anywhere
   // (across recordings AND gaps) like a local file. Media time (0..dayDur on
-  // the video element) is mapped to/from wall-clock segments via vodMap,
-  // which is parsed from the playlist's EXT-X-MAP/EXTINF lines.
-  interface VodEntry { rid: string; mediaStart: number; dur: number; }
+  // the video element) is mapped to/from wall-clock segments via vodMap
+  // (mapping helpers in $lib/vod-playlist.ts).
   let continuousMode = $state(false);
   let continuousReady = $state(false);
   let hlsInstance: any = null;
   let vodMap: VodEntry[] = [];
   let activeVodEntry: VodEntry | null = null;
+  // Rebuild resume target: set by the hls fatal-error path when the playlist
+  // went stale (rolling merge replaced recordings -> fragment 404s), consumed
+  // by the next enableContinuous() to restore the playback position.
+  let vodResume: { rid: string | null; offset: number; wallMs: number } | null = null;
+  let vodRebuilds = 0; // bounded per successful parse (reset in MANIFEST_PARSED)
   const CONTINUOUS_PREF_KEY = 'mibee_nvr_continuous_playback';
-
-  function mediaTimeFor(rid: string, offsetSec: number): number | null {
-    const e = vodMap.find((x) => x.rid === rid);
-    if (!e) return null;
-    return e.mediaStart + Math.max(0, Math.min(offsetSec, e.dur));
-  }
-
-  function vodEntryAt(mediaTime: number): VodEntry | null {
-    for (const e of vodMap) {
-      if (mediaTime >= e.mediaStart && mediaTime < e.mediaStart + e.dur) return e;
-    }
-    return vodMap.length > 0 ? vodMap[vodMap.length - 1] : null;
-  }
-
-  function parseVodPlaylist(text: string): VodEntry[] {
-    const entries: VodEntry[] = [];
-    let current: VodEntry | null = null;
-    for (const line of text.split('\n')) {
-      const mapMatch = line.match(/^#EXT-X-MAP:URI="\/api\/cameras\/[^/]+\/playback\/([^/]+)\/init\.mp4"/);
-      if (mapMatch) {
-        current = { rid: mapMatch[1], mediaStart: 0, dur: 0 };
-        entries.push(current);
-        continue;
-      }
-      const infMatch = line.match(/^#EXTINF:([\d.]+),/);
-      if (infMatch && current) {
-        current.dur += parseFloat(infMatch[1]);
-      }
-    }
-    let cum = 0;
-    for (const e of entries) {
-      e.mediaStart = cum;
-      cum += e.dur;
-    }
-    return entries;
-  }
 
   function teardownContinuous() {
     if (hlsInstance) {
@@ -380,10 +349,25 @@
     }
     vodMap = map;
     // Capture the start position BEFORE teardownContinuous() resets vodMap.
-    const entry = vodMap.find((x) => x.rid === recording!.id) ?? vodMap[0];
-    const startAt = entry.rid === recording.id
-      ? entry.mediaStart + Math.max(0, Math.min(startOffsetSec ?? videoCurrentTime, entry.dur))
-      : entry.mediaStart;
+    // Resume target wins (rebuild after stale-playlist 404s): exact recording
+    // match, else the period nearest the remembered wall clock.
+    const resume = vodResume;
+    vodResume = null;
+    let entry: VodEntry;
+    let startAt: number;
+    if (resume) {
+      entry = vodMap.find((x) => x.rid === resume.rid)
+        ?? nearestEntryByWallClock(vodMap, resume.wallMs);
+      const offset = Math.max(0, Math.min(resume.offset, entry.dur));
+      startAt = entry.mediaStart + offset;
+      videoCurrentTime = offset;
+      showToast(t('detail.continuousRebuilt'), 'info');
+    } else {
+      entry = vodMap.find((x) => x.rid === recording!.id) ?? vodMap[0];
+      startAt = entry.rid === recording.id
+        ? entry.mediaStart + Math.max(0, Math.min(startOffsetSec ?? videoCurrentTime, entry.dur))
+        : entry.mediaStart;
+    }
 
     const mod: any = await import('hls.js');
     const Hls = mod.default;
@@ -412,15 +396,37 @@
 
     hls.on(Hls.Events.MANIFEST_PARSED, () => {
       continuousReady = true;
+      vodRebuilds = 0;
       videoEl?.focus?.();
       if (videoEl) {
         try { videoEl.currentTime = startAt; } catch { /* not seekable yet */ }
-        activeVodEntry = vodEntryAt(startAt);
+        activeVodEntry = entryAt(vodMap, startAt);
         if (videoIsPlaying) void videoEl.play();
       }
     });
     hls.on(Hls.Events.ERROR, (_evt: unknown, data: any) => {
       if (!data?.fatal) return;
+      // Stale playlist (rolling merge replaced recordings -> fragment 404s) is
+      // the common fatal case: rebuild the session at the current position
+      // before giving up. Bounded to 2 rebuilds per successful parse so a
+      // genuinely broken stream falls through to per-segment mode.
+      if (continuousMode && vodRebuilds < 2) {
+        const v = videoEl;
+        const t = v ? v.currentTime : 0;
+        const cur = entryAt(vodMap, t);
+        if (cur) {
+          vodRebuilds++;
+          vodResume = {
+            rid: cur.rid,
+            offset: Math.max(0, t - cur.mediaStart),
+            wallMs: cur.wallStart ? cur.wallStart + Math.max(0, t - cur.mediaStart) * 1000 : 0,
+          };
+          console.warn('VOD HLS fatal error, rebuilding continuous session', data);
+          teardownContinuous();
+          void enableContinuous(null);
+          return;
+        }
+      }
       console.warn('VOD HLS fatal error, falling back to per-segment mode', data);
       teardownContinuous();
       continuousMode = false;
@@ -450,7 +456,7 @@
     if (continuousMode) {
       // Media timeline → within-recording offset; adopt the target recording's
       // metadata when playback crosses a recording boundary (discontinuity).
-      const entry = vodEntryAt(video.currentTime);
+      const entry = entryAt(vodMap, video.currentTime);
       if (entry) {
         videoCurrentTime = video.currentTime - entry.mediaStart;
         videoDuration = entry.dur;
@@ -668,7 +674,7 @@
     // Continuous mode: every target maps into the single media timeline —
     // cross-recording, cross-gap, anything. No source switch, no reload.
     if (continuousMode && continuousReady) {
-      const mt = mediaTimeFor(recordingId, offsetSeconds);
+      const mt = mediaTimeFor(vodMap, recordingId, offsetSeconds);
       if (mt != null && videoEl) {
         void recordTimelineSeek(recording.camera_id, 'segment');
         videoEl.currentTime = mt;


### PR DESCRIPTION
## 内容（#321 后续）

### 1. 返回导航保留观看日（用户反馈）

看前一天的录像点"返回"会回到今天——现在三条返回路径（Header 返回按钮、页内返回/删除后跳转、Escape）全部落回**观看中的那一天**：

- `RecordingDetail`：URL 常带 `?date=<观看日>`（加载/跨段采纳后 replaceState 同步，保留 `?t`/`?at` 深链参数）
- `Header`：详情路由下返回 = `#/recordings?date=<观看日>` 跳转（其他路由保持 `history.back()`）
- `Recordings`：读写 `?date` 参数（初始挂载 + hashchange + `selectedDate`→URL replaceState 同步，不堆历史）

### 2. 滚动合并后分片 404 的自动恢复

PR #342 留的观察项：滚动合并每小时替换录像 → 旧分片 URL 404 → hls.js 致命错误。此前会回退单段模式；现在**先原地重建**（≤2 次/成功解析）：

- playlist 每录像前新增 `#EXT-X-PROGRAM-DATE-TIME`（墙钟锚点）
- 新增 `$lib/vod-playlist.ts` 纯函数库（解析 / entryAt / 墙钟最近邻 / 媒体时间映射），vitest 10/10
- 致命错误 → 记录当前位置墙钟 → 重建会话 → 墙钟最近邻恢复位置（原录像 ID 已被合并吞掉时也能落回覆盖同一时刻的新段）→ 仍失败才回退单段模式

## M5 实测（CDP + Fetch 域拦截模拟 404 风暴）

- ✅ 前一天录像返回 → `#/recordings?date=<观看日>`，列表落回同一天
- ✅ 连续模式中 6×分片 404 → 自动重建，**位置精确恢复**（recovered@22381 ≈ 原位置+seek），模式保持连续
- vitest 585/585（新增 vod-playlist 10 项）；vod/merge Go 测试 VM 全绿（playlist 含 PDT 断言）

Refs #321（剩余子项：AVI demux 评估、H.265 wasm 兜底——评估结论见 issue 评论）
