### PR TITLE
feat(playback): AVI 录像帧浏览模式 — 可拖动 + 跨段无缝链 (#321)

### DIFF
--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mediaprobe"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -758,6 +759,10 @@ func (h *Handler) handleTimelapseFrames(w http.ResponseWriter, r *http.Request) 
 		WriteError(w, http.StatusNotFound, "recording not found")
 		return
 	}
+	if rec.Format == model.FormatAVI {
+		h.handleAviFrames(w, r, rec)
+		return
+	}
 	if rec.Format != model.FormatTimelapse && rec.Format != model.FormatMJPEG {
 		WriteError(w, http.StatusNotFound, "not a timelapse or MJPEG recording")
 		return
@@ -818,6 +823,93 @@ func (h *Handler) handleTimelapseFrames(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, frames)
 }
 
+// handleAviFrames serves the timelapse-frames listing contract for AVI
+// recordings (#321): video frames (complete JPEGs) indexed by walking the
+// movi chunk headers. The frontend JPEG cycler — which already has seamless
+// cross-segment chaining and seeking — consumes this exactly like timelapse
+// frames, giving AVI recordings seekable playback instead of the realtime-only
+// WebSocket player.
+func (h *Handler) handleAviFrames(w http.ResponseWriter, r *http.Request, rec *model.Recording) {
+	f, err := os.Open(rec.FilePath)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, "AVI file not found")
+		return
+	}
+	defer f.Close()
+
+	dmx, err := avi.NewDemuxer(f)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "parse AVI: "+err.Error())
+		return
+	}
+	entries, err := dmx.VideoFrameIndex()
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "index AVI frames: "+err.Error())
+		return
+	}
+
+	type TimelapseFrameInfo struct {
+		Filename  string `json:"filename"`
+		URL       string `json:"url"`
+		Size      int64  `json:"size"`
+		Timestamp string `json:"timestamp"`
+	}
+	started := rec.StartedAt
+	frames := make([]TimelapseFrameInfo, 0, len(entries))
+	for _, e := range entries {
+		name := fmt.Sprintf("f%06d.jpg", e.Index)
+		frames = append(frames, TimelapseFrameInfo{
+			Filename:  name,
+			URL:       fmt.Sprintf("/api/recordings/%s/timelapse-frames/%s", rec.ID, name),
+			Size:      int64(e.Size),
+			Timestamp: started.Add(time.Duration(e.PTSUs) * time.Microsecond).UTC().Format(time.RFC3339),
+		})
+	}
+	writeJSON(w, http.StatusOK, frames)
+}
+
+// handleAviFrame serves one JPEG frame out of an AVI recording by synthetic
+// filename (f%06d.jpg — see handleAviFrames).
+func (h *Handler) handleAviFrame(w http.ResponseWriter, r *http.Request, rec *model.Recording, filename string) {
+	var idx int
+	if _, err := fmt.Sscanf(filename, "f%d.jpg", &idx); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid AVI frame filename")
+		return
+	}
+	f, err := os.Open(rec.FilePath)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, "AVI file not found")
+		return
+	}
+	defer f.Close()
+	dmx, err := avi.NewDemuxer(f)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "parse AVI: "+err.Error())
+		return
+	}
+	entries, err := dmx.VideoFrameIndex()
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "index AVI frames: "+err.Error())
+		return
+	}
+	if idx < 0 || idx >= len(entries) {
+		WriteError(w, http.StatusNotFound, "AVI frame out of range")
+		return
+	}
+	e := entries[idx]
+	if _, err := f.Seek(e.Offset, io.SeekStart); err != nil {
+		WriteError(w, http.StatusInternalServerError, "seek AVI frame: "+err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "image/jpeg")
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(e.Size), 10))
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	if _, err := io.CopyN(w, f, int64(e.Size)); err != nil {
+		return // client went away
+	}
+}
+
 // handleTimelapseFrame handles GET /api/recordings/{id}/timelapse-frames/{filename}.
 // Serves an individual JPEG frame from a timelapse recording.
 func (h *Handler) handleTimelapseFrame(w http.ResponseWriter, r *http.Request) {
@@ -843,6 +935,10 @@ func (h *Handler) handleTimelapseFrame(w http.ResponseWriter, r *http.Request) {
 	}
 	if rec == nil {
 		WriteError(w, http.StatusNotFound, "recording not found")
+		return
+	}
+	if rec.Format == model.FormatAVI {
+		h.handleAviFrame(w, r, rec, filename)
 		return
 	}
 	if rec.Format != model.FormatTimelapse && rec.Format != model.FormatMJPEG {

--- a/internal/avi/demuxer.go
+++ b/internal/avi/demuxer.go
@@ -176,6 +176,75 @@ func (d *Demuxer) NextChunk() (*Chunk, error) {
 	}
 }
 
+// VideoFrameEntry describes one video frame inside the movi list WITHOUT its
+// payload — byte range + presentation time only.
+type VideoFrameEntry struct {
+	Index  int   // 0-based video frame index
+	Offset int64 // absolute file offset of the JPEG payload
+	Size   uint32
+	PTSUs  int64 // microseconds from stream start
+}
+
+// VideoFrameIndex walks the movi list reading ONLY chunk headers and returns
+// the video frames' byte ranges. The payloads are complete JPEGs (the
+// recorder stores camera MJPEG frames verbatim), so a frame can be served
+// by seeking to Offset and reading Size bytes. Header-walking keeps indexing
+// an AVI cheap (8 bytes read + one seek per chunk, no payload I/O).
+func (d *Demuxer) VideoFrameIndex() ([]VideoFrameEntry, error) {
+	if !d.atMovi {
+		if err := d.enterMovi(); err != nil {
+			return nil, err
+		}
+	}
+	var frames []VideoFrameEntry
+	idx := 0
+	for {
+		pos, err := d.r.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, fmt.Errorf("avi: index seek: %w", err)
+		}
+		var header [8]byte
+		if _, err := io.ReadFull(d.r, header[:]); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break // truncated tail — serve what we have
+			}
+			return nil, fmt.Errorf("avi: index read header: %w", err)
+		}
+		ckID := binary.LittleEndian.Uint32(header[0:4])
+		ckSize := binary.LittleEndian.Uint32(header[4:8])
+		if ckID == fccidx1 {
+			break
+		}
+		if ckID == fccLIST {
+			// 'rec ' list: skip type + payload.
+			skip := int64(ckSize) - 4 + 4
+			if _, err := d.r.Seek(skip, io.SeekCurrent); err != nil {
+				return nil, fmt.Errorf("avi: index skip list: %w", err)
+			}
+			continue
+		}
+		dataOff := pos + 8
+		skip := int64(ckSize)
+		if skip%2 == 1 {
+			skip++ // WORD alignment padding
+		}
+		if _, err := d.r.Seek(skip, io.SeekCurrent); err != nil {
+			return nil, fmt.Errorf("avi: index skip data: %w", err)
+		}
+		if chunkType, _ := classifyChunk(ckID); chunkType == ChunkVideo {
+			frames = append(frames, VideoFrameEntry{
+				Index:  idx,
+				Offset: dataOff,
+				Size:   ckSize,
+				PTSUs:  int64(idx) * int64(d.dwMicroSecPerFrame),
+			})
+			idx++
+		}
+	}
+	d.atEnd = true
+	return frames, nil
+}
+
 // parseHeaders reads and validates the RIFF header and hdrl list.
 func (d *Demuxer) parseHeaders() error {
 	// Read RIFF header.

--- a/internal/avi/frameindex_test.go
+++ b/internal/avi/frameindex_test.go
@@ -1,0 +1,102 @@
+package avi
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// buildTestAVI writes a small AVI with nFrames video frames (fake JPEGs) and
+// interleaved G.711 audio via the production muxer.
+func buildTestAVI(t *testing.T, dir, name string, nFrames int) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	m := NewMuxer(f, 640, 480, 8000, true)
+	for i := 0; i < nFrames; i++ {
+		jpeg := append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, bytes.Repeat([]byte{byte(i)}, 64)...)
+		jpeg = append(jpeg, 0xFF, 0xD9)
+		if err := m.WriteVideo(jpeg, int64(i)*100000); err != nil {
+			t.Fatalf("write frame %d: %v", i, err)
+		}
+		if err := m.WriteAudio(bytes.Repeat([]byte{0x55}, 1600), int64(i)*100000); err != nil {
+			t.Fatalf("write audio %d: %v", i, err)
+		}
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("close muxer: %v", err)
+	}
+	return path
+}
+
+func TestVideoFrameIndex(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestAVI(t, dir, "test.avi", 10)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	dmx, err := NewDemuxer(f)
+	if err != nil {
+		t.Fatalf("demuxer: %v", err)
+	}
+	entries, err := dmx.VideoFrameIndex()
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+	if len(entries) != 10 {
+		t.Fatalf("want 10 video frames, got %d", len(entries))
+	}
+	for i, e := range entries {
+		if e.Index != i {
+			t.Fatalf("entry %d has index %d", i, e.Index)
+		}
+		if e.Offset <= 0 || e.Offset+int64(e.Size) > int64(len(raw)) {
+			t.Fatalf("frame %d range [%d,%d) outside file (len %d)", i, e.Offset, e.Offset+int64(e.Size), len(raw))
+		}
+		payload := raw[e.Offset : e.Offset+int64(e.Size)]
+		if payload[0] != 0xFF || payload[1] != 0xD8 || payload[len(payload)-2] != 0xFF || payload[len(payload)-1] != 0xD9 {
+			t.Fatalf("frame %d payload is not the written JPEG (got % X ... % X)", i, payload[:4], payload[len(payload)-2:])
+		}
+		if payload[4] != byte(i) {
+			t.Fatalf("frame %d payload contains frame %d's marker byte", i, payload[4])
+		}
+		wantPTS := int64(i) * int64(dmx.MicroSecPerFrame())
+		if e.PTSUs != wantPTS {
+			t.Fatalf("frame %d PTS = %d, want %d (µs/frame=%d)", i, e.PTSUs, wantPTS, dmx.MicroSecPerFrame())
+		}
+	}
+}
+
+func TestVideoFrameIndex_SingleFrame(t *testing.T) {
+	dir := t.TempDir()
+	path := buildTestAVI(t, dir, "one.avi", 1)
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	dmx, err := NewDemuxer(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := dmx.VideoFrameIndex()
+	if err != nil {
+		t.Fatalf("index: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 frame, got %d", len(entries))
+	}
+}

--- a/internal/avi/frameindex_test.go
+++ b/internal/avi/frameindex_test.go
@@ -18,7 +18,7 @@ func buildTestAVI(t *testing.T, dir, name string, nFrames int) string {
 	}
 	defer f.Close()
 	m := NewMuxer(f, 640, 480, 8000, true)
-	for i := 0; i < nFrames; i++ {
+	for i := range nFrames {
 		jpeg := append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, bytes.Repeat([]byte{byte(i)}, 64)...)
 		jpeg = append(jpeg, 0xFF, 0xD9)
 		if err := m.WriteVideo(jpeg, int64(i)*100000); err != nil {

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786768019014';
+const CACHE_VERSION = 'mibee-nvr-1786770990887';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1547,5 +1547,9 @@
   "detail.continuousH265Unsupported": "This browser lacks MSE H.265 support — continuous playback unavailable (per-segment mode unaffected)",
   "detail.continuousFailed": "Continuous playback failed to start, fell back to per-segment mode",
   "detail.continuousBuilding": "Building the full-day index (first time may take a minute or two)…",
-  "detail.continuousRebuilt": "Recordings updated (rolling merge) — playback restored to your position"
+  "detail.continuousRebuilt": "Recordings updated (rolling merge) — playback restored to your position",
+  "detail.aviRealtime": "Realtime (audio)",
+  "detail.aviRealtimeTitle": "Switch to the legacy realtime stream (audio, not seekable)",
+  "detail.aviFrames": "Frame view (seekable)",
+  "detail.aviFramesTitle": "Switch to frame view (seekable, cross-segment continuous)"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1513,5 +1513,9 @@
   "detail.continuousH265Unsupported": "此浏览器的 MSE 不支持 H.265，连续播放不可用（单段模式不受影响）",
   "detail.continuousFailed": "连续播放初始化失败，已回退单段模式",
   "detail.continuousBuilding": "正在生成当日连续播放索引（首次可能需要一两分钟）…",
-  "detail.continuousRebuilt": "录像已更新（滚动合并），已自动恢复到当前进度"
+  "detail.continuousRebuilt": "录像已更新（滚动合并），已自动恢复到当前进度",
+  "detail.aviRealtime": "实时播放（带声音）",
+  "detail.aviRealtimeTitle": "切换到原实时流播放（含音频，不可拖动）",
+  "detail.aviFrames": "帧浏览（可拖动）",
+  "detail.aviFramesTitle": "切换到帧浏览模式（可拖动、跨段连续）"
 }

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -175,10 +175,14 @@
 
   // Effective playback mode: derived from recording.format + probed codec +
   // useFrameFallback (the latter flips a failed <video> to the cycler at runtime).
+  // AVI: default to the JPEG frame cycler (seekable + seamless chaining via
+  // the timelapse-frames contract); the legacy realtime WS player (audio)
+  // stays one toggle away (#321).
+  let aviLegacyMode = $state(false);
   let playbackMode = $derived.by<PlaybackMode>(() => {
     if (!recording) return 'unsupported';
     const f = recording.format;
-    if (f === 'avi') return 'avi';
+    if (f === 'avi') return aviLegacyMode ? 'avi' : 'timelapse';
     if (f === 'mjpeg' || f === 'timelapse') {
       if (useFrameFallback) return 'timelapse';
       const hasMerged = recording.merge_status === 'merged' && !!recording.merge_path;
@@ -220,6 +224,14 @@
     if (f === 'h264' || f === 'h265') {
       probedMergedCodec = '';
       void startVideoForRecording(recording, pendingTimelineSeekOffset);
+      return;
+    }
+    if (f === 'avi') {
+      // AVI recordings play through the JPEG cycler directly — frames are
+      // served from the AVI itself via the timelapse-frames contract, no
+      // merged-output codec probe.
+      probedMergedCodec = '';
+      initTimelapsePlayer();
       return;
     }
     if (f === 'timelapse' || f === 'mjpeg') {
@@ -1432,6 +1444,14 @@
         </div>
 
         <div class="flex items-center gap-3">
+          {#if recording?.format === 'avi'}
+            <button
+              onclick={() => (aviLegacyMode = true)}
+              class="px-2 py-1 rounded text-xs font-medium th-bg-tertiary th-text-secondary"
+              title={t('detail.aviRealtimeTitle')}>
+              {t('detail.aviRealtime')}
+            </button>
+          {/if}
           <span class="th-text-secondary text-sm font-mono">
             {tlCurrentFrame + 1} / {timelapseFrames.length}
           </span>
@@ -1474,6 +1494,14 @@
   {/if}
 {:else if playbackMode === 'avi'}
   <AviPlayback recordingId={currentId} />
+  <div class="px-4 py-2 th-bg-secondary border-t th-border flex justify-end">
+    <button
+      onclick={() => (aviLegacyMode = false)}
+      class="px-2 py-1 rounded text-xs font-medium th-bg-tertiary th-text-secondary"
+      title={t('detail.aviFramesTitle')}>
+      {t('detail.aviFrames')}
+    </button>
+  </div>
 {:else if playbackMode === 'mjpeg'}
   <MjpegPlayer bind:this={mjpegPlayer} recordingId={currentId} oninitdone={() => {}} />
   <div class="px-4 py-2 th-bg-tertiary">


### PR DESCRIPTION
## 内容（#321 AVI 子项）

按 issue 落档的评估结论实施：**AVI 载荷即完整 JPEG**（现有 WS 播放器一直直接当 image/jpeg 渲染佐证），因此复用 timelapse 帧端点契约接入已有 JPEG 轮播器——AVI 录像从"仅实时 WS 播放、不可拖动"升级为**可拖动 + 跨段无缝链**。

### 后端
- `internal/avi`：`Demuxer.VideoFrameIndex()` 只走 movi chunk 头（每 chunk 8 字节读 + 一次 seek，不碰载荷），产出帧字节区间 + PTS
- `timelapse-frames` 端点扩展 AVI：列表合成 `f%06d.jpg`（时间戳 = started_at + PTS）；单帧按索引 seek + 流式读出，`image/jpeg` + 缓存头

### 前端
- AVI 默认进入帧轮播器（seek / 倍速 / loop / 无缝链全部继承）
- 原实时 WS 播放器（含音频）保留一键互切：轮播侧"实时播放（带声音）"、WS 侧"帧浏览（可拖动）"

## 测试
- `internal/avi` 新增索引单测：生产 muxer fixture，10 帧字节级校验（SOI/EOI/帧序号标记）+ PTS 守恒（纯 Go 包，本地直跑）
- vitest 585/585；前端 build 绿
- **M5 真实 AVI E2E**（CDP 真实鼠标事件，04:56→04:58 背靠背录像段）：
  - ✅ AVI 打开即帧轮播器（1 / 636 帧）
  - ✅ 帧条拖动 seek（445 / 636）
  - ✅ **跨段无缝链 A→B**：DOM 持存无重挂载，B 段第 7 帧续播
  - ✅ 实时 WS ↔ 帧浏览双向切换
  - 0 console 错误

Refs #321（至此 issue 的全类型连续播放矩阵齐了：H.264/H.265 VOD HLS 时间轴、MJPEG/timelapse 帧轮播、AVI 帧轮播）
