### PR TITLE
fix(live,playback): MJPEG 直播黑屏四层修复 + 轮播器全天时间轴 (#321)

### DIFF
--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -41,7 +41,7 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 	// An already-active entry may be subscribed to a STALE StreamHub (the
 	// recorder reconnected and got a fresh hub) — rebind before serving, or
 	// the viewer would sit on a dead hub with zero frames forever.
-	if h.wsMgr.IsActive(id) {
+	if h.wsMgr.IsActive(id) && h.camMgr != nil {
 		if rec := h.camMgr.GetRecorder(id); rec != nil {
 			if hub := getStreamHub(rec); hub != nil && hub != h.wsMgr.ActiveHub(id) {
 				h.wsMgr.RebindHub(id, hub)

--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -37,7 +37,17 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// On-demand registration: if WebSocket stream not registered, register it
+	// On-demand registration: if WebSocket stream not registered, register it.
+	// An already-active entry may be subscribed to a STALE StreamHub (the
+	// recorder reconnected and got a fresh hub) — rebind before serving, or
+	// the viewer would sit on a dead hub with zero frames forever.
+	if h.wsMgr.IsActive(id) {
+		if rec := h.camMgr.GetRecorder(id); rec != nil {
+			if hub := getStreamHub(rec); hub != nil && hub != h.wsMgr.ActiveHub(id) {
+				h.wsMgr.RebindHub(id, hub)
+			}
+		}
+	}
 	if !h.wsMgr.IsActive(id) {
 		if h.camMgr == nil {
 			WriteError(w, http.StatusNotFound, "WebSocket stream not active")

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -367,6 +367,21 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 	r.setStatus(model.StatusRecording)
 	reader := bufio.NewReader(resp.Body)
 
+	// Stall watchdog: after a camera hiccup the TCP connection can survive as
+	// a zombie — open, but the device never sends another byte. Without a
+	// read deadline the loop blocks forever on the first Read, the latest-
+	// frame cache freezes, and live viewers sit on a static picture (observed
+	// on the ESP32 MiBeeCam: EOF reconnect succeeds, then silence). Arm a
+	// per-frame deadline; cameras send frames at ≥1fps, so 15s covers even
+	// slow timelapse-y devices while catching zombies.
+	const frameReadTimeout = 15 * time.Second
+	armDeadline := func() {
+		if rd, ok := resp.Body.(interface{ SetReadDeadline(time.Time) error }); ok {
+			_ = rd.SetReadDeadline(time.Now().Add(frameReadTimeout))
+		}
+	}
+	armDeadline()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -406,6 +421,7 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 			httpJpegLogger.Warn("skipping invalid frame (missing JPEG magic)", "camera_id", r.cfg.CameraID, "size", len(data))
 			continue
 		}
+		armDeadline() // frame received — re-arm the zombie-connection watchdog
 		// Cache latest frame for snapshot polling (before storage check,
 		// so live preview works even during storage issues). data is freshly allocated
 		// each frame (make or bytes.Buffer), so storing the pointer directly is safe —

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786770990887';
+const CACHE_VERSION = 'mibee-nvr-1786781010790';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -263,6 +263,47 @@ func (m *Manager) IsActive(camID string) bool {
 	return ok
 }
 
+// ActiveHub returns the StreamHub the registered entry is currently
+// subscribed to (nil when the stream is not active).
+func (m *Manager) ActiveHub(camID string) *model.StreamHub {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, ok := m.streams[camID]
+	if !ok {
+		return nil
+	}
+	return entry.hub
+}
+
+// RebindHub re-subscribes an active stream to a new StreamHub. Recorders that
+// reconnect get a FRESH hub from the camera manager; without a rebind the
+// entry keeps listening to the dead hub and every viewer goes black forever
+// (observed on flaky MJPEG cameras whose recorder reconnects often).
+func (m *Manager) RebindHub(camID string, hub *model.StreamHub) {
+	if hub == nil {
+		return
+	}
+	m.mu.Lock()
+	entry, ok := m.streams[camID]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	oldHub := entry.hub
+	entry.hub = hub
+	subID := entry.hubSubID
+	m.mu.Unlock()
+
+	if oldHub != nil {
+		// Unsubscribe OUTSIDE m.mu (drain calls writeFrame → RLock).
+		oldHub.Unsubscribe(subID)
+	}
+	_ = hub.Subscribe(subID, func(pts int64, au [][]byte) {
+		m.writeFrame(camID, pts, au)
+	})
+	wsLogger.Load().Info("WebSocket stream rebound to new StreamHub", "camera_id", camID)
+}
+
 // viewerCount returns the number of active viewers for a stream.
 func (m *Manager) viewerCount(camID string) int {
 	m.mu.RLock()

--- a/internal/wsstream/rebind_test.go
+++ b/internal/wsstream/rebind_test.go
@@ -1,0 +1,91 @@
+package wsstream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// TestRebindHub verifies that a registered stream follows a NEW hub after
+// RebindHub: frames on the old hub stop being forwarded and frames on the new
+// hub flow. This is the recorder-reconnect path — without the rebind, viewers
+// sit on the dead hub with zero frames forever (observed on flaky MJPEG cams).
+func TestRebindHub(t *testing.T) {
+	m := NewManager()
+	oldHub := newTestHub(t)
+	newHub := newTestHub(t)
+
+	if err := m.RegisterStream("cam1", model.FormatMJPEG, nil, nil, nil, oldHub); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if got := m.ActiveHub("cam1"); got != oldHub {
+		t.Fatal("ActiveHub must return the registered hub")
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", w, r)
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+	conn := dialWS(t, "ws"+srv.URL[4:])
+	defer conn.Close()
+	waitForViewer(t, m, "cam1")
+
+	// Frames on the OLD hub flow before the rebind (first message is codec
+	// info — skip it).
+	if _, err := readMessage(t, conn); err != nil {
+		t.Fatalf("codec-info message: %v", err)
+	}
+	broadcastFrame(t, oldHub, 1000, [][]byte{{0xFF, 0xD8, 0x00}})
+	if _, err := readMessage(t, conn); err != nil {
+		t.Fatalf("frame from old hub before rebind: %v", err)
+	}
+
+	// Rebind to the NEW hub (recorder reconnected).
+	m.RebindHub("cam1", newHub)
+	if got := m.ActiveHub("cam1"); got != newHub {
+		t.Fatal("ActiveHub must return the rebound hub")
+	}
+
+	// Frames on the old hub must no longer reach the viewer, frames on the new
+	// hub must. (A read-timeout would poison the gorilla connection, so assert
+	// by CONTENT: broadcast a stale marker on the old hub, then the real frame
+	// on the new hub — the next message the viewer receives must be the new
+	// hub's, not the stale one.)
+	broadcastFrame(t, oldHub, 2000, [][]byte{{0xAA}})
+	broadcastFrame(t, newHub, 3000, [][]byte{{0xFF, 0xD8, 0x01}})
+	msg, err := readMessage(t, conn)
+	if err != nil {
+		t.Fatalf("frame after rebind: %v", err)
+	}
+	for _, b := range msg {
+		if b == 0xAA {
+			t.Fatalf("stale frame from old hub leaked after rebind: % X", msg)
+		}
+	}
+	// The next message (if any) also must not carry the stale marker.
+	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	for {
+		_, msg2, err := conn.ReadMessage()
+		if err != nil {
+			break // timeout/closed — done
+		}
+		for _, b := range msg2 {
+			if b == 0xAA {
+				t.Fatalf("stale frame from old hub leaked after rebind (queued): % X", msg2)
+			}
+		}
+	}
+}
+
+// TestRebindHubUnknownStream is a no-op for unregistered cameras.
+func TestRebindHubUnknownStream(t *testing.T) {
+	m := NewManager()
+	m.RebindHub("nope", newTestHub(t)) // must not panic or register
+	if m.IsActive("nope") {
+		t.Fatal("rebind must not create an entry")
+	}
+}

--- a/web/src/components/MjpegLivePlayer.svelte
+++ b/web/src/components/MjpegLivePlayer.svelte
@@ -50,6 +50,12 @@
   let lastEtag: string | null = null;
   let wsConnection: WebSocket | null = null;
   let useWebSocket = true; // Try WebSocket first, fall back to HTTP polling
+  // Silence-watchdog state: a WS that stays open without any video frame is
+  // treated as dead (recorder-side hub went stale) → fall back to polling.
+  const WS_SILENCE_FALLBACK_MS = 5000;
+  let wsSilenceTimer: ReturnType<typeof setTimeout> | null = null;
+  let renderedOnce = false; // at least one frame has been painted
+  let frameSeenSinceOpen = false;
 
   function revokeBlobUrl() {
     if (currentBlobUrl) {
@@ -79,6 +85,26 @@
       if (resp.status === 304) {
         consecutiveErrors = 0;
         lastLoadTime = Date.now();
+        // A 304 is only usable when the player ALREADY rendered a frame. With
+        // cache:'no-cache' the browser can answer 304 from its own cache on
+        // the very first poll (recorder-side frame cache frozen), leaving the
+        // <img> empty forever — force one unconditional fetch so the viewer
+        // at least sees the cached frame, and live motion resumes when the
+        // recorder starts producing frames again.
+        if (!renderedOnce) {
+          renderedOnce = true; // guard against loops
+          try {
+            const fresh = await fetch(`${API_BASE}/cameras/${cameraId}/latest-frame`, { cache: 'reload', headers: authHeader ? { Authorization: authHeader } : {} });
+            if (fresh.ok && !destroyed) {
+              const blob = await fresh.blob();
+              if (blob.size > 0) {
+                revokeBlobUrl();
+                currentBlobUrl = URL.createObjectURL(blob);
+                if (imgEl) imgEl.src = currentBlobUrl;
+              }
+            }
+          } catch { /* best-effort */ }
+        }
         return;
       }
 
@@ -104,6 +130,7 @@
       if (imgEl) {
         imgEl.src = currentBlobUrl;
       }
+      renderedOnce = true;
 
       consecutiveErrors = 0;
       lastLoadTime = Date.now();
@@ -152,6 +179,19 @@
 
     wsConnection.onopen = () => {
       consecutiveErrors = 0;
+      // Silence watchdog: the socket can be OPEN yet carry zero frames (e.g.
+      // the recorder reconnected and the server-side subscription went stale).
+      // A connected-but-mute socket must fall back to HTTP polling like a
+      // failed one, or the player sits on "connecting" forever.
+      clearTimeout(wsSilenceTimer);
+      wsSilenceTimer = setTimeout(() => {
+        if (!destroyed && useWebSocket && !frameSeenSinceOpen) {
+          useWebSocket = false;
+          stopWebSocket();
+          startPolling();
+        }
+      }, WS_SILENCE_FALLBACK_MS);
+      frameSeenSinceOpen = false;
     };
 
     wsConnection.onmessage = async (event) => {
@@ -160,6 +200,10 @@
       if (data.length < 1) return;
 
       const msgType = data[0];
+      if (msgType === 0x02) {
+        frameSeenSinceOpen = true;
+        clearTimeout(wsSilenceTimer);
+      }
       // Video frame (0x02): nalus[0] contains the complete JPEG
       if (msgType === 0x02 && data.length >= 12) {
         const naluCount = (data[10] << 8) | data[11];
@@ -175,6 +219,7 @@
           revokeBlobUrl();
           currentBlobUrl = URL.createObjectURL(blob);
           if (imgEl) imgEl.src = currentBlobUrl;
+          renderedOnce = true;
 
           lastLoadTime = Date.now();
           if (streamState === 'loading' || streamState === 'frozen') {
@@ -214,6 +259,8 @@
   }
 
   function stopWebSocket() {
+    clearTimeout(wsSilenceTimer);
+    wsSilenceTimer = null;
     if (wsConnection) {
       wsConnection.onopen = null;
       wsConnection.onmessage = null;

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -928,8 +928,16 @@
     try {
       timelapseFrames = await getTimelapseFrames(currentId, signal);
       if (timelapseFrames.length > 0) {
-        await ensureFrameCached(0, signal);
-        prefetchAhead(0, signal);
+        if (pendingTimelineSeekOffset != null) {
+          // Cross-segment timeline seek: land on the frame nearest the
+          // requested offset instead of the segment start.
+          const target = frameIndexAtOffset(pendingTimelineSeekOffset);
+          pendingTimelineSeekOffset = null;
+          tlSeek(target);
+        } else {
+          await ensureFrameCached(0, signal);
+        }
+        prefetchAhead(pendingTimelineSeekOffset == null ? 0 : tlCurrentFrame, signal);
       }
     } catch (e) {
       if (signal.aborted) return;
@@ -1094,6 +1102,52 @@
     if (!el) return;
     if (document.fullscreenElement) document.exitFullscreen();
     else el.requestFullscreen();
+  }
+
+  // --- Day timeline on the frame cycler (MJPEG/timelapse/AVI) ---
+  // Maps the whole day's TimelineBar onto cycler frames: any click anywhere
+  // in the day lands on the nearest frame (same "scrub anywhere" UX as the
+  // H.264 continuous timeline), and cross-segment clicks switch in place.
+  function frameIndexAtOffset(offsetSec: number): number {
+    if (timelapseFrames.length === 0 || !recording) return 0;
+    const start = Date.parse(recording.started_at);
+    if (Number.isFinite(start) && timelapseFrames[0]?.timestamp) {
+      const targetMs = start + Math.max(0, offsetSec) * 1000;
+      for (let i = 0; i < timelapseFrames.length; i++) {
+        const ts = Date.parse(timelapseFrames[i].timestamp);
+        if (!Number.isNaN(ts) && ts >= targetMs) return i;
+      }
+      return timelapseFrames.length - 1;
+    }
+    const dur = recording.duration || 0;
+    if (dur > 0) {
+      return Math.min(timelapseFrames.length - 1, Math.floor((Math.max(0, offsetSec) / dur) * timelapseFrames.length));
+    }
+    return 0;
+  }
+
+  function cyclerOffsetSec(): number {
+    const f = timelapseFrames[tlCurrentFrame];
+    if (!recording || !f) return 0;
+    if (f.timestamp) {
+      const start = Date.parse(recording.started_at);
+      const d = Date.parse(f.timestamp) - start;
+      if (Number.isFinite(d) && Number.isFinite(start)) return Math.max(0, d / 1000);
+    }
+    const total = timelapseFrames.length || 1;
+    return (tlCurrentFrame / total) * (recording.duration || 0);
+  }
+
+  function handleCyclerTimelineSeek(recordingId: string, offsetSeconds: number) {
+    if (!recording) return;
+    const isSegmentSwitch = recordingId !== currentId;
+    void recordTimelineSeek(recording.camera_id, isSegmentSwitch ? 'segment' : 'intra');
+    if (isSegmentSwitch) {
+      pendingTimelineSeekOffset = offsetSeconds;
+      ontimelineseek(recordingId, offsetSeconds);
+    } else {
+      tlSeek(frameIndexAtOffset(offsetSeconds));
+    }
   }
 
   function getFrameTimestamp(): string {
@@ -1491,6 +1545,17 @@
         </div>
       </div>
     </div>
+
+    {#if recording?.camera_id}
+      <TimelineBar
+        cameraId={recording.camera_id}
+        date={timelineDate()}
+        currentRecording={recording}
+        currentVideoTime={cyclerOffsetSec()}
+        onseek={handleCyclerTimelineSeek}
+        showEvents={true}
+      />
+    {/if}
   {/if}
 {:else if playbackMode === 'avi'}
   <AviPlayback recordingId={currentId} />


### PR DESCRIPTION
## 背景

用户报告两个问题：
1. **`192.168.63.224`（MiBeeCam-S3，ESP32 ONVIF-JPEG）播放不了**——直播黑屏
2. **MJPEG 不能像 H.264 那样一天随意点击**

## 修复 1：MJPEG 直播黑屏（四层缺陷叠加，M5 真机逐层定位）

| 层 | 缺陷 | 修复 |
|---|---|---|
| wsstream | recorder 重连换新 StreamHub 后，已注册条目仍订阅**旧 Hub** → WS 连着却零帧（正常相机有完整 register 链，故障相机只有 serving） | `wsstream.RebindHub` + `handlers_ws` 对 IsActive 条目校验 Hub 一致性自动重绑；单测覆盖重绑后旧 Hub 帧不泄漏、新 Hub 帧到达 |
| 前端 WS | 连接成功但零帧时永远卡"正在连接"（只在 onerror/onclose 回退） | 5s 无帧看门狗回退 latest-frame 轮询 |
| 前端轮询 | `cache:'no-cache'` 首个轮询被浏览器以缓存 ETag 验证得 **304（无 body）**，recorder 帧缓存冻结时 img 永远空 | 从未渲染过帧时遇 304 强制 `cache:'reload'` 拉全量（至少显示缓存帧，流恢复自动动起来） |
| recorder | 相机抖动后 TCP 连接沦为"连着但零数据"僵尸，帧缓存冻结（304 循环/画面静止），原有 68s 空闲看门狗回收慢 | 读循环每帧设 **15s socket 读超时**，僵尸连接快速进入既有重连退避 |

M5 实测：恢复窗口内直播显示 **1920x1080 画面**；该 ESP32 相机并发连接有限（AGENTS 有记载），重启风暴期间会被设备 RST 进入退避，属设备侧特性——看门狗体系保证设备恢复后直播自愈。

## 修复 2：MJPEG/timelapse/AVI 轮播器挂全天时间轴（一天随意点击）

- 轮播分支渲染 TimelineBar（游标 = 当前帧偏移秒）
- 点击任意段/任意位置：同段按帧时间戳定位最近帧 seek；跨段原地切换录像 + 偏移落帧（`pendingTimelineSeekOffset` 复用）
- M5 实测：时间轴渲染 PASS、点击远处段切换 PASS

## 测试
- `wsstream` 新增 RebindHub 单测（重绑语义 + 未知相机 no-op），全包绿
- vitest 585/585；前端 build 绿；M5 CDP E2E（cycler 时间轴 2 项 PASS，直播恢复窗口 1 项 PASS）

Refs #321
