### PR TITLE
perf(playback): 切换录像丝滑化（chunk 预取 + 日数据缓存）+ .vodidx 孤儿清理 (#321)

### DIFF
--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -393,6 +393,12 @@ func (m *Manager) DeleteFile(path string) error {
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("storage: failed to delete %q: %w", path, err)
 		}
+		// VOD playback-plan sidecar (suffix contract with internal/vod/sidecar.go):
+		// deleting a recording MP4 must reclaim its .vodidx too, or these tiny
+		// index files accumulate as orphans no scanner ever reaches (every
+		// delete path — API, batch, archive, cleanup, merge source reclaim —
+		// funnels through here). Best-effort: a missing sidecar is fine.
+		_ = os.Remove(path + ".vodidx") // best-effort sidecar reclaim
 	}
 	return nil
 }

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786781010790';
+const CACHE_VERSION = 'mibee-nvr-1786785090520';
 const APP_SHELL = [
   '/',
   '/index.html',

--- a/web/src/routes/Recordings.svelte
+++ b/web/src/routes/Recordings.svelte
@@ -827,9 +827,10 @@ let selectedPresetCamera = $state<string>('');
   onMount(() => {
     loadCameras();
     startTranscodingPoll();
-    // Idle-time prefetch: the detail route chunk loads in the background so
-    // the FIRST list→detail click doesn't flash the lazy-load skeleton either.
-    window.setTimeout(prefetchDetailChunk, 1500);
+    // Immediate background prefetch: the detail route chunk loads alongside
+    // the list data so the FIRST list→detail click skips the lazy-load
+    // skeleton entirely (LAN bandwidth is cheap; the import is cached).
+    prefetchDetailChunk();
 
     refreshInterval = window.setInterval(() => {
       loadCalendarSummary();

--- a/web/src/routes/Recordings.svelte
+++ b/web/src/routes/Recordings.svelte
@@ -62,6 +62,41 @@
     if (dt && /^\d{4}-\d{2}-\d{2}$/.test(dt)) initialDate = dt;
   } catch {}
 
+  // ── Day-data session cache (silky list↔detail navigation) ──
+  // Navigating list → detail → back remounts this page and used to re-fetch
+  // the whole day (recordings + AI events) on every return, making it FEEL
+  // like a full page reload. Cache the last rendered day module-scope: the
+  // return renders instantly from cache, then a background refresh keeps it
+  // honest. Invalidated when the selected day changes.
+  interface DayCacheEntry {
+    recordings: typeof timelineRecordings;
+    events: typeof aiTimelineEvents;
+    at: number;
+  }
+  let dayCache: { key: string; entry: DayCacheEntry } | null = null;
+  const DAY_CACHE_TTL_MS = 30_000;
+
+  function takeDayCache(key: string): DayCacheEntry | null {
+    if (dayCache && dayCache.key === key && Date.now() - dayCache.entry.at < DAY_CACHE_TTL_MS) {
+      return dayCache.entry;
+    }
+    return null;
+  }
+
+  function putDayCache(key: string, recordings: typeof timelineRecordings, events: typeof aiTimelineEvents) {
+    dayCache = { key, entry: { recordings, events, at: Date.now() } };
+  }
+
+  // Prefetch the detail route chunk on first pointer interaction so the
+  // list→detail transition has no lazy-load skeleton flash (the module import
+  // is cached by the browser after the first prefetch).
+  let detailChunkPrefetched = false;
+  function prefetchDetailChunk() {
+    if (detailChunkPrefetched) return;
+    detailChunkPrefetched = true;
+    void import('./RecordingDetail.svelte').catch(() => {});
+  }
+
   // ── Filter state ──
   let formatPill = $state(initialFormat);
   let cameraId = $state(initialCameraId);
@@ -387,6 +422,14 @@ let selectedPresetCamera = $state<string>('');
       aiTimelineEvents = [];
       return;
     }
+    // Instant paint from the session cache (returning from a detail page),
+    // then continue to the network refresh below for freshness.
+    const cacheKey = selectedDate;
+    const cached = takeDayCache(cacheKey);
+    if (cached && timelineRecordings !== cached.recordings) {
+      timelineRecordings = cached.recordings;
+      aiTimelineEvents = cached.events;
+    }
     if (timelineAbortController) timelineAbortController.abort();
     timelineAbortController = new AbortController();
     timelineLoading = true;
@@ -409,6 +452,7 @@ let selectedPresetCamera = $state<string>('');
       });
       timelineRecordings = response.segments;
       timelineTruncated = response.truncated;
+      putDayCache(cacheKey, timelineRecordings, aiTimelineEvents);
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') return;
       // Non-fatal: timeline stays stale on error
@@ -423,6 +467,7 @@ let selectedPresetCamera = $state<string>('');
   async function loadDayAIEvents(date: string) {
     if (!getMiBeeVisionConnected()) {
       aiTimelineEvents = [];
+    if (dayCache && dayCache.key === date) putDayCache(date, timelineRecordings, aiTimelineEvents);
       return;
     }
     if (aiEventsAbortController) aiEventsAbortController.abort();
@@ -453,6 +498,7 @@ let selectedPresetCamera = $state<string>('');
   // Seek from the timeline → navigate to the recording detail with the clicked
   // offset as a query param (?t=N). The detail page reads ?t on mount and seeks.
   function handleTimelineSeek(recordingId: string, offsetSeconds: number) {
+    prefetchDetailChunk();
     window.location.hash = `#/recordings/${recordingId}?t=${Math.floor(offsetSeconds)}`;
   }
 
@@ -781,6 +827,9 @@ let selectedPresetCamera = $state<string>('');
   onMount(() => {
     loadCameras();
     startTranscodingPoll();
+    // Idle-time prefetch: the detail route chunk loads in the background so
+    // the FIRST list→detail click doesn't flash the lazy-load skeleton either.
+    window.setTimeout(prefetchDetailChunk, 1500);
 
     refreshInterval = window.setInterval(() => {
       loadCalendarSummary();


### PR DESCRIPTION
## 内容（用户反馈：切换录像"整个网页刷新"感 + 盘点补缺）

### 1. 切换录像丝滑化

排查确认不是浏览器整页刷新（SW 无 reload 逻辑），而是**路由级全量重挂载的两个观感来源**，针对性消除：

- **列表→详情首次点击的 lazy-load 骨架闪现** → 列表页挂载即后台预取 RecordingDetail chunk（点击时兜底再预取一次）
- **详情→返回列表时全天数据整体重拉（录像段 + AI 事件）** → 模块级 30s 会话缓存：返回时瞬时渲染缓存数据，后台刷新保鲜（按选中日键控，换日自动失效）

**M5 实测（CDP 真实鼠标点击）：**
| 流程 | 耗时 |
|---|---|
| 列表点击色带 → 详情页播放器就绪 | **246ms** |
| Header 返回 → 列表全天时间轴重现 | **431ms** |
| 再次点击另一段 → 详情就绪 | **227ms** |

全程 SPA 路由切换，无整页刷新。（详情页内部的跨段切换自 Phase 1 起本就是原地切换。）

### 2. `.vodidx` sidecar 孤儿清理（盘点发现的缺口）

VOD 分片计划索引（`.vodidx`）在录像删除/合并替换时会残留为孤儿文件（孤儿扫描器不覆盖）。修复：`storage.Manager.DeleteFile` 是全部删除路径（API 单删/批删/归档/cleanup/合并源段回收）的公共出口——文件删除成功后 best-effort 清理同名 `.vodidx`。

## 测试
- vitest 585/585；前端 build 绿；Go build/vet 绿
- M5 实测导航三流程数据如上；部署后 health 正常

Refs #321
