### PR TITLE
fix(merge): preserve audio across rolling-merge audio-config boundaries (#340)

### DIFF
--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -120,7 +120,8 @@ type RollingMergeConfig struct {
 //     MergeMP4Segments([bucketOrCreate, newSegment]) → RollingReplaceRecordings.
 //   - Per-camera non-blocking lock: one merge per camera at a time (same pattern
 //     as MergeManager.acquireMergeLock). Never blocks the recorder.
-//   - SPS/PPS change (camera reconnect with new params) → close current bucket,
+//   - SPS/PPS change (camera reconnect with new params) or audio config change
+//     (audio_enabled toggled, codec/config renegotiated) → close current bucket,
 //     start a new one.
 //
 // Benchmark data (see mp4merge_bench_test.go BenchmarkRollingMergeSimulation):
@@ -161,10 +162,25 @@ type bucketInfo struct {
 	mergedFilePath string // path to the accumulating merged file (empty = not yet created)
 	mergedRecID    string // DB recording ID of the merged row (for UPDATE on next append)
 	spsKey         string // SHA-256(SPS+PPS+VPS) for compatibility checking
+	audioKey       string // segmentAudioKey for audio compatibility checking
 	windowStart    time.Time
 	windowEnd      time.Time
 	segmentCount   int   // how many segments have been merged into this bucket
 	mergedFileSize int64 // current byte size of mergedFilePath (0 if no bucket yet)
+}
+
+// segmentAudioKey derives the audio compatibility key for a parsed segment.
+// Segments with different keys cannot be merged into one MP4 without dropping
+// the audio track (MergeMP4Segments' mixed-audio policy), so the rolling bucket
+// must break at every key change — otherwise the first mixed append produces a
+// video-only bucket whose subsequent appends keep mismatching forever (sticky
+// audio loss: the degraded bucket is the input to every later merge).
+func segmentAudioKey(info *SegmentInfo) string {
+	if !info.HasAudio {
+		return "none"
+	}
+	return fmt.Sprintf("%s:mulaw=%v:ts=%d:cfg=%x",
+		info.AudioCodec, info.G711MULaw, info.AudioTimescale, info.AudioConfig)
 }
 
 // bucketSizeLimit caps how large an accumulating rolling-merge bucket file can
@@ -806,13 +822,17 @@ func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID stri
 	return merged, nil //nolint:nilerr // TODO(#storage-overhaul): intentional — report partial merge count on ctx cancellation rather than failing the whole backfill.
 }
 
-// mergeBatchMP4 merges a batch of MP4 segments into a single output file.
+// mergeBatchMP4 merges a batch of MP4 segments into output file(s).
 // Uses ParseSegment + MergeMP4Segments (the same as the periodic MergeManager).
+// The batch is first split into consecutive audio-homogeneous runs: a batch
+// that straddles an audio toggle boundary (audio_enabled flipped, codec
+// renegotiated) must not merge across it — MergeMP4Segments' mixed-audio
+// policy would silently drop the audio from the whole output.
 // Returns the number of segments successfully merged.
 func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID string, recs []*model.Recording) (int, error) {
 	// Parse all segments.
 	infos := make([]*SegmentInfo, 0, len(recs))
-	sourcePaths := make([]string, 0, len(recs))
+	parsedRecs := make([]*model.Recording, 0, len(recs))
 	for _, rec := range recs {
 		info, err := ParseSegment(rec.FilePath)
 		if err != nil {
@@ -821,14 +841,12 @@ func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID st
 			continue
 		}
 		infos = append(infos, info)
-		sourcePaths = append(sourcePaths, rec.FilePath)
+		parsedRecs = append(parsedRecs, rec)
 	}
+
 	if len(infos) < 2 {
 		// Not enough parseable segments — mark only the valid ones as merged.
-		for _, rec := range recs {
-			if _, err := os.Stat(rec.FilePath); os.IsNotExist(err) {
-				continue // skip missing files, don't mark them
-			}
+		for _, rec := range parsedRecs {
 			if err := storage.RetryOnBusy(ctx, func() error {
 				return r.db.SetMergeStatus(ctx, []string{rec.ID}, model.MergeStatusMerged)
 			}); err != nil {
@@ -836,7 +854,68 @@ func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID st
 					"camera_id", cameraID, "recording_id", rec.ID, "error", err)
 			}
 		}
-		return len(recs), nil
+		return len(parsedRecs), nil
+	}
+
+	merged := 0
+	for _, run := range splitRunsByAudioKey(parsedRecs, infos) {
+		if len(run.infos) < 2 {
+			// Lone segment in its audio run — no merge partner within the run.
+			// Mark it merged; the file stays as a standalone recording.
+			if err := storage.RetryOnBusy(ctx, func() error {
+				return r.db.SetMergeStatus(ctx, []string{run.recs[0].ID}, model.MergeStatusMerged)
+			}); err != nil {
+				rollingLogger.Warn("backfill MP4: failed to mark singleton run",
+					"camera_id", cameraID, "recording_id", run.recs[0].ID, "error", err)
+			}
+			merged++
+			continue
+		}
+		n, err := r.mergeAudioRun(ctx, cameraID, run.recs, run.infos)
+		if err != nil {
+			rollingLogger.Warn("backfill MP4: run merge failed",
+				"camera_id", cameraID, "segments", len(run.recs), "error", err)
+			continue
+		}
+		merged += n
+	}
+	return merged, nil
+}
+
+// segmentRun is a consecutive, audio-homogeneous slice of a parsed batch.
+type segmentRun struct {
+	recs   []*model.Recording
+	infos  []*SegmentInfo
+	keyStr string
+}
+
+// splitRunsByAudioKey splits a parsed batch into consecutive runs sharing the
+// same segmentAudioKey. recs and infos are parallel slices (same length).
+func splitRunsByAudioKey(recs []*model.Recording, infos []*SegmentInfo) []segmentRun {
+	var runs []segmentRun
+	for i, info := range infos {
+		key := segmentAudioKey(info)
+		if len(runs) > 0 && runs[len(runs)-1].keyStr == key {
+			last := &runs[len(runs)-1]
+			last.recs = append(last.recs, recs[i])
+			last.infos = append(last.infos, info)
+			continue
+		}
+		runs = append(runs, segmentRun{
+			recs:   []*model.Recording{recs[i]},
+			infos:  []*SegmentInfo{info},
+			keyStr: key,
+		})
+	}
+	return runs
+}
+
+// mergeAudioRun merges one audio-homogeneous run into a single output file and
+// updates the DB atomically. Returns the number of source segments merged.
+func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID string, recs []*model.Recording, infos []*SegmentInfo) (int, error) {
+	sourcePaths := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		sourcePaths = append(sourcePaths, rec.FilePath)
 	}
 
 	// Create output file.
@@ -1350,6 +1429,9 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	h.Write(newInfo.VPS)
 	spsKey := hex.EncodeToString(h.Sum(nil))
 
+	// Compute audio compatibility key (see segmentAudioKey).
+	audioKey := segmentAudioKey(newInfo)
+
 	// Compute the window for this segment (natural-hour or configured window).
 	cfg := r.resolveRollingConfig(seg.cameraID)
 	windowStart, windowEnd := computeWindow(seg.startedAt, cfg.Window)
@@ -1382,6 +1464,18 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 				"old_key", bucket.spsKey[:8],
 				"new_key", spsKey[:8])
 			needNewBucket = true
+		} else if bucket.audioKey != audioKey {
+			// Audio presence/config changed (audio_enabled toggled, G.711 ↔ AAC
+			// renegotiated). Merging across the boundary would trip the
+			// mixed-audio policy in MergeMP4Segments and drop audio — and the
+			// degraded bucket would poison every later append. Start a new
+			// bucket at the boundary instead: each side keeps its own intact
+			// audio state.
+			rollingLogger.Info("audio config changed, starting new bucket",
+				"camera_id", seg.cameraID,
+				"old_key", bucket.audioKey,
+				"new_key", audioKey)
+			needNewBucket = true
 		} else if bucket.mergedFileSize > 0 && bucket.mergedFileSize+newInfo.MdatSize > bucketSizeLimit {
 			// Bucket approaching the 4 GiB MP4 mdat hard limit. Finalize it
 			// and start a fresh bucket within the same window. Without this,
@@ -1404,6 +1498,7 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 		bucket.mergedFilePath = ""
 		bucket.mergedRecID = ""
 		bucket.spsKey = ""
+		bucket.audioKey = ""
 		bucket.segmentCount = 0
 		bucket.mergedFileSize = 0
 		bucket.windowStart = windowStart
@@ -1432,6 +1527,7 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	bucket.mergedFilePath = outputPath
 	bucket.mergedRecID = mergedRecID
 	bucket.spsKey = spsKey
+	bucket.audioKey = audioKey
 	bucket.segmentCount++
 	// Track merged file size for the bucketSizeLimit check on the next append.
 	// One stat per merged segment is cheap (the file was just written and its
@@ -1542,6 +1638,12 @@ func (r *RollingMergeCoordinator) appendToBucket(
 		!bytesEqual(bucketInfo.SPS, newInfo.SPS) ||
 		!bytesEqual(bucketInfo.PPS, newInfo.PPS) {
 		return "", "", fmt.Errorf("bucket/segment codec mismatch during append")
+	}
+	// Same for audio: a mismatch here would silently drop the audio track for
+	// the whole bucket (and every future append — see segmentAudioKey).
+	if segmentAudioKey(bucketInfo) != segmentAudioKey(newInfo) {
+		return "", "", fmt.Errorf("bucket/segment audio mismatch during append (%s vs %s)",
+			segmentAudioKey(bucketInfo), segmentAudioKey(newInfo))
 	}
 
 	// Create new output file.

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -207,6 +207,244 @@ func TestRollingMerge_AppendMultiple(t *testing.T) {
 	require.Equal(t, 6, info.SampleCount, "merged file should contain all 3 segments' samples")
 }
 
+// waitForBucketAudio polls until the camera's bucket reaches the expected
+// segment count AND audio key (the audio key disambiguates a reset bucket from
+// the previous one — count alone can match stale state after a bucket break).
+func waitForBucketAudio(t *testing.T, r *RollingMergeCoordinator, cameraID string, expectedCount int, expectedAudioKey string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		bucketAny, ok := r.buckets.Load(cameraID)
+		if ok {
+			bi := bucketAny.(*bucketInfo)
+			bi.mu.Lock()
+			count, key := bi.segmentCount, bi.audioKey
+			bi.mu.Unlock()
+			if count == expectedCount && key == expectedAudioKey {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for bucket segmentCount=%d audioKey=%q for camera %s", expectedCount, expectedAudioKey, cameraID)
+}
+
+// ---------------------------------------------------------------------------
+// TestRollingMerge_AudioConfigChangeBreaksBucket — audio presence/config change
+// across segments (audio_enabled toggled mid-stream) must finalize the current
+// bucket and start a new one, NOT merge across the boundary. Merging across it
+// trips MergeMP4Segments' mixed-audio drop policy, and the resulting video-only
+// bucket poisons every subsequent append (sticky audio loss — observed live:
+// "audio presence/config mismatch across segments" warning repeating every
+// segment close long after all new segments carried audio).
+// ---------------------------------------------------------------------------
+
+// createAndInsertSegmentWithG711 is createAndInsertSegment with a G.711 μ-law
+// audio track (2 samples) muxed in.
+func createAndInsertSegmentWithG711(t *testing.T, env *mergeTestEnv, recordingID, cameraID string, startedAt time.Time) string {
+	t.Helper()
+	ctx := context.Background()
+
+	tempPath, finalPath, err := env.store.CreateSegment(cameraID, "h264")
+	require.NoError(t, err)
+
+	segDir := filepath.Dir(tempPath)
+	segFile := createH264SegmentWithG711Audio(t, segDir)
+	data, err := os.ReadFile(segFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tempPath, data, 0o644))
+	os.Remove(segFile)
+	require.NoError(t, env.store.CloseSegment(tempPath, finalPath))
+
+	fi, err := os.Stat(finalPath)
+	require.NoError(t, err)
+
+	rec := &model.Recording{
+		ID:         recordingID,
+		CameraID:   cameraID,
+		FilePath:   finalPath,
+		Format:     model.FormatH264,
+		StartedAt:  startedAt,
+		EndedAt:    startedAt.Add(30 * time.Second),
+		Duration:   30.0,
+		FileSize:   fi.Size(),
+		FrameCount: 2,
+	}
+	require.NoError(t, env.db.InsertRecording(ctx, rec))
+	return finalPath
+}
+
+func TestRollingMerge_AudioConfigChangeBreaksBucket(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{
+		RollingEnabled:  boolPtr(true),
+		RollingDebounce: "50ms",
+		RollingWindow:   "1h",
+	}
+	r := newTestRollingCoordinator(env, cfg, bus)
+	require.NoError(t, r.Start(context.Background()))
+	defer r.Stop()
+
+	cameraID := "cam-audio-boundary"
+	baseTime := time.Now().UTC().Truncate(time.Hour).Add(10 * time.Minute)
+
+	// Segment 1: video-only. Creates the first bucket.
+	p1 := createAndInsertSegment(t, env, "rec-plain", cameraID, baseTime)
+	publishSegmentCompleted(t, bus, cameraID, "rec-plain", p1, "h264", baseTime)
+	waitForBucketAudio(t, r, cameraID, 1, "none", 5*time.Second)
+
+	// Segment 2: audio arrives (audio_enabled toggled / codec negotiated).
+	// The audio key differs from the bucket's — a new bucket must start here.
+	p2 := createAndInsertSegmentWithG711(t, env, "rec-audio1", cameraID, baseTime.Add(30*time.Second))
+	publishSegmentCompleted(t, bus, cameraID, "rec-audio1", p2, "h264", baseTime.Add(30*time.Second))
+	audioInfo, err := ParseSegment(p2)
+	require.NoError(t, err)
+	audioKey := segmentAudioKey(audioInfo)
+	require.NotEqual(t, "none", audioKey)
+	waitForBucketAudio(t, r, cameraID, 1, audioKey, 5*time.Second)
+
+	// Segment 3: audio again. Must append to the SECOND bucket (audio intact),
+	// not trip the mixed-audio drop.
+	p3 := createAndInsertSegmentWithG711(t, env, "rec-audio2", cameraID, baseTime.Add(60*time.Second))
+	publishSegmentCompleted(t, bus, cameraID, "rec-audio2", p3, "h264", baseTime.Add(60*time.Second))
+	waitForBucketAudio(t, r, cameraID, 2, audioKey, 5*time.Second)
+
+	// Two merged recordings: the video-only bucket + the audio bucket.
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "audio boundary must produce two merged recordings, one per audio state")
+
+	var plainRec, audioRec *model.Recording
+	for i := range recs {
+		info, err := ParseSegment(recs[i].FilePath)
+		require.NoError(t, err)
+		switch {
+		case !info.HasAudio:
+			require.Nil(t, plainRec, "more than one video-only merged recording")
+			plainRec = &recs[i]
+		case info.HasAudio:
+			require.Nil(t, audioRec, "more than one audio merged recording")
+			audioRec = &recs[i]
+			// 2 G.711 samples per segment × 2 segments — audio survived the
+			// rolling merge instead of being dropped at the boundary.
+			require.Equal(t, 4, info.AudioSampleCount, "audio bucket must retain all audio samples")
+			require.Equal(t, "g711", info.AudioCodec)
+			require.True(t, info.G711MULaw, "audio bucket must retain the μ-law config")
+			require.Equal(t, 4, info.SampleCount, "audio bucket must retain all video samples")
+		}
+	}
+	require.NotNil(t, plainRec, "video-only bucket missing")
+	require.NotNil(t, audioRec, "audio bucket missing")
+}
+
+// ---------------------------------------------------------------------------
+// TestBackfillMP4_MixedAudioBatchSplitsRuns — a backfill batch straddling an
+// audio boundary must split into audio-homogeneous runs instead of tripping
+// the mixed-audio drop policy (which would strip audio from the whole output).
+// ---------------------------------------------------------------------------
+
+func TestBackfillMP4_MixedAudioBatchSplitsRuns(t *testing.T) {
+	env := newMergeTestEnv(t)
+	defer env.close(t)
+
+	bus := event.NewEventBus(16)
+	cfg := config.MergeConfig{RollingEnabled: boolPtr(true)}
+	r := newTestRollingCoordinator(env, cfg, bus)
+
+	cameraID := "cam-mixed-batch"
+	baseTime := time.Now().UTC().Truncate(time.Hour).Add(10 * time.Minute)
+
+	// A batch spanning the boundary: plain → audio → audio.
+	p1 := createAndInsertSegment(t, env, "rec-plain", cameraID, baseTime)
+	p2 := createAndInsertSegmentWithG711(t, env, "rec-a1", cameraID, baseTime.Add(30*time.Second))
+	p3 := createAndInsertSegmentWithG711(t, env, "rec-a2", cameraID, baseTime.Add(60*time.Second))
+
+	recs := []*model.Recording{
+		{ID: "rec-plain", CameraID: cameraID, FilePath: p1, Format: model.FormatH264, StartedAt: baseTime, EndedAt: baseTime.Add(30 * time.Second), Duration: 30, FileSize: 1},
+		{ID: "rec-a1", CameraID: cameraID, FilePath: p2, Format: model.FormatH264, StartedAt: baseTime.Add(30 * time.Second), EndedAt: baseTime.Add(60 * time.Second), Duration: 30, FileSize: 1},
+		{ID: "rec-a2", CameraID: cameraID, FilePath: p3, Format: model.FormatH264, StartedAt: baseTime.Add(60 * time.Second), EndedAt: baseTime.Add(90 * time.Second), Duration: 30, FileSize: 1},
+	}
+	// Recording rows were already inserted by the create helpers above.
+
+	merged, err := r.backfillCameraRecordings(context.Background(), cameraID, recs)
+	require.NoError(t, err)
+	require.Equal(t, 3, merged)
+
+	// The plain segment stays standalone; the two audio segments merge together.
+	dbRecs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, dbRecs, 2, "expected standalone plain + merged audio recordings")
+
+	var sawPlain, sawAudio bool
+	for i := range dbRecs {
+		info, err := ParseSegment(dbRecs[i].FilePath)
+		require.NoError(t, err)
+		if info.HasAudio {
+			sawAudio = true
+			require.Equal(t, 4, info.AudioSampleCount, "merged audio run must keep all audio samples")
+			require.Equal(t, 4, info.SampleCount)
+		} else {
+			sawPlain = true
+			require.Equal(t, 2, info.SampleCount, "plain segment must stay standalone")
+		}
+	}
+	require.True(t, sawPlain, "plain standalone recording missing")
+	require.True(t, sawAudio, "audio merged recording missing")
+}
+
+// ---------------------------------------------------------------------------
+// TestSplitRunsByAudioKey — unit test for the run splitter.
+// ---------------------------------------------------------------------------
+
+func TestSplitRunsByAudioKey(t *testing.T) {
+	none := &SegmentInfo{HasAudio: false}
+	g711u := &SegmentInfo{HasAudio: true, AudioCodec: "g711", G711MULaw: true, AudioTimescale: 8000}
+	g711a := &SegmentInfo{HasAudio: true, AudioCodec: "g711", G711MULaw: false, AudioTimescale: 8000}
+	aac := &SegmentInfo{HasAudio: true, AudioCodec: "aac", AudioTimescale: 44100, AudioConfig: []byte{0x12, 0x10}}
+
+	mk := func(n int, f func(i int) *SegmentInfo) ([]*model.Recording, []*SegmentInfo) {
+		recs := make([]*model.Recording, n)
+		infos := make([]*SegmentInfo, n)
+		for i := range n {
+			recs[i] = &model.Recording{ID: fmt.Sprintf("r%d", i)}
+			infos[i] = f(i)
+		}
+		return recs, infos
+	}
+
+	// none none | g711u g711u | none | aac  → 4 runs
+	recs, infos := mk(6, func(i int) *SegmentInfo {
+		switch i {
+		case 0, 1:
+			return none
+		case 2, 3:
+			return g711u
+		case 4:
+			return none
+		default:
+			return aac
+		}
+	})
+	runs := splitRunsByAudioKey(recs, infos)
+	require.Len(t, runs, 4)
+	require.Equal(t, []int{2, 2, 1, 1}, []int{len(runs[0].infos), len(runs[1].infos), len(runs[2].infos), len(runs[3].infos)})
+	require.Equal(t, "none", runs[0].keyStr)
+	require.Equal(t, segmentAudioKey(g711u), runs[1].keyStr)
+	require.Equal(t, "none", runs[2].keyStr)
+	require.Equal(t, segmentAudioKey(aac), runs[3].keyStr)
+	// A-law vs μ-law must be different keys (config bytes differ).
+	require.NotEqual(t, segmentAudioKey(g711u), segmentAudioKey(g711a))
+
+	// All-homogeneous batch → single run.
+	recs, infos = mk(3, func(int) *SegmentInfo { return g711u })
+	runs = splitRunsByAudioKey(recs, infos)
+	require.Len(t, runs, 1)
+	require.Len(t, runs[0].infos, 3)
+}
+
 // ---------------------------------------------------------------------------
 // TestRollingMerge_DisabledByDefault — when RollingEnabled=false, no merge happens.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

滚动合并桶只跟踪 SPS/PPS 兼容性，音频一致性未纳入。当相机音频状态在流中途变化（`audio_enabled` 开关、G.711 协商建立）时：

1. 有音分段追加到无音桶 → 触发 `MergeMP4Segments` 的混合音频丢弃策略（"audio presence/config mismatch across segments, dropping audio"）；
2. 降级后的**纯视频桶**成为后续每次追加的输入 → 永远 mismatch → **粘性丢音**：警告每个分段闭合都重复，即使之后所有新分段都带音频（GB28181 E2E 容器实测复现，连续 5+ 轮警告）。

这也解释了 #337-#340 联调时长跑容器里出现过的偶发 mixed 警告。

## 修复

- **桶级断链**：`bucketInfo` 增加 `audioKey`（codec + μ-law 标志 + timescale + config 字节）。键变化 → 终结旧桶、从有音分段起新桶 —— 与 SPS/PPS 变更同构。`appendToBucket` 增加防御性校验。
- **批切分**：`mergeBatchMP4`（实时批 + backfill 路径）将已解析批次按音频键切成连续同质 run，不再整批丢音；单段 run 保持独立录像。

## 测试

- `TestRollingMerge_AudioConfigChangeBreaksBucket` — 无音→G.711→G.711 追加，新桶保留全部 4 个音频样本（回归）
- `TestBackfillMP4_MixedAudioBatchSplitsRuns` — 混合批 backfill 切分（无音独立 + 有音合并）
- `TestSplitRunsByAudioKey` — 切分器单测（含 A-law/μ-law 键区分）
- 包内 192 测试全绿，golangci-lint 0 issues

## 实测（Docker E2E，VM197）

gbsim `-audio-codec ulaw`（补上此前未覆盖的 μ-law 全链路）→ INVITE → PS/RTP → 录制 → 滚动合并：
- 部署后 0 次 `dropping audio` 警告
- 滚动桶 MP4 含 `ulaw` sample entry（`ulaw=1 alaw=0`）

关联 #340（PS 音频轨解复用与录制）。