### PR TITLE
fix(gb28181): demux PSM-less audio streams + tolerate REGISTER source-port rotation

### DIFF
--- a/internal/gb28181/psdemux.go
+++ b/internal/gb28181/psdemux.go
@@ -94,11 +94,32 @@ type PSDemuxer struct {
 	// audioCodecs maps audio stream_ids (0xC0-0xDF) to demuxable codecs,
 	// populated from the PSM elementary_stream_map.
 	audioCodecs map[byte]string
+	// psmSeen/psmAudioEntries track the latest PSM: when a PSM declares any
+	// audio entries it is authoritative and undeclared audio streams stay
+	// dropped; with no PSM at all (or a video-only PSM) the codec is unknown
+	// and the no-PSM fallback below resolves it instead.
+	psmSeen         bool
+	psmAudioEntries int
+	// audioResolved latches fallback decisions (SDP hint or byte-shape
+	// heuristic) per stream_id. A later PSM declaration still overrides it.
+	audioResolved map[byte]string
+	// audioHint seeds the fallback with the codec declared in the device's
+	// INVITE answer SDP ("" = none).
+	audioHint    string
+	guessScanned int // bytes scanned while voting μ-law vs A-law
+	guessMulaw   int // hits in the μ-law quiet cluster (0xFD-0xFF / 0x7D-0x7F)
+	guessAlaw    int // hits in the A-law quiet cluster (0x54-0x56 / 0xD4-0xD6)
 	// audioPesBuf holds an audio PES that straddles an AU boundary (rare —
 	// audio PES packets are small enough to fit one RTP packet).
 	audioPesBuf []byte
 	// audioOut collects frames extracted during FeedAU; DrainAudio consumes.
 	audioOut []AudioFrame
+	// audioContPTSTicks continues the audio timeline across frames whose PES
+	// carries no PTS (some firmware omits audio PTS entirely): each frame
+	// advances by its sample count instead of inheriting the enclosing video
+	// AU's RTP clock.
+	audioContPTSTicks int64
+	audioContSet      bool
 	// ptsOffset aligns the PES PTS clock domain with the RTP timestamp
 	// domain: ptsOffset = firstVideoPESPTS - firstAU_RTPts. Audio PES PTS
 	// values are translated through it so audio and video share the video
@@ -204,7 +225,10 @@ feedLoop:
 				if d.audioCodecs == nil {
 					d.audioCodecs = make(map[byte]string)
 				}
-				for esID, st := range audioStreamTypes(psmData) {
+				entries := audioStreamTypes(psmData)
+				d.psmSeen = true
+				d.psmAudioEntries = len(entries)
+				for esID, st := range entries {
 					d.audioCodecs[esID] = audioStreamCodec(st)
 				}
 			}
@@ -340,8 +364,13 @@ func (d *PSDemuxer) establishClockOffset(pesData []byte, rtpTicks int64) {
 // emitAudio converts one audio PES payload into AudioFrames on the collector.
 func (d *PSDemuxer) emitAudio(payload []byte, streamID byte, pesPTS int64, hasPTS bool, rtpTicks int64) {
 	codec := d.audioCodecs[streamID]
+	if codec == "" && !(d.psmSeen && d.psmAudioEntries > 0) {
+		// No authoritative PSM declaration for this stream — resolve via the
+		// SDP hint / byte-shape fallback (see resolveFallbackAudioCodec).
+		codec = d.resolveFallbackAudioCodec(streamID, payload)
+	}
 	if codec == "" {
-		return // codec not declared in PSM (or unsupported: G.722/G.723/...)
+		return // not declared in PSM (or unsupported: G.722/G.723/...) and not inferable
 	}
 	if !d.ptsOffsetSet {
 		// No video PTS seen yet (audio-only start): anchor audio to the RTP
@@ -353,12 +382,18 @@ func (d *PSDemuxer) emitAudio(payload []byte, streamID byte, pesPTS int64, hasPT
 			return
 		}
 	}
-	pts := rtpTicks
+	var pts int64
 	if hasPTS {
 		pts = pesPTS - d.ptsOffset
 		if pts < 0 {
 			pts = rtpTicks
 		}
+	} else if d.audioContSet {
+		pts = d.audioContPTSTicks
+	} else {
+		d.audioContPTSTicks = rtpTicks
+		d.audioContSet = true
+		pts = rtpTicks
 	}
 
 	switch codec {
@@ -369,6 +404,7 @@ func (d *PSDemuxer) emitAudio(payload []byte, streamID byte, pesPTS int64, hasPT
 			PTSTicks: pts,
 			Samples:  len(payload),
 		})
+		d.audioContPTSTicks, d.audioContSet = pts+int64(len(payload)), true
 	case AudioCodecAAC:
 		// GB28181 devices send AAC with ADTS framing; strip each frame and
 		// derive the AudioSpecificConfig from the first header. Raw payloads
@@ -381,6 +417,8 @@ func (d *PSDemuxer) emitAudio(payload []byte, streamID byte, pesPTS int64, hasPT
 				PTSTicks: pts,
 				Samples:  1024,
 			})
+			pts += 1024
+			d.audioContPTSTicks, d.audioContSet = pts, true
 		}
 	}
 }

--- a/internal/gb28181/psdemux_audio.go
+++ b/internal/gb28181/psdemux_audio.go
@@ -1,7 +1,77 @@
 package gb28181
 
+import (
+	"fmt"
+	"log/slog"
+)
+
 // Audio-path helpers for the MPEG-PS demuxer: audio PES parsing, PTS
 // extraction, PSM audio stream enumeration, and AAC ADTS framing.
+
+// SetAudioCodecHint seeds the no-PSM audio fallback with the codec declared
+// in the device's INVITE answer SDP (a=rtpmap PCMA/PCMU/mpeg4-generic). The
+// hint is used only while the stream carries no PSM audio declaration — a
+// PSM (the device's own in-stream statement) always wins.
+func (d *PSDemuxer) SetAudioCodecHint(codec string) {
+	d.audioHint = codec
+}
+
+// resolveFallbackAudioCodec resolves the codec of an audio stream that no PSM
+// has declared: a previously latched decision, the SDP hint, or a byte-shape
+// heuristic (ADTS sync → AAC; μ-law vs A-law by quiet-cluster voting over the
+// first ~4KB of payload — near-silent samples cluster at 0xFF/0x7F for μ-law
+// and 0x55/0xD5 for A-law). Returns "" while evidence is still insufficient.
+func (d *PSDemuxer) resolveFallbackAudioCodec(streamID byte, payload []byte) string {
+	if c, ok := d.audioResolved[streamID]; ok {
+		return c
+	}
+	codec := d.guessAudioCodec(payload)
+	if codec == "" {
+		return ""
+	}
+	if d.audioResolved == nil {
+		d.audioResolved = make(map[byte]string)
+	}
+	d.audioResolved[streamID] = codec
+	slog.Info("gb28181: PS audio stream not declared in PSM — codec inferred",
+		"stream_id", fmt.Sprintf("0x%02X", streamID), "codec", codec,
+		"hint", d.audioHint, "mulaw_votes", d.guessMulaw, "alaw_votes", d.guessAlaw)
+	return codec
+}
+
+// guessAudioCodec applies the fallback detection order to one payload: ADTS
+// sync (self-describing AAC) → SDP hint → quiet-cluster voting. Voting
+// accumulates across calls until 4KB has been scanned.
+func (d *PSDemuxer) guessAudioCodec(payload []byte) string {
+	// ADTS sync at the payload start: frame length must be sane, which
+	// distinguishes real ADTS from G.711 bytes that happen to open with
+	// 0xFF 0Fx (μ-law near-silence).
+	if len(payload) >= 7 && payload[0] == 0xFF && payload[1]&0xF0 == 0xF0 {
+		frameLen := int(payload[3]&0x03)<<11 | int(payload[4])<<3 | int(payload[5])>>5
+		if frameLen >= 7 && frameLen <= 8192 {
+			return AudioCodecAAC
+		}
+	}
+	if d.audioHint != "" {
+		return d.audioHint
+	}
+	for _, b := range payload {
+		switch {
+		case b >= 0xFD, b >= 0x7D && b <= 0x7F:
+			d.guessMulaw++
+		case b >= 0x54 && b <= 0x56, b >= 0xD4 && b <= 0xD6:
+			d.guessAlaw++
+		}
+	}
+	d.guessScanned += len(payload)
+	if d.guessScanned < 4096 {
+		return "" // keep collecting votes
+	}
+	if d.guessMulaw >= d.guessAlaw {
+		return AudioCodecG711U
+	}
+	return AudioCodecG711A
+}
 
 // parseAudioPES parses an audio PES packet and returns the payload, its PTS
 // (when present), and the total PES length. Audio uses the standard

--- a/internal/gb28181/psdemux_audio_fallback_test.go
+++ b/internal/gb28181/psdemux_audio_fallback_test.go
@@ -1,0 +1,167 @@
+package gb28181
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildAudioPSVar is buildAudioPS with toggles: PSM present, audio entry in
+// the PSM, and PTS on the audio PES. Video PES always carries PTS (it anchors
+// the clock domain exactly like real devices).
+func buildAudioPSVar(videoNALU, audio []byte, psm, audioEntry, audioPTS bool, ptsVideo, ptsAudio int64) []byte {
+	var ps bytes.Buffer
+
+	ps.Write([]byte{0x00, 0x00, 0x01, 0xBA})
+	ps.Write([]byte{0x44, 0x00, 0x04, 0x00, 0x04, 0x01, 0x01, 0x89, 0xC3, 0xF8})
+
+	if psm {
+		ps.Write([]byte{0x00, 0x00, 0x01, 0xBC})
+		body := []byte{
+			0x02,       // version
+			0xC0,       // reserved
+			0x00, 0x00, // PS_info_length = 0
+		}
+		esMap := []byte{streamTypeH264, 0xE0, 0x00, 0x00}
+		if audioEntry {
+			esMap = append(esMap, streamTypeG711A, 0xC0, 0x00, 0x00)
+		}
+		body = append(body, byte(len(esMap)>>8), byte(len(esMap)))
+		body = append(body, esMap...)
+		ps.Write([]byte{byte(len(body) >> 8), byte(len(body))})
+		ps.Write(body)
+	}
+
+	if videoNALU != nil {
+		es := append([]byte{0x00, 0x00, 0x00, 0x01}, videoNALU...)
+		ps.Write([]byte{0x00, 0x00, 0x01, 0xE0})
+		pesHdrLen := 3 + 5
+		ps.Write([]byte{byte((pesHdrLen + len(es)) >> 8), byte(pesHdrLen + len(es))})
+		ps.Write([]byte{0x80, 0x80, 0x05})
+		ps.Write(encodePESPTS(ptsVideo))
+		ps.Write(es)
+	}
+
+	ps.Write([]byte{0x00, 0x00, 0x01, 0xC0})
+	if audioPTS {
+		hdrLen := 3 + 5
+		ps.Write([]byte{byte((hdrLen + len(audio)) >> 8), byte(hdrLen + len(audio))})
+		ps.Write([]byte{0x80, 0x80, 0x05})
+		ps.Write(encodePESPTS(ptsAudio))
+	} else {
+		hdrLen := 3
+		ps.Write([]byte{byte((hdrLen + len(audio)) >> 8), byte(hdrLen + len(audio))})
+		ps.Write([]byte{0x80, 0x00, 0x00})
+	}
+	ps.Write(audio)
+	return ps.Bytes()
+}
+
+// mulawIsh returns a G.711 μ-law-shaped payload: near-silent samples cluster
+// at 0xFF/0x7F, plus a few mid-amplitude speech bytes.
+func mulawIsh() []byte {
+	return append(bytes.Repeat([]byte{0xFF, 0x7F}, 60), 0x25, 0xA5, 0x30, 0xB0)
+}
+
+// alawIsh returns a G.711 A-law-shaped payload (quiet cluster 0x55/0xD5).
+func alawIsh() []byte {
+	return append(bytes.Repeat([]byte{0x55, 0xD5}, 60), 0x70, 0xF0, 0x74, 0xF4)
+}
+
+func feedAUs(t *testing.T, d *PSDemuxer, audio []byte, psm, audioEntry, audioPTS bool, n int) []AudioFrame {
+	t.Helper()
+	var frames []AudioFrame
+	for i := range n {
+		ps := buildAudioPSVar([]byte{0x67, 0x42}, audio, psm, audioEntry, audioPTS,
+			int64(90000+i*3000), int64(90160+i*3000))
+		_, err := d.FeedAU(ps, int64(9000+i*3000), true)
+		require.NoError(t, err)
+		frames = append(frames, d.DrainAudio()...)
+	}
+	return frames
+}
+
+func TestPSDemuxAudioHeuristicMulawNoPSM(t *testing.T) {
+	d := NewPSDemuxer()
+	// 40 payloads × 124B = 4960B scanned: the 4KB voting threshold crosses on
+	// the 34th, so only the tail emits — but it MUST emit.
+	frames := feedAUs(t, d, mulawIsh(), false, false, true, 40)
+	require.NotEmpty(t, frames, "heuristic must latch after 4KB of payload votes")
+	for _, f := range frames {
+		require.Equal(t, AudioCodecG711U, f.Codec)
+	}
+}
+
+func TestPSDemuxAudioHeuristicAlawNoPSM(t *testing.T) {
+	d := NewPSDemuxer()
+	frames := feedAUs(t, d, alawIsh(), false, false, true, 40)
+	require.NotEmpty(t, frames)
+	for _, f := range frames {
+		require.Equal(t, AudioCodecG711A, f.Codec)
+	}
+}
+
+func TestPSDemuxAudioVideoOnlyPSMStillFallsBack(t *testing.T) {
+	// A PSM with no audio entries is not an authoritative "no audio" when the
+	// stream still carries audio PES packets — the fallback engages.
+	d := NewPSDemuxer()
+	frames := feedAUs(t, d, mulawIsh(), true, false, true, 40)
+	require.NotEmpty(t, frames)
+	for _, f := range frames {
+		require.Equal(t, AudioCodecG711U, f.Codec)
+	}
+}
+
+func TestPSDemuxAudioHintResolvesImmediately(t *testing.T) {
+	d := NewPSDemuxer()
+	d.SetAudioCodecHint(AudioCodecG711A)
+	frames := feedAUs(t, d, mulawIsh(), false, false, true, 1)
+	require.Len(t, frames, 1)
+	require.Equal(t, AudioCodecG711A, frames[0].Codec)
+}
+
+func TestPSDemuxAudioADTSFallbackNoPSM(t *testing.T) {
+	d := NewPSDemuxer()
+	adts := buildADTS(bytes.Repeat([]byte{0x33}, 64), 44100, 1)
+	frames := feedAUs(t, d, adts, false, false, true, 1)
+	require.Len(t, frames, 1)
+	require.Equal(t, AudioCodecAAC, frames[0].Codec)
+	require.NotNil(t, frames[0].Config, "ADTS-derived AudioSpecificConfig expected")
+}
+
+func TestPSDemuxPSMArrivingOverridesHeuristic(t *testing.T) {
+	d := NewPSDemuxer()
+	// Phase 1: no PSM → heuristic latches μ-law.
+	frames := feedAUs(t, d, mulawIsh(), false, false, true, 40)
+	require.NotEmpty(t, frames)
+	require.Equal(t, AudioCodecG711U, frames[0].Codec)
+
+	// Phase 2: a PSM declaring A-law arrives — the device's own statement wins.
+	frames = feedAUs(t, d, alawIsh(), true, true, true, 1)
+	require.Len(t, frames, 1)
+	require.Equal(t, AudioCodecG711A, frames[0].Codec)
+}
+
+func TestPSDemuxAudioNoPTSContinuation(t *testing.T) {
+	d := NewPSDemuxer()
+	// Video PES (with PTS) anchors the clock; audio PES carries no PTS.
+	f1 := feedAUs(t, d, bytes.Repeat([]byte{0x77}, 100), true, true, false, 1)
+	require.Len(t, f1, 1)
+	require.Equal(t, int64(9000), f1[0].PTSTicks, "first PTS-less frame anchors to the AU RTP clock")
+
+	f2 := feedAUs(t, d, bytes.Repeat([]byte{0x78}, 100), true, true, false, 1)
+	require.Len(t, f2, 1)
+	require.Equal(t, f1[0].PTSTicks+100, f2[0].PTSTicks,
+		"PTS-less frames must advance by their sample count, not inherit the video AU clock")
+}
+
+func TestPSDemuxAudioNoPTSAudioOnlyDroppedUntilAnchor(t *testing.T) {
+	// Before any PTS-bearing PES establishes the clock domain, PTS-less audio
+	// cannot be placed on a timeline and is dropped (pre-existing behavior).
+	ps := buildAudioPSVar(nil, bytes.Repeat([]byte{0x77}, 50), false, false, false, 0, 0)
+	d := NewPSDemuxer()
+	_, err := d.FeedAU(ps, 9000, true)
+	require.NoError(t, err)
+	require.Empty(t, d.DrainAudio())
+}

--- a/internal/gb28181/rtp.go
+++ b/internal/gb28181/rtp.go
@@ -113,6 +113,13 @@ func (r *Receiver) SetTCPMode(mode TCPMode) {
 	r.tcpMode = mode
 }
 
+// SetAudioCodecHint seeds the PS demuxer's no-PSM audio fallback with the
+// codec declared in the device's INVITE answer SDP. No-op once the stream's
+// PSM declares the audio codec itself.
+func (r *Receiver) SetAudioCodecHint(codec string) {
+	r.demuxer.SetAudioCodecHint(codec)
+}
+
 // Start begins receiving RTP packets.
 // UDP mode: Binds to an available UDP port from PortManager.
 // TCP mode: Accepts an incoming TCP connection (conn must be non-nil).

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -599,6 +599,15 @@ func (s *Server) InviteChannel(deviceID, channelID string) error {
 		s.mu.Lock()
 		s.dialogs[channelID] = &inviteDialog{req: req, resp: resp}
 		s.mu.Unlock()
+		// Seed the no-PSM audio fallback from the answer SDP: devices that
+		// mux audio into the PS stream without ever sending a Program Stream
+		// Map are otherwise undecodable (the codec is unknowable from raw
+		// G.711 bytes). The hint yields to any later PSM declaration.
+		if rc := s.sessionMgr.GetReceiver(channelID); rc != nil {
+			if codec := sdpAudioCodec([]byte(resp.Body())); codec != "" {
+				rc.SetAudioCodecHint(codec)
+			}
+		}
 		// tcp-active: the device's answer SDP carries its media address —
 		// dial it now that the dialog is confirmed.
 		if s.cfg.MediaTransport == gb28181.MediaTCPActive {
@@ -996,13 +1005,15 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		}
 	} else {
 		slog.Info("gb28181: device registered", "device", deviceID, "source", req.Source(), "expires", expires)
-		// A re-REGISTER from a different address (device reboot, DHCP change,
-		// NAT rebind) invalidates the old media sessions: their INVITE
-		// dialogs pointed at the old address. Tear them down so the
-		// auto-INVITE below rebuilds fresh sessions.
+		// A re-REGISTER from a different IP (device reboot, DHCP change, NAT
+		// rebind) invalidates the old media sessions: their INVITE dialogs
+		// pointed at the old address. Tear them down so the auto-INVITE below
+		// rebuilds fresh sessions. The source PORT is not compared: SIP-over-
+		// UDP stacks may open a fresh socket per REGISTER, and media sessions
+		// are anchored by SDP addresses, not the REGISTER source port.
 		if existing, ok := s.deviceMgr.Device(deviceID); ok {
 			existing.Mu.RLock()
-			addrChanged := existing.NetAddr != req.Source()
+			addrChanged := hostOfAddr(existing.NetAddr) != hostOfAddr(req.Source())
 			existing.Mu.RUnlock()
 			if addrChanged {
 				slog.Info("gb28181: device address changed — recycling sessions", "device", deviceID, "new_source", req.Source())
@@ -1506,6 +1517,16 @@ func (s *Server) send401Challenge(req sip.Request, tx sip.ServerTransaction) {
 	value := fmt.Sprintf(`Digest realm="%s", nonce="%s", algorithm=MD5`, realm, generateNonce())
 	headers := []sip.Header{&sip.GenericHeader{HeaderName: "WWW-Authenticate", Contents: value}}
 	s.respond(req, tx, statusUnauthorized, "Unauthorized", headers)
+}
+
+// hostOfAddr extracts the IP from a "IP:port" source address. Used to detect
+// device address changes while tolerating source-port rotation (see
+// handleRegister).
+func hostOfAddr(addr string) string {
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		return h
+	}
+	return addr
 }
 
 // getAuthHeader extracts the Authorization header from a request. gosip's

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -559,3 +559,52 @@ func TestServer_Bye_Hook(t *testing.T) {
 		t.Fatalf("hook not called")
 	}
 }
+
+func TestHostOfAddr(t *testing.T) {
+	cases := map[string]string{
+		"192.168.63.152:36115": "192.168.63.152",
+		"10.0.0.1:5060":        "10.0.0.1",
+		"bare-addr":            "bare-addr",
+	}
+	for in, want := range cases {
+		if got := hostOfAddr(in); got != want {
+			t.Fatalf("hostOfAddr(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestServer_Register_PortRotationKeepsAddressStable(t *testing.T) {
+	// SIP-over-UDP stacks may open a fresh socket per REGISTER. A source-port
+	// change alone must NOT be treated as a device address change (which
+	// recycles media sessions); only an IP change may.
+	cfg := testConfig(t)
+	_, dm := startTestServer(t, cfg)
+
+	register := func(client *sipClient) {
+		req := buildRequest(t, sip.REGISTER, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), "")
+		res := client.roundTrip(req)
+		if res.StatusCode() != 401 {
+			t.Fatalf("first REGISTER status = %d, want 401", res.StatusCode())
+		}
+		auth := digestAuth(t, getChallenge(t, res), req, cfg.Password)
+		req2 := buildRequest(t, sip.REGISTER, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), "", auth)
+		if res2 := client.roundTrip(req2); res2.StatusCode() != 200 {
+			t.Fatalf("authed REGISTER status = %d, want 200", res2.StatusCode())
+		}
+	}
+
+	register(newSIPClient(t, cfg.SIPListen))
+	// A second socket — same IP, different source port — re-REGISTERs.
+	register(newSIPClient(t, cfg.SIPListen))
+
+	dev, ok := dm.Device(testDeviceID)
+	if !ok {
+		t.Fatalf("device %s no longer registered after port rotation", testDeviceID)
+	}
+	dev.Mu.RLock()
+	netAddr := dev.NetAddr
+	dev.Mu.RUnlock()
+	if !strings.Contains(netAddr, "127.0.0.1") {
+		t.Fatalf("device NetAddr = %q, want the newest client addr", netAddr)
+	}
+}

--- a/internal/gb28181/sip/talk.go
+++ b/internal/gb28181/sip/talk.go
@@ -370,3 +370,34 @@ func sdpAudioAddress(sdp []byte) (string, uint16, bool) {
 	}
 	return host, uint16(port), true
 }
+
+// sdpAudioCodec extracts the audio codec an SDP body declares on its m=audio
+// media line: PCMA→g711a, PCMU→g711u, mpeg4-generic→aac. Returns "" when the
+// body declares no usable audio codec. Used to seed the PS demuxer's no-PSM
+// audio fallback for devices that mux audio into the PS stream without ever
+// sending a Program Stream Map.
+func sdpAudioCodec(sdp []byte) string {
+	inAudio := false
+	for _, line := range splitCRLF(string(sdp)) {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "m="):
+			inAudio = strings.HasPrefix(line, "m=audio ")
+		case inAudio && strings.HasPrefix(line, "a=rtpmap:"):
+			// a=rtpmap:<pt> <encoding>/<clock> [/<params>]
+			fields := strings.Fields(strings.TrimPrefix(line, "a=rtpmap:"))
+			if len(fields) < 2 {
+				continue
+			}
+			switch strings.ToUpper(fields[1]) {
+			case "PCMA":
+				return gb28181.AudioCodecG711A
+			case "PCMU":
+				return gb28181.AudioCodecG711U
+			case "MPEG4-GENERIC":
+				return gb28181.AudioCodecAAC
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## 背景

设备团队反馈（mibee-rec .152 真机联调）：设备把 G.711 μ-law 音频 PES 复用进了同一路 PS/RTP 流，但**从不发送 PSM**，且音频 PES **不带 PTS**（抓包证据：610 个 RTP 包中音频 PES 410 个、PSM 0 个）。现有音频解复用按约定以 PSM 声明为钥匙（与 ZLMediaKit 等一致），无 PSM 即丢弃——联调被卡。

## 修复

**音频编解码三级判定**（优先级从高到低，高等级永远压制低等级）：
1. **PSM 声明** — 设备自己的在流声明，保持既有行为；声明过音频 entry 的 PSM 始终权威
2. **INVITE 应答 SDP hint** — 解析 200 OK 的 `m=audio` `a=rtpmap`（PCMA/PCMU/mpeg4-generic），注入解复用器
3. **字节形态启发式** — ADTS 同步字（帧长校验）→ AAC；μ-law/A-law 静音簇投票（前 4KB：μ 静音聚在 0xFF/0x7F，A 聚在 0x55/0xD5），无票数时默认 μ-law 并记日志

**无 PTS 音频帧时序**：按样本数推进音频时间线（`audioContPTSTicks`），不再继承所在视频 AU 的 RTP 时钟——否则两个视频帧之间的多个音频帧共享时间戳。

**REGISTER 源端口轮换容忍**：仅 IP 变化才回收媒体会话（`hostOfAddr`）——SIP-over-UDP 栈可能每个 REGISTER 换端口，而媒体会话锚定在 SDP 地址上，与 REGISTER 源端口无关。mibee-rec 新固件已观察到此行为。

## 验证

- 新增 8 个单测（启发式 μ/A、ADTS、hint、PSM 后到覆盖、无 PTS 推进、audio-only 丢弃）；包内 129 过，全量 4585 过，lint 0
- E2E（VM197 Docker，gbsim 复刻 mibee-rec 形态：`-no-psm -audio-no-pts -audio-codec ulaw`）：日志出现 `codec inferred … codec=g711u`，rolling-merge 开音频桶，落盘 MP4 含 `ulaw` 音轨 box + `avc1` 视频轨 ✓

## 备注

- 设备侧仍建议补 PSM（标准做法）+ GOP 收敛到 2-4s（当前 >75s 触发看门狗周期回收，录像有空窗）；本修复让无 PSM 设备也能直接出声，联调不再互相阻塞
- 关联 #340（PS 音频轨）、#341（路线图）