### PR TITLE
fix(gb28181): deflake TCP-active test + refresh GB28181 guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ For detailed setup, see [Getting Started](docs/en/getting-started.md).
 | RTSP (relay) | NVR → External | ✅ Done | Push-out: native Go relay to remote targets |
 | ONVIF | Camera ↔ NVR | ✅ Done | Discovery, PTZ, stream URI |
 | Xiaomi (CS2 + TUTK) | Camera → NVR | ✅ Done | CS2 P2P + legacy TUTK (7 models), cloud auth |
-| GB/T 28181 | Camera → NVR | ✅ Done | SIP platform, device registration, PTZ, playback |
+| GB/T 28181 | Camera → NVR | ✅ Done | SIP platform, auto-enrollment, audio + talk, subscriptions, PTZ, device-side playback |
 
 ## Use Cases
 

--- a/docs/en/gb28181-guide.md
+++ b/docs/en/gb28181-guide.md
@@ -1,23 +1,25 @@
-# GB/T 28181 Guide for MiBee NVR
+# MiBee NVR GB/T 28181 Guide
 
-This guide covers GB/T 28181 (Chinese national video surveillance standard) integration with MiBee NVR, including SIP platform configuration, device enrollment, PTZ control, playback, and troubleshooting.
+This guide covers MiBee NVR's GB/T 28181 (Chinese national video-surveillance standard) integration: SIP platform setup, device enrollment, audio, voice intercom, subscriptions, PTZ, device-side recording playback, and troubleshooting.
 
 ## What is GB/T 28181?
 
-GB/T 28181 is a Chinese national standard for video surveillance network systems, defining how IP cameras, NVRs, and platforms communicate over SIP and RTP/PS. MiBee NVR implements the **platform role** (UAS — answering side), which means:
+GB/T 28181 is China's national standard for networked video monitoring; it defines how IP cameras, NVRs, and platforms interoperate over SIP and RTP/PS. MiBee NVR implements the **platform role** (UAS):
 
-- Devices **REGISTER** with the NVR over SIP (UDP port 5060 by default)
-- Devices send **Keepalive** messages to maintain their online status
+- Devices **REGISTER** to the NVR over SIP (UDP port 5060 by default)
+- Devices send **Keepalive** heartbeats to stay online
 - The NVR **INVITEs** a channel to pull an RTP/PS media stream (pull model)
-- The NVR demuxes MPEG-PS into H.264/H.265 NALUs and feeds them to StreamHub
+- The NVR demuxes MPEG-PS into H.264/H.265 NALUs plus audio frames (G.711/AAC) and feeds the standard recording/streaming pipeline
 
-Supported camera brands include Hikvision, Dahua, Uniview, and other GB28181-compliant manufacturers.
+Compatibility matrix: GB/T 28181-2007/2011/2016/2022 (see `internal/gb28181/doc.go`). Supported vendors include Hikvision, Dahua, Uniview, and other GB28181-compliant manufacturers.
 
 ## Quick Start
 
-### Step 1: Enable GB28181 Server
+### Step 1: Enable the GB28181 server
 
-Open `mibee-nvr.yaml` and add the GB28181 server configuration:
+**Recommended: the web UI.** Open the NVR web UI → **Settings → GB28181**, flip the enable toggle, fill in the fields, and save (the password is write-only; leaving it blank keeps the current value).
+
+Equivalent YAML (`mibee-nvr.yaml`):
 
 ```yaml
 gb28181:
@@ -29,59 +31,41 @@ gb28181:
   port_range: "30000-30050"
   heartbeat_interval: "60s"
   catalog_interval: "30m"
-  tcp_mode: false
-  tcp_framing: "auto"
-  allowed_device_ids: []
+  media_transport: "udp"        # udp | tcp-passive | tcp-active
+  subscribe_catalog: true       # real-time channel-change push
+  subscribe_alarm: true         # alarm subscription
+  subscribe_mobile_position: false
+  subscribe_expires: "3600s"
+  allowed_device_ids: []        # empty = allow any device
 ```
 
 **Key parameters**:
-- `server_id`: Your NVR's 20-digit GB/T 28181 serial code (format: `34020000002000000001`)
-- `realm`: SIP digest-auth realm (typically your 10-digit area code, e.g., `3402000000`)
-- `password`: Secret for SIP digest authentication (encrypt via `mibee-nvr encrypt-config`)
-- `port_range`: RTP media port pool, format `"start-end"` (default `"30000-30050"`)
-- `tcp_mode`: Force TCP-passive mode for devices behind NAT (default `false`, UDP)
-- `tcp_framing`: TCP framing when `tcp_mode=true` — `"rfc4571"`, `"0x24"`, or `"auto"`
+- `server_id`: the NVR's 20-digit GB/T 28181 platform serial (must match the device side exactly)
+- `realm`: the SIP digest-auth realm (usually your 10-digit area code)
+- `password`: the SIP digest secret. **Empty = no authentication** (any device that can reach port 5060 can register — see Security)
+- `media_transport`: RTP transport — `udp` (default), `tcp-passive` (NVR listens, device connects — the Hikvision/Dahua NAT default), or `tcp-active` (NVR dials the device's answer address)
 
-### Step 2: Configure Your Camera
+### Step 2: Configure the camera
 
-On your GB28181 camera (Hikvision, Dahua, etc.), configure the SIP platform:
+On the camera's web UI, configure SIP platform access:
 
-**Hikvision example** (via web UI):
-- Navigate to **Network → Advanced Platform Access**
-- Set **Server Address** to your NVR's IP address
-- Set **Server Port** to `5060`
-- Set **Device ID** to your camera's 20-digit code (e.g., `34020000001320000001`)
-- Set **Password** to match your NVR's GB28181 password
-- Enable **Platform Access**
+**Hikvision**: *Network → Advanced Platform Access* — server address = NVR IP, server port `5060`, device ID = the camera's 20-digit code, password matching the NVR's, enable platform access.
 
-**Dahua example** (via web UI):
-- Navigate to **Network → TCP/IP → 28181**
-- Set **Server IP** to your NVR's IP address
-- Set **Server Port** to `5060`
-- Set **Device ID** to your camera's 20-digit code
-- Set **Device Domain** to match your NVR's realm (e.g., `3402000000`)
-- Set **Password** to match your NVR's GB28181 password
-- Enable **28181**
+**Dahua**: *Network → TCP/IP → 28181* — server IP/port/device ID/domain (realm)/password matching the NVR's, enable 28181.
 
-### Step 3: Start the NVR
+The device should REGISTER within seconds.
 
-```bash
-./mibee-nvr -config mibee-nvr.yaml
-```
+### Step 3: Auto-enrollment (zero manual setup)
 
-The GB28181 server will listen on UDP port 5060. Your camera should REGISTER within a few seconds.
+**No manual camera setup is required.** Once a device registers, the NVR automatically:
 
-### Step 4: View Registered Devices
+1. Records it in the device list and tracks online status (heartbeat timeout → offline)
+2. Queries its catalog and discovers every real video channel (organization nodes are skipped)
+3. Creates one camera per channel (`gb-<channelID>`), listed alongside ONVIF/RTSP cameras
+4. Auto-INVITEs each enrolled channel and starts recording
+5. Backfills manufacturer/model (DeviceInfo) and subscribes to catalog changes and alarms
 
-Open the MiBee NVR web UI and navigate to **GB28181** in the sidebar. You should see:
-
-- **Devices**: Registered GB28181 devices with online/offline status
-- **Channels**: Each device's video channels (typically channel 1 = main stream, channel 2 = sub-stream)
-- **PTZ**: PTZ control pad (if the channel supports PTZ)
-
-### Step 5: Add a Camera to Record
-
-Create a camera entry in your config that maps to a GB28181 channel:
+To bind a specific channel manually (optional), create the camera via the web form or YAML:
 
 ```yaml
 cameras:
@@ -91,412 +75,201 @@ cameras:
     gb28181:
       device_id: "34020000001320000001"
       channel_id: "34020000001320000001"
-      manufacturer: "Hikvision"
     recording_enabled: true
     enabled: true
 ```
 
-The NVR will:
-- Auto-detect the codec (H.264 or H.265) from the PS stream
-- INVITE the channel when the camera starts recording
-- Demux the MPEG-PS stream into NALUs
-- Feed the video to StreamHub for recording and live streaming (HLS, WebRTC, FLV, etc.)
+### Step 4: Enable audio (per camera)
+
+Audio is off by default. Turn on the **Audio** toggle in the camera's edit page (or `PUT /api/cameras/{id}` with `{"audio_enabled": true}`); the PS stream's audio track (G.711 A-law/μ-law, AAC) is then muxed into MP4 recordings and live streams.
+
+## Capability Overview
+
+| Capability | Status | Notes |
+|---|---|---|
+| REGISTER + Digest auth / allowlist | ✅ | 401 challenge, periodic re-register, unregister, IP-change session rebuild |
+| Auto-enrollment | ✅ | Register → catalog → per-channel cameras → auto streaming, zero config |
+| Live viewing (INVITE) | ✅ | UDP / TCP passive / TCP active (0x24, rfc4571, auto framing) |
+| Recording | ✅ | H.264/H.265, 30s segments, IDR-aligned, rolling merge |
+| Streaming out | ✅ | Via StreamHub to HLS/WebRTC/FLV/WS |
+| **Audio** | ✅ | G.711 A-law/μ-law + AAC → MP4 tracks + live audio; PSM-less streams auto-resolved |
+| **Voice intercom (talk)** | ✅ | Browser mic → camera speaker (one-click in LiveView) |
+| Device-side recording search/playback | ✅ | RecordInfo + fetch into the recordings library + speed/seek control |
+| PTZ + presets | ✅ | Direction/zoom/preset/cruise (FICommand) |
+| Catalog subscription | ✅ | Real-time channel-change NOTIFY instead of polling |
+| Alarm subscription | ✅ | → event bus/SSE/REST ring buffer |
+| Mobile-position subscription | ✅ | Vehicle-mounted cameras; REST trajectory query |
+| Time sync | ✅ | Device Query answered with platform time |
+| DeviceInfo/Status automation | ✅ | Brand/model backfill; keepalive preserves metadata |
+| Multi-level cascading / GB35114 | ⏸ | On demand (see #341) |
 
 ## Configuration Reference
 
-### Server Configuration
+### Server
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable GB28181 server |
-| `sip_listen` | string | `":5060"` | SIP UDP/TCP listen address |
-| `server_id` | string | (required) | NVR's 20-digit GB/T 28181 serial code |
-| `realm` | string | (required) | SIP digest-auth realm (10-digit area code) |
-| `password` | string | (required) | SIP digest-auth secret (encrypted) |
+| `enabled` | bool | `false` | Enable the GB28181 server |
+| `sip_listen` | string | `":5060"` | SIP UDP listen address |
+| `server_id` | string | (required) | Platform 20-digit serial |
+| `realm` | string | (required) | SIP digest realm |
+| `password` | string | (recommended) | SIP digest password; empty = no auth |
 | `port_range` | string | `"30000-30050"` | RTP media port pool (`"start-end"`) |
-| `heartbeat_interval` | string | `"60s"` | Device keepalive interval |
-| `catalog_interval` | string | `"30m"` | Catalog refresh interval |
-| `tcp_mode` | bool | `false` | Force TCP-passive mode for NAT traversal |
-| `tcp_framing` | string | `"auto"` | TCP framing: `"rfc4571"`, `"0x24"`, or `"auto"` |
-| `allowed_device_ids` | `[]string` | `[]` | Restrict registration to specific device IDs (empty = allow all) |
+| `heartbeat_interval` | string | `"60s"` | Expected device heartbeat interval |
+| `catalog_interval` | string | `"30m"` | Catalog poll interval (fallback when subscribed) |
+| `media_transport` | string | `"udp"` | `udp` / `tcp-passive` / `tcp-active` |
+| `sip_transport` | string | `"udp"` | Signaling transport: `udp` (add `tcp` listener optionally) |
+| `tcp_framing` | string | `"auto"` | TCP framing: `rfc4571` / `0x24` / `auto` |
+| `subscribe_catalog` | bool | `true` | Catalog subscription (real-time channel push) |
+| `subscribe_alarm` | bool | `true` | Alarm subscription |
+| `subscribe_mobile_position` | bool | `false` | Mobile-position subscription |
+| `subscribe_expires` | string | `"3600s"` | Subscription lifetime (auto-renewed at 80%) |
+| `allowed_device_ids` | `[]string` | `[]` | Registration allowlist (empty = allow all) |
 
-### Camera Configuration
+> `tcp_mode` (bool) is a legacy alias of `media_transport`, kept for YAML compatibility.
+
+### Camera
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `protocol` | string | Must be `"gb28181"` |
-| `gb28181.device_id` | string | Camera's 20-digit GB/T 28181 device code |
-| `gb28181.channel_id` | string | Camera's 20-digit GB/T 28181 channel code |
-| `gb28181.manufacturer` | string | Optional manufacturer name (e.g., `"Hikvision"`) |
+| `gb28181.device_id` | string | Device 20-digit code |
+| `gb28181.channel_id` | string | Channel 20-digit code |
+| `audio_enabled` | bool | Audio toggle (default false; enables MP4 audio tracks + live audio) |
+
+## Audio
+
+- **Codecs**: G.711 A-law / μ-law (8 kHz), AAC (ADTS auto-converted to ASC)
+- **Toggle**: per-camera `audio_enabled`; when off, demuxed audio frames are dropped
+- **PSM-less streams**: some firmware muxes audio into the PS stream without ever sending a PSM (or without declaring audio in it). The NVR resolves the codec in priority order: **PSM declaration → INVITE-answer SDP `a=rtpmap` → byte-shape heuristic** (ADTS sync → AAC; μ/A-law by quiet-cluster voting — μ-law silence clusters at 0xFF/0x7F, A-law at 0x55/0xD5). The decision is logged as `codec inferred`
+- **PTS-less audio**: frames without PES PTS advance the timeline by sample count, tolerating firmware that omits audio PTS
+- **Device-side recommendations**: mux audio into the same PS/RTP stream (same port + SSRC), declare it in the PSM (stream_type 0x90=μ-law / 0x91=A-law / 0x0F=AAC, stream_id 0xC0-0xDF), send G.711 as raw 8 kHz mono bytes
+
+## Voice Intercom (Talk)
+
+The LiveView page shows a **Talk** button for GB28181 cameras: browser mic → AudioWorklet downsample to 8 kHz → A-law encode → WebSocket upstream → the NVR sends an audio-only INVITE (`m=audio ... RTP/AVP 8`, `a=sendrecv`) → RTP to the device's receive address. Half-duplex: live audio and talk coexist.
+
+API: `GET /api/cameras/{id}/gb28181/talk` (WebSocket; binary frames = A-law bytes) and `GET /api/cameras/{id}/gb28181/talk/status`.
+
+## Subscriptions and Events
+
+- **Catalog**: channel-list changes arrive as NOTIFY in real time (merged into the channel table, cameras auto-enrolled)
+- **Alarm**: `GET /api/gb28181/devices/{id}/alarms` reads the ring buffer (latest 200); events also hit the bus (SSE `gb28181.alarm`)
+- **Mobile position**: `GET /api/gb28181/devices/{id}/positions` returns the trajectory
+- Toggles + lifetime in the settings page / table above; auto-renewal at 80% of lifetime
+
+## Device-Side Recording Search & Playback
+
+The Recordings page can search **recordings stored on the device** (RecordInfo) and fetch them: fetched segments go through the normal recording pipeline (segments on disk, recordings rows) and play back in the Recordings page with speed/seek control (INFO).
+
+API:
+- `GET /api/gb28181/channels/{id}/records?start=&end=` — search device recordings
+- `POST /api/gb28181/channels/{id}/playback` — start a fetch (body carries start/end)
+- `GET /api/gb28181/channels/{id}/playback` — fetch progress
+- `DELETE /api/gb28181/channels/{id}/playback` — stop
+- `POST /api/gb28181/channels/{id}/playback/control` — speed/seek/pause
 
 ## PTZ Control
 
-GB28181 PTZ control works via SIP MESSAGE with MANSCDP DeviceControl commands.
+PTZ is sent via MANSCDP DeviceControl. Supported: directions (incl. diagonals), zoom (needs `PTZType=2`), presets/cruise (FICommand). A channel's `PTZType` comes from its catalog entry (0=none, 1=pan/tilt, 2=pan/tilt+zoom).
 
-### Supported Directions
-
-- `up`, `down`, `left`, `right` — Pan/tilt movement
-- `up-left`, `up-right`, `down-left`, `down-right` — Diagonal movement
-- `zoom-in`, `zoom-out` — Zoom (requires `PTZType=2`)
-- `stop` — Stop all movement
-
-### PTZ Type
-
-Channels report `PTZType` from the catalog:
-- `0` — No PTZ support
-- `1` — Pan/tilt only
-- `2` — Pan/tilt + zoom
-
-### Web UI Control
-
-On the GB28181 devices page, click the PTZ pad for a channel with `PTZType > 0`:
-- Hold a direction button to move at speed 128
-- Release to stop
-- Click the center stop button to halt movement
-- Zoom in/out buttons appear for `PTZType=2`
-
-### API Control
+Web UI: the PTZ panel on the camera's LiveView page (press-and-hold movement, preset set/recall).
 
 ```bash
 curl -X POST http://localhost:9090/api/gb28181/channels/34020000001320000001/ptz \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic base64(username:password)" \
-  -d '{
-    "direction": "up",
-    "speed": 128
-  }'
+  -d '{"direction": "up", "speed": 128}'
 ```
 
-Response:
-```json
-{
-  "status": "ptz_sent",
-  "channel_id": "34020000001320000001",
-  "direction": "up",
-  "speed": 128
-}
-```
-
-## Playback
-
-GB28181 supports historical playback via INVITE with `PlayMode=PlayBack` and `StartTime`/`EndTime`. This feature is not yet implemented in the MiBee NVR web UI, but you can trigger it via the API:
-
-```bash
-curl -X POST http://localhost:9090/api/gb28181/channels/34020000001320000001/invite \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Basic base64(username:password)" \
-  -d '{
-    "playback": {
-      "start_time": "2026-01-01T00:00:00Z",
-      "end_time": "2026-01-01T01:00:00Z"
-    }
-  }'
-```
-
-This is a placeholder for future UI work. The underlying INVITE/BYE infrastructure already supports playback SDP negotiation.
-
-## Troubleshooting
-
-### Device Does Not Register
-
-**Symptom**: Device does not appear in the GB28181 devices list.
-
-**Solutions**:
-1. **Check SIP port**: Ensure `sip_listen` is listening on `:5060` (or your configured port):
-   ```bash
-   sudo netstat -ulnp | grep 5060
-   sudo ss -ulnp | grep 5060
-   ```
-
-2. **Check firewall**: Allow UDP port 5060:
-   ```bash
-   sudo ufw allow 5060/udp
-   # or
-   sudo iptables -A INPUT -p udp --dport 5060 -j ACCEPT
-   ```
-
-3. **Verify camera SIP settings**:
-   - Server IP matches your NVR's IP
-   - Server port is `5060`
-   - Device ID is 20 digits (GB/T 28181 format)
-   - Password matches your NVR's `gb28181.password`
-   - Platform access is enabled on the camera
-
-4. **Check NVR logs**:
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i gb28181
-   ```
-
-5. **Test SIP reachability**:
-   ```bash
-   # From the camera (if you have shell access):
-   nc -uvz nvr-ip 5060
-   ```
-
-### Heartbeat Timeout
-
-**Symptom**: Device registers but goes offline after a few minutes.
-
-**Cause**: Device heartbeat interval does not match NVR's `heartbeat_interval` (default 60s). Most cameras send keepalives every 60 seconds, but some use different intervals.
-
-**Solution**:
-1. Adjust `heartbeat_interval` in your config:
-   ```yaml
-   gb28181:
-     heartbeat_interval: "90s"  # or "30s", depending on your camera
-   ```
-
-2. Check camera SIP settings for its keepalive interval and match it.
-
-### No Video (Black Screen)
-
-**Symptom**: Channel invites successfully but live view is black.
-
-**Solutions**:
-1. **Check RTP port allocation**: Ensure `port_range` is not exhausted:
-   ```bash
-   # Check GB28181 devices page for "RTP Port" column
-   # Verify ports are in the configured range
-   ```
-
-2. **Check firewall for RTP ports**: Allow UDP ports in `port_range`:
-   ```bash
-   sudo ufw allow 30000:30050/udp
-   ```
-
-3. **Verify codec**: GB28181 uses MPEG-PS with stream_type 96 (H.264) or 97 (H.265). The NVR auto-detects this from the PS stream. If the camera sends an unsupported codec, demux will fail.
-
-4. **Check NVR logs for demux errors**:
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "psdemux\|demux"
-   ```
-
-5. **Test with direct RTP capture** (advanced):
-   ```bash
-   # Capture RTP from the camera's advertised port
-   sudo tcpdump -i any -w capture.pcap udp port <camera-rtp-port>
-   # Analyze with Wireshark to verify MPEG-PS structure
-   ```
-
-### Device Behind NAT (Network Address Translation)
-
-**Symptom**: Device registers but cannot establish RTP media (video never starts).
-
-**Cause**: RTP packets from the camera cannot reach the NVR because the camera is behind NAT and the SDP-advertised port is not forwarded.
-
-**Solutions**:
-1. **Enable TCP-passive mode** on the NVR:
-   ```yaml
-   gb28181:
-     tcp_mode: true
-     tcp_framing: "auto"
-   ```
-   TCP-passive mode requires the camera to initiate the TCP connection to the NVR, which works through NAT.
-
-2. **Configure port forwarding** on your router:
-   - Forward UDP ports `30000-30050` (or your `port_range`) to the NVR's IP address
-   - Forward UDP port `5060` (SIP) to the NVR's IP address
-
-3. **Use a VPN** (e.g., Tailscale, WireGuard) to bypass NAT:
-   - Install the VPN on both the NVR and the camera (if supported)
-   - Use VPN-assigned IPs in the camera's SIP settings
-
-4. **Check camera NAT traversal settings**:
-   - Hikvision: **Network → Advanced Platform Access → NAT Traversal**
-   - Dahua: **Network → TCP/IP → 28181 → NAT Mode**
-
-### Charset Issues (GBK vs UTF-8)
-
-**Symptom**: Catalog response has mojibake (garbled text) for Chinese device/channel names.
-
-**Cause**: GB/T 28181 devices often declare encoding as GB2312/GBK in the XML prolog (`<?xml ... encoding="GB2312"?>`) but may send actual UTF-8.
-
-**Solution**: The NVR's MANSCDP codec handles this automatically:
-- Strips the XML declaration before unmarshaling
-- Validates UTF-8 and falls back to GB18030 → GBK decoders
-- Logs a warning if charset fallback fails
-
-If you still see garbled text, check the camera's GB28181 configuration for encoding settings. Some older devices require explicit UTF-8 declaration.
-
-### Clock Sync Issues
-
-**Symptom**: Device rejects REGISTER with authentication failure even though credentials are correct.
-
-**Cause**: GB28181 digest authentication uses the SIP `Date` header for nonce freshness. If the NVR and device clocks are not synchronized, the device may reject the challenge.
-
-**Solution**:
-1. **Sync NVR clock** to NTP:
-   ```bash
-   sudo timedatectl set-ntp true
-   # or
-   sudo ntpdate pool.ntp.org
-   ```
-
-2. **Sync camera clock** to NTP (via camera web UI):
-   - Hikvision: **System → Time Configuration**
-   - Dahua: **System → General → Time**
-
-3. **Verify clock drift**:
-   ```bash
-   # On NVR
-   date
-   # On camera (if shell access)
-   date
-   ```
-
-### TCP Framing Issues
-
-**Symptom**: TCP-passive mode (`tcp_mode=true`) shows "read error" or "invalid length".
-
-**Cause**: `tcp_framing` setting does not match the camera's wire format.
-
-**Solutions**:
-1. Try each framing option:
-   ```yaml
-   gb28181:
-     tcp_mode: true
-     tcp_framing: "rfc4571"   # 2-byte big-endian length prefix
-     # or
-     tcp_framing: "0x24"      # RTSP interleaved ($ + channel + 2-byte length)
-     # or
-     tcp_framing: "auto"      # Detect from first bytes (default)
-   ```
-
-2. Check NVR logs for framing detection errors:
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "tcp\|framing\|0x24\|rfc4571"
-   ```
-
-3. **Note**: GB/T 28181-2016 and -2022 specify RFC4571 for RTP over TCP. The `0x24` mode models a vendor extension (RTSP interleaving). Use `"auto"` for mixed deployments.
-
-### PTZ Not Working
-
-**Symptom**: PTZ pad is disabled or PTZ commands have no effect.
-
-**Solutions**:
-1. **Check PTZType**: Verify the channel's `PTZType` from the catalog:
-   - `0` = No PTZ support (device firmware limitation)
-   - `1` = Pan/tilt only
-   - `2` = Pan/tilt + zoom
-
-2. **Check device online status**: PTZ commands fail with 409 if the device is offline.
-
-3. **Verify manufacturer support**: Not all GB28181 devices support PTZ via MANSCDP DeviceControl. Some use proprietary SIP extensions.
-
-4. **Check NVR logs for PTZ errors**:
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "ptz\|devicecontrol"
-   ```
+Directions: `up/down/left/right/up-left/up-right/down-left/down-right/zoom-in/zoom-out/stop`.
 
 ## API Reference
 
-### Device and Channel Endpoints
+### Devices & channels
+- `GET /api/gb28181/devices` — registered devices (ETag supported)
+- `GET /api/gb28181/devices/{id}/channels` — channel list
+- `POST /api/gb28181/devices/{id}/catalog-refresh` — trigger a catalog refresh (202)
+- `GET /api/gb28181/devices/{id}/alarms` — alarm ring buffer
+- `GET /api/gb28181/devices/{id}/positions` — mobile-position trajectory
 
-- `GET /api/gb28181/devices` — List registered devices (ETag support)
-- `GET /api/gb28181/channels` — List all channels across devices
-- `GET /api/gb28181/channels/{id}` — Get channel details (including PTZType)
-- `POST /api/gb28181/catalog/refresh` — Trigger catalog refresh (stub, 202 accepted)
+### Media sessions
+- `POST /api/gb28181/channels/{id}/invite` / `bye` — manual stream start/stop
+- `POST /api/gb28181/channels/{id}/ptz` — PTZ control
 
-### Media Session Endpoints
+### Device-side recordings
+- See the previous section
 
-- `POST /api/gb28181/channels/{id}/invite` — Invite a channel (stub, 202 accepted)
-- `POST /api/gb28181/channels/{id}/bye` — Send BYE to stop streaming (calls SessionManager.Bye)
+### Talk
+- `GET /api/cameras/{id}/gb28181/talk` (WebSocket), `GET .../talk/status`
 
-### PTZ Endpoints
+### Errors
 
-- `POST /api/gb28181/channels/{id}/ptz` — Send PTZ command
+| Status | Case |
+|--------|-------|
+| 400 | Missing/malformed body; unsupported PTZ |
+| 404 | Channel not found |
+| 409 | Device offline |
+| 500 | Internal error (MANSCDP encode/send failure) |
 
-PTZ request body:
-```json
-{
-  "direction": "up|down|left|right|up-left|up-right|down-left|down-right|zoom-in|zoom-out|stop",
-  "speed": 0-255
-}
-```
+## Troubleshooting
 
-PTZ directions:
-- `up`, `down`, `left`, `right` — Pan/tilt
-- `up-left`, `up-right`, `down-left`, `down-right` — Diagonal
-- `zoom-in`, `zoom-out` — Zoom (requires `PTZType=2`)
-- `stop` — Stop all movement
+### Device does not register
 
-### Error Responses
+1. Verify `sip_listen` is listening (`ss -ulnp | grep 5060`) and UDP 5060 is allowed through the firewall
+2. Check the five device-side fields: server IP / port 5060 / server ID (must equal `server_id` exactly) / realm / password
+3. Check logs: `journalctl -u mibee-nvr -f | grep -i gb28181` — `REGISTER auth failed` = password mismatch; `not in allowlist` = allowlist
+4. After changing the NVR password: the device's next re-REGISTER (within one registration cycle) fails with 403 and it goes offline; once the camera side is updated it recovers automatically, no re-enrollment needed
 
-| Status | Error | Description |
-|--------|-------|-------------|
-| 400 | Invalid body | Missing or malformed PTZ body |
-| 404 | Channel not found | `ErrChannelNotFound` |
-| 409 | Device offline | `ErrDeviceOffline` |
-| 400 | PTZ unsupported | `ErrPTZUnsupported` (PTZType=0) |
-| 400 | Zoom unsupported | `ErrZoomUnsupported` (PTZType=1) |
-| 500 | Internal error | Failed to encode MANSCDP or send MESSAGE |
+### Black screen / no stream
 
-## Supported Protocols and Features
+1. Check the `port_range` isn't exhausted and the UDP range is firewall-allowed
+2. Behind NAT, switch to `media_transport: tcp-passive`
+3. On TCP framing errors, try `tcp_framing: rfc4571 / 0x24 / auto`
+4. Codec: H.264/H.265 auto-detected, no configuration needed
 
-### SIP (Session Initiation Protocol)
-- **REGISTER**: Device registration with digest authentication
-- **Keepalive**: Heartbeat messages for online/offline tracking
-- **INVITE**: Pull a live or playback media stream
-- **BYE**: Tear down a media session
-- **MESSAGE**: Send MANSCDP commands (catalog request, device control)
+### No audio
 
-### Media (RTP/PS)
-- **RTP over UDP**: Default transport (port range configurable)
-- **RTP over TCP**: Optional TCP-passive mode for NAT traversal
-  - Framing: RFC4571 (standard), 0x24 (vendor extension), auto-detect
-- **MPEG-PS demuxing**: Extract H.264 (stream_type 96) or H.265 (stream_type 97) NALUs
-- **StreamHub integration**: Non-blocking frame fan-out to HLS, WebRTC, FLV, etc.
+1. Confirm the camera's **Audio** toggle is on (`audio_enabled`, off by default)
+2. Look for the `codec inferred` log line — PSM-less devices get their codec auto-resolved; if the line never appears and there is no audio track, capture the stream and confirm the device actually muxes audio into the PS stream
+3. See the device-side recommendations under Audio; PSM-less audio works here (auto fallback) but other platforms (ZLMediaKit etc.) drop it — devices should ideally declare audio in the PSM
 
-### MANSCDP (Management and Control)
-- **Catalog**: Device/channel list with PTZType, manufacturer, model
-- **DeviceInfo**: Device firmware/hardware details
-- **DeviceControl**: PTZ commands (direction, speed)
+### Periodic session recycling
 
-## Limitations and Known Issues
+Logs show `recycling stale session reason=no keyframe` and recordings have a gap every minute or so: the device's keyframe interval (GOP) exceeds the NVR's 75s watchdog. This is the designed self-healing (the re-INVITE forces a fresh IDR), but the device GOP should ideally be **2-4 seconds**.
 
-### Playback UI
-Playback INVITE is supported in the session manager but not yet exposed in the web UI. Use the API endpoint `POST /api/gb28181/channels/{id}/invite` with `playback.start_time` and `playback.end_time` as a workaround.
+### REGISTER source-port rotation
 
-### TCP 0x24 Mode
-The `0x24` TCP framing mode models a vendor extension (RTSP interleaved). GB/T 28181-2016 and -2022 specify RFC4571 as the standard. Use `"auto"` for mixed deployments; use `"rfc4571"` for strict compliance.
+Some SIP stacks use a fresh source port per REGISTER. The NVR compares **IP only** when detecting address changes; port rotation never recycles sessions.
 
-### Device-Specific Behavior
-- **Hikvision**: Supports full catalog, PTZ, and playback. Some older models may require GBK charset fallback.
-- **Dahua**: Supports full catalog, PTZ, and playback. NAT traversal settings vary by firmware.
-- **Uniview**: Similar to Hikvision, but may have different PTZ command semantics.
-- **Other brands**: Support varies. Minimal devices implement only REGISTER/keepalive/INVITE.
+### Heartbeat timeouts
 
-### Port Exhaustion on RPi 3B
-The default `port_range` is `"30000-30050"` (51 ports). If you have many concurrent GB28181 streams, expand the range:
-```yaml
-gb28181:
-  port_range: "30000-30100"  # 101 ports
-```
+If the device drops offline, align its heartbeat interval with `heartbeat_interval` (default 60s) on either side.
 
-On RPi 3B, keep the pool under 200 ports to avoid ephemeral port exhaustion.
+### Mojibake (GBK vs UTF-8)
 
-## Security Considerations
+The MANSCDP codec strips the XML declaration, validates UTF-8, and falls back to GB18030/GBK automatically. If names still look garbled, check the device's encoding setting.
 
-- **Digest authentication**: GB28181 uses SIP digest auth (like HTTP Basic but with nonce hashing). The `password` field is encrypted when `NVR_ENCRYPTION_KEY` is set.
-- **Device ID restriction**: Use `allowed_device_ids` to whitelist specific 20-digit device codes. Empty list = allow all.
-- **Network exposure**: GB28181 runs on UDP port 5060 by default. If your NVR is exposed to the internet, use a firewall or VPN to restrict access.
-- **No commercial content**: This implementation is open-source and free. No Pro/P2P features are included or referenced.
+### Clock sync
 
-## Support Resources
+If authentication or recording searches misbehave due to clock drift: the NVR answers TimeSync queries automatically; keep both sides NTP-synced.
 
-### Documentation
-- [MiBee NVR Getting Started](./getting-started.md)
-- [MiBee NVR Configuration Guide](./configuration.md)
-- [MiBee NVR API Reference](./api/README.md)
+## Limitations & Known Issues
 
-### GB/T 28181 References
-- GB/T 28181-2016: Information technology — Technical requirements for video surveillance networking system
-- GB/T 28181-2022: Latest revision (adds TCP-passive, improved catalog)
+- **Device-self pseudo-channel**: after an NVR restart, catalog-capable multi-channel devices briefly get a "device-self" camera that never streams. Known issue; archive it manually after restart. Tracked in #352
+- **Talk real-device coverage**: voice intercom is E2E-verified against a simulator; the real-device loopback is tracked in #353
+- **TCP 0x24 framing**: a vendor extension (GB/T 28181-2016/2022 specify RFC4571); use `auto` for mixed fleets
+- **Multi-level cascading / GB35114**: not implemented, on demand (#341)
+- **Alarm-triggered streaming**: alarm events are on the bus; automated alarm → INVITE linkage is tracked in #355
 
-### Community Support
-- GitHub Issues: [MiBee NVR Issues](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues)
-- Discussions: [MiBee NVR Discussions](https://github.com/Mi-Bee-Studio/MiBeeNvr/discussions)
+## Security
 
----
+- **Authentication**: always set `password` (empty = any reachable device can register). Combine with the `allowed_device_ids` allowlist for defense in depth
+- **Transport**: SIP/RTP are plaintext (GB35114 TLS/SM crypto not implemented). Public deployments must sit behind a firewall/VPN — do not expose 5060 or the port pool directly
+- **Port pool**: 51 ports by default; extend as needed (keep under ~200 on RPi 3B)
 
-This guide provides comprehensive coverage of GB/T 28181 integration with MiBee NVR. For specific camera models, check manufacturer documentation for GB28181 capabilities and limitations.
+## Resources
+
+- [Getting Started](./getting-started.md) · [Configuration](./configuration.md) · [API Reference](./api/README.md)
+- GB/T 28181-2016 / 2022 standard texts
+- [GitHub Issues](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues) · [Discussions](https://github.com/Mi-Bee-Studio/MiBeeNvr/discussions)

--- a/docs/zh/gb28181-guide.md
+++ b/docs/zh/gb28181-guide.md
@@ -1,23 +1,25 @@
 # MiBee NVR GB/T 28181 指南
 
-本指南介绍 MiBee NVR 的 GB/T 28181（中国视频监控国家标准）集成，包括 SIP 平台配置、设备接入、PTZ 控制、回放和故障排除。
+本指南介绍 MiBee NVR 的 GB/T 28181（中国视频监控国家标准）集成：SIP 平台配置、设备接入、音频、语音对讲、订阅推送、PTZ、设备录像回放和故障排除。
 
 ## 什么是 GB/T 28181？
 
 GB/T 28181 是中国视频监控网络系统的国家标准，定义了 IP 摄像机、NVR 和平台通过 SIP 和 RTP/PS 通信的方式。MiBee NVR 实现**平台角色**（UAS — 应答方），这意味着：
 
 - 设备通过 SIP（UDP 端口 5060，默认）**REGISTER** 到 NVR
-- 设备发送 **Keepalive** 消息维持在线状态
+- 设备发送 **Keepalive** 心跳维持在线状态
 - NVR **INVITE** 通道拉取 RTP/PS 媒体流（拉流模式）
-- NVR 将 MPEG-PS 解复用为 H.264/H.265 NALU，并通过 StreamHub 分发
+- NVR 将 MPEG-PS 解复用为 H.264/H.265 NALU 与音频帧（G.711/AAC），进入标准录像/直播管线
 
-支持的摄像机品牌包括海康威视、大华、宇视和其他 GB28181 兼容制造商。
+兼容矩阵：GB/T 28181-2007/2011/2016/2022（见 `internal/gb28181/doc.go`）。支持的摄像机品牌包括海康威视、大华、宇视和其它 GB28181 兼容制造商。
 
 ## 快速开始
 
 ### 步骤 1：启用 GB28181 服务器
 
-打开 `mibee-nvr.yaml` 并添加 GB28181 服务器配置：
+**推荐：Web 设置页**。打开 NVR Web UI → **设置 → GB28181**，打开启用开关并填写参数后保存（密码为只写字段，留空保存表示保持不变）。
+
+等价的 YAML 配置（`mibee-nvr.yaml`）：
 
 ```yaml
 gb28181:
@@ -29,59 +31,41 @@ gb28181:
   port_range: "30000-30050"
   heartbeat_interval: "60s"
   catalog_interval: "30m"
-  tcp_mode: false
-  tcp_framing: "auto"
-  allowed_device_ids: []
+  media_transport: "udp"        # udp | tcp-passive | tcp-active
+  subscribe_catalog: true       # 通道变更实时推送
+  subscribe_alarm: true         # 报警订阅
+  subscribe_mobile_position: false
+  subscribe_expires: "3600s"
+  allowed_device_ids: []        # 空 = 允许所有设备注册
 ```
 
 **关键参数**：
-- `server_id`：您的 NVR 的 20 位 GB/T 28181 序列号（格式：`34020000002000000001`）
-- `realm`： SIP 摘要认证域（通常是您的 10 位区域码，例如 `3402000000`）
-- `password`：SIP 摘要认证密钥（通过 `mibee-nvr encrypt-config` 加密）
-- `port_range`：RTP 媒体端口池，格式 `"start-end"`（默认 `"30000-30050"`）
-- `tcp_mode`：强制 TCP 被动模式用于 NAT 后设备（默认 `false`，UDP）
-- `tcp_framing`：`tcp_mode=true` 时的 TCP 组帧 — `"rfc4571"`、`"0x24"` 或 `"auto"`
+- `server_id`：NVR 的 20 位 GB/T 28181 平台编号（设备端需完全一致）
+- `realm`：SIP 摘要认证域（通常为 10 位区域码）
+- `password`：SIP 摘要认证密码。**留空 = 不鉴权**（任何能访问 5060 端口的设备都可注册，见"安全考虑"）
+- `media_transport`：RTP 媒体传输 —— `udp`（默认）、`tcp-passive`（NVR 监听、设备连接，海康/大华 NAT 默认）、`tcp-active`（NVR 拨向设备应答地址）
 
 ### 步骤 2：配置摄像机
 
-在您的 GB28181 摄像机（海康、大华等）上，配置 SIP 平台：
+在 GB28181 摄像机（海康、大华等）上配置 SIP 平台接入：
 
-**海康威视示例**（通过 Web UI）：
-- 导航至 **网络 → 高级平台接入**
-- 设置 **服务器地址** 为您的 NVR IP 地址
-- 设置 **服务器端口** 为 `5060`
-- 设置 **设备 ID** 为您的摄像机 20 位编码（例如 `34020000001320000001`）
-- 设置 **密码** 匹配您的 NVR GB28181 密码
-- 启用 **平台接入**
+**海康威视**（Web UI）：**网络 → 高级平台接入** —— 服务器地址填 NVR IP、服务器端口 `5060`、设备 ID 填 20 位国标码、密码与 NVR 一致、启用平台接入。
 
-**大华示例**（通过 Web UI）：
-- 导航至 **网络 → TCP/IP → 28181**
-- 设置 **服务器 IP** 为您的 NVR IP 地址
-- 设置 **服务器端口** 为 `5060`
-- 设置 **设备 ID** 为您的摄像机 20 位编码
-- 设置 **设备域** 匹配您的 NVR realm（例如 `3402000000`）
-- 设置 **密码** 匹配您的 NVR GB28181 密码
-- 启用 **28181**
+**大华**（Web UI）：**网络 → TCP/IP → 28181** —— 服务器 IP/端口/设备 ID/设备域（realm）/密码与 NVR 一致、启用 28181。
 
-### 步骤 3：启动 NVR
+设备应在几秒内 REGISTER 成功。
 
-```bash
-./mibee-nvr -config mibee-nvr.yaml
-```
+### 步骤 3：自动入册（零手动配置）
 
-GB28181 服务器将在 UDP 端口 5060 上监听。您的摄像机应在几秒内 REGISTER。
+**无需手动添加相机。** 设备注册成功后 NVR 自动完成：
 
-### 步骤 4：查看已注册设备
+1. 记入设备列表并跟踪在线状态（心跳超时判离线）
+2. 自动查询目录（Catalog），发现全部真实视频通道（组织节点自动跳过）
+3. 每个通道自动创建一台相机（`gb-<通道ID>`），与 ONVIF/RTSP 相机并列出现在相机列表
+4. 自动 INVITE 拉流开始录像
+5. 自动补全厂商/型号（DeviceInfo），订阅目录变更与报警推送
 
-打开 MiBee NVR Web UI 并在侧边栏导航至 **GB28181**。您应该看到：
-
-- **设备**：已注册的 GB28181 设备及在线/离线状态
-- **通道**：每个设备的视频通道（通常通道 1 = 主码流，通道 2 = 子码流）
-- **PTZ**：PTZ 控制面板（如果通道支持 PTZ）
-
-### 步骤 5：添加摄像机进行录像
-
-在您的配置中创建一个映射到 GB28181 通道的摄像机条目：
+需要手动绑定特殊通道时，也可以用 YAML 或 Web 表单显式创建：
 
 ```yaml
 cameras:
@@ -91,16 +75,33 @@ cameras:
     gb28181:
       device_id: "34020000001320000001"
       channel_id: "34020000001320000001"
-      manufacturer: "Hikvision"
     recording_enabled: true
     enabled: true
 ```
 
-NVR 将：
-- 从 PS 流自动检测编解码器（H.264 或 H.265）
-- 当摄像机开始录像时 INVITE 通道
-- 将 MPEG-PS 流解复用为 NALU
-- 将视频送入 StreamHub 进行录像和直播（HLS、WebRTC、FLV 等）
+### 步骤 4：开启音频（按相机）
+
+音频默认关闭。在相机编辑页打开 **音频** 开关（或 API `PUT /api/cameras/{id}` `{"audio_enabled": true}`）后，PS 流中的音频轨（G.711 A-law/μ-law、AAC）会写入 MP4 音轨并进入直播音频。
+
+## 功能总览
+
+| 能力 | 状态 | 说明 |
+|---|---|---|
+| REGISTER + Digest 鉴权 / 白名单 | ✅ | 401 挑战、周期重注册、注销、IP 变化自动重建会话 |
+| 自动入册 | ✅ | 注册 → 目录 → 通道建卡 → 自动拉流，零手动配置 |
+| 实时点播（INVITE） | ✅ | UDP / TCP 被动 / TCP 主动（0x24、rfc4571、auto 组帧） |
+| 录像 | ✅ | H.264/H.265，30s 分片、IDR 对齐、滚动合并 |
+| 直播 | ✅ | 经 StreamHub 进 HLS/WebRTC/FLV/WS 全部协议 |
+| **音频** | ✅ | G.711 A-law/μ-law + AAC → MP4 音轨 + 直播音频；无 PSM 流自动兜底 |
+| **语音对讲** | ✅ | 浏览器麦克风 → 设备扬声器（LiveView 一键对讲） |
+| 设备录像检索/回放 | ✅ | RecordInfo + 回放取流进录像库（Recordings 页）+ 倍速/拖动 |
+| PTZ + 预置位 | ✅ | 方向/变倍/预置位/巡航（FICommand） |
+| 目录订阅 | ✅ | 通道变更实时 NOTIFY，替代纯轮询 |
+| 报警订阅 | ✅ | → 事件总线/SSE/REST 环形缓存 |
+| 移动位置订阅 | ✅ | 车载/布控球场景，REST 查询轨迹 |
+| 时钟同步 | ✅ | 设备发 Query，平台应答标准时间 |
+| 设备信息/状态自动化 | ✅ | 厂商/型号自动补全，keepalive 不丢元数据 |
+| 多级级联 / GB35114 国密 | ⏸ | 按需评估（见 #341） |
 
 ## 配置参考
 
@@ -109,394 +110,166 @@ NVR 将：
 | 参数 | 类型 | 默认值 | 描述 |
 |-----------|------|---------|-------------|
 | `enabled` | bool | `false` | 启用 GB28181 服务器 |
-| `sip_listen` | string | `":5060"` | SIP UDP/TCP 监听地址 |
-| `server_id` | string | (必需) | NVR 的 20 位 GB/T 28181 序列号 |
-| `realm` | string | (必需) | SIP 摘要认证域（10 位区域码） |
-| `password` | string | (必需) | SIP 摘要认证密钥（已加密） |
+| `sip_listen` | string | `":5060"` | SIP UDP 监听地址 |
+| `server_id` | string | (必填) | 平台 20 位国标编号 |
+| `realm` | string | (必填) | SIP 摘要认证域 |
+| `password` | string | (建议设置) | SIP 摘要认证密码；留空 = 不鉴权 |
 | `port_range` | string | `"30000-30050"` | RTP 媒体端口池（`"start-end"`） |
-| `heartbeat_interval` | string | `"60s"` | 设备心跳间隔 |
-| `catalog_interval` | string | `"30m"` | 目录刷新间隔 |
-| `tcp_mode` | bool | `false` | 强制 TCP 被动模式用于 NAT 穿透 |
-| `tcp_framing` | string | `"auto"` | TCP 组帧：`"rfc4571"`、`"0x24"` 或 `"auto"` |
-| `allowed_device_ids` | `[]string` | `[]` | 限制注册到特定设备 ID（空 = 允许所有） |
+| `heartbeat_interval` | string | `"60s"` | 期望的设备心跳间隔 |
+| `catalog_interval` | string | `"30m"` | 目录轮询间隔（订阅开启时仅作兜底） |
+| `media_transport` | string | `"udp"` | 媒体传输：`udp` / `tcp-passive` / `tcp-active` |
+| `sip_transport` | string | `"udp"` | 信令传输：`udp`（可叠加 `tcp` 监听） |
+| `tcp_framing` | string | `"auto"` | TCP 组帧：`"rfc4571"`、`"0x24"`、`"auto"` |
+| `subscribe_catalog` | bool | `true` | 目录订阅（通道变更实时推送） |
+| `subscribe_alarm` | bool | `true` | 报警订阅 |
+| `subscribe_mobile_position` | bool | `false` | 移动位置订阅（静止相机无需开启） |
+| `subscribe_expires` | string | `"3600s"` | 订阅有效期（80% 时自动续订） |
+| `allowed_device_ids` | `[]string` | `[]` | 注册白名单（空 = 允许所有） |
 
-### 摄像机配置
+> `tcp_mode`（bool）是 `media_transport` 的旧别名，保留仅为 YAML 兼容。
+
+### 相机配置
 
 | 参数 | 类型 | 描述 |
 |-----------|------|-------------|
 | `protocol` | string | 必须为 `"gb28181"` |
-| `gb28181.device_id` | string | 摄像机的 20 位 GB/T 28181 设备编码 |
-| `gb28181.channel_id` | string | 摄像机的 20 位 GB/T 28181 通道编码 |
-| `gb28181.manufacturer` | string | 可选制造商名称（例如 `"Hikvision"`） |
+| `gb28181.device_id` | string | 设备 20 位国标编码 |
+| `gb28181.channel_id` | string | 通道 20 位国标编码 |
+| `audio_enabled` | bool | 音频开关（默认 false，开启后录 MP4 音轨 + 直播音频） |
+
+## 音频
+
+- **编解码**：G.711 A-law / μ-law（8kHz）、AAC（ADTS 封装自动转 ASC）
+- **开关**：按相机 `audio_enabled`，关闭时丢弃解复用出的音频帧
+- **无 PSM 流兜底**：部分固件把音频复用进 PS 流但不发 PSM（或 PSM 不声明音频）。NVR 按优先级判定编解码：**PSM 声明 → INVITE 应答 SDP `a=rtpmap` → 字节启发式**（ADTS 同步字 → AAC；μ/A-law 按静音簇投票，4KB 内静音样本 μ-law 聚 0xFF/0x7F、A-law 聚 0x55/0xD5）。判定时记 INFO 日志 `codec inferred`
+- **无 PTS 音频**：按样本数推进时间线，兼容省略音频 PTS 的固件
+- **设备端接入要求**（推荐做法）：音频复用进同一路 PS/RTP 流（同端口同 SSRC），PSM 声明音频（stream_type 0x90=μ-law / 0x91=A-law / 0x0F=AAC，stream_id 0xC0-0xDF），G.711 发 8kHz 单声道裸字节
+
+## 语音对讲
+
+LiveView 页国标相机有 **对讲** 按钮：浏览器麦克风 → AudioWorklet 降采样到 8kHz → A-law 编码 → WebSocket 上行 → NVR 发起 audio-only INVITE（`m=audio ... RTP/AVP 8`，`a=sendrecv`）→ 设备接收地址收 RTP。半双工：直播音频与对讲下行并存。
+
+API：`GET /api/cameras/{id}/gb28181/talk`（WebSocket，二进制帧 = A-law 字节）、`GET /api/cameras/{id}/gb28181/talk/status`。
+
+## 订阅与事件
+
+- **目录订阅**：设备通道变更通过 NOTIFY 实时推送（合并进通道表并自动建卡）
+- **报警订阅**：`GET /api/gb28181/devices/{id}/alarms` 查询环形缓存（最近 200 条），同时进事件总线（SSE `gb28181.alarm`）
+- **移动位置订阅**：`GET /api/gb28181/devices/{id}/positions` 查询位置轨迹
+- 三个开关与有效期见设置页 / 上表；到期前 80% 自动续订
+
+## 设备录像检索与回放
+
+Recordings 页可按国标通道检索**设备侧存储的录像**（RecordInfo）并取回：取回片段经正常录像管线落盘（分段、记录行），在 Recordings 页直接播放，支持倍速/拖动（INFO 控制）。
+
+API：
+- `GET /api/gb28181/channels/{id}/records?start=&end=` — 检索设备录像列表
+- `POST /api/gb28181/channels/{id}/playback` — 开始取回（body 含 start/end）
+- `GET /api/gb28181/channels/{id}/playback` — 取回进度
+- `DELETE /api/gb28181/channels/{id}/playback` — 停止
+- `POST /api/gb28181/channels/{id}/playback/control` — 倍速/拖动/暂停
 
 ## PTZ 控制
 
-GB28181 PTZ 控制通过带 MANSCDP DeviceControl 命令的 SIP MESSAGE 实现。
+PTZ 经 MANSCDP DeviceControl 下发。支持方向（含对角）、变倍（需 `PTZType=2`）、预置位/巡航（FICommand）。通道的 `PTZType` 来自目录报告（0=无、1=云台、2=云台+变倍）。
 
-### 支持的方向
-
-- `up`、`down`、`left`、`right` — 云台/倾斜移动
-- `up-left`、`up-right`、`down-left`、`down-right` — 对角移动
-- `zoom-in`、`zoom-out` — 变倍（需要 `PTZType=2`）
-- `stop` — 停止所有移动
-
-### PTZ 类型
-
-通道从目录报告 `PTZType`：
-- `0` — 无 PTZ 支持
-- `1` — 仅云台/倾斜
-- `2` — 云台/倾斜 + 变倍
-
-### Web UI 控制
-
-在 GB28181 设备页面，点击 `PTZType > 0` 的通道的 PTZ 面板：
-- 按住方向按钮以速度 128 移动
-- 释放以停止
-- 点击中心停止按钮停止移动
-- `PTZType=2` 时显示变倍 in/out 按钮
-
-### API 控制
+Web UI：LiveView 相机页 PTZ 面板（按住移动、松开停止、预置位调用/设置）。
 
 ```bash
 curl -X POST http://localhost:9090/api/gb28181/channels/34020000001320000001/ptz \
   -H "Content-Type: application/json" \
   -H "Authorization: Basic base64(username:password)" \
-  -d '{
-    "direction": "up",
-    "speed": 128
-  }'
+  -d '{"direction": "up", "speed": 128}'
 ```
 
-响应：
-```json
-{
-  "status": "ptz_sent",
-  "channel_id": "34020000001320000001",
-  "direction": "up",
-  "speed": 128
-}
-```
+方向：`up/down/left/right/up-left/up-right/down-left/down-right/zoom-in/zoom-out/stop`。
 
-## 回放
+## API 参考
 
-GB28181 通过带 `PlayMode=PlayBack` 和 `StartTime`/`EndTime` 的 INVITE 支持历史回放。此功能尚未在 MiBee NVR Web UI 中实现，但您可以通过 API 触发：
+### 设备与通道
+- `GET /api/gb28181/devices` — 已注册设备（支持 ETag）
+- `GET /api/gb28181/devices/{id}/channels` — 设备通道列表
+- `POST /api/gb28181/devices/{id}/catalog-refresh` — 触发目录刷新（202）
+- `GET /api/gb28181/devices/{id}/alarms` — 报警环形缓存
+- `GET /api/gb28181/devices/{id}/positions` — 移动位置轨迹
 
-```bash
-curl -X POST http://localhost:9090/api/gb28181/channels/34020000001320000001/invite \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Basic base64(username:password)" \
-  -d '{
-    "playback": {
-      "start_time": "2026-01-01T00:00:00Z",
-      "end_time": "2026-01-01T01:00:00Z"
-    }
-  }'
-```
+### 媒体会话
+- `POST /api/gb28181/channels/{id}/invite` / `bye` — 手动拉流/停流
+- `POST /api/gb28181/channels/{id}/ptz` — PTZ 控制
 
-这是未来 UI 工作的占位符。底层的 INVITE/BYE 基础设施已支持回放 SDP 协商。
+### 录像检索/回放（设备侧）
+- 见上节
+
+### 语音对讲
+- `GET /api/cameras/{id}/gb28181/talk`（WebSocket）、`GET .../talk/status`
+
+### 错误响应
+
+| 状态 | 场景 |
+|--------|-------|
+| 400 | 请求体缺失/畸形；不支持的 PTZ |
+| 404 | 通道不存在 |
+| 409 | 设备离线 |
+| 500 | 内部错误（MANSCDP 编码/发送失败） |
 
 ## 故障排除
 
 ### 设备未注册
 
-**症状**：设备未出现在 GB28181 设备列表中。
-
-**解决方案**：
-1. **检查 SIP 端口**：确保 `sip_listen` 正在监听 `:5060`（或您配置的端口）：
-   ```bash
-   sudo netstat -ulnp | grep 5060
-   sudo ss -ulnp | grep 5060
-   ```
-
-2. **检查防火墙**：允许 UDP 端口 5060：
-   ```bash
-   sudo ufw allow 5060/udp
-   # 或
-   sudo iptables -A INPUT -p udp --dport 5060 -j ACCEPT
-   ```
-
-3. **验证摄像机 SIP 设置**：
-   - 服务器 IP 匹配您的 NVR IP
-   - 服务器端口为 `5060`
-   - 设备 ID 为 20 位（GB/T 28181 格式）
-   - 密码匹配您的 NVR `gb28181.password`
-   - 摄像机上启用了平台接入
+1. 确认 `sip_listen` 监听（`ss -ulnp | grep 5060`）与防火墙放行 UDP 5060
+2. 核对设备端五要素：服务器 IP/端口 5060/服务器 ID（须与 `server_id` 完全一致）/域（realm）/密码
+3. 看日志：`journalctl -u mibee-nvr -f | grep -i gb28181` —— `REGISTER auth failed` = 密码不匹配；`not in allowlist` = 白名单
+4. 改过 NVR 密码后：设备下一次重注册（≤1 个注册周期）会 403 掉线，设备端同步修改后自动恢复，无需重新入册
 
-4. **检查 NVR 日志**：
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i gb28181
-   ```
+### 视频黑屏 / 无流
 
-5. **测试 SIP 可达性**：
-   ```bash
-   # 从摄像机（如果有 shell 访问权限）：
-   nc -uvz nvr-ip 5060
-   ```
+1. 检查 `port_range` 未耗尽、防火墙放行该 UDP 段
+2. NAT 场景切换 `media_transport: tcp-passive`
+3. TCP 组帧报错时依次尝试 `tcp_framing: rfc4571 / 0x24 / auto`
+4. 编码：H.264/H.265 自动探测，无需配置
 
-### 心跳超时
+### 音频无声
 
-**症状**：设备注册但几分钟后离线。
+1. 确认相机 **音频开关** 已开启（`audio_enabled`，默认关）
+2. 看日志 `codec inferred` —— 无 PSM 设备会自动判定编解码；若始终无此日志且无音轨，抓包确认设备确实把音频复用进了 PS 流
+3. 设备端推荐做法见"音频"节；无 PSM 也能出声（自动兜底），但其它平台（ZLMediaKit 等）会丢，建议设备侧补 PSM 声明
 
-**原因**：设备心跳间隔不匹配 NVR 的 `heartbeat_interval`（默认 60 秒）。大多数摄像机每 60 秒发送一次心跳，但有些使用不同的间隔。
+### 会话周期性回收重邀
 
-**解决方案**：
-1. 在您的配置中调整 `heartbeat_interval`：
-   ```yaml
-   gb28181:
-     heartbeat_interval: "90s"  # 或 "30s"，取决于您的摄像机
-   ```
-
-2. 检查摄像机 SIP 设置的心跳间隔并匹配它。
+日志出现 `recycling stale session reason=no keyframe` 且录像每隔约一分多钟有空窗：设备关键帧间隔（GOP）超过 NVR 的 75 秒看门狗。属正常自愈行为（重邀强制出新 IDR），但建议把设备 GOP 收敛到 **2-4 秒**。
 
-### 无视频（黑屏）
+### REGISTER 源端口轮换
 
-**症状**：通道 INVITE 成功但实时预览为黑屏。
+部分 SIP 栈每个 REGISTER 换源端口。NVR 仅按 **IP** 判断地址变化，端口轮换不会回收会话，无需处理。
 
-**解决方案**：
-1. **检查 RTP 端口分配**：确保 `port_range` 未耗尽：
-   ```bash
-   # 检查 GB28181 设备页面的 "RTP Port" 列
-   # 验证端口在配置的范围内
-   ```
-
-2. **检查 RTP 端口防火墙**：允许 `port_range` 中的 UDP 端口：
-   ```bash
-   sudo ufw allow 30000:30050/udp
-   ```
-
-3. **验证编解码器**：GB28181 使用 stream_type 96（H.264）或 97（H.265）的 MPEG-PS。NVR 从 PS 流自动检测。如果摄像机发送不支持的编解码器，解复用将失败。
-
-4. **检查 NVR 日志中的解复用错误**：
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "psdemux\|demux"
-   ```
-
-5. **通过直接 RTP 捕获测试**（高级）：
-   ```bash
-   # 从摄像机通告的端口捕获 RTP
-   sudo tcpdump -i any -w capture.pcap udp port <camera-rtp-port>
-   # 用 Wireshark 分析以验证 MPEG-PS 结构
-   ```
-
-### NAT 后设备（网络地址转换）
+### 心跳超时掉线
 
-**症状**：设备注册但无法建立 RTP 媒体（视频从未开始）。
+设备心跳间隔与 NVR `heartbeat_interval`（默认 60s）不匹配时调整任一侧。
 
-**原因**：来自摄像机的 RTP 数据包无法到达 NVR，因为摄像机位于 NAT 后且 SDP 通告端口未转发。
+### 字符集乱码（GBK vs UTF-8）
 
-**解决方案**：
-1. **在 NVR 上启用 TCP 被动模式**：
-   ```yaml
-   gb28181:
-     tcp_mode: true
-     tcp_framing: "auto"
-   ```
-   TCP 被动模式要求摄像机向 NVR 发起 TCP 连接，这可以通过 NAT 工作。
+MANSCDP 编解码器自动处理：剥离 XML 声明、UTF-8 校验、GB18030/GBK 回退。仍乱码时检查设备端编码设置。
 
-2. **在路由器上配置端口转发**：
-   - 将 UDP 端口 `30000-30050`（或您的 `port_range`）转发到 NVR IP 地址
-   - 将 UDP 端口 `5060`（SIP）转发到 NVR IP 地址
+### 时钟同步
 
-3. **使用 VPN**（例如 Tailscale、WireGuard）绕过 NAT：
-   - 在 NVR 和摄像机上安装 VPN（如果支持）
-   - 在摄像机 SIP 设置中使用 VPN 分配的 IP
+设备因时钟漂移鉴权异常或录像检索时间不对时：NVR 自动应答设备的 TimeSync 查询；两侧建议均同步 NTP。
 
-4. **检查摄像机 NAT 穿透设置**：
-   - 海康：**网络 → 高级平台接入 → NAT 穿透**
-   - 大华：**网络 → TCP/IP → 28181 → NAT 模式**
+## 限制与已知问题
 
-### 字符集问题（GBK vs UTF-8）
-
-**症状**：目录响应的中文设备/通道名称显示为乱码（mojibake）。
-
-**原因**：GB/T 28181 设备通常在 XML prolog（`<?xml ... encoding="GB2312"?>`）中声明编码为 GB2312/GBK，但可能实际发送 UTF-8。
-
-**解决方案**：NVR 的 MANSCDP 编解码器自动处理此问题：
-- 在解组前剥离 XML 声明
-- 验证 UTF-8 并回退到 GB18030 → GBK 解码器
-- 如果字符集回退失败则记录警告
-
-如果您仍然看到乱码，请检查摄像机 GB28181 配置中的编码设置。某些旧设备需要显式 UTF-8 声明。
-
-### 时钟同步问题
-
-**症状**：设备即使凭据正确也因认证失败拒绝 REGISTER。
-
-**原因**：GB28181 摘要认证使用 SIP `Date` 头进行 nonce 新鲜度。如果 NVR 和设备时钟未同步，设备可能会拒绝质询。
-
-**解决方案**：
-1. **将 NVR 时钟同步到 NTP**：
-   ```bash
-   sudo timedatectl set-ntp true
-   # 或
-   sudo ntpdate pool.ntp.org
-   ```
-
-2. **将摄像机时钟同步到 NTP**（通过摄像机 Web UI）：
-   - 海康：**系统 → 时间配置**
-   - 大华：**系统 → 常规 → 时间**
-
-3. **验证时钟漂移**：
-   ```bash
-   # 在 NVR 上
-   date
-   # 在摄像机上（如果有 shell 访问）
-   date
-   ```
-
-### TCP 组帧问题
-
-**症状**：TCP 被动模式（`tcp_mode=true`）显示 "read error" 或 "invalid length"。
-
-**原因**：`tcp_framing` 设置不匹配摄像机的线格式。
-
-**解决方案**：
-1. 尝试每个组帧选项：
-   ```yaml
-   gb28181:
-     tcp_mode: true
-     tcp_framing: "rfc4571"   # 2 字节大端长度前缀
-     # 或
-     tcp_framing: "0x24"      # RTSP 交织（$ + 通道 + 2 字节长度）
-     # 或
-     tcp_framing: "auto"      # 从首字节检测（默认）
-   ```
-
-2. 检查 NVR 日志中的组帧检测错误：
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "tcp\|framing\|0x24\|rfc4571"
-   ```
-
-3. **注意**：GB/T 28181-2016 和 -2022 指定 RFC4571 用于 RTP over TCP。`0x24` 模式模拟供应商扩展（RTSP 交织）。对于混合部署使用 `"auto"`。
-
-### PTZ 不工作
-
-**症状**：PTZ 面板被禁用或 PTZ 命令无效。
-
-**解决方案**：
-1. **检查 PTZType**：从目录验证通道的 `PTZType`：
-   - `0` = 无 PTZ 支持（设备固件限制）
-   - `1` = 仅云台/倾斜
-   - `2` = 云台/倾斜 + 变倍
-
-2. **检查设备在线状态**：如果设备离线，PTZ 命令将以 409 失败。
-
-3. **验证制造商支持**：并非所有 GB28181 设备都通过 MANSCDP DeviceControl 支持 PTZ。有些使用专有的 SIP 扩展。
-
-4. **检查 NVR 日志中的 PTZ 错误**：
-   ```bash
-   journalctl -u mibee-nvr -f | grep -i "ptz\|devicecontrol"
-   ```
-
-## API 参考
-
-### 设备和通道端点
-
-- `GET /api/gb28181/devices` — 列出已注册设备（支持 ETag）
-- `GET /api/gb28181/channels` — 列出所有设备上的所有通道
-- `GET /api/gb28181/channels/{id}` — 获取通道详细信息（包括 PTZType）
-- `POST /api/gb28181/catalog/refresh` — 触发目录刷新（存根，202 已接受）
-
-### 媒体会话端点
-
-- `POST /api/gb28181/channels/{id}/invite` — INVITE 通道（存根，202 已接受）
-- `POST /api/gb28181/channels/{id}/bye` — 发送 BYE 停止流（调用 SessionManager.Bye）
-
-### PTZ 端点
-
-- `POST /api/gb28181/channels/{id}/ptz` — 发送 PTZ 命令
-
-PTZ 请求体：
-```json
-{
-  "direction": "up|down|left|right|up-left|up-right|down-left|down-right|zoom-in|zoom-out|stop",
-  "speed": 0-255
-}
-```
-
-PTZ 方向：
-- `up`、`down`、`left`、`right` — 云台/倾斜
-- `up-left`、`up-right`、`down-left`、`down-right` — 对角
-- `zoom-in`、`zoom-out` — 变倍（需要 `PTZType=2`）
-- `stop` — 停止所有移动
-
-### 错误响应
-
-| 状态 | 错误 | 描述 |
-|--------|-------|-------------|
-| 400 | Invalid body | 缺少或格式错误的 PTZ body |
-| 404 | Channel not found | `ErrChannelNotFound` |
-| 409 | Device offline | `ErrDeviceOffline` |
-| 400 | PTZ unsupported | `ErrPTZUnsupported`（PTZType=0） |
-| 400 | Zoom unsupported | `ErrZoomUnsupported`（PTZType=1） |
-| 500 | Internal error | 无法编码 MANSCDP 或发送 MESSAGE |
-
-## 支持的协议和功能
-
-### SIP（会话发起协议）
-- **REGISTER**：带摘要认证的设备注册
-- **Keepalive**：心跳消息用于在线/离线跟踪
-- **INVITE**：拉取直播或回放媒体流
-- **BYE**：拆除媒体会话
-- **MESSAGE**：发送 MANSCDP 命令（目录请求、设备控制）
-
-### 媒体（RTP/PS）
-- **RTP over UDP**：默认传输（端口范围可配置）
-- **RTP over TCP**：可选 TCP 被动模式用于 NAT 穿透
-  - 组帧：RFC4571（标准）、0x24（供应商扩展）、自动检测
-- **MPEG-PS 解复用**：提取 H.264（stream_type 96）或 H.265（stream_type 97）NALU
-- **StreamHub 集成**：非阻塞帧分发到 HLS、WebRTC、FLV 等
-
-### MANSCDP（管理和控制）
-- **Catalog**：设备/通道列表，包含 PTZType、制造商、型号
-- **DeviceInfo**：设备固件/硬件详细信息
-- **DeviceControl**：PTZ 命令（方向、速度）
-
-## 限制和已知问题
-
-### 回放 UI
-回放 INVITE 在会话管理器中受支持，但尚未在 Web UI 中公开。使用 API 端点 `POST /api/gb28181/channels/{id}/invite` 并附带 `playback.start_time` 和 `playback.end_time` 作为临时解决方案。
-
-### TCP 0x24 模式
-`0x24` TCP 组帧模式模拟供应商扩展（RTSP 交织）。GB/T 28181-2016 和 -2022 指定 RFC4571 为标准。对于混合部署使用 `"auto"`；对于严格合规使用 `"rfc4571"`。
-
-### 设备特定行为
-- **海康威视**：支持完整目录、PTZ 和回放。某些旧型号可能需要 GBK 字符集回退。
-- **大华**：支持完整目录、PTZ 和回放。NAT 穿透设置因固件而异。
-- **宇视**：与海康类似，但 PTZ 命令语义可能不同。
-- **其他品牌**：支持情况各异。最小设备仅实现 REGISTER/keepalive/INVITE。
-
-### RPi 3B 上的端口耗尽
-默认 `port_range` 为 `"30000-30050"`（51 个端口）。如果您有许多并发的 GB28181 流，请扩展范围：
-```yaml
-gb28181:
-  port_range: "30000-30100"  # 101 个端口
-```
-
-在 RPi 3B 上，保持池低于 200 个端口以避免临时端口耗尽。
+- **设备自注册伪通道**：NVR 重启后，多通道目录设备会短暂出现一台"设备自身通道"的相机（不推流）。已知问题，重启后手动归档即可，跟踪于 #352
+- **对讲真机覆盖**：语音对讲目前经模拟器 E2E 验证，真机回环验证跟踪于 #353
+- **TCP 0x24 组帧**：非标准扩展（GB/T 28181-2016/2022 指定 RFC4571），混合部署用 `auto`
+- **多级级联 / GB35114**：未实现，按需评估（#341）
+- **报警联动点播**：报警事件已进总线，联动自动拉流跟踪于 #355
 
 ## 安全考虑
 
-- **摘要认证**：GB28181 使用 SIP 摘要认证（类似 HTTP Basic 但使用 nonce 哈希）。当设置 `NVR_ENCRYPTION_KEY` 时，`password` 字段会被加密。
-- **设备 ID 限制**：使用 `allowed_device_ids` 白名单特定的 20 位设备编码。空列表 = 允许所有。
-- **网络暴露**：GB28181 默认在 UDP 端口 5060 上运行。如果您的 NVR 暴露在互联网上，请使用防火墙或 VPN 限制访问。
-- **无商业内容**：此实现是开源且免费的。不包含或引用任何 Pro/P2P 功能。
+- **鉴权**：务必设置 `password`（留空 = 任何可达设备都能注册）。配合 `allowed_device_ids` 白名单双层防护
+- **传输**：SIP/RTP 为明文（GB35114 国密/TLS 未实现）。公网部署必须用防火墙/VPN 收敛暴露面，勿直接暴露 5060 与端口池
+- **端口池**：默认 51 路，按并发需求扩展（RPi 3B 建议 <200）
 
 ## 支持资源
 
-### 文档
-- [MiBee NVR 快速开始](./getting-started.md)
-- [MiBee NVR 配置指南](./configuration.md)
-- [MiBee NVR API 参考](./api/README.md)
-
-### GB/T 28181 参考资料
-- GB/T 28181-2016：信息技术 — 视频监控联网系统技术要求
-- GB/T 28181-2022：最新版本（增加 TCP 被动、改进目录）
-
-### 社区支持
-- GitHub Issues: [MiBee NVR Issues](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues)
-- Discussions: [MiBee NVR Discussions](https://github.com/Mi-Bee-Studio/MiBeeNvr/discussions)
-
----
-
-本指南提供了 MiBee NVR GB/T 28181 集成的全面覆盖。对于特定摄像机型号，请查阅制造商文档以了解 GB28181 功能和限制。
+- [快速开始](./getting-started.md) · [配置指南](./configuration.md) · [API 参考](./api/README.md)
+- GB/T 28181-2016 / 2022 国家标准文本
+- [GitHub Issues](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues) · [Discussions](https://github.com/Mi-Bee-Studio/MiBeeNvr/discussions)

--- a/internal/gb28181/session_test.go
+++ b/internal/gb28181/session_test.go
@@ -608,16 +608,27 @@ func TestSessionInviteTCPPassive(t *testing.T) {
 // setup:active with port 9, and ConnectActiveTCP dials the device address
 // from the answer SDP.
 func TestSessionInviteTCPActive(t *testing.T) {
-	// Device-side media listener.
+	// Device-side media listener. The accepted connection is held open until
+	// test cleanup: closing it immediately (as this test once did) races the
+	// receiver's Running() lifecycle — the read loop can hit EOF and flip
+	// Running back off between the 50ms Eventually polls, timing the wait out.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
+	devConnCh := make(chan net.Conn, 1)
 	go func() {
 		c, err := ln.Accept()
 		if err == nil {
-			c.Close()
+			devConnCh <- c
 		}
 	}()
+	t.Cleanup(func() {
+		select {
+		case c := <-devConnCh:
+			_ = c.Close()
+		default:
+		}
+	})
 	devPort := ln.Addr().(*net.TCPAddr).Port
 
 	pm := NewPortManager(31100, 31110)


### PR DESCRIPTION
## CI 修复

`TestSessionInviteTCPActive` 在 main push CI 上间歇性失败（#349/#350 合并各挂一次，PR CI 反而绿）：测试里的假设备 Accept 后**立即关闭连接**，接收器读循环可能在 50ms 轮询间隙内完成「启动→EOF→退出」整个生命周期，`Eventually(Running)` 观察不到。修复：保持已接受连接到测试清理。`-race -count=20` 全绿。

## 文档同步（zh/en 双语重写）

旧指南停留在 #326 时代，已过时的内容（手动加相机 YAML 为必经步骤、"回放 UI 未实现"、缺订阅/对讲/音频）全部更新：

- 快速开始改为 **Web 设置页优先** + 自动入册（零手动配置）
- 新增章节：音频（含无 PSM 三级兜底）、语音对讲、订阅与事件、设备录像检索回放
- 配置参考补全 `media_transport` / `sip_transport` / `subscribe_*`，`tcp_mode` 标注为旧别名
- API 参考补全 alarms / positions / records / playback / talk 端点
- 故障排除新增：密码变更影响、无 PSM 音频、GOP>75s 看门狗回收、REGISTER 端口轮换
- 已知问题与后续跟进对齐 issue（#352 幻影相机 / #353 对讲真机 / #355 报警联动）
- README 功能行同步

关联：#341 总跟踪；遗留项已拆 #351-#355 跟进。