### PR TITLE
feat(gb28181): cross-protocol dedup — one camera per physical device

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -235,6 +235,24 @@ type gb28181ChannelPayload struct {
 	Manufacturer string `json:"manufacturer,omitempty"`
 }
 
+// createBodyHost extracts the host IP from a create-camera body's URL or
+// ONVIF endpoint ("" when neither carries one). Feeds the cross-protocol
+// dedup against registered GB28181 devices.
+func createBodyHost(rawURL, onvifEndpoint string) string {
+	for _, raw := range []string{strings.TrimSpace(rawURL), strings.TrimSpace(onvifEndpoint)} {
+		if raw == "" {
+			continue
+		}
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			return u.Hostname()
+		}
+		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
+			return host
+		}
+	}
+	return ""
+}
+
 func (p *gb28181ChannelPayload) toConfig() config.GB28181ChannelConfig {
 	return config.GB28181ChannelConfig{
 		DeviceID:     p.DeviceID,
@@ -285,6 +303,10 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		SubnetHints []string `json:"subnet_hints"`
 		// GB28181 SIP device/channel binding (protocol "gb28181")
 		GB28181 *gb28181ChannelPayload `json:"gb28181"`
+		// AllowDuplicate opts in to adding a pull camera (onvif/rtsp/http)
+		// whose host IP already belongs to a registered GB28181 device.
+		// Default false: one camera per physical device.
+		AllowDuplicate bool `json:"allow_duplicate"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
@@ -312,6 +334,37 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 	isPush := body.Protocol == "srt" || body.Protocol == "rtmp"
 	// GB28181 cameras: no URL — identified by SIP DeviceID/ChannelID.
 	isGB28181 := body.Protocol == "gb28181"
+	// Cross-protocol dedup: a pull camera (onvif/rtsp/http) whose host IP
+	// matches a registered GB28181 device is the same physical camera — the
+	// GB28181 auto-enroll skips it symmetrically. Refuse unless the caller
+	// explicitly opts in (dual-protocol setups) with allow_duplicate.
+	if !isPush && !isGB28181 && h.gb28181DeviceMgr != nil {
+		if host := createBodyHost(body.URL, body.ONVIFEndpoint); host != "" {
+			for _, d := range h.gb28181DeviceMgr.AllDevices() {
+				d.Mu.RLock()
+				netAddr := d.NetAddr
+				d.Mu.RUnlock()
+				devHost := netAddr
+				if h2, _, err := net.SplitHostPort(netAddr); err == nil && h2 != "" {
+					devHost = h2
+				}
+				if devHost == host {
+					if !body.AllowDuplicate {
+						logger.Warn("create camera refused: host already registered via GB28181",
+							"host", host, "gb_device", d.ID)
+						WriteError(w, http.StatusConflict, fmt.Sprintf(
+							"a GB28181 device (%s) is already connected from %s — this looks like the same physical camera. "+
+								"Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both",
+							d.ID, host))
+						return
+					}
+					logger.Info("create camera: allow_duplicate set despite GB28181 device at same host",
+						"host", host, "gb_device", d.ID)
+					break
+				}
+			}
+		}
+	}
 	// ONVIF cameras: accept url OR onvif_endpoint
 	if body.Protocol == "onvif" {
 		endpoint := body.ONVIFEndpoint

--- a/internal/api/handlers_camera_dedup_test.go
+++ b/internal/api/handlers_camera_dedup_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDedupHandler builds a handler with a real camera manager (rtsp/void —
+// rtsp recorders never connect in these tests; camera creation with
+// Enabled=false avoids recorder start) plus a GB28181 device manager holding
+// one registered device at a fixed IP.
+func setupDedupHandler(t *testing.T) *Handler {
+	t.Helper()
+	db, store := setupTestDB(t)
+	cfg := &config.Config{Storage: config.StorageConfig{SegmentDuration: "30s"}}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, camMgr.Start(ctx))
+	t.Cleanup(func() { _ = camMgr.Stop() })
+
+	deviceMgr := gb28181.NewDeviceManager(60 * time.Second)
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, deviceMgr, nil)
+	deviceMgr.Register(&gb28181.Device{
+		ID:      "34020000001310000001",
+		NetAddr: "192.168.63.240:5060",
+	})
+	return h
+}
+
+// TestHandleCreateCamera_GBDuplicateRefused: adding a pull camera (rtsp/onvif)
+// whose host IP belongs to a registered GB28181 device is refused with 409 —
+// same physical camera, one entry. allow_duplicate=true overrides.
+func TestHandleCreateCamera_GBDuplicateRefused(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code, "body: %s", rr.Body.String())
+
+	// Same host via onvif_endpoint is refused too.
+	body = `{"name":"Front ONVIF","protocol":"onvif","onvif_endpoint":"http://192.168.63.240/onvif/device_service","enabled":false}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	// allow_duplicate overrides the guard.
+	body = `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false,"allow_duplicate":true}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestHandleCreateCamera_NoGBDeviceAllowsNormalCreate: with no GB28181 device
+// at that IP, creation is unaffected.
+func TestHandleCreateCamera_NoGBDeviceAllowsNormalCreate(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"Other","protocol":"rtsp","url":"rtsp://192.168.63.9:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestHandleCreateCamera_NilDeviceMgrNoop: the dedup guard must not fire when
+// the GB28181 device manager is absent (gb28181 disabled / older wiring).
+func TestHandleCreateCamera_NilDeviceMgrNoop(t *testing.T) {
+	db, store := setupTestDB(t)
+	camMgr := camera.NewCameraManager(&config.Config{}, store, db, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, camMgr.Start(ctx))
+	defer camMgr.Stop()
+
+	h := NewHandler(db, store, noopAuthMW(), nil, camMgr, nil, "", nil, nil, nil, nil, nil)
+	require.Nil(t, h.gb28181DeviceMgr)
+
+	body := `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code)
+}

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -9,6 +9,10 @@ package camera
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -90,10 +94,23 @@ func (cm *CameraManager) GetGB28181Recorder(cameraID string) *recorder.GB28181Re
 // auto-appear in the Cameras list — matching ONVIF auto-add. Dedup is by
 // channel: a multi-channel device (NVR) gets one camera per video channel.
 // Idempotent: if a camera with matching GB28181.ChannelID exists, returns nil.
-func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name string) error {
+//
+// sourceIP is the device's SIP source address host ("" when unknown). When a
+// camera of another protocol already streams from the same IP, the device is
+// physically present under a different identity — auto-enroll is skipped so
+// one physical camera never yields two recording entries. Manual camera
+// creation (API/web) is the escape hatch for deliberately dual-protocol setups.
+func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
 	// Check if a camera for this channel already exists.
 	if _, ok := cm.GB28181CameraIDByChannel(deviceID, channelID); ok {
 		return nil // Already enrolled
+	}
+	if sourceIP != "" {
+		if existingID, ok := cm.CameraIDByHostIP(sourceIP); ok {
+			slog.Info("gb28181: auto-enroll skipped — another camera already streams from the device IP",
+				"device", deviceID, "channel", channelID, "source_ip", sourceIP, "existing_camera", existingID)
+			return nil
+		}
 	}
 
 	cameraName := name
@@ -111,6 +128,44 @@ func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name string) e
 	}
 	_, err := cm.AddCamera(context.Background(), cam)
 	return err
+}
+
+// CameraIDByHostIP resolves an active non-GB28181 camera whose pull URL or
+// ONVIF endpoint points at the given IP. Used by GB28181 auto-enroll to keep
+// one camera per physical device when a dual-protocol camera registers.
+// GB28181 cameras are excluded (their dedup key is the channel ID, not IP).
+func (cm *CameraManager) CameraIDByHostIP(ip string) (string, bool) {
+	if ip == "" {
+		return "", false
+	}
+	snap := cm.loadSnapshot()
+	for _, cfg := range snap.configs {
+		if cfg.Protocol == string(model.ProtoGB28181) {
+			continue
+		}
+		if cameraHostIP(cfg) == ip {
+			return cfg.ID, true
+		}
+	}
+	return "", false
+}
+
+// cameraHostIP extracts the host from a camera's URL or ONVIF endpoint
+// ("" when neither carries one — push/ingest cameras, GB28181, xiaomi P2P).
+func cameraHostIP(cfg *config.CameraConfig) string {
+	for _, raw := range []string{cfg.URL, cfg.ONVIFEndpoint} {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			return u.Hostname()
+		}
+		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 // GB28181CameraIDByChannel resolves the MiBee camera bound to a GB28181

--- a/internal/camera/gb28181_dedup_test.go
+++ b/internal/camera/gb28181_dedup_test.go
@@ -1,0 +1,87 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// gbDedupConfig builds a config with one ONVIF camera at a fixed IP.
+func gbDedupConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{{
+		ID:            "front-onvif",
+		Name:          "Front ONVIF",
+		Protocol:      "onvif",
+		URL:           "",
+		ONVIFEndpoint: "http://192.168.63.240/onvif/device_service",
+	}}
+	return cfg
+}
+
+func TestCameraIDByHostIP(t *testing.T) {
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	id, ok := mgr.CameraIDByHostIP("192.168.63.240")
+	require.True(t, ok)
+	require.Equal(t, "front-onvif", id)
+
+	_, ok = mgr.CameraIDByHostIP("192.168.63.999")
+	require.False(t, ok)
+	_, ok = mgr.CameraIDByHostIP("")
+	require.False(t, ok, "empty IP must never match")
+}
+
+func TestCameraIDByHostIP_IgnoresGB28181Cameras(t *testing.T) {
+	cfg := gbDedupConfig(t)
+	cfg.Cameras = append(cfg.Cameras, config.CameraConfig{
+		ID:       "gb-34020000001320000001",
+		Protocol: "gb28181",
+		GB28181:  config.GB28181ChannelConfig{DeviceID: "d", ChannelID: "34020000001320000001"},
+	})
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// GB cameras have no URL; they must not participate in IP matching.
+	_, ok := mgr.CameraIDByHostIP("192.168.63.240")
+	require.True(t, ok)
+}
+
+func TestEnsureGB28181Camera_SkipsWhenHostCameraExists(t *testing.T) {
+	// The camera registers via GB28181 AFTER it was added as ONVIF from the
+	// same IP: auto-enroll must skip instead of creating a second entry.
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000001", "34020000001320000001", "GB Channel", "192.168.63.240"))
+
+	// No gb- camera created; the ONVIF camera is untouched.
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000001", "34020000001320000001")
+	require.False(t, ok, "auto-enroll must be suppressed on host collision")
+	snap := mgr.loadSnapshot()
+	require.Len(t, snap.configs, 1)
+}
+
+func TestEnsureGB28181Camera_EnrollsWhenNoCollision(t *testing.T) {
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000009", "34020000001320000009", "", "192.168.63.9"))
+
+	id, ok := mgr.GB28181CameraIDByChannel("34020000001310000009", "34020000001320000009")
+	require.True(t, ok)
+	require.Equal(t, "gb-34020000001320000009", id)
+}
+
+func TestEnsureGB28181Camera_EmptySourceIPStillEnrolls(t *testing.T) {
+	// Unknown source ("" — e.g. device resolved before NetAddr recorded):
+	// behave like today, enroll by channel identity.
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000002", "34020000001320000002", "", ""))
+
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000002", "34020000001320000002")
+	require.True(t, ok)
+}

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -61,7 +61,10 @@ const (
 type CameraEnroller interface {
 	// EnsureGB28181Camera creates a camera bound to the device/channel pair
 	// (idempotent). name is the human-readable channel name (may be empty).
-	EnsureGB28181Camera(deviceID, channelID, name string) error
+	// sourceIP is the device's SIP source host ("" unknown) — auto-enroll is
+	// skipped when another camera already streams from that IP (dual-protocol
+	// dedup; manual creation bypasses it).
+	EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error
 	// GB28181CameraIDByChannel resolves the MiBee camera ID bound to a
 	// device/channel pair, independent of the camera-ID naming convention.
 	GB28181CameraIDByChannel(deviceID, channelID string) (string, bool)
@@ -1063,8 +1066,9 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		// setup. Runs in a goroutine to avoid blocking the SIP response.
 		if !channelExists {
 			if enrol := s.enroller(); enrol != nil {
+				srcHost := hostOfAddr(req.Source())
 				go func() {
-					if err := enrol.EnsureGB28181Camera(deviceID, deviceID, ""); err != nil {
+					if err := enrol.EnsureGB28181Camera(deviceID, deviceID, "", srcHost); err != nil {
 						slog.Warn("gb28181: auto-enroll camera failed", "device", deviceID, "error", err)
 					}
 				}()
@@ -1282,6 +1286,14 @@ func (s *Server) handleMessage(req sip.Request, tx sip.ServerTransaction) {
 // catalog-change NOTIFY: registers channels, persists them, enrolls cameras
 // for new ones, and auto-INVITEs channels that have a camera but no session.
 func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
+	// Source host for cross-protocol auto-enroll dedup (dual-protocol cameras
+	// that already stream via ONVIF/RTSP from the same IP).
+	srcHost := ""
+	if d, ok := s.deviceMgr.Device(deviceID); ok {
+		d.Mu.RLock()
+		srcHost = hostOfAddr(d.NetAddr)
+		d.Mu.RUnlock()
+	}
 	for _, item := range items {
 		// Parental=1 entries are organization/group nodes, not video
 		// channels — registering them as INVITEable channels breaks
@@ -1331,7 +1343,7 @@ func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
 				name := item.Name
 				devID, chID := deviceID, item.DeviceID
 				go func() {
-					if err := enrol.EnsureGB28181Camera(devID, chID, name); err != nil {
+					if err := enrol.EnsureGB28181Camera(devID, chID, name, srcHost); err != nil {
 						slog.Warn("gb28181: auto-enroll channel camera failed", "device", devID, "channel", chID, "error", err)
 					}
 				}()


### PR DESCRIPTION
## 问题

同一台物理相机同时打开 ONVIF + GB28181 接 NVR 时会出现**两个相机条目、双份录像**：

1. **先 ONVIF 后国标**：设备注册后 GB28181 自动入册（`EnsureGB28181Camera`）从不查询已有 ONVIF/RTSP 相机 → 新建 `gb-` 条目
2. **先国标后 ONVIF**：发现列表手动添加（`POST /api/cameras`）从不查询已注册国标设备 → 新建 ONVIF 条目

两套身份体系（ONVIF 序列号 vs 国标 20 位编码）没有官方映射，但**设备 IP** 是可靠的连接键。

## 方案：双向 IP 碰撞去重

**方向 1（国标入册时）**：`EnsureGB28181Camera` 增加 sourceIP 参数（REGISTER 源地址 host，catalog 路径取自设备 NetAddr）。入册前调 `CameraIDByHostIP`——快照里任何非国标相机的 URL/ONVIFEndpoint host 命中同 IP → 跳过入册并记 info 日志。手动创建相机不受限（双协议刻意场景的逃生门）。

**方向 2（创建相机时）**：`handleCreateCamera` 对拉流协议（onvif/rtsp/http）提取 URL/endpoint host，与 `gb28181DeviceMgr.AllDevices()` 的注册源地址比对，命中 → **409** + 明确提示（用现有条目 / 先归档 / 或传 `allow_duplicate: true` 保留双份）。

**边界**：push/ingest（srt/rtmp）、gb28181、xiaomi P2P 无 host 概念永不匹配；国标相机间去重仍按通道 ID（现状）；设备管理器为 nil（国标关闭）时护栏不生效。存量重复条目仍可用 `mibee-nvr merge-cameras` 清理。

## 测试

- camera 包 5 个新测试：host 提取、GB 相机排除、碰撞跳过、无碰撞正常入册、空 sourceIP 回退现状
- api 包 3 个新测试：409 拒绝（rtsp/onvif_endpoint 两形态）、不同 IP 放行、nil 设备管理器不拦截
- 全量 4600+ 过，lint 0