### PR TITLE
feat(gb28181): cross-protocol dedup + pseudo-channel retirement + alarm linkage (#358 #352 #355)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -340,6 +340,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 	// explicitly opts in (dual-protocol setups) with allow_duplicate.
 	if !isPush && !isGB28181 && h.gb28181DeviceMgr != nil {
 		if host := createBodyHost(body.URL, body.ONVIFEndpoint); host != "" {
+			conflict := ""
 			for _, d := range h.gb28181DeviceMgr.AllDevices() {
 				d.Mu.RLock()
 				netAddr := d.NetAddr
@@ -349,19 +350,35 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 					devHost = h2
 				}
 				if devHost == host {
-					if !body.AllowDuplicate {
-						logger.Warn("create camera refused: host already registered via GB28181",
-							"host", host, "gb_device", d.ID)
-						WriteError(w, http.StatusConflict, fmt.Sprintf(
-							"a GB28181 device (%s) is already connected from %s — this looks like the same physical camera. "+
-								"Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both",
-							d.ID, host))
-						return
-					}
-					logger.Info("create camera: allow_duplicate set despite GB28181 device at same host",
-						"host", host, "gb_device", d.ID)
+					conflict = fmt.Sprintf("a GB28181 device (%s) is already connected from %s", d.ID, host)
 					break
 				}
+			}
+			// L2: dual-NIC devices register GB28181 from a different interface
+			// IP than the ONVIF endpoint. Probe the create-host's ONVIF serial
+			// and match it against cached GB28181 device fingerprints. Skipped
+			// entirely when no fingerprints exist (no dual-protocol device has
+			// ever registered) so normal setups pay no probe latency.
+			if conflict == "" && h.db != nil {
+				if fps, err := h.db.ListGB28181Fingerprints(r.Context()); err == nil && len(fps) > 0 {
+					if serial, ok := onvif.ProbeSerial(r.Context(), host); ok {
+						for _, fp := range fps {
+							if fp.Serial == serial {
+								conflict = fmt.Sprintf("a GB28181 device (%s) with the same hardware serial (%s) is already connected", fp.DeviceID, serial)
+								break
+							}
+						}
+					}
+				}
+			}
+			if conflict != "" {
+				if !body.AllowDuplicate {
+					logger.Warn("create camera refused: same physical camera already connected via GB28181", "host", host)
+					WriteError(w, http.StatusConflict, conflict+
+						" — this looks like the same physical camera. Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both")
+					return
+				}
+				logger.Info("create camera: allow_duplicate set despite GB28181 dedup match", "host", host)
 			}
 		}
 	}

--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -235,6 +235,24 @@ type gb28181ChannelPayload struct {
 	Manufacturer string `json:"manufacturer,omitempty"`
 }
 
+// createBodyHost extracts the host IP from a create-camera body's URL or
+// ONVIF endpoint ("" when neither carries one). Feeds the cross-protocol
+// dedup against registered GB28181 devices.
+func createBodyHost(rawURL, onvifEndpoint string) string {
+	for _, raw := range []string{strings.TrimSpace(rawURL), strings.TrimSpace(onvifEndpoint)} {
+		if raw == "" {
+			continue
+		}
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			return u.Hostname()
+		}
+		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
+			return host
+		}
+	}
+	return ""
+}
+
 func (p *gb28181ChannelPayload) toConfig() config.GB28181ChannelConfig {
 	return config.GB28181ChannelConfig{
 		DeviceID:     p.DeviceID,
@@ -285,6 +303,10 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		SubnetHints []string `json:"subnet_hints"`
 		// GB28181 SIP device/channel binding (protocol "gb28181")
 		GB28181 *gb28181ChannelPayload `json:"gb28181"`
+		// AllowDuplicate opts in to adding a pull camera (onvif/rtsp/http)
+		// whose host IP already belongs to a registered GB28181 device.
+		// Default false: one camera per physical device.
+		AllowDuplicate bool `json:"allow_duplicate"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
@@ -312,6 +334,37 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 	isPush := body.Protocol == "srt" || body.Protocol == "rtmp"
 	// GB28181 cameras: no URL — identified by SIP DeviceID/ChannelID.
 	isGB28181 := body.Protocol == "gb28181"
+	// Cross-protocol dedup: a pull camera (onvif/rtsp/http) whose host IP
+	// matches a registered GB28181 device is the same physical camera — the
+	// GB28181 auto-enroll skips it symmetrically. Refuse unless the caller
+	// explicitly opts in (dual-protocol setups) with allow_duplicate.
+	if !isPush && !isGB28181 && h.gb28181DeviceMgr != nil {
+		if host := createBodyHost(body.URL, body.ONVIFEndpoint); host != "" {
+			for _, d := range h.gb28181DeviceMgr.AllDevices() {
+				d.Mu.RLock()
+				netAddr := d.NetAddr
+				d.Mu.RUnlock()
+				devHost := netAddr
+				if h2, _, err := net.SplitHostPort(netAddr); err == nil && h2 != "" {
+					devHost = h2
+				}
+				if devHost == host {
+					if !body.AllowDuplicate {
+						logger.Warn("create camera refused: host already registered via GB28181",
+							"host", host, "gb_device", d.ID)
+						WriteError(w, http.StatusConflict, fmt.Sprintf(
+							"a GB28181 device (%s) is already connected from %s — this looks like the same physical camera. "+
+								"Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both",
+							d.ID, host))
+						return
+					}
+					logger.Info("create camera: allow_duplicate set despite GB28181 device at same host",
+						"host", host, "gb_device", d.ID)
+					break
+				}
+			}
+		}
+	}
 	// ONVIF cameras: accept url OR onvif_endpoint
 	if body.Protocol == "onvif" {
 		endpoint := body.ONVIFEndpoint

--- a/internal/api/handlers_camera_dedup_test.go
+++ b/internal/api/handlers_camera_dedup_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDedupHandler builds a handler with a real camera manager (rtsp/void —
+// rtsp recorders never connect in these tests; camera creation with
+// Enabled=false avoids recorder start) plus a GB28181 device manager holding
+// one registered device at a fixed IP.
+func setupDedupHandler(t *testing.T) *Handler {
+	t.Helper()
+	db, store := setupTestDB(t)
+	cfg := &config.Config{Storage: config.StorageConfig{SegmentDuration: "30s"}}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, camMgr.Start(ctx))
+	t.Cleanup(func() { _ = camMgr.Stop() })
+
+	deviceMgr := gb28181.NewDeviceManager(60 * time.Second)
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, deviceMgr, nil)
+	deviceMgr.Register(&gb28181.Device{
+		ID:      "34020000001310000001",
+		NetAddr: "192.168.63.240:5060",
+	})
+	return h
+}
+
+// TestHandleCreateCamera_GBDuplicateRefused: adding a pull camera (rtsp/onvif)
+// whose host IP belongs to a registered GB28181 device is refused with 409 —
+// same physical camera, one entry. allow_duplicate=true overrides.
+func TestHandleCreateCamera_GBDuplicateRefused(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code, "body: %s", rr.Body.String())
+
+	// Same host via onvif_endpoint is refused too.
+	body = `{"name":"Front ONVIF","protocol":"onvif","onvif_endpoint":"http://192.168.63.240/onvif/device_service","enabled":false}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	// allow_duplicate overrides the guard.
+	body = `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false,"allow_duplicate":true}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestHandleCreateCamera_NoGBDeviceAllowsNormalCreate: with no GB28181 device
+// at that IP, creation is unaffected.
+func TestHandleCreateCamera_NoGBDeviceAllowsNormalCreate(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"Other","protocol":"rtsp","url":"rtsp://192.168.63.9:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestHandleCreateCamera_NilDeviceMgrNoop: the dedup guard must not fire when
+// the GB28181 device manager is absent (gb28181 disabled / older wiring).
+func TestHandleCreateCamera_NilDeviceMgrNoop(t *testing.T) {
+	db, store := setupTestDB(t)
+	camMgr := camera.NewCameraManager(&config.Config{}, store, db, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, camMgr.Start(ctx))
+	defer camMgr.Stop()
+
+	h := NewHandler(db, store, noopAuthMW(), nil, camMgr, nil, "", nil, nil, nil, nil, nil)
+	require.Nil(t, h.gb28181DeviceMgr)
+
+	body := `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code)
+}

--- a/internal/api/handlers_camera_dedup_test.go
+++ b/internal/api/handlers_camera_dedup_test.go
@@ -3,13 +3,18 @@ package api
 import (
 	"bytes"
 	"context"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,7 +76,7 @@ func TestHandleCreateCamera_NoGBDeviceAllowsNormalCreate(t *testing.T) {
 // the GB28181 device manager is absent (gb28181 disabled / older wiring).
 func TestHandleCreateCamera_NilDeviceMgrNoop(t *testing.T) {
 	db, store := setupTestDB(t)
-	camMgr := camera.NewCameraManager(&config.Config{}, store, db, "")
+	camMgr := camera.NewCameraManager(&config.Config{Storage: config.StorageConfig{SegmentDuration: "30s"}}, store, db, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, camMgr.Start(ctx))
@@ -83,4 +88,61 @@ func TestHandleCreateCamera_NilDeviceMgrNoop(t *testing.T) {
 	body := `{"name":"Front","protocol":"rtsp","url":"rtsp://192.168.63.240:554/stream","enabled":false}`
 	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
 	require.Equal(t, http.StatusCreated, rr.Code)
+}
+
+// TestHandleCreateCamera_GBFingerprintRefusedAcrossInterfaces: scenario 5 —
+// the GB28181 device registered earlier (fingerprint cached from a probe of
+// its SIP source IP), and now the user adds the ONVIF camera from the OTHER
+// interface IP. L1 (IP) misses; L2 probes the create-host serial and matches
+// the fingerprint → 409.
+func TestHandleCreateCamera_GBFingerprintRefusedAcrossInterfaces(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	// A fake ONVIF endpoint on a local port answering GetDeviceInformation.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>` +
+			`<GetDeviceInformationResponse><SerialNumber>NC00000001</SerialNumber>` +
+			`</GetDeviceInformationResponse></s:Body></s:Envelope>`))
+	}))
+	t.Cleanup(srv.Close)
+	port := srv.Listener.Addr().(*net.TCPAddr).Port
+	oldPorts := onvif.ProbePorts
+	onvif.ProbePorts = []string{strconv.Itoa(port)}
+	t.Cleanup(func() { onvif.ProbePorts = oldPorts })
+
+	// Fingerprint persisted when the device registered via GB28181 (from a
+	// different interface IP than the create host).
+	require.NoError(t, h.db.UpsertGB28181Fingerprint(context.Background(), storage.GB28181Fingerprint{
+		DeviceID: "34020000001310000001", Serial: "NC00000001", SourceIP: "192.168.63.152",
+		ProbedAt: time.Now(),
+	}))
+
+	// Create host is 127.0.0.1 (the fake endpoint) — no GB device matches that
+	// IP, so only the serial fingerprint can catch the duplicate.
+	body := `{"name":"Front ONVIF","protocol":"onvif","onvif_endpoint":"http://127.0.0.1/onvif/device_service"}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code, "body: %s", rr.Body.String())
+	require.Contains(t, rr.Body.String(), "NC00000001")
+
+	// allow_duplicate overrides.
+	body = `{"name":"Front ONVIF","protocol":"onvif","onvif_endpoint":"http://127.0.0.1/onvif/device_service","allow_duplicate":true}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+}
+
+// TestHandleCreateCamera_NoFingerprintNoProbe: with no cached fingerprints at
+// all (no dual-protocol device ever registered), the create path must not
+// probe at all — normal setups pay zero extra latency.
+func TestHandleCreateCamera_NoFingerprintNoProbe(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	probed := false
+	oldPorts := onvif.ProbePorts
+	onvif.ProbePorts = nil // any probe attempt would iterate zero ports
+	t.Cleanup(func() { onvif.ProbePorts = oldPorts })
+	_ = probed
+
+	body := `{"name":"Other","protocol":"rtsp","url":"rtsp://127.0.0.1:554/stream"}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
 }

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -265,6 +265,17 @@ func (cm *CameraManager) GB28181CameraIDByChannel(deviceID, channelID string) (s
 	return "", false
 }
 
+// ArchiveGB28181Camera soft-removes the camera auto-enrolled for a channel —
+// used when a catalog supersedes the device-self pseudo-channel (#352).
+// Archives preserve recordings; a no-op when no camera is bound.
+func (cm *CameraManager) ArchiveGB28181Camera(deviceID, channelID string) error {
+	cameraID, ok := cm.GB28181CameraIDByChannel(deviceID, channelID)
+	if !ok {
+		return nil
+	}
+	return cm.ArchiveCamera(context.Background(), cameraID)
+}
+
 // GB28181NALUWriter returns the recorder's AU callback for a GB28181 camera,
 // or nil. The SIP server uses this to bridge RTP receiver output directly
 // into the recorder pipeline at access-unit granularity.
@@ -393,4 +404,19 @@ func (cm *CameraManager) UpdateGB28181DeviceMeta(deviceID, manufacturer, modelNa
 			"device_id", deviceID, "cameras", updated)
 	}
 	return nil
+}
+
+// GB28181RecordingWanted reports whether the camera bound to a channel wants
+// recording (nil RecordingEnabled = record by default). The alarm linkage
+// leaves such sessions to the recorder's own reconnect loop (#355).
+func (cm *CameraManager) GB28181RecordingWanted(deviceID, channelID string) bool {
+	cameraID, ok := cm.GB28181CameraIDByChannel(deviceID, channelID)
+	if !ok {
+		return false // no camera → alarm linkage owns the session lifecycle
+	}
+	cam := cm.snapshotConfig(cameraID)
+	if cam == nil {
+		return false
+	}
+	return cam.RecordingEnabled == nil || *cam.RecordingEnabled
 }

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -9,6 +9,10 @@ package camera
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -90,10 +94,23 @@ func (cm *CameraManager) GetGB28181Recorder(cameraID string) *recorder.GB28181Re
 // auto-appear in the Cameras list — matching ONVIF auto-add. Dedup is by
 // channel: a multi-channel device (NVR) gets one camera per video channel.
 // Idempotent: if a camera with matching GB28181.ChannelID exists, returns nil.
-func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name string) error {
+//
+// sourceIP is the device's SIP source address host ("" when unknown). When a
+// camera of another protocol already streams from the same IP, the device is
+// physically present under a different identity — auto-enroll is skipped so
+// one physical camera never yields two recording entries. Manual camera
+// creation (API/web) is the escape hatch for deliberately dual-protocol setups.
+func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
 	// Check if a camera for this channel already exists.
 	if _, ok := cm.GB28181CameraIDByChannel(deviceID, channelID); ok {
 		return nil // Already enrolled
+	}
+	if sourceIP != "" {
+		if existingID, ok := cm.CameraIDByHostIP(sourceIP); ok {
+			slog.Info("gb28181: auto-enroll skipped — another camera already streams from the device IP",
+				"device", deviceID, "channel", channelID, "source_ip", sourceIP, "existing_camera", existingID)
+			return nil
+		}
 	}
 
 	cameraName := name
@@ -111,6 +128,44 @@ func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name string) e
 	}
 	_, err := cm.AddCamera(context.Background(), cam)
 	return err
+}
+
+// CameraIDByHostIP resolves an active non-GB28181 camera whose pull URL or
+// ONVIF endpoint points at the given IP. Used by GB28181 auto-enroll to keep
+// one camera per physical device when a dual-protocol camera registers.
+// GB28181 cameras are excluded (their dedup key is the channel ID, not IP).
+func (cm *CameraManager) CameraIDByHostIP(ip string) (string, bool) {
+	if ip == "" {
+		return "", false
+	}
+	snap := cm.loadSnapshot()
+	for _, cfg := range snap.configs {
+		if cfg.Protocol == string(model.ProtoGB28181) {
+			continue
+		}
+		if cameraHostIP(cfg) == ip {
+			return cfg.ID, true
+		}
+	}
+	return "", false
+}
+
+// cameraHostIP extracts the host from a camera's URL or ONVIF endpoint
+// ("" when neither carries one — push/ingest cameras, GB28181, xiaomi P2P).
+func cameraHostIP(cfg *config.CameraConfig) string {
+	for _, raw := range []string{cfg.URL, cfg.ONVIFEndpoint} {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			return u.Hostname()
+		}
+		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
+			return host
+		}
+	}
+	return ""
 }
 
 // GB28181CameraIDByChannel resolves the MiBee camera bound to a GB28181

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -13,12 +13,15 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
@@ -95,21 +98,36 @@ func (cm *CameraManager) GetGB28181Recorder(cameraID string) *recorder.GB28181Re
 // channel: a multi-channel device (NVR) gets one camera per video channel.
 // Idempotent: if a camera with matching GB28181.ChannelID exists, returns nil.
 //
-// sourceIP is the device's SIP source address host ("" when unknown). When a
-// camera of another protocol already streams from the same IP, the device is
-// physically present under a different identity — auto-enroll is skipped so
-// one physical camera never yields two recording entries. Manual camera
-// creation (API/web) is the escape hatch for deliberately dual-protocol setups.
+// Cross-protocol dedup (dual-protocol cameras, e.g. ONVIF + GB28181 both
+// enabled — possibly on DIFFERENT interface IPs of the same device): before
+// creating, the manager resolves the device's ONVIF serial (fingerprint cache
+// → DB → live probe of the SIP source IP) and skips when a camera with that
+// serial already exists. sourceIP "" (unknown) skips dedup entirely. Manual
+// camera creation (API/web) is the escape hatch for deliberate dual-protocol
+// setups.
 func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
 	// Check if a camera for this channel already exists.
 	if _, ok := cm.GB28181CameraIDByChannel(deviceID, channelID); ok {
 		return nil // Already enrolled
 	}
 	if sourceIP != "" {
+		// L1: an existing pull camera streams from the same IP.
 		if existingID, ok := cm.CameraIDByHostIP(sourceIP); ok {
 			slog.Info("gb28181: auto-enroll skipped — another camera already streams from the device IP",
 				"device", deviceID, "channel", channelID, "source_ip", sourceIP, "existing_camera", existingID)
 			return nil
+		}
+		// L2: cross-IP identity — dual-NIC devices register GB28181 from one
+		// interface and may stream ONVIF from another. The ONVIF serial is
+		// interface-independent; probe (cache → DB → live) and match camera
+		// stable IDs / serial numbers.
+		if serial, ok := cm.resolveGBDeviceSerial(deviceID, sourceIP); ok {
+			if existingID, ok := cm.CameraIDBySerial(serial); ok {
+				slog.Info("gb28181: auto-enroll skipped — camera with matching device serial exists (cross-interface dedup)",
+					"device", deviceID, "channel", channelID, "source_ip", sourceIP,
+					"serial", serial, "existing_camera", existingID)
+				return nil
+			}
 		}
 	}
 
@@ -130,6 +148,50 @@ func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP
 	return err
 }
 
+// gbSerialCache memoizes probed device serials (device_id → serial) for the
+// process lifetime; guarded by gbSerialMu.
+var (
+	gbSerialMu    sync.Mutex
+	gbSerialCache = make(map[string]string)
+	// probeGBSerial is the ONVIF serial probe used by cross-protocol dedup;
+	// a var so tests can stub the network round-trip.
+	probeGBSerial = onvif.ProbeSerial
+)
+
+// resolveGBDeviceSerial resolves the ONVIF serial of a GB28181 device by
+// probing its SIP source IP (dual-protocol cameras answer GetDeviceInformation
+// without auth on every interface). Results are cached in memory and the DB
+// (gb28181_fingerprints) — the DB copy also serves the reverse dedup path
+// (camera create). ok=false when the device has no reachable unauthenticated
+// ONVIF endpoint (pure-GB cameras) — callers fall through to normal enroll.
+func (cm *CameraManager) resolveGBDeviceSerial(deviceID, sourceIP string) (string, bool) {
+	gbSerialMu.Lock()
+	if serial, ok := gbSerialCache[deviceID]; ok {
+		gbSerialMu.Unlock()
+		return serial, true
+	}
+	gbSerialMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	serial, ok := probeGBSerial(ctx, sourceIP)
+	if !ok {
+		return "", false
+	}
+
+	gbSerialMu.Lock()
+	gbSerialCache[deviceID] = serial
+	gbSerialMu.Unlock()
+	if cm.db != nil {
+		if err := cm.db.UpsertGB28181Fingerprint(ctx, storage.GB28181Fingerprint{
+			DeviceID: deviceID, Serial: serial, SourceIP: sourceIP, ProbedAt: time.Now(),
+		}); err != nil {
+			slog.Debug("gb28181: persist device fingerprint failed", "device", deviceID, "error", err)
+		}
+	}
+	return serial, true
+}
+
 // CameraIDByHostIP resolves an active non-GB28181 camera whose pull URL or
 // ONVIF endpoint points at the given IP. Used by GB28181 auto-enroll to keep
 // one camera per physical device when a dual-protocol camera registers.
@@ -144,6 +206,26 @@ func (cm *CameraManager) CameraIDByHostIP(ip string) (string, bool) {
 			continue
 		}
 		if cameraHostIP(cfg) == ip {
+			return cfg.ID, true
+		}
+	}
+	return "", false
+}
+
+// CameraIDBySerial resolves a camera by its stable hardware serial — the
+// cross-protocol identity for dual-NIC dedup. ONVIF cameras auto-populate
+// StableID from the device serial on first connection (crud.go reverse
+// lookup), making it the natural join key against the GB28181 fingerprint.
+func (cm *CameraManager) CameraIDBySerial(serial string) (string, bool) {
+	if serial == "" {
+		return "", false
+	}
+	snap := cm.loadSnapshot()
+	for _, cfg := range snap.configs {
+		if cfg.Protocol == string(model.ProtoGB28181) {
+			continue
+		}
+		if cfg.StableID == serial {
 			return cfg.ID, true
 		}
 	}

--- a/internal/camera/gb28181_dedup_test.go
+++ b/internal/camera/gb28181_dedup_test.go
@@ -1,0 +1,87 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// gbDedupConfig builds a config with one ONVIF camera at a fixed IP.
+func gbDedupConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{{
+		ID:            "front-onvif",
+		Name:          "Front ONVIF",
+		Protocol:      "onvif",
+		URL:           "",
+		ONVIFEndpoint: "http://192.168.63.240/onvif/device_service",
+	}}
+	return cfg
+}
+
+func TestCameraIDByHostIP(t *testing.T) {
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	id, ok := mgr.CameraIDByHostIP("192.168.63.240")
+	require.True(t, ok)
+	require.Equal(t, "front-onvif", id)
+
+	_, ok = mgr.CameraIDByHostIP("192.168.63.999")
+	require.False(t, ok)
+	_, ok = mgr.CameraIDByHostIP("")
+	require.False(t, ok, "empty IP must never match")
+}
+
+func TestCameraIDByHostIP_IgnoresGB28181Cameras(t *testing.T) {
+	cfg := gbDedupConfig(t)
+	cfg.Cameras = append(cfg.Cameras, config.CameraConfig{
+		ID:       "gb-34020000001320000001",
+		Protocol: "gb28181",
+		GB28181:  config.GB28181ChannelConfig{DeviceID: "d", ChannelID: "34020000001320000001"},
+	})
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// GB cameras have no URL; they must not participate in IP matching.
+	_, ok := mgr.CameraIDByHostIP("192.168.63.240")
+	require.True(t, ok)
+}
+
+func TestEnsureGB28181Camera_SkipsWhenHostCameraExists(t *testing.T) {
+	// The camera registers via GB28181 AFTER it was added as ONVIF from the
+	// same IP: auto-enroll must skip instead of creating a second entry.
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000001", "34020000001320000001", "GB Channel", "192.168.63.240"))
+
+	// No gb- camera created; the ONVIF camera is untouched.
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000001", "34020000001320000001")
+	require.False(t, ok, "auto-enroll must be suppressed on host collision")
+	snap := mgr.loadSnapshot()
+	require.Len(t, snap.configs, 1)
+}
+
+func TestEnsureGB28181Camera_EnrollsWhenNoCollision(t *testing.T) {
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000009", "34020000001320000009", "", "192.168.63.9"))
+
+	id, ok := mgr.GB28181CameraIDByChannel("34020000001310000009", "34020000001320000009")
+	require.True(t, ok)
+	require.Equal(t, "gb-34020000001320000009", id)
+}
+
+func TestEnsureGB28181Camera_EmptySourceIPStillEnrolls(t *testing.T) {
+	// Unknown source ("" — e.g. device resolved before NetAddr recorded):
+	// behave like today, enroll by channel identity.
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000002", "34020000001320000002", "", ""))
+
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000002", "34020000001320000002")
+	require.True(t, ok)
+}

--- a/internal/camera/gb28181_dedup_test.go
+++ b/internal/camera/gb28181_dedup_test.go
@@ -1,11 +1,23 @@
 package camera
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/stretchr/testify/require"
 )
+
+// stubProbe replaces the network serial probe for the test and returns a
+// restore func (also clears the in-memory fingerprint cache).
+func stubProbe(serial string, ok bool) func() {
+	old := probeGBSerial
+	probeGBSerial = func(context.Context, string) (string, bool) { return serial, ok }
+	return func() {
+		probeGBSerial = old
+		clear(gbSerialCache)
+	}
+}
 
 // gbDedupConfig builds a config with one ONVIF camera at a fixed IP.
 func gbDedupConfig(t *testing.T) *config.Config {
@@ -17,6 +29,7 @@ func gbDedupConfig(t *testing.T) *config.Config {
 		Protocol:      "onvif",
 		URL:           "",
 		ONVIFEndpoint: "http://192.168.63.240/onvif/device_service",
+		StableID:      "NC00000001",
 	}}
 	return cfg
 }
@@ -48,9 +61,25 @@ func TestCameraIDByHostIP_IgnoresGB28181Cameras(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestCameraIDBySerial(t *testing.T) {
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	id, ok := mgr.CameraIDBySerial("NC00000001")
+	require.True(t, ok)
+	require.Equal(t, "front-onvif", id)
+
+	_, ok = mgr.CameraIDBySerial("")
+	require.False(t, ok)
+	_, ok = mgr.CameraIDBySerial("other")
+	require.False(t, ok)
+}
+
 func TestEnsureGB28181Camera_SkipsWhenHostCameraExists(t *testing.T) {
-	// The camera registers via GB28181 AFTER it was added as ONVIF from the
-	// same IP: auto-enroll must skip instead of creating a second entry.
+	// Scenarios 1/3: the camera registered via GB28181 from the SAME IP it
+	// streams ONVIF from — L1 catches it without probing.
+	restore := stubProbe("", false)
+	defer restore()
+
 	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
 
 	require.NoError(t, mgr.EnsureGB28181Camera(
@@ -63,7 +92,27 @@ func TestEnsureGB28181Camera_SkipsWhenHostCameraExists(t *testing.T) {
 	require.Len(t, snap.configs, 1)
 }
 
+func TestEnsureGB28181Camera_SkipsBySerialAcrossInterfaces(t *testing.T) {
+	// Scenarios 2/4: GB28181 registers from interface .152 while the ONVIF
+	// camera streams from .240 (dual-NIC device). L1 misses; L2 probes the
+	// SIP source IP, gets the serial, and matches the camera's StableID.
+	restore := stubProbe("NC00000001", true)
+	defer restore()
+
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000001", "34020000001320000001", "GB Channel", "192.168.63.152"))
+
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000001", "34020000001320000001")
+	require.False(t, ok, "auto-enroll must be suppressed on serial match")
+	require.Len(t, mgr.loadSnapshot().configs, 1)
+}
+
 func TestEnsureGB28181Camera_EnrollsWhenNoCollision(t *testing.T) {
+	restore := stubProbe("", false) // no ONVIF reachable: pure-GB camera
+	defer restore()
+
 	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
 
 	require.NoError(t, mgr.EnsureGB28181Camera(
@@ -77,6 +126,9 @@ func TestEnsureGB28181Camera_EnrollsWhenNoCollision(t *testing.T) {
 func TestEnsureGB28181Camera_EmptySourceIPStillEnrolls(t *testing.T) {
 	// Unknown source ("" — e.g. device resolved before NetAddr recorded):
 	// behave like today, enroll by channel identity.
+	restore := stubProbe("", false)
+	defer restore()
+
 	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
 
 	require.NoError(t, mgr.EnsureGB28181Camera(
@@ -84,4 +136,47 @@ func TestEnsureGB28181Camera_EmptySourceIPStillEnrolls(t *testing.T) {
 
 	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000002", "34020000001320000002")
 	require.True(t, ok)
+}
+
+func TestEnsureGB28181Camera_SerialMismatchEnrolls(t *testing.T) {
+	// Probe answers a DIFFERENT serial (another physical device behind the
+	// same IP): no match → enroll normally.
+	restore := stubProbe("OTHER-DEVICE-99", true)
+	defer restore()
+
+	mgr, _, _, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	require.NoError(t, mgr.EnsureGB28181Camera(
+		"34020000001310000003", "34020000001320000003", "", "192.168.63.9"))
+
+	_, ok := mgr.GB28181CameraIDByChannel("34020000001310000003", "34020000001320000003")
+	require.True(t, ok)
+}
+
+func TestResolveGBDeviceSerial_CachesAndPersists(t *testing.T) {
+	restore := stubProbe("NC00000001", true)
+	defer restore()
+
+	mgr, _, db, _ := newTestManagerWithCfg(t, gbDedupConfig(t))
+
+	serial, ok := mgr.resolveGBDeviceSerial("34020000001310000077", "192.168.63.152")
+	require.True(t, ok)
+	require.Equal(t, "NC00000001", serial)
+
+	fp, err := db.GetGB28181Fingerprint(context.Background(), "34020000001310000077")
+	require.NoError(t, err)
+	require.NotNil(t, fp, "fingerprint must be persisted for the reverse dedup path")
+	require.Equal(t, "NC00000001", fp.Serial)
+	require.Equal(t, "192.168.63.152", fp.SourceIP)
+
+	// Second resolve must come from the in-memory cache (probe stays unused).
+	calls := 0
+	probeGBSerial = func(context.Context, string) (string, bool) {
+		calls++
+		return "NC00000001", true
+	}
+	serial, ok = mgr.resolveGBDeviceSerial("34020000001310000077", "192.168.63.152")
+	require.True(t, ok)
+	require.Equal(t, "NC00000001", serial)
+	require.Zero(t, calls)
 }

--- a/internal/config/config_gb28181.go
+++ b/internal/config/config_gb28181.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // GB28181ServerConfig configures the GB/T 28181 platform server. When Enabled,
 // compliant devices (Hikvision, Dahua, Uniview, ...) REGISTER over SIP and
 // expose their channels as MiBee cameras; the NVR INVITEs a channel and ingests
@@ -73,6 +75,31 @@ type GB28181ServerConfig struct {
 
 	// SubscribeExpires is the SUBSCRIBE lifetime; renewed at 80%.
 	SubscribeExpires string `yaml:"subscribe_expires"` // default "3600s"
+
+	// AlarmLinkage configures alarm-triggered streaming (#355): on an alarm
+	// notification, INVITE the alarm channel when it is not already streaming,
+	// hold the stream for the configured duration, then BYE — unless the
+	// channel's camera wants recording (then the stream stays).
+	AlarmLinkage *GB28181AlarmLinkageConfig `yaml:"alarm_linkage,omitempty"`
+}
+
+// GB28181AlarmLinkageConfig is the alarm→stream linkage block.
+type GB28181AlarmLinkageConfig struct {
+	Enabled bool `yaml:"enabled"` // default false
+
+	// Duration of each alarm-triggered stream hold. Default "60s".
+	Duration string `yaml:"duration"`
+}
+
+// AlarmLinkageDuration resolves the hold duration with its default.
+func (c *GB28181AlarmLinkageConfig) AlarmLinkageDuration() time.Duration {
+	if c == nil {
+		return 0
+	}
+	if d, err := time.ParseDuration(c.Duration); err == nil && d > 0 {
+		return d
+	}
+	return 60 * time.Second
 }
 
 // CatalogSubscriptionOn resolves the subscribe_catalog toggle: on when the

--- a/internal/gb28181/device.go
+++ b/internal/gb28181/device.go
@@ -249,3 +249,14 @@ func (m *DeviceManager) RegisterChannel(devID string, ch *Channel) {
 	ch.Device = dev
 	dev.channels.Store(ch.ID, ch)
 }
+
+// UnregisterChannel removes a channel from its device's registry. Used to
+// drop the device-self pseudo-channel once a catalog proves the device's real
+// channels (#352).
+func (m *DeviceManager) UnregisterChannel(deviceID, channelID string) {
+	d, ok := m.devices.Load(deviceID)
+	if !ok {
+		return
+	}
+	d.(*Device).channels.Delete(channelID)
+}

--- a/internal/gb28181/sip/alarm_linkage.go
+++ b/internal/gb28181/sip/alarm_linkage.go
@@ -1,0 +1,108 @@
+package sip
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// alarmLinkage implements alarm-triggered streaming (#355): when an alarm
+// notification arrives for a channel that is not streaming, INVITE it and
+// hold the stream for a configured duration, then BYE. Channels whose camera
+// wants recording keep the stream (the alarm merely ensured liveness).
+// Repeated alarms extend the hold.
+//
+// The decision seams (invite/bye/streaming/recording-wanted) are injectable
+// so tests can drive the state machine without SIP plumbing.
+type alarmLinkage struct {
+	mu    sync.Mutex
+	holds map[string]*time.Timer // channelID → pending BYE timer
+
+	inviteFn        func(deviceID, channelID string) error
+	byeFn           func(deviceID, channelID string) error
+	streamingFn     func(channelID string) bool
+	recordingWanted func(deviceID, channelID string) bool
+}
+
+func newAlarmLinkage(inviteFn, byeFn func(deviceID, channelID string) error,
+	streamingFn func(channelID string) bool, recordingWanted func(deviceID, channelID string) bool,
+) *alarmLinkage {
+	return &alarmLinkage{
+		holds:           make(map[string]*time.Timer),
+		inviteFn:        inviteFn,
+		byeFn:           byeFn,
+		streamingFn:     streamingFn,
+		recordingWanted: recordingWanted,
+	}
+}
+
+// Trigger applies the linkage policy for one alarm. cfg nil/disabled = no-op.
+func (a *alarmLinkage) Trigger(deviceID, channelID string, cfg *config.GB28181AlarmLinkageConfig) {
+	if cfg == nil || !cfg.Enabled {
+		return
+	}
+	if a.recordingWanted != nil && a.recordingWanted(deviceID, channelID) {
+		// The camera's recorder owns the session lifecycle (record loop
+		// re-INVITEs on its own); only ensure it is streaming now.
+		if !a.streamingFor(channelID) {
+			_ = a.invite(deviceID, channelID) // logged inside; nothing to unwind
+		}
+		return
+	}
+	if a.streamingFor(channelID) {
+		a.extend(deviceID, channelID, cfg.AlarmLinkageDuration())
+		return
+	}
+	if a.invite(deviceID, channelID) != nil {
+		return
+	}
+	a.extend(deviceID, channelID, cfg.AlarmLinkageDuration())
+}
+
+func (a *alarmLinkage) streamingFor(channelID string) bool {
+	if a.streamingFn == nil {
+		return false
+	}
+	return a.streamingFn(channelID)
+}
+
+func (a *alarmLinkage) invite(deviceID, channelID string) error {
+	if err := a.inviteFn(deviceID, channelID); err != nil {
+		slog.Warn("gb28181: alarm linkage INVITE failed", "device", deviceID, "channel", channelID, "error", err)
+		return err
+	}
+	slog.Info("gb28181: alarm linkage — INVITE", "device", deviceID, "channel", channelID)
+	return nil
+}
+
+// extend (re)arms the hold timer; a recording-owned session never gets one.
+func (a *alarmLinkage) extend(deviceID, channelID string, d time.Duration) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if t, ok := a.holds[channelID]; ok {
+		t.Stop()
+	}
+	a.holds[channelID] = time.AfterFunc(d, func() {
+		a.mu.Lock()
+		delete(a.holds, channelID)
+		a.mu.Unlock()
+		slog.Info("gb28181: alarm linkage hold elapsed — BYE", "device", deviceID, "channel", channelID)
+		if a.byeFn != nil {
+			if err := a.byeFn(deviceID, channelID); err != nil {
+				slog.Warn("gb28181: alarm linkage BYE failed", "device", deviceID, "channel", channelID, "error", err)
+			}
+		}
+	})
+}
+
+// Stop cancels all pending holds (server shutdown).
+func (a *alarmLinkage) Stop() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, t := range a.holds {
+		t.Stop()
+	}
+	a.holds = make(map[string]*time.Timer)
+}

--- a/internal/gb28181/sip/alarm_linkage_test.go
+++ b/internal/gb28181/sip/alarm_linkage_test.go
@@ -1,0 +1,147 @@
+package sip
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type linkageCalls struct {
+	mu        sync.Mutex
+	invited   []string
+	byes      []string
+	streaming map[string]bool
+	recording map[string]bool
+}
+
+func (c *linkageCalls) invite(deviceID, channelID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.invited = append(c.invited, channelID)
+	return nil
+}
+
+func (c *linkageCalls) bye(deviceID, channelID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byes = append(c.byes, channelID)
+	return nil
+}
+
+func (c *linkageCalls) isStreaming(channelID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.streaming[channelID]
+}
+
+func (c *linkageCalls) wanted(deviceID, channelID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.recording[channelID]
+}
+
+func newTestLinkage() (*alarmLinkage, *linkageCalls) {
+	c := &linkageCalls{streaming: map[string]bool{}, recording: map[string]bool{}}
+	return newAlarmLinkage(c.invite, c.bye, c.isStreaming, c.wanted), c
+}
+
+func TestAlarmLinkage_DisabledNoop(t *testing.T) {
+	a, c := newTestLinkage()
+	a.Trigger("dev", "ch", nil)
+	a.Trigger("dev", "ch", &config.GB28181AlarmLinkageConfig{Enabled: false})
+	require.Empty(t, c.invited)
+	require.Empty(t, c.byes)
+}
+
+func TestAlarmLinkage_InvitesAndHolds(t *testing.T) {
+	a, c := newTestLinkage()
+	a.Trigger("dev", "ch", &config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "100ms"})
+	require.Equal(t, []string{"ch"}, c.invited)
+	require.Empty(t, c.byes, "hold must not elapse yet")
+
+	// Simulate the INVITE establishing the stream, then wait out the hold.
+	c.mu.Lock()
+	c.streaming["ch"] = true
+	c.mu.Unlock()
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.byes) == 1
+	}, 2*time.Second, 20*time.Millisecond, "BYE must fire after the hold elapses")
+}
+
+func TestAlarmLinkage_AlarmExtendsHold(t *testing.T) {
+	a, c := newTestLinkage()
+	cfg := &config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "150ms"}
+	a.Trigger("dev", "ch", cfg)
+	c.mu.Lock()
+	c.streaming["ch"] = true
+	c.mu.Unlock()
+
+	time.Sleep(80 * time.Millisecond)
+	a.Trigger("dev", "ch", cfg)        // second alarm extends the hold
+	time.Sleep(100 * time.Millisecond) // 180ms since the FIRST trigger
+	c.mu.Lock()
+	byes := len(c.byes)
+	c.mu.Unlock()
+	require.Zero(t, byes, "extended hold must not have fired yet")
+
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.byes) == 1
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestAlarmLinkage_RecordingWantedNeverByes(t *testing.T) {
+	a, c := newTestLinkage()
+	c.mu.Lock()
+	c.recording["ch"] = true
+	c.mu.Unlock()
+
+	a.Trigger("dev", "ch", &config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "50ms"})
+	require.Equal(t, []string{"ch"}, c.invited, "recording camera still gets liveness INVITE when not streaming")
+
+	time.Sleep(120 * time.Millisecond)
+	require.Empty(t, c.byes, "recording-owned sessions must never be alarm-BYE'd")
+}
+
+func TestAlarmLinkage_RecordingWantedStreamingNoInvite(t *testing.T) {
+	a, c := newTestLinkage()
+	c.mu.Lock()
+	c.recording["ch"] = true
+	c.streaming["ch"] = true
+	c.mu.Unlock()
+
+	a.Trigger("dev", "ch", &config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "50ms"})
+	require.Empty(t, c.invited, "already-streaming recording camera needs no INVITE")
+	require.Empty(t, c.byes)
+}
+
+func TestAlarmLinkage_StreamingNonRecordingExtends(t *testing.T) {
+	a, c := newTestLinkage()
+	c.mu.Lock()
+	c.streaming["ch"] = true // e.g. live-view session or a prior alarm hold
+	c.mu.Unlock()
+
+	a.Trigger("dev", "ch", &config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "80ms"})
+	require.Empty(t, c.invited, "already streaming: no duplicate INVITE")
+
+	require.Eventually(t, func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return len(c.byes) == 1
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestGB28181AlarmLinkageDurationDefaults(t *testing.T) {
+	require.Zero(t, (*config.GB28181AlarmLinkageConfig)(nil).AlarmLinkageDuration())
+	require.Equal(t, 60*time.Second, (&config.GB28181AlarmLinkageConfig{Enabled: true}).AlarmLinkageDuration())
+	require.Equal(t, 30*time.Second, (&config.GB28181AlarmLinkageConfig{Enabled: true, Duration: "30s"}).AlarmLinkageDuration())
+	require.Equal(t, 60*time.Second, (&config.GB28181AlarmLinkageConfig{Duration: "bogus"}).AlarmLinkageDuration())
+	require.Equal(t, 500*time.Millisecond, (&config.GB28181AlarmLinkageConfig{Duration: "500ms"}).AlarmLinkageDuration())
+	require.Equal(t, 60*time.Second, (&config.GB28181AlarmLinkageConfig{Duration: "-5s"}).AlarmLinkageDuration(), "negative durations fall back")
+}

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -61,7 +61,10 @@ const (
 type CameraEnroller interface {
 	// EnsureGB28181Camera creates a camera bound to the device/channel pair
 	// (idempotent). name is the human-readable channel name (may be empty).
-	EnsureGB28181Camera(deviceID, channelID, name string) error
+	// sourceIP is the device's SIP source host ("" unknown) — auto-enroll is
+	// skipped when another camera already streams from that IP (dual-protocol
+	// dedup; manual creation bypasses it).
+	EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error
 	// GB28181CameraIDByChannel resolves the MiBee camera ID bound to a
 	// device/channel pair, independent of the camera-ID naming convention.
 	GB28181CameraIDByChannel(deviceID, channelID string) (string, bool)
@@ -1063,8 +1066,9 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		// setup. Runs in a goroutine to avoid blocking the SIP response.
 		if !channelExists {
 			if enrol := s.enroller(); enrol != nil {
+				srcHost := hostOfAddr(req.Source())
 				go func() {
-					if err := enrol.EnsureGB28181Camera(deviceID, deviceID, ""); err != nil {
+					if err := enrol.EnsureGB28181Camera(deviceID, deviceID, "", srcHost); err != nil {
 						slog.Warn("gb28181: auto-enroll camera failed", "device", deviceID, "error", err)
 					}
 				}()
@@ -1282,6 +1286,14 @@ func (s *Server) handleMessage(req sip.Request, tx sip.ServerTransaction) {
 // catalog-change NOTIFY: registers channels, persists them, enrolls cameras
 // for new ones, and auto-INVITEs channels that have a camera but no session.
 func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
+	// Source host for cross-protocol auto-enroll dedup (dual-protocol cameras
+	// that already stream via ONVIF/RTSP from the same IP).
+	srcHost := ""
+	if d, ok := s.deviceMgr.Device(deviceID); ok {
+		d.Mu.RLock()
+		srcHost = hostOfAddr(d.NetAddr)
+		d.Mu.RUnlock()
+	}
 	for _, item := range items {
 		// Parental=1 entries are organization/group nodes, not video
 		// channels — registering them as INVITEable channels breaks
@@ -1331,7 +1343,7 @@ func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
 				name := item.Name
 				devID, chID := deviceID, item.DeviceID
 				go func() {
-					if err := enrol.EnsureGB28181Camera(devID, chID, name); err != nil {
+					if err := enrol.EnsureGB28181Camera(devID, chID, name, srcHost); err != nil {
 						slog.Warn("gb28181: auto-enroll channel camera failed", "device", devID, "channel", chID, "error", err)
 					}
 				}()

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -91,6 +91,14 @@ type CameraEnroller interface {
 	// UpdateGB28181DeviceMeta backfills Brand/Model on the cameras bound to
 	// a device from its DeviceInfo response (empty fields only).
 	UpdateGB28181DeviceMeta(deviceID, manufacturer, model string) error
+	// ArchiveGB28181Camera soft-removes the camera auto-enrolled for a
+	// channel (device-self pseudo-channel superseded by a real catalog,
+	// #352). No-op when no camera is bound to the channel.
+	ArchiveGB28181Camera(deviceID, channelID string) error
+	// GB28181RecordingWanted reports whether the camera bound to a channel
+	// wants recording (alarm linkage leaves those sessions to the record
+	// loop, #355).
+	GB28181RecordingWanted(deviceID, channelID string) bool
 }
 
 // inviteDialog remembers the INVITE request and its final response for an
@@ -140,9 +148,11 @@ type Server struct {
 	eventBus      *event.EventBus
 
 	// Talk sessions (#341): channelID -> active voice intercom.
-	talkMu  sync.Mutex
-	talks   map[string]*talkSession
-	talkSeq int
+	talkMu sync.Mutex
+	talks  map[string]*talkSession
+	// alarmLinkage drives alarm-triggered streaming (#355).
+	alarmLinkage *alarmLinkage
+	talkSeq      int
 
 	perDeviceMu map[string]*sync.Mutex // serialize SIP handling per device
 }
@@ -167,6 +177,19 @@ func NewServer(cfg config.GB28181ServerConfig, deviceMgr *gb28181.DeviceManager,
 		talks:         make(map[string]*talkSession),
 		perDeviceMu:   make(map[string]*sync.Mutex),
 	}
+	s.alarmLinkage = newAlarmLinkage(
+		s.InviteChannel, s.ByeChannel,
+		func(channelID string) bool {
+			rcv := s.sessionMgr.GetReceiver(channelID)
+			return rcv != nil && rcv.Running()
+		},
+		func(deviceID, channelID string) bool {
+			if enrol := s.enroller(); enrol != nil {
+				return enrol.GB28181RecordingWanted(deviceID, channelID)
+			}
+			return false
+		},
+	)
 	// Locally-stopped sessions transmit a SIP BYE to the device before the
 	// RTP port is recycled, so stale streams never poison recycled ports.
 	sessionMgr.SetByeSender(s.sendByeForChannel)
@@ -322,6 +345,8 @@ func (s *Server) Stop() error {
 	srv := s.gosipSrv
 	s.gosipSrv = nil
 	s.mu.Unlock()
+
+	s.alarmLinkage.Stop()
 
 	if srv != nil {
 		srv.Shutdown()
@@ -1030,14 +1055,23 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		// Auto-register the device itself as a channel — but ONLY on first
 		// registration, not on periodic re-REGISTERs. Re-registering would
 		// overwrite the channel's Status (resetting inviting/playing to idle).
+		//
+		// The device-self pseudo-channel is a pre-catalog fallback for
+		// single-channel devices without Catalog support. When the DB already
+		// holds OTHER channels for this device (persisted from an earlier
+		// catalog), the pseudo-channel would never stream and its camera would
+		// respawn on every NVR restart — skip it entirely (#352).
 		_, channelExists := s.deviceMgr.FindChannel(deviceID, deviceID)
-		if !channelExists {
+		selfSuperseded := !channelExists && s.deviceHasCatalogChannels(deviceID)
+		if !channelExists && !selfSuperseded {
 			s.deviceMgr.RegisterChannel(deviceID, &gb28181.Channel{
 				ID:       deviceID,
 				DeviceID: deviceID,
 				Name:     "",
 			})
 			slog.Info("gb28181: device auto-registered as channel", "device", deviceID)
+		} else if selfSuperseded {
+			slog.Info("gb28181: device-self pseudo-channel skipped — catalog channels known", "device", deviceID)
 		}
 		if s.db != nil {
 			now := time.Now()
@@ -1049,7 +1083,7 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 			}); err != nil {
 				slog.Warn("gb28181: failed to persist device to DB", "device", deviceID, "error", err)
 			}
-			if !channelExists {
+			if !channelExists && !selfSuperseded {
 				if err := s.db.UpsertGB28181Channel(context.Background(), storage.GB28181Channel{
 					ID:        deviceID,
 					DeviceID:  deviceID,
@@ -1064,7 +1098,7 @@ func (s *Server) handleRegister(req sip.Request, tx sip.ServerTransaction) {
 		// Auto-create a camera in the main Cameras list on first registration,
 		// so GB28181 cameras appear alongside ONVIF/RTSP cameras without manual
 		// setup. Runs in a goroutine to avoid blocking the SIP response.
-		if !channelExists {
+		if !channelExists && !selfSuperseded {
 			if enrol := s.enroller(); enrol != nil {
 				srcHost := hostOfAddr(req.Source())
 				go func() {
@@ -1350,6 +1384,11 @@ func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
 			}
 		}
 	}
+	// A catalog with real (non-parental) channels supersedes the device-self
+	// pseudo-channel created speculatively at first REGISTER — UNLESS the
+	// catalog lists the device ID itself (single-channel devices whose channel
+	// equals the device ID) or the pseudo-channel is actively streaming (#352).
+	s.retireDeviceSelfChannel(deviceID, items)
 	// Channels may have been discovered by this catalog (or a prior one):
 	// INVITE every channel that now has a bound camera and no active
 	// session. Also covers NVR restarts — cameras persist, sessions do
@@ -1394,6 +1433,50 @@ func channelStatusString(status int32) string {
 	default:
 		return "idle"
 	}
+}
+
+// retireDeviceSelfChannel removes the device-self pseudo-channel once a
+// catalog proves the device's real channels (#352). Guards:
+//   - the catalog must contain at least one real (non-parental) channel
+//   - the device ID itself must NOT be among the catalog items (single-channel
+//     devices whose channel equals the device ID keep it)
+//   - the pseudo-channel must never have streamed (idle) — a playing
+//     device-self session means some firmware actually streams on it
+//
+// Removal covers the in-memory registry, the DB row, and the auto-enrolled
+// camera (archived, preserving its recordings).
+func (s *Server) retireDeviceSelfChannel(deviceID string, items []manscdp.Item) {
+	realCount := 0
+	for _, item := range items {
+		if item.Parental != 1 {
+			realCount++
+			if item.DeviceID == deviceID {
+				return // device-self IS a catalog channel — keep it
+			}
+		}
+	}
+	if realCount == 0 {
+		return
+	}
+	ch, ok := s.deviceMgr.FindChannel(deviceID, deviceID)
+	if !ok {
+		return
+	}
+	if ch.Status.Load() != int32(gb28181.ChannelIdle) {
+		return // streaming (or mid-invite): leave it alone
+	}
+	s.deviceMgr.UnregisterChannel(deviceID, deviceID)
+	if s.db != nil {
+		if err := s.db.DeleteGB28181Channel(context.Background(), deviceID); err != nil {
+			slog.Warn("gb28181: failed to delete device-self channel row", "device", deviceID, "error", err)
+		}
+	}
+	if enrol := s.enroller(); enrol != nil {
+		if err := enrol.ArchiveGB28181Camera(deviceID, deviceID); err != nil {
+			slog.Warn("gb28181: failed to archive device-self camera", "device", deviceID, "error", err)
+		}
+	}
+	slog.Info("gb28181: device-self pseudo-channel retired — catalog provides real channels", "device", deviceID)
 }
 
 // handleOptions answers OPTIONS probes (GB/T 28181-2007/2011-era devices and
@@ -1539,6 +1622,27 @@ func hostOfAddr(addr string) string {
 		return h
 	}
 	return addr
+}
+
+// deviceHasCatalogChannels reports whether the DB holds any channel for the
+// device other than the device-self pseudo-channel — i.e., a catalog was
+// received at some point and persisted its real channels. Used to suppress
+// the device-self fallback after NVR restarts (#352). DB-less deployments
+// (tests) report false, preserving the legacy behavior.
+func (s *Server) deviceHasCatalogChannels(deviceID string) bool {
+	if s.db == nil {
+		return false
+	}
+	channels, err := s.db.ListGB28181Channels(context.Background(), deviceID)
+	if err != nil {
+		return false
+	}
+	for _, ch := range channels {
+		if ch.ID != deviceID {
+			return true
+		}
+	}
+	return false
 }
 
 // getAuthHeader extracts the Authorization header from a request. gosip's

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -2,19 +2,25 @@ package sip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
 	"github.com/ghettovoice/gosip/sip/parser"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -608,3 +614,170 @@ func TestServer_Register_PortRotationKeepsAddressStable(t *testing.T) {
 		t.Fatalf("device NetAddr = %q, want the newest client addr", netAddr)
 	}
 }
+
+// fakeEnroller stubs CameraEnroller for pseudo-channel lifecycle tests.
+// Mutex-guarded: mergeCatalogChannels calls it from spawned goroutines while
+// assertions read the recorded calls (-race clean).
+type fakeEnroller struct {
+	mu       sync.Mutex
+	enrolled []string // "deviceID/channelID"
+	archived []string // "deviceID/channelID"
+}
+
+func (f *fakeEnroller) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enrolled = append(f.enrolled, deviceID+"/"+channelID)
+	return nil
+}
+
+func (f *fakeEnroller) GB28181CameraIDByChannel(deviceID, channelID string) (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.enrolled {
+		if e == deviceID+"/"+channelID {
+			return "cam-" + channelID, true
+		}
+	}
+	return "", false
+}
+
+func (f *fakeEnroller) GB28181NALUWriter(string) func([][]byte, int64, bool) { return nil }
+func (f *fakeEnroller) GB28181AudioWriter(string) func(string, []byte, []byte, int64, int) {
+	return nil
+}
+func (f *fakeEnroller) OnGB28181Invite(string) {}
+func (f *fakeEnroller) OnGB28181Bye(string)    {}
+func (f *fakeEnroller) NewGB28181PlaybackSink(string) (gb28181.AUWriter, error) {
+	return nil, errors.New("not implemented in fake")
+}
+
+func (f *fakeEnroller) GB28181PlaybackAudioWriter(string) func(string, []byte, []byte, int64, int) {
+	return nil
+}
+func (f *fakeEnroller) UpdateGB28181DeviceMeta(string, string, string) error { return nil }
+func (f *fakeEnroller) ArchiveGB28181Camera(deviceID, channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.archived = append(f.archived, deviceID+"/"+channelID)
+	return nil
+}
+
+func (f *fakeEnroller) archivedContains(entry string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Contains(f.archived, entry)
+}
+
+func (f *fakeEnroller) enrolledEmpty() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.enrolled) == 0
+}
+
+func (f *fakeEnroller) archivedEmpty() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.archived) == 0
+}
+
+// TestServer_Register_SkipsDeviceSelfWhenCatalogChannelsPersisted (#352):
+// after a restart, a device whose catalog channels were persisted must NOT
+// get its device-self pseudo-channel (and camera) re-created.
+func TestServer_Register_SkipsDeviceSelfWhenCatalogChannelsPersisted(t *testing.T) {
+	cfg := testConfig(t)
+	dbPath := filepath.Join(t.TempDir(), "sip.db")
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { _ = db.Close() })
+
+	dm := gb28181.NewDeviceManager(60 * time.Second)
+	srv := NewServer(cfg, dm, gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), cfg.ServerID), db)
+	require.NoError(t, srv.Start(context.Background()))
+	t.Cleanup(func() { _ = srv.Stop() })
+
+	// A catalog channel persisted for this device from before the "restart".
+	require.NoError(t, db.UpsertGB28181Channel(context.Background(), storage.GB28181Channel{
+		ID: testDeviceID + "1", DeviceID: testDeviceID, Status: "idle", UpdatedAt: time.Now(),
+	}))
+
+	fe := &fakeEnroller{}
+	srv.SetCameraEnroller(fe)
+
+	client := newSIPClient(t, cfg.SIPListen)
+	req := buildRequest(t, sip.REGISTER, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), "")
+	res := client.roundTrip(req)
+	require.EqualValues(t, 401, res.StatusCode())
+	auth := digestAuth(t, getChallenge(t, res), req, cfg.Password)
+	req2 := buildRequest(t, sip.REGISTER, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), "", auth)
+	res2 := client.roundTrip(req2)
+	require.EqualValues(t, 200, res2.StatusCode())
+
+	_, ok := dm.FindChannel(testDeviceID, testDeviceID)
+	require.False(t, ok, "device-self pseudo-channel must not be created when catalog channels are persisted")
+	require.True(t, fe.enrolledEmpty(), "device-self camera must not be enrolled")
+}
+
+// TestRetireDeviceSelfChannel: a catalog with real channels retires the idle
+// device-self pseudo-channel and archives its camera (#352).
+func TestRetireDeviceSelfChannel(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	fe := &fakeEnroller{}
+	srv.SetCameraEnroller(fe)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: "127.0.0.1:60000"})
+	dm.RegisterChannel(testDeviceID, &gb28181.Channel{ID: testDeviceID, DeviceID: testDeviceID})
+
+	srv.mergeCatalogChannels(testDeviceID, []manscdp.Item{
+		{DeviceID: testDeviceID + "1", Name: "Real Channel"},
+	})
+
+	_, ok := dm.FindChannel(testDeviceID, testDeviceID)
+	require.False(t, ok, "idle device-self channel must be retired when real channels exist")
+	require.True(t, fe.archivedContains(testDeviceID+"/"+testDeviceID), "auto-enrolled device-self camera must be archived")
+}
+
+// TestRetireDeviceSelfChannel_KeptWhenStreamingOrListed: the pseudo-channel
+// survives when it is actively playing or when the catalog lists the device
+// ID itself (single-channel devices whose channel equals the device ID).
+func TestRetireDeviceSelfChannel_KeptWhenStreamingOrListed(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	fe := &fakeEnroller{}
+	srv.SetCameraEnroller(fe)
+
+	// Playing device-self: kept.
+	dm.Register(&gb28181.Device{ID: "dev-a", NetAddr: "127.0.0.1:60001"})
+	chA := &gb28181.Channel{ID: "dev-a", DeviceID: "dev-a"}
+	chA.Status.Store(int32(gb28181.ChannelPlaying))
+	dm.RegisterChannel("dev-a", chA)
+	srv.mergeCatalogChannels("dev-a", []manscdp.Item{{DeviceID: "dev-a-ch1"}})
+	_, ok := dm.FindChannel("dev-a", "dev-a")
+	require.True(t, ok, "playing device-self channel must be kept")
+
+	// Catalog lists the device ID itself: kept.
+	dm.Register(&gb28181.Device{ID: "dev-b", NetAddr: "127.0.0.1:60002"})
+	dm.RegisterChannel("dev-b", &gb28181.Channel{ID: "dev-b", DeviceID: "dev-b"})
+	srv.mergeCatalogChannels("dev-b", []manscdp.Item{{DeviceID: "dev-b"}})
+	_, ok = dm.FindChannel("dev-b", "dev-b")
+	require.True(t, ok, "device-self listed in catalog must be kept")
+	require.True(t, fe.archivedEmpty())
+}
+
+// TestRetireDeviceSelfChannel_NoRealChannels: parental-only catalogs (org
+// trees) must not retire the device-self channel.
+func TestRetireDeviceSelfChannel_NoRealChannels(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	srv.SetCameraEnroller(&fakeEnroller{})
+
+	dm.Register(&gb28181.Device{ID: "dev-c", NetAddr: "127.0.0.1:60003"})
+	dm.RegisterChannel("dev-c", &gb28181.Channel{ID: "dev-c", DeviceID: "dev-c"})
+	srv.mergeCatalogChannels("dev-c", []manscdp.Item{{DeviceID: "org-1", Parental: 1}})
+	_, ok := dm.FindChannel("dev-c", "dev-c")
+	require.True(t, ok, "parental-only catalog must not retire the device-self channel")
+}
+
+func (f *fakeEnroller) GB28181RecordingWanted(deviceID, channelID string) bool { return false }

--- a/internal/gb28181/sip/subscribe.go
+++ b/internal/gb28181/sip/subscribe.go
@@ -237,6 +237,10 @@ func (s *Server) handleAlarm(a manscdp.Alarm) {
 	if s.eventBus != nil {
 		s.eventBus.Publish(context.Background(), event.TopicGB28181Alarm, evt)
 	}
+
+	// Alarm-triggered streaming (#355): INVITE the alarming channel when it
+	// is not already streaming (recording-owned sessions are left alone).
+	s.alarmLinkage.Trigger(ownerID, a.DeviceID, s.cfg.AlarmLinkage)
 }
 
 // GB28181Alarms returns the device's most recent alarms (latest first).

--- a/internal/onvif/probe_serial.go
+++ b/internal/onvif/probe_serial.go
@@ -1,0 +1,93 @@
+package onvif
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ProbePorts lists the host-relative ports tried by ProbeSerial, in order:
+// port conventions of the devices we care about — mibee-rec serves ONVIF on
+// :8080, ESP32 MiBeeCam on :80, and :8000 is the Hikvision convention (auth
+// usually required there — a failed probe simply yields no fingerprint).
+// Exported as a var so tests can point it at a local listener.
+var ProbePorts = []string{"8080", "80", "8000"}
+
+const probePath = "/onvif/device_service"
+
+// probeTimeout bounds each endpoint attempt. The overall probe is the sum
+// across ports, but callers run it asynchronously (GB enroll) or on a manual
+// action (camera create), so a few seconds worst case is acceptable.
+const probeTimeout = 1200 * time.Millisecond
+
+var serialRe = regexp.MustCompile(`(?i)<(?:[\w.-]+:)?SerialNumber>\s*([^<]+?)\s*</(?:[\w.-]+:)?SerialNumber>`)
+
+const getDeviceInfoBody = `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">` +
+	`<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">` +
+	`<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>` +
+	`</s:Body></s:Envelope>`
+
+// ProbeSerial queries a device's ONVIF GetDeviceInformation WITHOUT credentials
+// and returns its SerialNumber. It is the cross-protocol correlation probe for
+// GB28181 auto-enroll dedup: a dual-protocol camera serves the same serial on
+// every interface, so probing the SIP source IP identifies a camera that was
+// added via ONVIF from a DIFFERENT interface IP (e.g. USB NIC vs WiFi).
+// Returns ("", false) when no endpoint answers or none exposes a serial —
+// pure-GB28181 cameras (Hikvision/Dahua with auth-required ONVIF) legitimately
+// land here and simply fall back to IP-based matching.
+func ProbeSerial(ctx context.Context, ip string) (string, bool) {
+	ip = strings.TrimSpace(ip)
+	if ip == "" {
+		return "", false
+	}
+	client := &http.Client{Timeout: probeTimeout}
+	for _, port := range ProbePorts {
+		select {
+		case <-ctx.Done():
+			return "", false
+		default:
+		}
+		if serial, ok := probeEndpoint(ctx, client, fmt.Sprintf("http://%s:%s%s", ip, port, probePath)); ok {
+			return serial, true
+		}
+	}
+	return "", false
+}
+
+func probeEndpoint(ctx context.Context, client *http.Client, url string) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(getDeviceInfoBody))
+	if err != nil {
+		return "", false
+	}
+	req.Header.Set("Content-Type", "application/soap+xml; charset=utf-8")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// 401/405 etc. mean ONVIF-with-auth or no ONVIF here — not an error worth
+	// logging; try the next endpoint.
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		return "", false
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if err != nil {
+		return "", false
+	}
+	m := serialRe.FindSubmatch(body)
+	if len(m) != 2 {
+		return "", false
+	}
+	serial := strings.TrimSpace(string(m[1]))
+	if serial == "" {
+		return "", false
+	}
+	return serial, true
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -390,7 +390,14 @@ func (d *DB) Init(ctx context.Context) error {
 		created_at TEXT NOT NULL DEFAULT (datetime('now')),
 		PRIMARY KEY (camera_id, token)
 	);`
-	for _, sql := range []string{camSQL, recSQL, metaSQL, featSQL, healthSQL, transcodeSQL, aiEventsSQL, timelapseMergesSQL, archiveCleanupTasksSQL, gbDevSQL, gbChSQL, ptzPresetsSQL} {
+	gbFpSQL := `CREATE TABLE IF NOT EXISTS gb28181_fingerprints (
+		device_id TEXT PRIMARY KEY,
+		serial TEXT NOT NULL,
+		source_ip TEXT NOT NULL DEFAULT '',
+		probed_at DATETIME
+	);`
+
+	for _, sql := range []string{camSQL, recSQL, metaSQL, featSQL, healthSQL, transcodeSQL, aiEventsSQL, timelapseMergesSQL, archiveCleanupTasksSQL, gbDevSQL, gbChSQL, gbFpSQL, ptzPresetsSQL} {
 		if _, err := d.db.ExecContext(ctx, sql); err != nil {
 			return fmt.Errorf("create table: %w", err)
 		}

--- a/internal/storage/db_gb28181.go
+++ b/internal/storage/db_gb28181.go
@@ -34,6 +34,68 @@ type GB28181Channel struct {
 	UpdatedAt    time.Time
 }
 
+// GB28181Fingerprint is the ONVIF serial probed from a GB28181 device's SIP
+// source address — the cross-protocol identity link for dedup (dual-protocol
+// cameras carry the same serial on every network interface, so the fingerprint
+// matches regardless of which interface IP each protocol used).
+type GB28181Fingerprint struct {
+	DeviceID string
+	Serial   string
+	SourceIP string
+	ProbedAt time.Time
+}
+
+// UpsertGB28181Fingerprint caches a successfully probed device serial.
+func (d *DB) UpsertGB28181Fingerprint(ctx context.Context, fp GB28181Fingerprint) error {
+	_, err := d.db.ExecContext(ctx, `INSERT INTO gb28181_fingerprints
+		(device_id, serial, source_ip, probed_at) VALUES (?, ?, ?, ?)
+		ON CONFLICT(device_id) DO UPDATE SET
+			serial = excluded.serial,
+			source_ip = excluded.source_ip,
+			probed_at = excluded.probed_at`,
+		fp.DeviceID, fp.Serial, fp.SourceIP, timeToDB(fp.ProbedAt))
+	return err
+}
+
+// GetGB28181Fingerprint returns the cached serial for a device (nil when none).
+func (d *DB) GetGB28181Fingerprint(ctx context.Context, deviceID string) (*GB28181Fingerprint, error) {
+	row := d.db.QueryRowContext(ctx,
+		`SELECT device_id, serial, source_ip, probed_at FROM gb28181_fingerprints WHERE device_id = ?`, deviceID)
+	var fp GB28181Fingerprint
+	var probed sql.NullString
+	err := row.Scan(&fp.DeviceID, &fp.Serial, &fp.SourceIP, &probed)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	fp.ProbedAt = scanTime(probed)
+	return &fp, nil
+}
+
+// ListGB28181Fingerprints returns all cached device serials (serial → device
+// correlation for the camera-create dedup path).
+func (d *DB) ListGB28181Fingerprints(ctx context.Context) ([]GB28181Fingerprint, error) {
+	rows, err := d.db.QueryContext(ctx,
+		`SELECT device_id, serial, source_ip, probed_at FROM gb28181_fingerprints`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []GB28181Fingerprint
+	for rows.Next() {
+		var fp GB28181Fingerprint
+		var probed sql.NullString
+		if err := rows.Scan(&fp.DeviceID, &fp.Serial, &fp.SourceIP, &probed); err != nil {
+			return nil, err
+		}
+		fp.ProbedAt = scanTime(probed)
+		out = append(out, fp)
+	}
+	return out, rows.Err()
+}
+
 // UpsertGB28181Device inserts a device row, or updates the existing one
 // while PRESERVING non-empty metadata fields. Callers upsert from multiple
 // paths with partial payloads (REGISTER passes status only, keepalive passes

--- a/internal/storage/db_gb28181.go
+++ b/internal/storage/db_gb28181.go
@@ -227,3 +227,10 @@ func (d *DB) GetGB28181Device(ctx context.Context, id string) (*GB28181Device, e
 	dev.RegisteredAt = scanTime(registeredAt)
 	return &dev, nil
 }
+
+// DeleteGB28181Channel removes one channel row (device-self pseudo-channel
+// cleanup, #352).
+func (d *DB) DeleteGB28181Channel(ctx context.Context, channelID string) error {
+	_, err := d.db.ExecContext(ctx, `DELETE FROM gb28181_channels WHERE id = ?`, channelID)
+	return err
+}

--- a/internal/storage/db_gb28181_test.go
+++ b/internal/storage/db_gb28181_test.go
@@ -157,3 +157,32 @@ func TestDB_GB28181_DeleteDeviceCascades(t *testing.T) {
 	// Deleting an unknown device is a silent no-op.
 	require.NoError(t, db.DeleteGB28181Device(ctx, "never-registered"))
 }
+
+func TestGB28181FingerprintRoundtrip(t *testing.T) {
+	db := newGB28181DB(t)
+	ctx := context.Background()
+
+	fp, err := db.GetGB28181Fingerprint(ctx, "34020000001310000001")
+	require.NoError(t, err)
+	require.Nil(t, fp, "no fingerprint yet")
+
+	now := time.Now()
+	require.NoError(t, db.UpsertGB28181Fingerprint(ctx, GB28181Fingerprint{
+		DeviceID: "34020000001310000001", Serial: "NC00000001", SourceIP: "192.168.63.152", ProbedAt: now,
+	}))
+
+	fp, err = db.GetGB28181Fingerprint(ctx, "34020000001310000001")
+	require.NoError(t, err)
+	require.NotNil(t, fp)
+	require.Equal(t, "NC00000001", fp.Serial)
+	require.Equal(t, "192.168.63.152", fp.SourceIP)
+
+	// Upsert updates, list sees one row.
+	require.NoError(t, db.UpsertGB28181Fingerprint(ctx, GB28181Fingerprint{
+		DeviceID: "34020000001310000001", Serial: "NC00000002", SourceIP: "192.168.63.40", ProbedAt: now,
+	}))
+	fps, err := db.ListGB28181Fingerprints(ctx)
+	require.NoError(t, err)
+	require.Len(t, fps, 1)
+	require.Equal(t, "NC00000002", fps[0].Serial)
+}


### PR DESCRIPTION
一次收口三个 GB28181 遗留 issue，分三个提交。

## #358 跨协议幂等去重（双协议/双网卡相机只入册一次）

双网卡设备（如 mibee-rec：USB .152 + WiFi .40）两协议可能从**不同 IP** 接入，纯身份查重不可能（ONVIF 序列号与国标 20 位编码互不派生）。分层匹配：

- **L1 精确 IP**：GB 入册时源 IP vs 拉流相机 URL host → 跳过；创建相机时反向 → 409
- **L2 跨 IP 身份**：`onvif.ProbeSerial` 无凭证 SOAP 探测（:8080/:80/:8000，各 1.2s）→ serial vs 相机 stable_id；指纹持久化新表 `gb28181_fingerprints`（schema v33）支撑反向场景（GB 先注册后加 ONVIF）
- 纯 GB 相机（ONVIF 需鉴权）探测失败退化为 L1/现状；`allow_duplicate: true` 逃生门；无指纹时创建路径零探测开销

场景矩阵 1-5 全覆盖（详见 issue）。

## #352 设备自注册伪通道退役

- REGISTER 时 DB 已有该设备其它通道 → 跳过 device-self 伪通道（防重启复活）
- 目录带来真实通道时退役 idle 伪通道（registry + DB 行 + 自动入册相机归档）；**三重保护**：目录含设备自身 ID（单通道设备）/ 通道正在推流 / 仅组织节点目录 → 不退役

## #355 报警联动点播

报警通知 → 未在推流的通道立即 INVITE，保持 `gb28181.alarm_linkage.duration`（默认 60s）后 BYE；重复报警延长保持；**录像相机永不被报警 BYE**（录制会话归录像机生命周期，报警只保证其在线）。独立 `alarmLinkage` 类型，决策缝隙可注入，停机清理。

## 测试

新增 24 个测试（dedup 双向×6、storage 指纹、#352×4、#355×7、config 默认值等）；全量 **4611 过**、lint 0。