### PR TITLE
feat(discovery): stable device identity + UDP broadcast responder (#330, #334)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,16 @@
 # HTTP server listen address (default: ":9090")
 server:
   listen: ":9090"
+  # Stable device identity for LAN clients (mobile apps bind to this ID
+  # instead of the IP). device_id is generated automatically on first start
+  # and never changes afterwards; device_name defaults to the system hostname.
+  # device_id: ""
+  # device_name: ""
+  # LAN self-announcement for clients that cannot use multicast/mDNS.
+  # discovery:
+  #   udp:
+  #     enabled: true   # answer "MIBEE-NVR-DISCv1?" probes on UDP 49090
+  #     port: 49090
 
 # HTTP security response headers.
 # frame_ancestors controls who may embed the Web UI in an <iframe> via the CSP

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -50,6 +50,11 @@ type HealthResponse struct {
 	Uptime        string                 `json:"uptime"`
 	SetupRequired bool                   `json:"setup_required"`
 	Cameras       *CameraHealthSummary   `json:"cameras,omitempty"`
+	// DeviceID / DeviceName give LAN clients a stable identity to anchor on
+	// instead of an IP address (#330). Empty until the config provides them
+	// (the ID is generated and persisted on first config load).
+	DeviceID   string `json:"device_id,omitempty"`
+	DeviceName string `json:"device_name,omitempty"`
 }
 
 // CameraHealthSummary provides aggregated camera health in the /api/health response.

--- a/internal/api/handlers_health_test.go
+++ b/internal/api/handlers_health_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/health"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,38 @@ func setupHealthHandler(t *testing.T, mgr HealthManager) *Handler {
 	h := TestHandler(db, store)
 	h.healthMgr = mgr
 	return h
+}
+
+// --- GET /api/health (public) tests ---
+
+func TestHealth_Endpoint_DeviceIdentity(t *testing.T) {
+	t.Parallel()
+	h := setupHealthHandler(t, nil)
+	h.config = &config.Config{}
+	h.config.Server.DeviceID = "11111111-2222-4333-8444-555555555555"
+	h.config.Server.DeviceName = "living-room-nvr"
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/health", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp HealthResponse
+	parseJSON(t, rr, &resp)
+	require.Equal(t, "11111111-2222-4333-8444-555555555555", resp.DeviceID)
+	require.Equal(t, "living-room-nvr", resp.DeviceName)
+}
+
+func TestHealth_Endpoint_DeviceIdentityOmittedWithoutConfig(t *testing.T) {
+	t.Parallel()
+	h := setupHealthHandler(t, nil)
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/health", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// omitempty: absent identity must not surface as empty strings.
+	var raw map[string]any
+	parseJSON(t, rr, &raw)
+	require.NotContains(t, raw, "device_id")
+	require.NotContains(t, raw, "device_name")
 }
 
 // --- handleGetHealthStatus tests ---

--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -121,6 +121,12 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	// SetupRequired — true when no password is configured
 	resp.SetupRequired = h.config != nil && h.config.Auth.PasswordHash == "" && h.config.Auth.Password == ""
+
+	// Stable device identity for LAN clients (#330)
+	if h.config != nil {
+		resp.DeviceID = h.config.Server.DeviceID
+		resp.DeviceName = h.config.Server.DeviceName
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -43,6 +43,25 @@ func applyConfigDefaults(cfg *Config) {
 	if env := strings.TrimSpace(os.Getenv("NVR_FRAME_ANCESTORS")); env != "" {
 		cfg.Security.FrameAncestors = env
 	}
+	// Device identity (#330): the name defaults to the system hostname and is
+	// intentionally NOT persisted (an explicit server.device_name overrides it;
+	// a hostname change is reflected on the next restart). The ID itself is
+	// generated and persisted by Load via ensureDeviceIdentity because it must
+	// stay stable across restarts.
+	if cfg.Server.DeviceName == "" {
+		if hn, err := os.Hostname(); err == nil && hn != "" {
+			cfg.Server.DeviceName = hn
+		}
+	}
+	// LAN discovery (#334): UDP broadcast responder on by default — it carries
+	// no more information than the already-public GET /api/health.
+	if cfg.Server.Discovery.UDP.Enabled == nil {
+		enabled := true
+		cfg.Server.Discovery.UDP.Enabled = &enabled
+	}
+	if cfg.Server.Discovery.UDP.Port == 0 {
+		cfg.Server.Discovery.UDP.Port = DefaultUDPPort
+	}
 	// Storage
 	if strings.TrimSpace(cfg.Storage.RootDir) == "" {
 		cfg.Storage.RootDir = "/var/lib/mibee-nvr"

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -23,7 +23,33 @@ type ServerConfig struct {
 	// works (browsers will warn). See deploy/AGENTS.md.
 	CertFile string `yaml:"cert_file"`
 	KeyFile  string `yaml:"key_file"`
+	// DeviceID is a stable per-install identity (UUIDv4). Generated on first
+	// load and persisted so it survives restarts and IP changes (#330).
+	// Exposed via GET /api/health for LAN clients that anchor on an ID
+	// instead of an IP address.
+	DeviceID   string `yaml:"device_id,omitempty"`
+	DeviceName string `yaml:"device_name,omitempty"`
+	// Discovery controls how the NVR announces itself on the LAN for clients
+	// that cannot rely on subnet scanning or multicast (mDNS).
+	Discovery DiscoveryConfig `yaml:"discovery"`
 }
+
+// DiscoveryConfig groups LAN self-announcement mechanisms.
+type DiscoveryConfig struct {
+	UDP UDPDiscoveryConfig `yaml:"udp"`
+}
+
+// UDPDiscoveryConfig is the UDP broadcast responder (MIBEE-NVR-DISC/v1, #334):
+// listens on 0.0.0.0:49090 and answers the exact probe "MIBEE-NVR-DISCv1?"
+// with a unicast JSON identity payload. This is the discovery fallback for
+// multicast-restricted Wi-Fi where mDNS does not travel.
+type UDPDiscoveryConfig struct {
+	Enabled *bool `yaml:"enabled"` // default true
+	Port    int   `yaml:"port"`    // default DefaultUDPPort
+}
+
+// DefaultUDPPort is the default UDP listen port for the discovery responder.
+const DefaultUDPPort = 49090
 
 type StorageConfig struct {
 	RootDir         string `yaml:"root_dir"`         // default "/mnt/data/nvr"

--- a/internal/config/device_id.go
+++ b/internal/config/device_id.go
@@ -38,6 +38,7 @@ func EnsureDeviceIdentity(path string, cfg *Config) error {
 		return nil
 	}
 	if _, err := os.Stat(path); err != nil {
+		//nolint:nilerr // missing config file = caller built cfg out of band; deliberately a no-op
 		return nil
 	}
 	cfg.Server.DeviceID = newDeviceID()

--- a/internal/config/device_id.go
+++ b/internal/config/device_id.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"time"
+)
+
+// newDeviceID returns a random UUIDv4 string (RFC 4122). Built on crypto/rand
+// directly — one call site does not justify a third-party UUID dependency.
+func newDeviceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is effectively unrecoverable; derive from the
+		// clock so the process still starts with a syntactically valid ID.
+		seed := time.Now().UnixNano()
+		for i := range b {
+			b[i] = byte(seed >> (uint(i%8) * 8))
+		}
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// EnsureDeviceIdentity generates and persists the device ID on first startup.
+// Subsequent calls keep the stored value (identity must survive restarts and
+// IP changes). Only called from the startup path — deliberately NOT from
+// Load(), which is also used read-only (e.g. tests loading the shipped
+// config.example.yaml must not rewrite repo files). Skipped when the config
+// file does not exist (Load callers always have one; a missing file here
+// means the caller constructed cfg out of band). The rewrite is best-effort:
+// on failure the in-memory ID is kept and the caller logs a warning rather
+// than failing startup.
+func EnsureDeviceIdentity(path string, cfg *Config) error {
+	if cfg == nil || cfg.Server.DeviceID != "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+	cfg.Server.DeviceID = newDeviceID()
+	return Save(path, cfg)
+}

--- a/internal/config/device_id_test.go
+++ b/internal/config/device_id_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// reUUIDv4 matches the canonical 8-4-4-4-12 lowercase hex UUID form.
+var reUUIDv4 = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestNewDeviceIDIsUUIDv4(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]bool, 100)
+	for range 100 {
+		id := newDeviceID()
+		require.Regexp(t, reUUIDv4, id)
+		require.False(t, seen[id], "duplicate UUID in 100 draws: %s", id)
+		seen[id] = true
+	}
+}
+
+func TestEnsureDeviceIdentityGeneratesAndPersists(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mibee-nvr.yaml")
+
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	require.NoError(t, Save(path, cfg))
+	require.Empty(t, cfg.Server.DeviceID, "fresh config must not have an ID yet")
+
+	require.NoError(t, EnsureDeviceIdentity(path, cfg))
+	id := cfg.Server.DeviceID
+	require.Regexp(t, reUUIDv4, id)
+
+	// The ID must be persisted — a fresh Load keeps the same value.
+	reloaded, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, id, reloaded.Server.DeviceID)
+
+	// A second run over the persisted config must not rotate the ID.
+	require.NoError(t, EnsureDeviceIdentity(path, reloaded))
+	require.Equal(t, id, reloaded.Server.DeviceID, "existing persisted ID must be preserved")
+}
+
+func TestEnsureDeviceIdentitySkipsMissingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.yaml")
+
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	// No error, no file created — out-of-band configs are left alone.
+	require.NoError(t, EnsureDeviceIdentity(path, cfg))
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "must not create the config file")
+	require.Empty(t, cfg.Server.DeviceID, "no in-memory side effect when file is missing")
+}
+
+func TestEnsureDeviceIdentityKeepsExistingID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mibee-nvr.yaml")
+
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	cfg.Server.DeviceID = "pre-existing-id"
+	require.NoError(t, Save(path, cfg))
+
+	// Load returns a pointer; mutating the copy under test must not leak a rewrite.
+	require.NoError(t, EnsureDeviceIdentity(path, cfg))
+	require.Equal(t, "pre-existing-id", cfg.Server.DeviceID)
+}
+
+func TestDiscoveryDefaultsApplied(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	require.NotNil(t, cfg.Server.Discovery.UDP.Enabled)
+	require.True(t, *cfg.Server.Discovery.UDP.Enabled)
+	require.Equal(t, DefaultUDPPort, cfg.Server.Discovery.UDP.Port)
+	require.NotEmpty(t, cfg.Server.DeviceName, "device name defaults to hostname")
+}
+
+func TestDiscoveryPortValidation(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	cfg.Server.Discovery.UDP.Port = 70000
+	err := Validate(cfg)
+	require.ErrorContains(t, err, "server.discovery.udp.port")
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -84,6 +84,10 @@ func validateConfigDetails(cfg *Config) error {
 			return fmt.Errorf("server.tls_listen %q is set but server.cert_file / server.key_file are missing", cfg.Server.TLSListen)
 		}
 	}
+	// LAN discovery responder port validation (0 = not set, defaults applied)
+	if p := cfg.Server.Discovery.UDP.Port; p < 0 || p > 65535 {
+		return fmt.Errorf("server.discovery.udp.port must be between 1 and 65535, got %d", p)
+	}
 	// cameras must have id and url
 	seen := make(map[string]int)
 	for i, c := range cfg.Cameras {

--- a/internal/discovery/responder.go
+++ b/internal/discovery/responder.go
@@ -101,9 +101,13 @@ func (r *UDPResponder) Start(_ context.Context) error {
 	}
 	r.mu.Lock()
 	r.conn = conn
-	r.done = make(chan struct{})
+	done := make(chan struct{})
+	r.done = done
 	r.mu.Unlock()
-	go r.serve(conn)
+	// Pass done explicitly: reading r.done inside serve would race with Stop
+	// resetting the field to nil before the goroutine's first statement runs
+	// (observed as "panic: close of nil channel" under TestRunFree_SmokeStartStop).
+	go r.serve(conn, done)
 	slog.Info("discovery: udp responder listening", "addr", conn.LocalAddr().String())
 	return nil
 }
@@ -136,8 +140,8 @@ func (r *UDPResponder) Addr() *net.UDPAddr {
 	return r.conn.LocalAddr().(*net.UDPAddr)
 }
 
-func (r *UDPResponder) serve(conn *net.UDPConn) {
-	defer close(r.done)
+func (r *UDPResponder) serve(conn *net.UDPConn, done chan struct{}) {
+	defer close(done)
 	buf := make([]byte, probeBufSize)
 	for {
 		n, src, err := conn.ReadFromUDP(buf)

--- a/internal/discovery/responder.go
+++ b/internal/discovery/responder.go
@@ -1,0 +1,199 @@
+// Package discovery implements LAN self-announcement for NVR clients that
+// cannot rely on subnet scanning or multicast mDNS.
+//
+// UDP responder (MIBEE-NVR-DISC/v1, #334): listens on 0.0.0.0:49090 and
+// answers the exact probe "MIBEE-NVR-DISCv1?" with a unicast JSON payload:
+//
+//	{"v":1,"id":"<device_id>","name":"<device_name>","api":9090,"tls":false}
+//
+// This is the fallback for multicast-restricted Wi-Fi (common on consumer
+// APs) where mDNS does not travel. Clients treat the reply's source address
+// as the NVR host and are expected to cross-check GET /api/health before
+// trusting the responder — the payload deliberately carries no more
+// information than that already-public endpoint.
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ProbeV1 is the exact byte payload a client sends to discover NVRs.
+const ProbeV1 = "MIBEE-NVR-DISCv1?"
+
+// probeBufSize caps the datagram we are willing to read; anything larger
+// than the probe cannot match it and is dropped without a reply.
+const probeBufSize = 64
+
+// replyMinInterval throttles replies per source IP so a probe flood cannot
+// turn the responder into a broadcast amplification vector.
+const replyMinInterval = 100 * time.Millisecond
+
+// replyIPCacheCap bounds the per-IP throttle map; when full it is reset
+// rather than grown (a reset only briefly restores the rate limit for
+// previously-throttled IPs — acceptable for a discovery convenience path).
+const replyIPCacheCap = 1024
+
+// udpResponse is the MIBEE-NVR-DISC/v1 reply payload.
+type udpResponse struct {
+	V    int    `json:"v"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	API  int    `json:"api"`
+	TLS  bool   `json:"tls"`
+}
+
+// UDPResponder answers MIBEE-NVR-DISC/v1 probes over UDP. It implements the
+// pkg/app.Service interface (Name/Start/Stop).
+type UDPResponder struct {
+	payload []byte
+	port    int
+
+	mu   sync.Mutex
+	conn *net.UDPConn
+	done chan struct{}
+
+	lastReplyMu sync.Mutex
+	lastReply   map[string]time.Time
+}
+
+// NewUDPResponder pre-marshals the identity payload. apiPort is the HTTP API
+// port (parsed from server.listen via ParseAPIPort); tls reports whether the
+// HTTPS listener is enabled. port 0 binds an ephemeral port (tests).
+func NewUDPResponder(deviceID, deviceName string, apiPort int, tls bool, port int) *UDPResponder {
+	payload, err := json.Marshal(udpResponse{
+		V:    1,
+		ID:   deviceID,
+		Name: deviceName,
+		API:  apiPort,
+		TLS:  tls,
+	})
+	if err != nil {
+		// json.Marshal of this plain struct cannot fail; keep the zero value
+		// so Start still listens (and drops probes) rather than panicking.
+		slog.Error("discovery: marshal response payload", "error", err)
+		payload = nil
+	}
+	return &UDPResponder{
+		payload:   payload,
+		port:      port,
+		lastReply: make(map[string]time.Time),
+	}
+}
+
+// Name implements pkg/app.Service.
+func (r *UDPResponder) Name() string { return "discovery" }
+
+// Start binds the UDP socket and serves probes until Stop. A bind failure
+// (e.g. port already in use) is returned to the caller, who treats the
+// responder as optional and logs without failing startup.
+func (r *UDPResponder) Start(_ context.Context) error {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: r.port})
+	if err != nil {
+		return fmt.Errorf("bind udp %d: %w", r.port, err)
+	}
+	r.mu.Lock()
+	r.conn = conn
+	r.done = make(chan struct{})
+	r.mu.Unlock()
+	go r.serve(conn)
+	slog.Info("discovery: udp responder listening", "addr", conn.LocalAddr().String())
+	return nil
+}
+
+// Stop closes the socket and waits for the serve goroutine to exit.
+func (r *UDPResponder) Stop() error {
+	r.mu.Lock()
+	conn := r.conn
+	done := r.done
+	r.conn = nil
+	r.done = nil
+	r.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if done != nil {
+		<-done
+	}
+	return nil
+}
+
+// Addr returns the bound UDP address (nil before Start or after Stop).
+// Primarily for tests binding to ephemeral port 0.
+func (r *UDPResponder) Addr() *net.UDPAddr {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.conn == nil {
+		return nil
+	}
+	return r.conn.LocalAddr().(*net.UDPAddr)
+}
+
+func (r *UDPResponder) serve(conn *net.UDPConn) {
+	defer close(r.done)
+	buf := make([]byte, probeBufSize)
+	for {
+		n, src, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			return // socket closed by Stop, or unrecoverable read error
+		}
+		if string(buf[:n]) != ProbeV1 {
+			continue
+		}
+		if !r.allowReply(src.IP.String()) {
+			continue
+		}
+		if _, err := conn.WriteToUDP(r.payload, src); err != nil {
+			// Commonly ECONNREFUSED after the probing socket closed; keep serving.
+			continue
+		}
+	}
+}
+
+// allowReply enforces the per-IP throttle.
+func (r *UDPResponder) allowReply(ip string) bool {
+	now := time.Now()
+	r.lastReplyMu.Lock()
+	defer r.lastReplyMu.Unlock()
+	if len(r.lastReply) >= replyIPCacheCap {
+		r.lastReply = make(map[string]time.Time)
+	}
+	if t, ok := r.lastReply[ip]; ok && now.Sub(t) < replyMinInterval {
+		return false
+	}
+	r.lastReply[ip] = now
+	return true
+}
+
+// ParseAPIPort extracts the numeric port from a server.listen value. Accepts
+// ":9090", "0.0.0.0:9090", "192.0.2.1:9090", and bare "9090". Returns the
+// default 9090 for anything unparseable — the reply is advisory, and clients
+// re-verify against /api/health anyway.
+func ParseAPIPort(listen string) int {
+	listen = strings.TrimSpace(listen)
+	if listen == "" {
+		return 9090
+	}
+	if !strings.Contains(listen, ":") {
+		if p, err := strconv.Atoi(listen); err == nil && p > 0 && p < 65536 {
+			return p
+		}
+		return 9090
+	}
+	_, portStr, err := net.SplitHostPort(listen)
+	if err != nil {
+		return 9090
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil || p <= 0 || p > 65535 {
+		return 9090
+	}
+	return p
+}

--- a/internal/discovery/responder_test.go
+++ b/internal/discovery/responder_test.go
@@ -1,0 +1,116 @@
+package discovery
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startTestResponder starts a responder on an ephemeral port and returns it
+// plus the bound address.
+func startTestResponder(t *testing.T) (*UDPResponder, *net.UDPAddr) {
+	t.Helper()
+	r := NewUDPResponder("test-device-id", "test-host", 9090, false, 0)
+	require.NoError(t, r.Start(t.Context()))
+	addr := r.Addr()
+	require.NotNil(t, addr, "responder did not bind")
+	t.Cleanup(func() { _ = r.Stop() })
+	return r, addr
+}
+
+// probeOnce sends a single datagram and waits for a reply.
+func probeOnce(t *testing.T, addr *net.UDPAddr, payload string, wait time.Duration) ([]byte, bool) {
+	t.Helper()
+	c, err := net.DialUDP("udp4", nil, addr)
+	require.NoError(t, err)
+	defer c.Close()
+	_, err = c.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, c.SetReadDeadline(time.Now().Add(wait)))
+	buf := make([]byte, 512)
+	n, err := c.Read(buf)
+	if err != nil {
+		return nil, false
+	}
+	return buf[:n], true
+}
+
+func TestUDPResponder_ReplyPayload(t *testing.T) {
+	t.Parallel()
+	_, addr := startTestResponder(t)
+
+	reply, ok := probeOnce(t, addr, ProbeV1, 2*time.Second)
+	require.True(t, ok, "expected a reply to the v1 probe")
+
+	var got struct {
+		V    int    `json:"v"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		API  int    `json:"api"`
+		TLS  bool   `json:"tls"`
+	}
+	require.NoError(t, json.Unmarshal(reply, &got))
+	require.Equal(t, 1, got.V)
+	require.Equal(t, "test-device-id", got.ID)
+	require.Equal(t, "test-host", got.Name)
+	require.Equal(t, 9090, got.API)
+	require.False(t, got.TLS)
+}
+
+func TestUDPResponder_IgnoresForeignPayload(t *testing.T) {
+	t.Parallel()
+	_, addr := startTestResponder(t)
+
+	// Wrong payload and near-miss variants must not trigger a reply.
+	for _, p := range []string{
+		"",
+		"MIBEE-NVR-DISCv1",        // missing '?'
+		"mibee-nvr-discv1?",       // wrong case
+		"MIBEE-NVR-DISCv1? extra", // trailing bytes
+		"\x00\x01\x02",
+	} {
+		_, ok := probeOnce(t, addr, p, 300*time.Millisecond)
+		require.False(t, ok, "unexpected reply to payload %q", p)
+	}
+}
+
+func TestUDPResponder_RateLimitPerIP(t *testing.T) {
+	t.Parallel()
+	_, addr := startTestResponder(t)
+
+	reply, ok := probeOnce(t, addr, ProbeV1, 2*time.Second)
+	require.True(t, ok, "first probe must be answered")
+	require.NotEmpty(t, reply)
+
+	// An immediate second probe from the same source is throttled.
+	_, ok = probeOnce(t, addr, ProbeV1, 300*time.Millisecond)
+	require.False(t, ok, "second probe within the throttle window must not be answered")
+}
+
+func TestUDPResponder_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := startTestResponder(t)
+	require.NoError(t, r.Stop())
+	require.NoError(t, r.Stop())
+	require.Nil(t, r.Addr(), "Addr must be nil after Stop")
+}
+
+func TestParseAPIPort(t *testing.T) {
+	t.Parallel()
+	cases := map[string]int{
+		"":              9090,
+		":9090":         9090,
+		"0.0.0.0:9090":  9090,
+		"192.0.2.1:80":  80,
+		"9091":          9091,
+		"host.example:": 9090, // empty port
+		"not-a-port":    9090,
+		":-1":           9090,
+	}
+	for in, want := range cases {
+		require.Equal(t, want, ParseAPIPort(in), "input %q", in)
+	}
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -61,6 +61,13 @@ import (
 func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), error) {
 	deps := &appDeps{cfg: cfg, configPath: configPath}
 
+	// Step -1: Stable device identity (#330) — generate + persist the
+	// device_id on first startup so LAN clients can anchor on an ID instead
+	// of an IP. Best-effort: a read-only config keeps the in-memory ID.
+	if err := config.EnsureDeviceIdentity(configPath, cfg); err != nil {
+		slog.Warn("failed to persist device identity", "path", configPath, "error", err)
+	}
+
 	// Step 0: Ensure storage root directory exists
 	if err := os.MkdirAll(cfg.Storage.RootDir, 0o755); err != nil {
 		return nil, nil, fmt.Errorf("create storage dir %s: %w", cfg.Storage.RootDir, err)

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -14,6 +14,8 @@ import (
 	"log/slog"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/autodiscover"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/discovery"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 )
 
@@ -381,6 +383,39 @@ func registerServices(a *App, deps *appDeps) error {
 			},
 		}); err != nil {
 			return fmt.Errorf("register gb28181: %w", err)
+		}
+	}
+
+	// 11.7. discovery (optional) — UDP broadcast responder (MIBEE-NVR-DISC/v1)
+	// for LAN clients on multicast-restricted networks. Bind failures are
+	// logged, never fatal: discovery is a convenience path. Treated as enabled
+	// when the pointer is nil so manually-constructed configs (tests) behave
+	// like ApplyDefaults output.
+	if deps.cfg.Server.Discovery.UDP.Enabled == nil || *deps.cfg.Server.Discovery.UDP.Enabled {
+		port := deps.cfg.Server.Discovery.UDP.Port
+		if port == 0 {
+			port = config.DefaultUDPPort
+		}
+		responder := discovery.NewUDPResponder(
+			deps.cfg.Server.DeviceID,
+			deps.cfg.Server.DeviceName,
+			discovery.ParseAPIPort(deps.cfg.Server.Listen),
+			deps.cfg.Server.TLSListen != "",
+			port,
+		)
+		if err := a.Register(&serviceFunc{
+			name: "discovery",
+			startFunc: func(ctx context.Context) error {
+				if err := responder.Start(ctx); err != nil {
+					slog.Error("discovery: udp responder disabled", "error", err)
+				}
+				return nil
+			},
+			stopFunc: func() error {
+				return responder.Stop()
+			},
+		}); err != nil {
+			return fmt.Errorf("register discovery: %w", err)
 		}
 	}
 

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -14,7 +14,6 @@ import (
 	"log/slog"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/autodiscover"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/discovery"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 )
@@ -390,18 +389,15 @@ func registerServices(a *App, deps *appDeps) error {
 	// for LAN clients on multicast-restricted networks. Bind failures are
 	// logged, never fatal: discovery is a convenience path. Treated as enabled
 	// when the pointer is nil so manually-constructed configs (tests) behave
-	// like ApplyDefaults output.
+	// like ApplyDefaults output. Port 0 binds an ephemeral port (tests);
+	// ApplyDefaults supplies 49090 for real configs.
 	if deps.cfg.Server.Discovery.UDP.Enabled == nil || *deps.cfg.Server.Discovery.UDP.Enabled {
-		port := deps.cfg.Server.Discovery.UDP.Port
-		if port == 0 {
-			port = config.DefaultUDPPort
-		}
 		responder := discovery.NewUDPResponder(
 			deps.cfg.Server.DeviceID,
 			deps.cfg.Server.DeviceName,
 			discovery.ParseAPIPort(deps.cfg.Server.Listen),
 			deps.cfg.Server.TLSListen != "",
-			port,
+			deps.cfg.Server.Discovery.UDP.Port,
 		)
 		if err := a.Register(&serviceFunc{
 			name: "discovery",

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -141,6 +141,10 @@ func minimalConfig(t *testing.T) (*config.Config, string) {
 	cfg.Transcoding.Enabled = false
 	cfg.RemoteLog.Enabled = false
 	cfg.Health.Enabled = false
+	// Keep the UDP discovery responder out of the shared tests — it would bind
+	// the well-known port 49090; TestRunFree_DiscoveryService covers it on an
+	// ephemeral port instead.
+	cfg.Server.Discovery.UDP.Enabled = &falseVal
 
 	return cfg, dir
 }
@@ -227,6 +231,41 @@ func TestRunFree_ServiceOrder_GB28181Disabled(t *testing.T) {
 	for _, name := range svcs {
 		if name == "gb28181" {
 			t.Errorf("Services() contains %q, want absent when gb28181.enabled=false", name)
+		}
+	}
+}
+
+// TestRunFree_ServiceOrder_DiscoveryEnabled asserts the UDP discovery
+// responder registers in the discovery slot (after archive-deleter, before ws)
+// when enabled. Binds an ephemeral port (0) so parallel test runs never
+// contend for the production port 49090.
+func TestRunFree_ServiceOrder_DiscoveryEnabled(t *testing.T) {
+	t.Helper()
+	cfg, _ := minimalConfig(t)
+
+	trueVal := true
+	cfg.Server.Discovery.UDP.Enabled = &trueVal
+	cfg.Server.Discovery.UDP.Port = 0
+
+	a, err := RunFree(cfg, filepath.Join(cfg.Storage.RootDir, "mibee-nvr.yaml"))
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+
+	svcs := a.Services()
+	t.Logf("observed Services() = %v", svcs)
+
+	expected := []string{"db", "startup-bg", "camera", "health", "merge", "rolling-merge", "mergeScheduler", "cleanup", "archive-deleter", "discovery", "ws", "hls", "api-handler"}
+	if len(svcs) != len(expected) {
+		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
+	}
+	for i, want := range expected {
+		if i >= len(svcs) {
+			t.Errorf("Services()[%d] missing, want %q", i, want)
+			continue
+		}
+		if svcs[i] != want {
+			t.Errorf("Services()[%d] = %q, want %q", i, svcs[i], want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #330, Closes #334.

## What

**Device identity (#330)**
- `server.device_id`: UUIDv4 generated on first startup and persisted to the config — survives restarts and IP changes. `server.device_name` defaults to the system hostname (explicit value overrides).
- `GET /api/health` (public) now carries `device_id` / `device_name` so LAN clients can anchor on a stable identity instead of an IP address.

**UDP discovery responder (#334)**
- New `internal/discovery` package implementing the MIBEE-NVR-DISC/v1 protocol: listens on `0.0.0.0:49090` and answers the exact probe `MIBEE-NVR-DISCv1?` with a unicast JSON identity payload (`{v,id,name,api,tls}`).
- The fallback for multicast-restricted Wi-Fi where mDNS does not travel. The payload carries no more information than the already-public `/api/health`.
- Per-IP reply throttle (100 ms) prevents broadcast amplification; bind failures are logged and never block startup.
- Config: `server.discovery.udp.{enabled,port}`, default on / 49090.

## Notes
- Identity generation lives in the startup path (not `config.Load`) so read-only loads (tests reading `config.example.yaml`) never rewrite repo files.
- Registering as an app service: a fast Stop could race the serve goroutine reading the done channel (`close of nil channel` under `-race`) — fixed by passing the channel explicitly; covered by a dedicated service-order test on an ephemeral port.

## Tested
- Unit tests: config identity generation/persistence/skip-missing-file, discovery reply payload / foreign-payload drop / per-IP throttle / stop idempotence, health handler identity fields.
- Full `go test -race ./...` green (Linux x86_64).
- Real-device validation on the Banana Pi M5: health returns the ID, ID stable across service restarts (persisted in YAML), cross-host unicast + directed-broadcast probes answered correctly (`tls` flag reflects the HTTPS listener), throttle effective, no new log errors, Web UI unaffected.