### PR TITLE
fix(api): /api/cameras/{id}/protocols entries now snake_case (#332)

### DIFF
--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -69,10 +69,12 @@ func (r *StreamRegistry) protocolsForCodec(codec model.Format) []string {
 }
 
 // ProtocolDetail describes a protocol's availability for the API response.
+// json tags are snake_case like every other API response field (#332) —
+// the Go field names used to leak through encoding/json's default naming.
 type ProtocolDetail struct {
-	Protocol  string
-	Available bool
-	Reason    string
+	Protocol  string `json:"protocol"`
+	Available bool   `json:"available"`
+	Reason    string `json:"reason"`
 }
 
 // ProtocolsDetailForCodec returns detailed protocol availability for the given codec.

--- a/web/src/components/ProtocolSwitcher.svelte
+++ b/web/src/components/ProtocolSwitcher.svelte
@@ -111,13 +111,13 @@
     try {
       const result = await apiRequest<ProtocolsResponse>(`/cameras/${cameraId}/protocols`);
       availableProtocols = result.protocols
-        .filter(p => p.Available)
-        .map(p => p.Protocol);
+        .filter(p => p.available)
+        .map(p => p.protocol);
       // Store backend reasons for unavailable protocols
       const reasons: Record<string, string> = {};
       for (const p of result.protocols) {
-        if (!p.Available && p.Reason) {
-          reasons[p.Protocol] = p.Reason;
+        if (!p.available && p.reason) {
+          reasons[p.protocol] = p.reason;
         }
       }
       protocolReasons = reasons;

--- a/web/src/lib/__tests__/stream-selection.test.ts
+++ b/web/src/lib/__tests__/stream-selection.test.ts
@@ -21,11 +21,11 @@ const H264_RESP: ProtocolsResponse = {
   encoding: 'h264',
   default: 'webrtc',
   protocols: [
-    { Protocol: 'webrtc', Available: true, Reason: '' },
-    { Protocol: 'flv', Available: true, Reason: '' },
-    { Protocol: 'll-hls', Available: true, Reason: '' },
-    { Protocol: 'hls', Available: true, Reason: '' },
-    { Protocol: 'wasm', Available: true, Reason: '' },
+    { protocol: 'webrtc', available: true, reason: '' },
+    { protocol: 'flv', available: true, reason: '' },
+    { protocol: 'll-hls', available: true, reason: '' },
+    { protocol: 'hls', available: true, reason: '' },
+    { protocol: 'wasm', available: true, reason: '' },
   ],
 };
 
@@ -34,11 +34,11 @@ const H265_RESP: ProtocolsResponse = {
   encoding: 'h265',
   default: 'hls',
   protocols: [
-    { Protocol: 'hls', Available: true, Reason: '' },
-    { Protocol: 'll-hls', Available: true, Reason: '' },
-    { Protocol: 'wasm', Available: true, Reason: '' },
-    { Protocol: 'webrtc', Available: false, Reason: 'WebRTC does not support H.265' },
-    { Protocol: 'flv', Available: false, Reason: 'FLV cannot decode H.265 in browser' },
+    { protocol: 'hls', available: true, reason: '' },
+    { protocol: 'll-hls', available: true, reason: '' },
+    { protocol: 'wasm', available: true, reason: '' },
+    { protocol: 'webrtc', available: false, reason: 'WebRTC does not support H.265' },
+    { protocol: 'flv', available: false, reason: 'FLV cannot decode H.265 in browser' },
   ],
 };
 
@@ -51,7 +51,7 @@ describe('pickCameraMode', () => {
     const resp: ProtocolsResponse = {
       encoding: 'jpeg',
       default: 'mjpeg',
-      protocols: [{ Protocol: 'mjpeg', Available: true, Reason: '' }],
+      protocols: [{ protocol: 'mjpeg', available: true, reason: '' }],
     };
     expect(pickCameraMode(cam, resp, FULL_CAPS)).toBe('mjpeg');
   });

--- a/web/src/lib/stream-selection.ts
+++ b/web/src/lib/stream-selection.ts
@@ -33,9 +33,9 @@ export function isAudioCapable(camera: Camera): boolean {
 
 /** Mirrors the backend `cameraProtocolsResponse` (internal/api/handler.go:533). */
 export interface ProtocolDetail {
-  Protocol: string;
-  Available: boolean;
-  Reason: string;
+  protocol: string;
+  available: boolean;
+  reason: string;
 }
 
 export interface ProtocolsResponse {
@@ -73,7 +73,7 @@ export const FALLBACK_ORDER: readonly CameraMode[] = ['webrtc', 'flv', 'hls', 'm
  */
 export function fallbackChain(resp: ProtocolsResponse | null): CameraMode[] {
   if (!resp) return [];
-  const available = new Set(resp.protocols.filter((p) => p.Available).map((p) => p.Protocol.toLowerCase()));
+  const available = new Set(resp.protocols.filter((p) => p.available).map((p) => p.protocol.toLowerCase()));
   const chain: CameraMode[] = [];
   for (const proto of FALLBACK_ORDER) {
     if (available.has(proto)) chain.push(proto);
@@ -156,7 +156,7 @@ export function pickCameraMode(
     return opts.isUnsupported ? 'unsupported' : 'snapshot';
   }
 
-  const available = new Set(resp ? resp.protocols.filter((p) => p.Available).map((p) => p.Protocol.toLowerCase()) : []);
+  const available = new Set(resp ? resp.protocols.filter((p) => p.available).map((p) => p.protocol.toLowerCase()) : []);
   const backendDefault = (resp?.default || '').toLowerCase();
 
   // Choose the "candidate" protocol: override > backend default > legacy.
@@ -297,7 +297,7 @@ export function buildCandidateChain(
     return [];
   }
 
-  const available = new Set(resp ? resp.protocols.filter((p) => p.Available).map((p) => p.Protocol.toLowerCase()) : []);
+  const available = new Set(resp ? resp.protocols.filter((p) => p.available).map((p) => p.protocol.toLowerCase()) : []);
 
   // (3) User override pins the chain to a single mode (if still usable).
   // When the backend response is null (fetch failed, NOT "empty list"), we have


### PR DESCRIPTION
Closes #332.

`ProtocolDetail` had no json tags, so Go field names (`Protocol`/`Available`/`Reason`) leaked into the wire format — inconsistent with every other endpoint's snake_case. Adds tags and updates the web SPA consumers (`ProtocolDetail` type, `ProtocolSwitcher`, `stream-selection` usage sites) plus test fixtures.

## Tested
- Full `go test -race ./...` green (Linux x86_64).
- Frontend build + stream-selection unit tests (49) green.
- Real-device check on the Banana Pi M5: endpoint returns `{"protocols":[{"protocol":"mjpeg","available":true,"reason":""}],...}`; Surveillance grid renders and H.265 cameras select the WebCodecs player (chain built from the renamed fields).