### PR TITLE
chore(db): whitelist CheckpointWAL mode before SQL interpolation (#318)

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -513,6 +513,13 @@ func (d *DB) Optimize(ctx context.Context) error {
 // CheckpointWAL performs a WAL checkpoint operation.
 // Mode can be "PASSIVE", "FULL", "RESTART", or "TRUNCATE".
 func (d *DB) CheckpointWAL(ctx context.Context, mode string) (busy int, logFrames int, checkpointedFrames int, err error) {
+	// PRAGMA does not accept bound parameters, so the mode is interpolated into
+	// the statement text — whitelist it so no caller can smuggle arbitrary SQL.
+	switch mode {
+	case "PASSIVE", "FULL", "RESTART", "TRUNCATE":
+	default:
+		return 0, 0, 0, fmt.Errorf("invalid checkpoint mode: %q", mode)
+	}
 	query := fmt.Sprintf("PRAGMA wal_checkpoint(%s)", mode)
 	row := d.db.QueryRowContext(ctx, query)
 	err = row.Scan(&busy, &logFrames, &checkpointedFrames)

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1625,6 +1625,22 @@ func TestCheckpointWALTruncate(t *testing.T) {
 	t.Logf("TRUNCATE checkpoint: busy=%d logFrames=%d ckptFrames=%d", busy, logFrames, ckptFrames)
 }
 
+func TestCheckpointWALInvalidMode(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test_ckpt_invalid.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	defer db.Close()
+
+	for _, mode := range []string{"", "passive", "PASSIVE) OR 1=1--", "TRUNCATE; DROP TABLE recordings"} {
+		_, _, _, err := db.CheckpointWAL(ctx, mode)
+		require.Error(t, err, "mode %q must be rejected", mode)
+		require.Contains(t, err.Error(), "invalid checkpoint mode")
+	}
+}
+
 func TestGetWALSize(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test_walsize.db")


### PR DESCRIPTION
Closes #318

## Summary
- `CheckpointWAL` interpolates the mode into a `PRAGMA` statement (PRAGMA does not accept bound parameters). Added the whitelist `switch` proposed in the issue — only `PASSIVE`/`FULL`/`RESTART`/`TRUNCATE` pass through; anything else returns an error before reaching SQL.
- Unit test covers the default branch with empty/lowercase/SQL-injection-shaped inputs.

The audit in the issue already confirmed the other scanner hits (patterns 1–5) are false positives with values bound via `?`; no changes needed there. The optional cnb.cool scanner-side suppression (action item 2) is platform work outside this repo.