### PR TITLE
fix(gb28181): live view freezes every ~3min — long-GOP session recycling + stale WebRTC hub binding

### DIFF
--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -49,9 +49,12 @@ const speculativeAckDelay = 2500 * time.Millisecond
 
 // Session-watchdog tuning: recycle a session when the stream stalls for
 // streamStaleAfter or no keyframe has been seen for idrStaleAfter (checked
-// every idrWatchInterval).
+// every idrWatchInterval). idrStaleAfter must comfortably exceed real
+// devices' GOP lengths — IPCs with 2-4 minute GOPs are common, and a
+// threshold inside the GOP recycles healthy streams forever (observed: a
+// ~3min-GOP source recycled every ~80s, breaking every live view each cycle).
 const (
-	idrStaleAfter    = 75 * time.Second
+	idrStaleAfter    = 10 * time.Minute
 	streamStaleAfter = 45 * time.Second
 	idrWatchInterval = 15 * time.Second
 )

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -298,16 +298,25 @@ func (m *Manager) RegisterStream(camID string, hub *model.StreamHub, sps []byte)
 		return
 	}
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.streamProfile[camID] = fmtpForProfile(sps)
-	if _, ok := m.hubSubs[camID]; ok {
-		return // already registered
+	if sub, ok := m.hubSubs[camID]; ok {
+		if sub.hub == hub {
+			m.mu.Unlock()
+			return // already registered on this hub
+		}
+		m.mu.Unlock()
+		// The GB session was recycled (or the recorder restarted) and handed
+		// out a NEW hub — resubscribe, or every viewer stays fed by the dead
+		// one (frozen video until a page reload re-registers).
+		sub.hub.Unsubscribe(sub.subID)
+		m.mu.Lock()
 	}
 	subID := "webrtc-" + camID
 	_ = hub.Subscribe(subID, func(pts int64, au [][]byte) {
 		m.WriteH264(camID, pts, au)
 	})
 	m.hubSubs[camID] = &hubSubscription{hub: hub, subID: subID}
+	m.mu.Unlock()
 	logger.Info("WebRTC stream registered", "camera_id", camID)
 }
 

--- a/internal/webrtc/manager_test.go
+++ b/internal/webrtc/manager_test.go
@@ -879,3 +879,27 @@ func TestFmtpForProfile(t *testing.T) {
 		"level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f",
 		fmtpForProfile(nil), "no SPS yet")
 }
+
+// TestRegisterStreamRebindsOnHubChange: a GB session recycle hands out a NEW
+// hub — RegisterStream must resubscribe (the old guard kept feeding viewers
+// from the dead hub: frozen video until a page reload).
+func TestRegisterStreamRebindsOnHubChange(t *testing.T) {
+	m := NewManager()
+	hub1 := model.NewStreamHub()
+	hub2 := model.NewStreamHub()
+
+	m.RegisterStream("cam-rebind", hub1, nil)
+	require.Same(t, hub1, m.hubSubs["cam-rebind"].hub)
+
+	// Same hub re-registration stays a no-op.
+	m.RegisterStream("cam-rebind", hub1, nil)
+	require.Same(t, hub1, m.hubSubs["cam-rebind"].hub)
+
+	// New hub swaps the subscription.
+	m.RegisterStream("cam-rebind", hub2, nil)
+	require.Same(t, hub2, m.hubSubs["cam-rebind"].hub)
+	require.Equal(t, "webrtc-cam-rebind", m.hubSubs["cam-rebind"].subID)
+
+	m.UnregisterStream("cam-rebind")
+	require.Nil(t, m.hubSubs["cam-rebind"])
+}


### PR DESCRIPTION
## Symptom
All GB-channel live views freeze a few minutes in (users read it as "国标摄像头都看不了"); a page reload temporarily fixes it.

## Root causes (two, compounding)
1. **Session watchdog recycled healthy long-GOP streams forever.** `idrStaleAfter` was 75s while the source camera's GOP is ~80s — the watchdog ("no keyframe", `since_last_packet=0s`) BYE+re-INVITEd right before every natural IDR, on a ~3:17 loop.
2. **Each recycle replaced the channel's StreamHub, but WebRTC viewers stayed bound to the dead one.** `RegisterStream`'s already-registered guard ignored the new hub → frozen track until a page reload re-registered.

## Fix
- `idrStaleAfter`: 75s → 10min (long GOPs are legal; recycle remains a safety net for genuinely IDR-less encoders)
- `RegisterStream`: rebinds to a changed hub (unsubscribe old → subscribe new); same-hub calls stay no-ops
- Unit test for the rebind path

## Verified on hardware
- pion WHEP probe: 60s+ continuous receive, zero stalls (previously froze within seconds in-browser)
- 10-min window post-fix: zero session recycles (was one every ~3:17)
- Unattended recovery path exercised: source device dropped and re-registered → BYE → re-INVITE → first RTP → frames resume, no manual reload needed