### PR TITLE
feat(vision): offline compensation re-push — recover missed segments on heartbeat return (#329)

### DIFF
--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -248,6 +248,34 @@ func (d *DB) ListRecordings(ctx context.Context, filter model.RecordingFilter) (
 	return scanRecordingRows(rows)
 }
 
+// ListRecordingsForVisionRepush returns up to limit recordings whose segments
+// completed within [since, until] and that Vision has not finished processing —
+// the offline-compensation window for the vision push coordinator (#329).
+// The window is keyed on ended_at (completion): segments that started before
+// the pause but landed while offline must still be compensated; a small grace
+// on since covers ordering slack between segment completion and the push
+// attempt. Excludes timelapse segments (never pushed live) and merged segments
+// (files are typically reclaimed by the merge pipeline), and drops anything
+// already in a terminal ai_status (completed/failed).
+func (d *DB) ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error) {
+	defer d.observeQuery("ListRecordingsForVisionRepush", time.Now())
+	rows, err := d.readConn().QueryContext(ctx, `
+		SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived
+		FROM recordings
+		WHERE ended_at>=? AND ended_at<=?
+			AND format != 'timelapse'
+			AND COALESCE(merge_status,'') NOT IN ('merged','daily_merged')
+			AND COALESCE(ai_status,'') IN ('','pending','processing')
+		ORDER BY started_at ASC
+		LIMIT ?;`,
+		timeToDB(since.Add(-time.Minute)), timeToDB(until), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list recordings for vision repush: %w", err)
+	}
+	defer rows.Close()
+	return scanRecordingRows(rows)
+}
+
 // ListRecordingsWithTotal returns a page of recordings plus the total count matching the
 // filter. It runs ListRecordings (covering index, no sort) for the page, and a cached
 // CountRecordingsWithFilter for the total — collapsing repeated counts for the same

--- a/internal/storage/db_vision_repush_test.go
+++ b/internal/storage/db_vision_repush_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRecordingsForVisionRepush(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	insert := func(id string, format model.Format, startedAt, endedAt time.Time, mergeStatus, aiStatus string) {
+		t.Helper()
+		r := &model.Recording{
+			ID: id, CameraID: "cam1", FilePath: "/data/" + id + ".mp4",
+			Format: format, StartedAt: startedAt, EndedAt: endedAt,
+			FileSize: 100, FrameCount: 10,
+		}
+		if mergeStatus != "" {
+			r.MergeStatus = mergeStatus
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+		if aiStatus != "" {
+			require.NoError(t, db.UpdateRecordingAIStatus(ctx, id, aiStatus, ""))
+		}
+	}
+
+	insert("repush-pending", "mp4", now.Add(-20*time.Minute), now.Add(-19*time.Minute), "", "")
+	insert("repush-processing", "mp4", now.Add(-18*time.Minute), now.Add(-17*time.Minute), "", "processing")
+	insert("skip-completed", "mp4", now.Add(-16*time.Minute), now.Add(-15*time.Minute), "", "completed")
+	insert("skip-failed", "mp4", now.Add(-14*time.Minute), now.Add(-13*time.Minute), "", "failed")
+	insert("skip-timelapse", "timelapse", now.Add(-12*time.Minute), now.Add(-11*time.Minute), "", "")
+	insert("skip-merged", "mp4", now.Add(-10*time.Minute), now.Add(-9*time.Minute), "merged", "")
+	// Completed before the offline window (ended 3h ago) — outside bounds.
+	insert("skip-old", "mp4", now.Add(-3*time.Hour), now.Add(-3*time.Hour+time.Minute), "", "")
+
+	recs, err := db.ListRecordingsForVisionRepush(ctx, now.Add(-2*time.Hour), now, 500)
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(recs))
+	for _, r := range recs {
+		ids = append(ids, r.ID)
+	}
+	require.ElementsMatch(t, []string{"repush-pending", "repush-processing"}, ids,
+		"only non-terminal, non-timelapse, non-merged segments inside the window qualify")
+
+	// Limit is honored (ascending start order).
+	capped, err := db.ListRecordingsForVisionRepush(ctx, now.Add(-2*time.Hour), now, 1)
+	require.NoError(t, err)
+	require.Len(t, capped, 1)
+	require.Equal(t, "repush-pending", capped[0].ID)
+}

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -17,37 +17,63 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
+
+// Offline-compensation bounds (#329). A long offline gap is capped so the
+// recovery burst can't storm Vision or the disk; segments beyond the window
+// are skipped (they would mostly be merged away anyway).
+const (
+	repushWindow = 2 * time.Hour
+	repushMax    = 500
+	repushPacing = 200 * time.Millisecond
+)
+
+// Repusher abstracts the recordings lookup needed for offline compensation.
+// Production wiring passes *storage.DB; tests use fakes. Kept as an interface
+// so the coordinator stays testable without SQLite.
+type Repusher interface {
+	ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error)
+}
 
 // Coordinator 订阅 segment.completed 事件,在 Vision 健康时把视频文件推送给 Vision。
 type Coordinator struct {
-	health      *HealthTracker
-	eventBus    *event.EventBus
-	eventCh     chan event.Event
-	cfg         func() config.VisionConfig
-	storageRoot func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
-	client      *http.Client
-	wg          sync.WaitGroup
-	cancelFn    context.CancelFunc
-	mu          sync.Mutex
+	health       *HealthTracker
+	eventBus     *event.EventBus
+	eventCh      chan event.Event
+	cfg          func() config.VisionConfig
+	storageRoot  func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
+	db           Repusher      // nil → 补偿重推禁用(测试/降级部署)
+	client       *http.Client
+	wg           sync.WaitGroup
+	cancelFn     context.CancelFunc
+	mu           sync.Mutex
+	runCtx       context.Context // 供恢复回调 goroutine 使用(Start 时设置)
+	pausedSince  time.Time       // 推送暂停窗口起点(mu 保护;零值=未暂停)
+	compensating atomic.Bool     // 补偿重推 single-flight
 }
 
-// NewCoordinator 创建推送协调器。
-func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus) *Coordinator {
+// NewCoordinator 创建推送协调器。db 可为 nil(禁用离线补偿)。
+func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus, db Repusher) *Coordinator {
 	vcfg := cfg()
-	return &Coordinator{
+	c := &Coordinator{
 		health:      NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
 		eventBus:    eventBus,
 		cfg:         cfg,
 		storageRoot: storageRoot,
+		db:          db,
 		client: &http.Client{
 			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
 	}
+	// 心跳恢复(不健康→健康)触发离线补偿重推 (#329)。
+	c.health.SetOnRecovery(c.compensateOffline)
+	return c
 }
 
 // Health 返回 HealthTracker,供 API handler 记录心跳。
@@ -67,6 +93,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	c.mu.Lock()
 	ctx, c.cancelFn = context.WithCancel(ctx)
+	c.runCtx = ctx
 	c.mu.Unlock()
 
 	c.wg.Add(1)
@@ -117,6 +144,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 		return
 	}
 	if !c.health.IsHealthy() {
+		c.markPaused()
 		slog.Debug("vision not healthy, skip push",
 			"recording_id", seg.RecordingID)
 		return
@@ -177,5 +205,111 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"recording_id", seg.RecordingID,
 			"camera_id", seg.CameraID,
 			"size_mb", seg.FileSize/1024/1024)
+	}
+}
+
+// markPaused records the start of a push-pause window (first segment skipped
+// while Vision is unhealthy). The timestamp bounds the offline-compensation
+// query when Vision recovers (#329).
+func (c *Coordinator) markPaused() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pausedSince.IsZero() {
+		c.pausedSince = time.Now()
+		slog.Info("vision push paused — offline window starts (segments will be compensated on recovery)",
+			"since", c.pausedSince)
+	}
+}
+
+// rearmPaused restores the pause window with the given start (used when
+// Vision drops again mid-compensation, so the next recovery retries the
+// remainder instead of only the new gap).
+func (c *Coordinator) rearmPaused(since time.Time) {
+	c.mu.Lock()
+	c.pausedSince = since
+	c.mu.Unlock()
+}
+
+// takePausedSince returns and clears the pause-window start.
+func (c *Coordinator) takePausedSince() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	since := c.pausedSince
+	c.pausedSince = time.Time{}
+	return since
+}
+
+// compensateOffline re-pushes segments that completed while Vision was
+// offline. Triggered by the health tracker's recovery callback — a heartbeat
+// after an unhealthy gap. New segments keep flowing through the event loop
+// concurrently; Vision dedups by X-Recording-Id, so overlap is harmless.
+func (c *Coordinator) compensateOffline() {
+	c.mu.Lock()
+	ctx := c.runCtx
+	c.mu.Unlock()
+	if ctx == nil || ctx.Err() != nil {
+		return
+	}
+	since := c.takePausedSince()
+	if since.IsZero() || c.db == nil {
+		return
+	}
+	// Only one compensation run at a time (heartbeats can flap).
+	if !c.compensating.CompareAndSwap(false, true) {
+		c.rearmPaused(since)
+		return
+	}
+	defer c.compensating.Store(false)
+
+	if time.Since(since) > repushWindow {
+		since = time.Now().Add(-repushWindow)
+	}
+
+	recs, err := c.db.ListRecordingsForVisionRepush(ctx, since, time.Now(), repushMax)
+	if err != nil {
+		c.rearmPaused(since)
+		slog.Warn("vision compensation lookup failed", "error", err)
+		return
+	}
+	if len(recs) == 0 {
+		slog.Debug("vision recovered — nothing to compensate")
+		return
+	}
+	slog.Info("vision recovered — re-pushing segments missed while offline",
+		"count", len(recs), "since", since)
+
+	pushed := 0
+	for _, rec := range recs {
+		if ctx.Err() != nil {
+			return
+		}
+		if !c.health.IsHealthy() {
+			// Dropped again mid-compensation: restore the window so the next
+			// recovery retries the remainder.
+			c.rearmPaused(since)
+			slog.Warn("vision unhealthy during compensation — stopping early",
+				"pushed", pushed, "total", len(recs))
+			return
+		}
+		c.handleSegment(ctx, recordingToSegment(rec))
+		pushed++
+		// Pace the burst so a long offline gap doesn't storm Vision.
+		time.Sleep(repushPacing)
+	}
+	slog.Info("vision offline compensation finished", "pushed", pushed, "window", time.Since(since).Round(time.Second))
+}
+
+// recordingToSegment synthesizes the push payload from a DB recording row.
+// encoding is not persisted on the recordings table — Vision sniffs the codec
+// from the MP4 payload when the header is empty.
+func recordingToSegment(r model.Recording) event.SegmentCompleted {
+	return event.SegmentCompleted{
+		CameraID:    r.CameraID,
+		FilePath:    r.FilePath,
+		Format:      string(r.Format),
+		StartedAt:   r.StartedAt.UTC().Format(time.RFC3339Nano),
+		EndedAt:     r.EndedAt.UTC().Format(time.RFC3339Nano),
+		FileSize:    r.FileSize,
+		RecordingID: r.ID,
 	}
 }

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -1,0 +1,169 @@
+package vision
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthTrackerRecoveryCallback(t *testing.T) {
+	h := NewHealthTracker(60)
+
+	var fired atomic.Int32
+	h.SetOnRecovery(func() { fired.Add(1) })
+
+	// First heartbeat: unhealthy → healthy transition fires recovery.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.True(t, h.IsHealthy())
+	require.Eventually(t, func() bool { return fired.Load() == 1 },
+		2*time.Second, 20*time.Millisecond, "recovery callback not fired on first heartbeat")
+
+	// Subsequent heartbeats while already healthy must NOT fire again.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.Equal(t, int32(1), fired.Load())
+}
+
+func TestCoordinatorPauseWindowTracking(t *testing.T) {
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: "http://127.0.0.1:1"}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil, // no DB → compensation disabled, but pause tracking still runs
+	)
+
+	require.True(t, c.takePausedSince().IsZero(), "no pause before any skip")
+
+	c.markPaused()
+	first := c.takePausedSince()
+	require.False(t, first.IsZero())
+
+	// Idempotent while armed: repeated skips don't move the window start.
+	c.rearmPaused(first)
+	c.markPaused()
+	require.Equal(t, first, c.takePausedSince(), "markPaused must not overwrite an armed window")
+
+	// takePausedSince clears the window.
+	require.True(t, c.takePausedSince().IsZero())
+}
+
+type fakeRepusher struct {
+	mu   sync.Mutex
+	recs []model.Recording
+}
+
+// Mirror of the SQL window: completion-keyed with a 1-minute grace on since.
+func (f *fakeRepusher) ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	grace := since.Add(-time.Minute)
+	out := make([]model.Recording, 0, len(f.recs))
+	for _, r := range f.recs {
+		if !r.EndedAt.Before(grace) && !r.EndedAt.After(until) {
+			out = append(out, r)
+		}
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// Core #329 scenario: segments skipped while offline are re-pushed when the
+// consumer's heartbeat recovers.
+func TestCoordinatorOfflineCompensation(t *testing.T) {
+	var mu sync.Mutex
+	pushed := map[string]int{}
+
+	visionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pushed[r.Header.Get("X-Recording-Id")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer visionSrv.Close()
+
+	rp := &fakeRepusher{}
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: visionSrv.URL}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		rp,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	// Vision is offline (no heartbeat): live pushes are skipped.
+	segPath := filepath.Join(t.TempDir(), "seg1.mp4")
+	require.NoError(t, os.WriteFile(segPath, make([]byte, 16), 0o644))
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam1", FilePath: segPath, Format: "mp4",
+		FileSize: 16, RecordingID: "rec-live",
+	})
+	// Give the event loop a moment — the push must be skipped, not delivered.
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	require.Zero(t, pushed["rec-live"], "live push must be skipped while offline")
+	mu.Unlock()
+
+	// The missed segment is discoverable in the DB on recovery.
+	rp.mu.Lock()
+	rp.recs = []model.Recording{{
+		ID: "rec-live", CameraID: "cam1", FilePath: segPath, Format: "mp4",
+		StartedAt: time.Now().Add(-time.Minute), EndedAt: time.Now(),
+		FileSize: 16, MergeStatus: model.MergeStatusPending,
+	}}
+	rp.mu.Unlock()
+
+	// Heartbeat recovery → compensation fires → the missed segment is pushed.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushed["rec-live"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "compensation push did not arrive")
+
+	// Exactly once — no duplicate pushes from the same recovery.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, 1, pushed["rec-live"])
+	mu.Unlock()
+
+	// The pause window is consumed: another recovery with no new offline gap
+	// pushes nothing.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, 1, pushed["rec-live"])
+	mu.Unlock()
+}
+
+func TestRecordingToSegment(t *testing.T) {
+	st := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	et := st.Add(30 * time.Second)
+	seg := recordingToSegment(model.Recording{
+		ID: "r1", CameraID: "cam1", FilePath: "/data/cam1/x.mp4",
+		Format: "mp4", StartedAt: st, EndedAt: et, FileSize: 123,
+	})
+	require.Equal(t, "r1", seg.RecordingID)
+	require.Equal(t, "cam1", seg.CameraID)
+	require.Equal(t, "mp4", seg.Format)
+	require.Equal(t, int64(123), seg.FileSize)
+	require.Equal(t, "2026-08-16T12:00:00Z", seg.StartedAt)
+	require.Equal(t, "2026-08-16T12:00:30Z", seg.EndedAt)
+}

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -18,10 +18,11 @@ type HeartbeatStatus struct {
 // NVR 的推送协调器在推送段之前检查 IsHealthy()——只在 Vision 健康时推送,
 // 避免向不可用的 Vision 发请求。Vision 恢复后,心跳恢复,推送自动续上。
 type HealthTracker struct {
-	mu       sync.RWMutex
-	lastSeen time.Time
-	status   HeartbeatStatus
-	timeout  time.Duration
+	mu         sync.RWMutex
+	lastSeen   time.Time
+	status     HeartbeatStatus
+	timeout    time.Duration
+	onRecovery func()
 }
 
 // NewHealthTracker 创建健康追踪器。timeoutSecs ≤ 0 时默认 60 秒。
@@ -34,12 +35,28 @@ func NewHealthTracker(timeoutSecs int) *HealthTracker {
 	}
 }
 
+// SetOnRecovery registers a callback fired (on its own goroutine) when a
+// heartbeat arrives after an unhealthy gap — the hook that triggers offline
+// compensation in the push coordinator (#329). Optional; nil disables.
+func (h *HealthTracker) SetOnRecovery(f func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.onRecovery = f
+}
+
 // RecordHeartbeat 记录一次 Vision 心跳。
 func (h *HealthTracker) RecordHeartbeat(status HeartbeatStatus) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	wasHealthy := !h.lastSeen.IsZero() && time.Since(h.lastSeen) < h.timeout
 	h.lastSeen = time.Now()
 	h.status = status
+	cb := h.onRecovery
+	h.mu.Unlock()
+	if !wasHealthy && cb != nil {
+		// Fire off the request goroutine — the heartbeat handler must not
+		// block on compensation work.
+		go cb()
+	}
 }
 
 // IsHealthy 返回 Vision 是否健康(最近 timeout 内收到过心跳)。

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -273,6 +273,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			func() config.VisionConfig { return cfg.Vision },
 			func() string { return cfg.Storage.RootDir },
 			deps.eventBus,
+			db,
 		)
 		slog.Info("Vision push integration enabled",
 			"url", cfg.Vision.URL,


### PR DESCRIPTION
Closes #329

## Summary
心跳超时暂停推送期间完成的段不再永久丢失——消费方恢复健康时自动补推：

1. **暂停窗口记录**：首个段因不健康被跳过时记下窗口起点（`markPaused`）
2. **恢复钩子**：`HealthTracker` 在 不健康→健康 跃迁时触发 `onRecovery` 回调（独立 goroutine，不阻塞心跳 handler）
3. **补偿查询**：`ListRecordingsForVisionRepush`（新 DB 方法）取窗口内完成、`ai_status` 未达终态（排除 completed/failed）、非 timelapse、非 merged 的段，按时间序重推
4. **防护**：2h 窗口 / 最多 500 段 / 200ms 步进；single-flight 防抖动重复触发；补偿途中再次失联则重新布防窗口，下次恢复续推剩余部分
5. **窗口按 `ended_at`（完成时间）+ 1 分钟宽限**：暂停前开始、离线期间完成的段不会被漏掉（按 started_at 会漏）

## 设计要点
- 重推复用现有 POST 上传路径（`handleSegment`），幂等性靠消费方 `X-Recording-Id` 去重（issue 已确认无害）
- 补偿在独立 goroutine 运行——重推期间新段照常走事件循环（"优先新段"结构上成立）
- `recordingToSegment` 不带 encoding（recordings 表无该列），Vision 从 MP4 payload 嗅探

## Tests
- `internal/vision/coordinator_test.go`：恢复回调触发/不重复触发、暂停窗口 mark/take/rearm 语义、端到端离线→恢复→补推（fake Vision HTTP server + fake Repusher，验证跳过→补推→恰好一次）、payload 转换
- `internal/storage/db_vision_repush_test.go`：SQL 过滤矩阵（pending/processing 补推；completed/failed/timelapse/merged/窗口外排除）+ limit