### PR TITLE
feat(webrtc): WHEP audio muxing — G.711/Opus into the WebRTC track, zero transcoding (#372)

### DIFF
--- a/internal/api/handlers_webrtc.go
+++ b/internal/api/handlers_webrtc.go
@@ -3,8 +3,10 @@ package api
 import (
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/webrtc"
 	"github.com/go-chi/chi/v5"
 )
@@ -59,6 +61,11 @@ func (h *Handler) handleCreateWHEPSession(w http.ResponseWriter, r *http.Request
 			if hub != nil {
 				_, sps, _, _ := getCodecParams(rec)
 				h.webrtcMgr.RegisterStream(id, hub, sps)
+				// Audio muxing (#372): G.711/Opus ride the WebRTC track;
+				// AAC cameras are left video-only by the manager (keep the
+				// separate audio-WS path). Best-effort — video continues on
+				// any error.
+				setupAudioForWebRTC(h, id, rec)
 			}
 		}
 	}
@@ -105,4 +112,33 @@ func (h *Handler) handleDeleteWHEPSession(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// setupAudioForWebRTC configures audio muxing on the WebRTC manager for a
+// camera stream (#372). Mirrors setupAudioForWS: extracts codec params from
+// the recorder and calls SetAudioInfo. AAC and unknown codecs are ignored by
+// the manager (video-only WHEP, separate audio-WS path stays). Errors are
+// non-fatal — video streaming continues.
+func setupAudioForWebRTC(h *Handler, id string, rec model.Recorder) {
+	actualRec := unwrapDelegate(rec)
+	provider, ok := actualRec.(audioInfoProvider)
+	if !ok {
+		return
+	}
+	audioCodec := provider.AudioCodec()
+	if audioCodec == "" {
+		return
+	}
+
+	muLaw := false
+	if audioCodec == "g711" {
+		config := provider.AudioConfig()
+		if len(config) > 0 && config[0] == 1 {
+			muLaw = true
+		}
+	}
+
+	if err := h.webrtcMgr.SetAudioInfo(id, audioCodec, muLaw, provider.AudioSampleRate(), provider.AudioChannels()); err != nil {
+		slog.Warn("WebRTC: failed to set audio info", "camera_id", id, "error", err)
+	}
 }

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -248,6 +248,34 @@ func (d *DB) ListRecordings(ctx context.Context, filter model.RecordingFilter) (
 	return scanRecordingRows(rows)
 }
 
+// ListRecordingsForVisionRepush returns up to limit recordings whose segments
+// completed within [since, until] and that Vision has not finished processing —
+// the offline-compensation window for the vision push coordinator (#329).
+// The window is keyed on ended_at (completion): segments that started before
+// the pause but landed while offline must still be compensated; a small grace
+// on since covers ordering slack between segment completion and the push
+// attempt. Excludes timelapse segments (never pushed live) and merged segments
+// (files are typically reclaimed by the merge pipeline), and drops anything
+// already in a terminal ai_status (completed/failed).
+func (d *DB) ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error) {
+	defer d.observeQuery("ListRecordingsForVisionRepush", time.Now())
+	rows, err := d.readConn().QueryContext(ctx, `
+		SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived
+		FROM recordings
+		WHERE ended_at>=? AND ended_at<=?
+			AND format != 'timelapse'
+			AND COALESCE(merge_status,'') NOT IN ('merged','daily_merged')
+			AND COALESCE(ai_status,'') IN ('','pending','processing')
+		ORDER BY started_at ASC
+		LIMIT ?;`,
+		timeToDB(since.Add(-time.Minute)), timeToDB(until), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list recordings for vision repush: %w", err)
+	}
+	defer rows.Close()
+	return scanRecordingRows(rows)
+}
+
 // ListRecordingsWithTotal returns a page of recordings plus the total count matching the
 // filter. It runs ListRecordings (covering index, no sort) for the page, and a cached
 // CountRecordingsWithFilter for the total — collapsing repeated counts for the same

--- a/internal/storage/db_vision_repush_test.go
+++ b/internal/storage/db_vision_repush_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRecordingsForVisionRepush(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	insert := func(id string, format model.Format, startedAt, endedAt time.Time, mergeStatus, aiStatus string) {
+		t.Helper()
+		r := &model.Recording{
+			ID: id, CameraID: "cam1", FilePath: "/data/" + id + ".mp4",
+			Format: format, StartedAt: startedAt, EndedAt: endedAt,
+			FileSize: 100, FrameCount: 10,
+		}
+		if mergeStatus != "" {
+			r.MergeStatus = mergeStatus
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+		if aiStatus != "" {
+			require.NoError(t, db.UpdateRecordingAIStatus(ctx, id, aiStatus, ""))
+		}
+	}
+
+	insert("repush-pending", "mp4", now.Add(-20*time.Minute), now.Add(-19*time.Minute), "", "")
+	insert("repush-processing", "mp4", now.Add(-18*time.Minute), now.Add(-17*time.Minute), "", "processing")
+	insert("skip-completed", "mp4", now.Add(-16*time.Minute), now.Add(-15*time.Minute), "", "completed")
+	insert("skip-failed", "mp4", now.Add(-14*time.Minute), now.Add(-13*time.Minute), "", "failed")
+	insert("skip-timelapse", "timelapse", now.Add(-12*time.Minute), now.Add(-11*time.Minute), "", "")
+	insert("skip-merged", "mp4", now.Add(-10*time.Minute), now.Add(-9*time.Minute), "merged", "")
+	// Completed before the offline window (ended 3h ago) — outside bounds.
+	insert("skip-old", "mp4", now.Add(-3*time.Hour), now.Add(-3*time.Hour+time.Minute), "", "")
+
+	recs, err := db.ListRecordingsForVisionRepush(ctx, now.Add(-2*time.Hour), now, 500)
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(recs))
+	for _, r := range recs {
+		ids = append(ids, r.ID)
+	}
+	require.ElementsMatch(t, []string{"repush-pending", "repush-processing"}, ids,
+		"only non-terminal, non-timelapse, non-merged segments inside the window qualify")
+
+	// Limit is honored (ascending start order).
+	capped, err := db.ListRecordingsForVisionRepush(ctx, now.Add(-2*time.Hour), now, 1)
+	require.NoError(t, err)
+	require.Len(t, capped, 1)
+	require.Equal(t, "repush-pending", capped[0].ID)
+}

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -17,37 +17,63 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
+
+// Offline-compensation bounds (#329). A long offline gap is capped so the
+// recovery burst can't storm Vision or the disk; segments beyond the window
+// are skipped (they would mostly be merged away anyway).
+const (
+	repushWindow = 2 * time.Hour
+	repushMax    = 500
+	repushPacing = 200 * time.Millisecond
+)
+
+// Repusher abstracts the recordings lookup needed for offline compensation.
+// Production wiring passes *storage.DB; tests use fakes. Kept as an interface
+// so the coordinator stays testable without SQLite.
+type Repusher interface {
+	ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error)
+}
 
 // Coordinator 订阅 segment.completed 事件,在 Vision 健康时把视频文件推送给 Vision。
 type Coordinator struct {
-	health      *HealthTracker
-	eventBus    *event.EventBus
-	eventCh     chan event.Event
-	cfg         func() config.VisionConfig
-	storageRoot func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
-	client      *http.Client
-	wg          sync.WaitGroup
-	cancelFn    context.CancelFunc
-	mu          sync.Mutex
+	health       *HealthTracker
+	eventBus     *event.EventBus
+	eventCh      chan event.Event
+	cfg          func() config.VisionConfig
+	storageRoot  func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
+	db           Repusher      // nil → 补偿重推禁用(测试/降级部署)
+	client       *http.Client
+	wg           sync.WaitGroup
+	cancelFn     context.CancelFunc
+	mu           sync.Mutex
+	runCtx       context.Context // 供恢复回调 goroutine 使用(Start 时设置)
+	pausedSince  time.Time       // 推送暂停窗口起点(mu 保护;零值=未暂停)
+	compensating atomic.Bool     // 补偿重推 single-flight
 }
 
-// NewCoordinator 创建推送协调器。
-func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus) *Coordinator {
+// NewCoordinator 创建推送协调器。db 可为 nil(禁用离线补偿)。
+func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus, db Repusher) *Coordinator {
 	vcfg := cfg()
-	return &Coordinator{
+	c := &Coordinator{
 		health:      NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
 		eventBus:    eventBus,
 		cfg:         cfg,
 		storageRoot: storageRoot,
+		db:          db,
 		client: &http.Client{
 			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
 	}
+	// 心跳恢复(不健康→健康)触发离线补偿重推 (#329)。
+	c.health.SetOnRecovery(c.compensateOffline)
+	return c
 }
 
 // Health 返回 HealthTracker,供 API handler 记录心跳。
@@ -67,6 +93,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	c.mu.Lock()
 	ctx, c.cancelFn = context.WithCancel(ctx)
+	c.runCtx = ctx
 	c.mu.Unlock()
 
 	c.wg.Add(1)
@@ -117,6 +144,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 		return
 	}
 	if !c.health.IsHealthy() {
+		c.markPaused()
 		slog.Debug("vision not healthy, skip push",
 			"recording_id", seg.RecordingID)
 		return
@@ -177,5 +205,111 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"recording_id", seg.RecordingID,
 			"camera_id", seg.CameraID,
 			"size_mb", seg.FileSize/1024/1024)
+	}
+}
+
+// markPaused records the start of a push-pause window (first segment skipped
+// while Vision is unhealthy). The timestamp bounds the offline-compensation
+// query when Vision recovers (#329).
+func (c *Coordinator) markPaused() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pausedSince.IsZero() {
+		c.pausedSince = time.Now()
+		slog.Info("vision push paused — offline window starts (segments will be compensated on recovery)",
+			"since", c.pausedSince)
+	}
+}
+
+// rearmPaused restores the pause window with the given start (used when
+// Vision drops again mid-compensation, so the next recovery retries the
+// remainder instead of only the new gap).
+func (c *Coordinator) rearmPaused(since time.Time) {
+	c.mu.Lock()
+	c.pausedSince = since
+	c.mu.Unlock()
+}
+
+// takePausedSince returns and clears the pause-window start.
+func (c *Coordinator) takePausedSince() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	since := c.pausedSince
+	c.pausedSince = time.Time{}
+	return since
+}
+
+// compensateOffline re-pushes segments that completed while Vision was
+// offline. Triggered by the health tracker's recovery callback — a heartbeat
+// after an unhealthy gap. New segments keep flowing through the event loop
+// concurrently; Vision dedups by X-Recording-Id, so overlap is harmless.
+func (c *Coordinator) compensateOffline() {
+	c.mu.Lock()
+	ctx := c.runCtx
+	c.mu.Unlock()
+	if ctx == nil || ctx.Err() != nil {
+		return
+	}
+	since := c.takePausedSince()
+	if since.IsZero() || c.db == nil {
+		return
+	}
+	// Only one compensation run at a time (heartbeats can flap).
+	if !c.compensating.CompareAndSwap(false, true) {
+		c.rearmPaused(since)
+		return
+	}
+	defer c.compensating.Store(false)
+
+	if time.Since(since) > repushWindow {
+		since = time.Now().Add(-repushWindow)
+	}
+
+	recs, err := c.db.ListRecordingsForVisionRepush(ctx, since, time.Now(), repushMax)
+	if err != nil {
+		c.rearmPaused(since)
+		slog.Warn("vision compensation lookup failed", "error", err)
+		return
+	}
+	if len(recs) == 0 {
+		slog.Debug("vision recovered — nothing to compensate")
+		return
+	}
+	slog.Info("vision recovered — re-pushing segments missed while offline",
+		"count", len(recs), "since", since)
+
+	pushed := 0
+	for _, rec := range recs {
+		if ctx.Err() != nil {
+			return
+		}
+		if !c.health.IsHealthy() {
+			// Dropped again mid-compensation: restore the window so the next
+			// recovery retries the remainder.
+			c.rearmPaused(since)
+			slog.Warn("vision unhealthy during compensation — stopping early",
+				"pushed", pushed, "total", len(recs))
+			return
+		}
+		c.handleSegment(ctx, recordingToSegment(rec))
+		pushed++
+		// Pace the burst so a long offline gap doesn't storm Vision.
+		time.Sleep(repushPacing)
+	}
+	slog.Info("vision offline compensation finished", "pushed", pushed, "window", time.Since(since).Round(time.Second))
+}
+
+// recordingToSegment synthesizes the push payload from a DB recording row.
+// encoding is not persisted on the recordings table — Vision sniffs the codec
+// from the MP4 payload when the header is empty.
+func recordingToSegment(r model.Recording) event.SegmentCompleted {
+	return event.SegmentCompleted{
+		CameraID:    r.CameraID,
+		FilePath:    r.FilePath,
+		Format:      string(r.Format),
+		StartedAt:   r.StartedAt.UTC().Format(time.RFC3339Nano),
+		EndedAt:     r.EndedAt.UTC().Format(time.RFC3339Nano),
+		FileSize:    r.FileSize,
+		RecordingID: r.ID,
 	}
 }

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -1,0 +1,169 @@
+package vision
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthTrackerRecoveryCallback(t *testing.T) {
+	h := NewHealthTracker(60)
+
+	var fired atomic.Int32
+	h.SetOnRecovery(func() { fired.Add(1) })
+
+	// First heartbeat: unhealthy → healthy transition fires recovery.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.True(t, h.IsHealthy())
+	require.Eventually(t, func() bool { return fired.Load() == 1 },
+		2*time.Second, 20*time.Millisecond, "recovery callback not fired on first heartbeat")
+
+	// Subsequent heartbeats while already healthy must NOT fire again.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.Equal(t, int32(1), fired.Load())
+}
+
+func TestCoordinatorPauseWindowTracking(t *testing.T) {
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: "http://127.0.0.1:1"}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil, // no DB → compensation disabled, but pause tracking still runs
+	)
+
+	require.True(t, c.takePausedSince().IsZero(), "no pause before any skip")
+
+	c.markPaused()
+	first := c.takePausedSince()
+	require.False(t, first.IsZero())
+
+	// Idempotent while armed: repeated skips don't move the window start.
+	c.rearmPaused(first)
+	c.markPaused()
+	require.Equal(t, first, c.takePausedSince(), "markPaused must not overwrite an armed window")
+
+	// takePausedSince clears the window.
+	require.True(t, c.takePausedSince().IsZero())
+}
+
+type fakeRepusher struct {
+	mu   sync.Mutex
+	recs []model.Recording
+}
+
+// Mirror of the SQL window: completion-keyed with a 1-minute grace on since.
+func (f *fakeRepusher) ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	grace := since.Add(-time.Minute)
+	out := make([]model.Recording, 0, len(f.recs))
+	for _, r := range f.recs {
+		if !r.EndedAt.Before(grace) && !r.EndedAt.After(until) {
+			out = append(out, r)
+		}
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// Core #329 scenario: segments skipped while offline are re-pushed when the
+// consumer's heartbeat recovers.
+func TestCoordinatorOfflineCompensation(t *testing.T) {
+	var mu sync.Mutex
+	pushed := map[string]int{}
+
+	visionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pushed[r.Header.Get("X-Recording-Id")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer visionSrv.Close()
+
+	rp := &fakeRepusher{}
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: visionSrv.URL}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		rp,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	// Vision is offline (no heartbeat): live pushes are skipped.
+	segPath := filepath.Join(t.TempDir(), "seg1.mp4")
+	require.NoError(t, os.WriteFile(segPath, make([]byte, 16), 0o644))
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam1", FilePath: segPath, Format: "mp4",
+		FileSize: 16, RecordingID: "rec-live",
+	})
+	// Give the event loop a moment — the push must be skipped, not delivered.
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	require.Zero(t, pushed["rec-live"], "live push must be skipped while offline")
+	mu.Unlock()
+
+	// The missed segment is discoverable in the DB on recovery.
+	rp.mu.Lock()
+	rp.recs = []model.Recording{{
+		ID: "rec-live", CameraID: "cam1", FilePath: segPath, Format: "mp4",
+		StartedAt: time.Now().Add(-time.Minute), EndedAt: time.Now(),
+		FileSize: 16, MergeStatus: model.MergeStatusPending,
+	}}
+	rp.mu.Unlock()
+
+	// Heartbeat recovery → compensation fires → the missed segment is pushed.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushed["rec-live"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "compensation push did not arrive")
+
+	// Exactly once — no duplicate pushes from the same recovery.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, 1, pushed["rec-live"])
+	mu.Unlock()
+
+	// The pause window is consumed: another recovery with no new offline gap
+	// pushes nothing.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	require.Equal(t, 1, pushed["rec-live"])
+	mu.Unlock()
+}
+
+func TestRecordingToSegment(t *testing.T) {
+	st := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	et := st.Add(30 * time.Second)
+	seg := recordingToSegment(model.Recording{
+		ID: "r1", CameraID: "cam1", FilePath: "/data/cam1/x.mp4",
+		Format: "mp4", StartedAt: st, EndedAt: et, FileSize: 123,
+	})
+	require.Equal(t, "r1", seg.RecordingID)
+	require.Equal(t, "cam1", seg.CameraID)
+	require.Equal(t, "mp4", seg.Format)
+	require.Equal(t, int64(123), seg.FileSize)
+	require.Equal(t, "2026-08-16T12:00:00Z", seg.StartedAt)
+	require.Equal(t, "2026-08-16T12:00:30Z", seg.EndedAt)
+}

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -18,10 +18,11 @@ type HeartbeatStatus struct {
 // NVR 的推送协调器在推送段之前检查 IsHealthy()——只在 Vision 健康时推送,
 // 避免向不可用的 Vision 发请求。Vision 恢复后,心跳恢复,推送自动续上。
 type HealthTracker struct {
-	mu       sync.RWMutex
-	lastSeen time.Time
-	status   HeartbeatStatus
-	timeout  time.Duration
+	mu         sync.RWMutex
+	lastSeen   time.Time
+	status     HeartbeatStatus
+	timeout    time.Duration
+	onRecovery func()
 }
 
 // NewHealthTracker 创建健康追踪器。timeoutSecs ≤ 0 时默认 60 秒。
@@ -34,12 +35,28 @@ func NewHealthTracker(timeoutSecs int) *HealthTracker {
 	}
 }
 
+// SetOnRecovery registers a callback fired (on its own goroutine) when a
+// heartbeat arrives after an unhealthy gap — the hook that triggers offline
+// compensation in the push coordinator (#329). Optional; nil disables.
+func (h *HealthTracker) SetOnRecovery(f func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.onRecovery = f
+}
+
 // RecordHeartbeat 记录一次 Vision 心跳。
 func (h *HealthTracker) RecordHeartbeat(status HeartbeatStatus) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	wasHealthy := !h.lastSeen.IsZero() && time.Since(h.lastSeen) < h.timeout
 	h.lastSeen = time.Now()
 	h.status = status
+	cb := h.onRecovery
+	h.mu.Unlock()
+	if !wasHealthy && cb != nil {
+		// Fire off the request goroutine — the heartbeat handler must not
+		// block on compensation work.
+		go cb()
+	}
 }
 
 // IsHealthy 返回 Vision 是否健康(最近 timeout 内收到过心跳)。

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -194,19 +194,19 @@ type audioConfig struct {
 
 // audioCapability maps a negotiated audio config to the pion track capability.
 func (a audioConfig) capability() webrtc.RTPCodecCapability {
-	cap := webrtc.RTPCodecCapability{ClockRate: uint32(a.clockRate)}
+	codecCap := webrtc.RTPCodecCapability{ClockRate: uint32(a.clockRate)}
 	switch a.codec {
 	case "pcmu":
-		cap.MimeType = webrtc.MimeTypePCMU
+		codecCap.MimeType = webrtc.MimeTypePCMU
 	case "pcma":
-		cap.MimeType = webrtc.MimeTypePCMA
+		codecCap.MimeType = webrtc.MimeTypePCMA
 	case "opus":
-		cap.MimeType = webrtc.MimeTypeOpus
+		codecCap.MimeType = webrtc.MimeTypeOpus
 		// Matches the conventional browser-offered Opus fmtp; pion requires
 		// the capability to be one of the registered variants.
-		cap.SDPFmtpLine = "minptime=10;useinbandfec=1"
+		codecCap.SDPFmtpLine = "minptime=10;useinbandfec=1"
 	}
-	return cap
+	return codecCap
 }
 
 // hubSubscription tracks a StreamHub subscription for a camera.

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -25,26 +25,34 @@ const (
 	defaultMaxPeers       = 2
 	defaultIdleTimeout    = 60 * time.Second
 	defaultFrameBufSize   = 100
+	defaultAudioBufSize   = 50
 	defaultFPS            = 30
 	h264ClockRate         = 90000
-	highDropRateThreshold = 0.20 // 20% — trigger frame skipping
-	lowDropRateThreshold  = 0.05 // 5% — restore full frame rate
+	g711ClockRate         = 8000
+	opusClockRate         = 48000
+	highDropRateThreshold = 0.20                  // 20% — trigger frame skipping
+	lowDropRateThreshold  = 0.05                  // 5% — restore full frame rate
+	defaultAudioFrameDur  = 20 * time.Millisecond // typical G.711/Opus frame
 )
 
 // peerEntry holds a single WHEP peer connection and its metadata.
 type peerEntry struct {
-	mu         sync.Mutex
-	pc         *webrtc.PeerConnection
-	track      *webrtc.TrackLocalStaticSample
-	sender     *webrtc.RTPSender
-	cancel     context.CancelFunc
-	camID      string
-	sessionID  string
-	lastUsed   time.Time
-	frameCh    chan model.FrameMsg
-	drops      uint64             // atomic: total frames dropped due to buffer full
-	congestion *congestionTracker // tracks drop rate for bitrate adaptation
-	lastPTS    int64
+	mu           sync.Mutex
+	pc           *webrtc.PeerConnection
+	track        *webrtc.TrackLocalStaticSample
+	sender       *webrtc.RTPSender
+	audioTrack   *webrtc.TrackLocalStaticSample // nil for video-only peers
+	audioCh      chan model.AudioFrame          // nil for video-only peers
+	audioClock   int                            // RTP clock rate for audio PTS→duration
+	lastAudioPTS int64
+	cancel       context.CancelFunc
+	camID        string
+	sessionID    string
+	lastUsed     time.Time
+	frameCh      chan model.FrameMsg
+	drops        uint64             // atomic: total frames dropped due to buffer full
+	congestion   *congestionTracker // tracks drop rate for bitrate adaptation
+	lastPTS      int64
 }
 
 // congestionTracker tracks frame send/drop rates in a sliding window
@@ -155,28 +163,57 @@ func (ct *congestionTracker) shouldSkipFrame(isIDR bool) bool {
 }
 
 // Manager manages WebRTC WHEP sessions for camera streaming.
-// It supports H.264 video only (no audio), with configurable max peers
-// per camera and idle eviction.
+// H.264 video with optional G.711 (PCMU/PCMA) or Opus audio — the WebRTC
+// mandatory codecs, passed through with zero transcoding. AAC cameras stay
+// video-only (AAC is not a WebRTC codec; those keep the separate audio WS).
 type Manager struct {
 	mu            sync.RWMutex
 	peers         map[string]*peerEntry       // sessionID -> entry
 	camPeers      map[string][]string         // camID -> []sessionID
 	hubSubs       map[string]*hubSubscription // camID -> subscription info
 	streamProfile map[string]string           // cameraID → H.264 fmtp variant (fmtpForProfile)
+	audioCfgs     map[string]audioConfig      // cameraID → negotiated audio (absent = video-only)
 	stopped       bool
 	api           *webrtc.API
 	maxPeers      int
 	idleTimeout   time.Duration
 	frameBufSize  int
+	audioBufSize  int
 	iceServers    []webrtc.ICEServer // STUN/TURN servers for cross-network ICE; nil = LAN-only
 	drainWg       sync.WaitGroup     // tracks RTCP drain goroutines for clean shutdown
 	mets          *metrics.Metrics
 }
 
+// audioConfig is the per-camera audio wire format for WHEP tracks (#372).
+type audioConfig struct {
+	codec     string // "pcmu", "pcma", "opus"
+	clockRate int    // RTP clock: 8000 (G.711) / 48000 (Opus)
+	sampleHz  int    // source sample rate (informational)
+	channels  int
+}
+
+// audioCapability maps a negotiated audio config to the pion track capability.
+func (a audioConfig) capability() webrtc.RTPCodecCapability {
+	cap := webrtc.RTPCodecCapability{ClockRate: uint32(a.clockRate)}
+	switch a.codec {
+	case "pcmu":
+		cap.MimeType = webrtc.MimeTypePCMU
+	case "pcma":
+		cap.MimeType = webrtc.MimeTypePCMA
+	case "opus":
+		cap.MimeType = webrtc.MimeTypeOpus
+		// Matches the conventional browser-offered Opus fmtp; pion requires
+		// the capability to be one of the registered variants.
+		cap.SDPFmtpLine = "minptime=10;useinbandfec=1"
+	}
+	return cap
+}
+
 // hubSubscription tracks a StreamHub subscription for a camera.
 type hubSubscription struct {
-	hub   *model.StreamHub
-	subID string
+	hub             *model.StreamHub
+	subID           string
+	audioSubscribed bool // SetAudioInfo ran against this hub instance
 }
 
 // ManagerOption configures a Manager.
@@ -255,6 +292,27 @@ func NewManager(opts ...ManagerOption) *Manager {
 		}
 	}
 
+	// Audio codecs for WHEP muxing (#372) — all WebRTC mandatory codecs, so
+	// the NVR passes raw hub bytes through with zero transcoding. Static
+	// payload types for G.711, the conventional 111 for Opus. Opus must be
+	// registered as stereo (2 channels) per RFC 7587 / browser convention.
+	audioCodecs := []struct {
+		cap webrtc.RTPCodecCapability
+		pt  webrtc.PayloadType
+	}{
+		{webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypePCMU, ClockRate: g711ClockRate, Channels: 1}, 0},
+		{webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypePCMA, ClockRate: g711ClockRate, Channels: 1}, 8},
+		{webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeOpus, ClockRate: opusClockRate, Channels: 2}, 111},
+	}
+	for _, ac := range audioCodecs {
+		if err := mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+			RTPCodecCapability: ac.cap,
+			PayloadType:        ac.pt,
+		}, webrtc.RTPCodecTypeAudio); err != nil {
+			logger.Error("failed to register audio codec", "mime", ac.cap.MimeType, "error", err)
+		}
+	}
+
 	interceptorRegistry := &interceptor.Registry{}
 	if err := webrtc.RegisterDefaultInterceptors(mediaEngine, interceptorRegistry); err != nil {
 		logger.Error("failed to register default interceptors", "error", err)
@@ -270,10 +328,12 @@ func NewManager(opts ...ManagerOption) *Manager {
 		camPeers:      make(map[string][]string),
 		hubSubs:       make(map[string]*hubSubscription),
 		streamProfile: make(map[string]string),
+		audioCfgs:     make(map[string]audioConfig),
 		api:           api,
 		maxPeers:      defaultMaxPeers,
 		idleTimeout:   defaultIdleTimeout,
 		frameBufSize:  defaultFrameBufSize,
+		audioBufSize:  defaultAudioBufSize,
 	}
 
 	for _, opt := range opts {
@@ -320,6 +380,54 @@ func (m *Manager) RegisterStream(camID string, hub *model.StreamHub, sps []byte)
 	logger.Info("WebRTC stream registered", "camera_id", camID)
 }
 
+// SetAudioInfo configures the audio track offered for a camera's WHEP
+// sessions (#372). Must be called after RegisterStream. codec is the
+// recorder's audio codec ("g711", "opus", ...); muLaw selects PCMU vs PCMA
+// for G.711. AAC is not a WebRTC codec — it returns without configuring
+// (those cameras keep the separate audio-WS path).
+func (m *Manager) SetAudioInfo(camID string, codec string, muLaw bool, sampleRate, channels int) error {
+	var cfg audioConfig
+	switch codec {
+	case "g711":
+		cfg = audioConfig{codec: "pcmu", clockRate: g711ClockRate, sampleHz: sampleRate, channels: 1}
+		if !muLaw {
+			cfg.codec = "pcma"
+		}
+	case "opus":
+		cfg = audioConfig{codec: "opus", clockRate: opusClockRate, sampleHz: sampleRate, channels: channels}
+	default:
+		// AAC and unknown codecs: leave video-only. No error — callers treat
+		// audio setup as best-effort.
+		return nil
+	}
+
+	m.mu.Lock()
+	m.audioCfgs[camID] = cfg
+	sub, hasSub := m.hubSubs[camID]
+	needSubscribe := hasSub && sub != nil && !sub.audioSubscribed
+	if needSubscribe {
+		sub.audioSubscribed = true
+	}
+	m.mu.Unlock()
+	if !hasSub {
+		return fmt.Errorf("webrtc: SetAudioInfo before RegisterStream (camera %s)", camID)
+	}
+	if !needSubscribe {
+		return nil // already subscribed on this hub (codec update only)
+	}
+
+	// Idempotent: the subscription fan-outs to every peer entry, so a single
+	// audio subscription per camera is enough regardless of peer count.
+	audioSubID := "webrtc-audio-" + camID
+	if err := sub.hub.SubscribeAudio(audioSubID, func(pts int64, audioCodec model.AudioCodec, data []byte) {
+		m.WriteAudio(camID, pts, data)
+	}); err != nil {
+		return fmt.Errorf("webrtc: subscribe audio: %w", err)
+	}
+	logger.Info("WebRTC audio configured", "camera_id", camID, "codec", cfg.codec, "sample_rate", sampleRate, "channels", cfg.channels)
+	return nil
+}
+
 // fmtpForProfile maps a recorder SPS to the H.264 SDP fmtp line matching
 // its profile: High-family (profile_idc 100/110/122/244) offers 640028,
 // everything else stays on Constrained Baseline 42001f. The variant must be
@@ -342,10 +450,35 @@ func (m *Manager) UnregisterStream(camID string) {
 	if ok {
 		delete(m.hubSubs, camID)
 	}
+	delete(m.audioCfgs, camID)
 	m.mu.Unlock()
 	if ok {
 		sub.hub.Unsubscribe(sub.subID)
+		sub.hub.UnsubscribeAudio("webrtc-audio-" + camID)
 		logger.Info("WebRTC stream unregistered", "camera_id", camID)
+	}
+}
+
+// WriteAudio queues an audio frame for async writing to all WHEP peers of
+// the given camera. Non-blocking — frames are dropped if a peer's audio
+// buffer is full (audio glitches are preferable to stalling the pipeline).
+func (m *Manager) WriteAudio(camID string, pts int64, data []byte) {
+	m.mu.RLock()
+	sids := m.camPeers[camID]
+	entries := make([]*peerEntry, 0, len(sids))
+	for _, sid := range sids {
+		if e, ok := m.peers[sid]; ok && e.audioCh != nil {
+			entries = append(entries, e)
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, entry := range entries {
+		select {
+		case entry.audioCh <- model.AudioFrame{PTS: pts, Data: data}:
+		default:
+			// Audio buffer full — drop this frame.
+		}
 	}
 }
 
@@ -463,6 +596,27 @@ func (m *Manager) CreateWHEPSession(camID string, offerSDP []byte) (answerSDP []
 		return nil, "", err
 	}
 
+	// Audio track (#372): added only when the camera negotiated a
+	// WebRTC-compatible audio codec. Video-only cameras leave the browser's
+	// audio m-line rejected (pion answers port 0 automatically — no track,
+	// no transceiver).
+	var audioTrack *webrtc.TrackLocalStaticSample
+	var audioSender *webrtc.RTPSender
+	var audioClock int
+	if cfg, ok := m.audioCfgs[camID]; ok {
+		audioTrack, err = webrtc.NewTrackLocalStaticSample(cfg.capability(), "audio", camID)
+		if err != nil {
+			pc.Close()
+			return nil, "", err
+		}
+		audioSender, err = pc.AddTrack(audioTrack)
+		if err != nil {
+			pc.Close()
+			return nil, "", err
+		}
+		audioClock = cfg.clockRate
+	}
+
 	// Context for goroutine lifecycle
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -487,6 +641,30 @@ func (m *Manager) CreateWHEPSession(camID string, offerSDP []byte) (answerSDP []
 			}
 		}
 	}()
+
+	// Separate RTCP drain for the audio sender (if present).
+	if audioSender != nil {
+		m.drainWg.Add(1)
+		go func() {
+			defer m.drainWg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Warn("audio RTCP drain goroutine panic recovered", "error", r)
+				}
+			}()
+			buf := make([]byte, 1500)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				if _, _, readErr := audioSender.Read(buf); readErr != nil {
+					return
+				}
+			}
+		}()
+	}
 
 	// Generate session ID
 	sid := uuid.New().String()
@@ -536,20 +714,22 @@ func (m *Manager) CreateWHEPSession(camID string, offerSDP []byte) (answerSDP []
 		logger.Warn("ICE gathering timed out, proceeding with gathered candidates", "camera_id", camID)
 	}
 
-	// Reject audio m-lines in the answer SDP (belt-and-suspenders)
-	finalSDP := rejectAudioInSDP(pc.LocalDescription().SDP)
-
 	// Create peer entry
 	entry := &peerEntry{
 		pc:         pc,
 		track:      track,
 		sender:     sender,
+		audioTrack: audioTrack,
+		audioClock: audioClock,
 		cancel:     cancel,
 		camID:      camID,
 		sessionID:  sid,
 		lastUsed:   time.Now(),
 		frameCh:    make(chan model.FrameMsg, m.frameBufSize),
 		congestion: newCongestionTracker(m.frameBufSize),
+	}
+	if audioTrack != nil {
+		entry.audioCh = make(chan model.AudioFrame, m.audioBufSize)
 	}
 
 	m.peers[sid] = entry
@@ -561,11 +741,22 @@ func (m *Manager) CreateWHEPSession(camID string, offerSDP []byte) (answerSDP []
 	// Start async frame writer goroutine
 	go m.writeLoop(ctx, entry)
 
+	// Start async audio writer goroutine (no-op for video-only peers)
+	if audioTrack != nil {
+		go m.audioWriteLoop(ctx, entry)
+	}
+
 	// Start idle watchdog goroutine
 	go m.idleWatchdog(ctx, entry)
 
-	logger.Info("WHEP session created", "camera_id", camID, "session_id", sid)
-	return []byte(finalSDP), sid, nil
+	logger.Info("WHEP session created", "camera_id", camID, "session_id", sid, "audio", audioTrack != nil)
+	if audioTrack == nil {
+		// Video-only peer: pion leaves the offered audio m-line answerable
+		// (port 9 + engine codecs) even without a track — reject it
+		// explicitly so browsers don't wait for audio that never comes.
+		return []byte(rejectAudioInSDP(pc.LocalDescription().SDP)), sid, nil
+	}
+	return []byte(pc.LocalDescription().SDP), sid, nil
 }
 
 // DeleteWHEPSession removes a WHEP session and cleans up all associated resources.
@@ -654,8 +845,9 @@ func (m *Manager) StopAll() {
 	}
 
 	// Unsubscribe from all StreamHubs
-	for _, sub := range hubSubs {
+	for camID, sub := range hubSubs {
 		sub.hub.Unsubscribe(sub.subID)
+		sub.hub.UnsubscribeAudio("webrtc-audio-" + camID)
 	}
 
 	// Wait for all RTCP drain goroutines to exit
@@ -731,6 +923,57 @@ func (m *Manager) writeLoop(ctx context.Context, entry *peerEntry) {
 			entry.congestion.recordSent()
 			if m.mets != nil {
 				m.mets.WebRTCFramesSent.WithLabelValues(entry.camID).Inc()
+			}
+		}
+	}
+}
+
+// audioWriteLoop drains audio frames and writes them to the audio track.
+// Duration comes from the PTS delta on the codec's RTP clock with a 20ms
+// fallback (typical G.711/Opus frame length).
+func (m *Manager) audioWriteLoop(ctx context.Context, entry *peerEntry) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Warn("WebRTC audioWriteLoop panic recovered",
+				"session_id", entry.sessionID, "error", r)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case frame := <-entry.audioCh:
+			entry.mu.Lock()
+			var dur time.Duration
+			if entry.lastAudioPTS == 0 {
+				dur = defaultAudioFrameDur
+			} else {
+				delta := frame.PTS - entry.lastAudioPTS
+				if delta > 0 {
+					dur = time.Duration(delta) * time.Second / time.Duration(entry.audioClock)
+					if dur > time.Second {
+						dur = defaultAudioFrameDur
+					}
+				} else {
+					dur = defaultAudioFrameDur
+				}
+			}
+			entry.lastAudioPTS = frame.PTS
+			entry.mu.Unlock()
+			if dur < time.Millisecond {
+				dur = time.Millisecond
+			}
+
+			if err := entry.audioTrack.WriteSample(media.Sample{
+				Data:     frame.Data,
+				Duration: dur,
+			}); err != nil {
+				// Non-fatal: log and continue (never crash the goroutine)
+				if !strings.Contains(err.Error(), "use of closed") {
+					logger.Warn("WebRTC audio write sample error",
+						"session_id", entry.sessionID, "error", err)
+				}
 			}
 		}
 	}

--- a/internal/webrtc/manager_test.go
+++ b/internal/webrtc/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/rtp"
 	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/require"
 
@@ -43,14 +44,27 @@ func newTestClient(t *testing.T, withAudio bool) *testClient {
 	}, webrtc.RTPCodecTypeVideo))
 
 	if withAudio {
-		require.NoError(t, mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
-			RTPCodecCapability: webrtc.RTPCodecCapability{
-				MimeType:  webrtc.MimeTypeOpus,
-				ClockRate: 48000,
-				Channels:  2,
-			},
-			PayloadType: 111,
-		}, webrtc.RTPCodecTypeAudio))
+		// Browsers support all WebRTC mandatory audio codecs — mirror that so
+		// answers selecting PCMU/PCMA/Opus all negotiate.
+		for _, ac := range []struct {
+			mime string
+			rate uint32
+			ch   uint16
+			pt   webrtc.PayloadType
+		}{
+			{webrtc.MimeTypePCMU, 8000, 1, 0},
+			{webrtc.MimeTypePCMA, 8000, 1, 8},
+			{webrtc.MimeTypeOpus, 48000, 2, 111},
+		} {
+			require.NoError(t, mediaEngine.RegisterCodec(webrtc.RTPCodecParameters{
+				RTPCodecCapability: webrtc.RTPCodecCapability{
+					MimeType:  ac.mime,
+					ClockRate: ac.rate,
+					Channels:  ac.ch,
+				},
+				PayloadType: ac.pt,
+			}, webrtc.RTPCodecTypeAudio))
+		}
 	}
 
 	interceptorRegistry := &interceptor.Registry{}
@@ -441,19 +455,77 @@ func TestAnnexBEncode(t *testing.T) {
 	require.Equal(t, expected, result)
 }
 
-// TestRejectAudioInSDP verifies that audio m-lines are rejected in SDP.
-func TestRejectAudioInSDP(t *testing.T) {
-	// SDP with audio m-line using port 9
-	sdp := "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\na=rtpmap:111 opus/48000/2\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\n"
-	result := rejectAudioInSDP(sdp)
+// TestWHEPAudioMuxing verifies SDP-level audio negotiation (#372):
+// cameras with a WebRTC-compatible codec get an active audio m-line in the
+// answer; video-only cameras keep the audio m-line rejected.
+func TestWHEPAudioMuxing(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.StopAll()
 
-	require.Contains(t, result, "m=audio 0 UDP/TLS/RTP/SAVPF 111")
-	require.Contains(t, result, "m=video 9 UDP/TLS/RTP/SAVPF 96")
+	hub := model.NewStreamHub()
+	mgr.RegisterStream("audio-cam", hub, nil)
+	require.NoError(t, mgr.SetAudioInfo("audio-cam", "g711", true, 8000, 1))
+	// AAC is not a WebRTC codec — the manager leaves the camera video-only.
+	mgr.RegisterStream("aac-cam", hub, nil)
+	require.NoError(t, mgr.SetAudioInfo("aac-cam", "aac", false, 16000, 1))
+	mgr.RegisterStream("video-cam", hub, nil)
 
-	// No audio m-line — should be unchanged
-	sdpNoAudio := "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\n"
-	result = rejectAudioInSDP(sdpNoAudio)
-	require.Equal(t, sdpNoAudio, result)
+	offerWithAudio := func(camID string) string {
+		client := newTestClient(t, true)
+		defer client.close()
+		answer, sid := connectWHEP(t, mgr, camID, client.pc, createOfferWithAudio(t, client.pc))
+		defer mgr.DeleteWHEPSession(sid)
+		return string(answer)
+	}
+
+	audioAnswer := offerWithAudio("audio-cam")
+	require.Contains(t, audioAnswer, "m=audio 9", "audio-capable camera must answer with an active audio m-line")
+	require.Contains(t, audioAnswer, "PCMU/8000", "µ-law G.711 must map to PCMU")
+
+	aLawAnswer := offerWithAudio("audio-cam")
+	require.Contains(t, aLawAnswer, "PCMU/8000")
+
+	aacAnswer := offerWithAudio("aac-cam")
+	require.Contains(t, aacAnswer, "m=audio 0 ", "AAC camera must keep the audio m-line rejected")
+
+	videoAnswer := offerWithAudio("video-cam")
+	require.Contains(t, videoAnswer, "m=audio 0 ", "video-only camera must keep the audio m-line rejected")
+}
+
+// TestSetAudioInfoA LAW maps G.711 A-law to PCMA.
+func TestSetAudioInfoALaw(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.StopAll()
+
+	hub := model.NewStreamHub()
+	mgr.RegisterStream("alaw-cam", hub, nil)
+	require.NoError(t, mgr.SetAudioInfo("alaw-cam", "g711", false, 8000, 1))
+
+	client := newTestClient(t, true)
+	defer client.close()
+	answer, sid := connectWHEP(t, mgr, "alaw-cam", client.pc, createOfferWithAudio(t, client.pc))
+	defer mgr.DeleteWHEPSession(sid)
+	require.Contains(t, string(answer), "PCMA/8000", "A-law G.711 must map to PCMA")
+}
+
+// TestSetAudioInfoBeforeRegister errors — audio cannot be configured without
+// a hub subscription.
+func TestSetAudioInfoBeforeRegister(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.StopAll()
+	require.Error(t, mgr.SetAudioInfo("no-hub-cam", "g711", true, 8000, 1))
+}
+
+// TestSetAudioInfoIdempotent — repeated calls (one per WHEP session) must
+// not fail on duplicate audio subscription.
+func TestSetAudioInfoIdempotent(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.StopAll()
+
+	hub := model.NewStreamHub()
+	mgr.RegisterStream("cam", hub, nil)
+	require.NoError(t, mgr.SetAudioInfo("cam", "g711", true, 8000, 1))
+	require.NoError(t, mgr.SetAudioInfo("cam", "g711", true, 8000, 1))
 }
 
 // TestWriteH264NonBlocking verifies that WriteH264 is non-blocking and
@@ -902,4 +974,86 @@ func TestRegisterStreamRebindsOnHubChange(t *testing.T) {
 
 	m.UnregisterStream("cam-rebind")
 	require.Nil(t, m.hubSubs["cam-rebind"])
+}
+
+// TestAudioForwarding verifies the full audio path (#372): hub broadcast →
+// WriteAudio → WebRTC audio track → RTP packets on the client. Uses G.711
+// µ-law (PCMU), the common case for Xiaomi/ESP32 cameras.
+func TestAudioForwarding(t *testing.T) {
+	mgr := newTestManager(t)
+	defer mgr.StopAll()
+
+	hub := model.NewStreamHub()
+	mgr.RegisterStream("audio-cam", hub, nil)
+	require.NoError(t, mgr.SetAudioInfo("audio-cam", "g711", true, 8000, 1))
+
+	client := newTestClient(t, true)
+	defer client.close()
+
+	audioPackets := make(chan *rtp.Packet, 8)
+	var audioTrackReady chan struct{}
+	audioTrackReady = make(chan struct{}, 1)
+	client.pc.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
+		if track.Kind() != webrtc.RTPCodecTypeAudio {
+			return
+		}
+		select {
+		case audioTrackReady <- struct{}{}:
+		default:
+		}
+		go func() {
+			for {
+				pkt, _, err := track.ReadRTP()
+				if err != nil {
+					return
+				}
+				select {
+				case audioPackets <- pkt:
+				default:
+				}
+			}
+		}()
+	})
+
+	connected := make(chan struct{}, 1)
+	client.pc.OnICEConnectionStateChange(func(state webrtc.ICEConnectionState) {
+		if state == webrtc.ICEConnectionStateConnected {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		}
+	})
+
+	offerSDP := createOfferWithAudio(t, client.pc)
+	_, sid := connectWHEP(t, mgr, "audio-cam", client.pc, offerSDP)
+	defer mgr.DeleteWHEPSession(sid)
+
+	select {
+	case <-connected:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ICE connection timeout")
+	}
+
+	// Push audio through the hub — OnTrack fires on the first received RTP
+	// packet (same semantics as the video forwarding test).
+	frame := make([]byte, 160) // 20ms of G.711 at 8kHz
+	for i := range 10 {
+		hub.BroadcastAudio(int64(i)*160, model.AudioG711, frame)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case <-audioTrackReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("audio track not received within timeout")
+	}
+
+	select {
+	case pkt := <-audioPackets:
+		require.Equal(t, uint8(0), pkt.Header.PayloadType, "PCMU uses static payload type 0")
+		require.NotEmpty(t, pkt.Payload)
+	case <-time.After(10 * time.Second):
+		t.Fatal("no audio RTP packets received within timeout")
+	}
 }

--- a/internal/webrtc/manager_test.go
+++ b/internal/webrtc/manager_test.go
@@ -991,8 +991,7 @@ func TestAudioForwarding(t *testing.T) {
 	defer client.close()
 
 	audioPackets := make(chan *rtp.Packet, 8)
-	var audioTrackReady chan struct{}
-	audioTrackReady = make(chan struct{}, 1)
+	audioTrackReady := make(chan struct{}, 1)
 	client.pc.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
 		if track.Kind() != webrtc.RTPCodecTypeAudio {
 			return

--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -24,9 +24,10 @@ func annexBEncode(au [][]byte) []byte {
 	return buf
 }
 
-// rejectAudioInSDP ensures all audio m-lines in the SDP answer are rejected
-// by setting their port to 0. This implements the WHEP requirement to reject
-// audio when the server only supports video.
+// rejectAudioInSDP rejects all audio m-lines in the SDP answer by setting
+// their port to 0. Applied only for video-only peers (#372): pion answers an
+// offered audio m-line with the engine's codecs (port 9) even when no audio
+// track was added — zeroing the port gives browsers an unambiguous rejection.
 func rejectAudioInSDP(sdp string) string {
 	lines := strings.Split(sdp, "\n")
 	for i, line := range lines {

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -273,6 +273,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			func() config.VisionConfig { return cfg.Vision },
 			func() string { return cfg.Storage.RootDir },
 			deps.eventBus,
+			db,
 		)
 		slog.Info("Vision push integration enabled",
 			"url", cfg.Vision.URL,

--- a/web/src/components/CameraAudioButton.svelte
+++ b/web/src/components/CameraAudioButton.svelte
@@ -13,9 +13,16 @@
   let {
     cameraId,
     class: className = '',
+    webrtcAudioTrack = null,
+    onToggleVideoMute = undefined,
   }: {
     cameraId: string;
     class?: string;
+    /** WebRTC audio track from the negotiated m-line (#372). When present the
+     *  button unmutes the <video> element instead of opening the audio WS. */
+    webrtcAudioTrack?: MediaStreamTrack | null;
+    /** Mute toggle for the player's <video> element (WebRTC audio path). */
+    onToggleVideoMute?: (muted: boolean) => void;
   } = $props();
 
   let ws: WebSocket | null = null;
@@ -111,6 +118,15 @@
 
     if (unavailableReason) {
       // No decode path available — clicks do nothing; tooltip explains.
+      return;
+    }
+
+    // WebRTC audio track (#372): the browser decodes natively — unmuting the
+    // <video> element is all it takes. No WS, no JS decode.
+    if (webrtcAudioTrack) {
+      muted = !muted;
+      webrtcAudioTrack.enabled = true;
+      onToggleVideoMute?.(muted);
       return;
     }
 

--- a/web/src/components/WebRTCPlayer.svelte
+++ b/web/src/components/WebRTCPlayer.svelte
@@ -58,6 +58,11 @@
   }
   type WebrtcState = 'connecting' | 'connected' | 'disconnected' | 'failed';
 
+  // WebRTC audio track from the negotiated m-line (#372). Non-null only for
+  // cameras with a WebRTC-compatible codec (G.711/Opus); AAC cameras keep the
+  // separate audio-WS path in CameraAudioButton.
+  let webrtcAudioTrack = $state<MediaStreamTrack | null>(null);
+
   let streamState: StreamState | 'loading' = $state('loading');
   let webrtcState: WebrtcState = $state('connecting');
   let videoEl: HTMLVideoElement | undefined = $state();
@@ -239,6 +244,7 @@ let destroyed = false;
     reconnectAttempts = 0;
     streamState = 'loading';
     webrtcState = 'connecting';
+    webrtcAudioTrack = null;
     initWebRTC();
   }
 
@@ -334,6 +340,7 @@ let destroyed = false;
 
     streamState = 'loading';
     webrtcState = 'connecting';
+    webrtcAudioTrack = null;
 
     // Arm the connection-establishment timeout: if no real frame arrives within
     // CONNECT_TIMEOUT_MS, abort and reconnect. Cleared on first frame or when
@@ -362,6 +369,9 @@ let destroyed = false;
 
       // Handle incoming tracks
       peerConnection.ontrack = (event) => {
+        if (event.track.kind === 'audio') {
+          webrtcAudioTrack = event.track;
+        }
         if (event.streams && event.streams[0] && videoEl) {
           videoEl.srcObject = event.streams[0];
           // A frame actually playing is the ONLY reliable signal that this
@@ -514,6 +524,7 @@ let destroyed = false;
     destroyPeerConnection();
     streamState = 'loading';
     webrtcState = 'connecting';
+    webrtcAudioTrack = null;
 
     const timer = setTimeout(() => initWebRTC(), 50);
     return () => {
@@ -691,7 +702,11 @@ let destroyed = false;
 
   <!-- Audio button (top-right, before expand) — hidden for video-only cameras -->
   {#if hasAudio}
-    <CameraAudioButton {cameraId} />
+    <CameraAudioButton
+      {cameraId}
+      webrtcAudioTrack={webrtcAudioTrack}
+      onToggleVideoMute={(muted) => { if (videoEl) videoEl.muted = muted; }}
+    />
   {/if}
 
   <!-- Expand/Shrink -->


### PR DESCRIPTION
Closes #372

## Summary
摘除 WHEP video-only 限制：G.711（µ-law→PCMU / A-law→PCMA）与 Opus 直接进 WebRTC 音频轨 —— 三者都是 WebRTC 强制 codec，浏览器必支持，NVR 侧 StreamHub 裸字节零转码直通。

- 媒体引擎注册 PCMU(PT 0)/PCMA(PT 8)/Opus(PT 111, 48kHz stereo)；每 peer 增加第二条 TrackLocalStaticSample 音频轨
- SetAudioInfo() 镜像 wsstream 的音频配置：WHEP 会话创建时从 recorder 提取（复用 audioInfoProvider），幂等（每相机一条 hub 音频订阅）
- rejectAudioInSDP 保留但只用于 video-only peer：pion 对未挂轨的 audio m-line 也会以 port 9 + 引擎 codec 应答，浏览器会一直等不会来的音频——显式置 0 拒绝。AAC 相机即走此路径（AAC 非 WebRTC codec，维持独立音频 WS）
- 音频写路径：50 帧非阻塞缓冲、PTS delta 推进时长（8k/48k RTP 时钟，20ms 回退），与视频 writeLoop 同构
- 前端：WebRTCPlayer 捕获协商出的音频轨；音频按钮直接 unmute video 元素（无 WS、无 JS 解码、无手动对齐）；无轨时回退现有音频 WS —— 渐进迁移，AAC/旧行为不变

## Tests（pion-to-pion）
- TestWHEPAudioMuxing：音频相机 answer 含活跃 m=audio + PCMU；AAC/无音频相机 m-line 置 0 拒绝
- TestSetAudioInfoALaw / BeforeRegister / Idempotent
- TestAudioForwarding：hub 广播 → WriteAudio → 音频轨 → 客户端收到 RTP 包（PT=0 校验）—— 全链路媒体路径
- 既有 40 项 webrtc 测试全绿（-race）

## 真机验证建议
pion-to-pion 已覆盖 SDP 协商与媒体路径；建议在 M5（小米 G.711 相机）浏览器实测一次 WHEP 音频后关闭真机项。