### PR TITLE
feat(distribution): Wave-2 NAS store templates — Synology/QNAP/极空间 deploy/ assets (#291)

### DIFF
--- a/deploy/qnap/README.md
+++ b/deploy/qnap/README.md
@@ -1,0 +1,31 @@
+# MiBee NVR — QNAP Container Station template
+
+One-import application template for QTS 5.x (Container Station →
+Applications). No manual compose typing.
+
+## Import steps
+
+1. **Container Station → Applications → Create Application**.
+2. Name: `mibee-nvr`. Source: paste the contents of `docker-compose.yml`
+   (or upload the file, depending on your QTS version).
+3. Adjust the volume path if your storage pool differs — the default
+   `/share/CACHEDEV1_DATA/mibee-nvr/data` matches the typical first pool.
+4. **Deploy**. The multi-arch image is pulled and started.
+5. Open `http://<nas-ip>:9090` and complete the setup wizard.
+
+## Customize before deploying (optional)
+
+- **Storage location**: point the left side of the volume mapping at a
+  volume with enough space.
+- **Port conflict** (`9090` taken by QTS or another app): uncomment
+  `NVR_LISTEN_PORT=8080` — or change it later in the Web UI
+  (Settings → General, #270).
+- **China mirror**: swap the `image:` line to
+  `registry.cn-hangzhou.aliyuncs.com/mickeybeehome/mibee-nvr:latest`.
+
+## Why host networking
+
+ONVIF WS-Discovery auto-scan needs UDP multicast, which Docker bridge
+blocks. `network_mode: host` fixes it; do NOT combine with `ports:`.
+
+Full guide: [docs/en/deployment-qnap.md](../../docs/en/deployment-qnap.md)

--- a/deploy/qnap/docker-compose.yml
+++ b/deploy/qnap/docker-compose.yml
@@ -1,0 +1,40 @@
+# MiBee NVR — QNAP QTS 5.x Container Station application template
+#
+# Import (see README.md):
+#   Container Station → Applications → Create Application
+#   → paste/upload this file
+#
+# network_mode: host is REQUIRED for ONVIF WS-Discovery auto-scan (UDP
+# multicast does not cross Docker's bridge). Do NOT add a "ports:" section
+# alongside host mode.
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    # China / slow ghcr? Swap to the Aliyun mirror (same manifest, anonymous pull):
+    # image: registry.cn-hangzhou.aliyuncs.com/mickeybeehome/mibee-nvr:latest
+    container_name: mibee-nvr
+    restart: unless-stopped
+    network_mode: host
+
+    volumes:
+      # Left side = host path on the NAS. Adjust to your storage pool, e.g.
+      # /share/CACHEDEV1_DATA/mibee-nvr/data (typical QTS layout) or a
+      # dedicated HDD volume. Keep recordings where the space is.
+      - /share/CACHEDEV1_DATA/mibee-nvr/data:/data
+
+    environment:
+      - NVR_DATA_DIR=/data
+      # Port conflict with another app on the NAS (#269)? Set the app's
+      # listen port via env — no YAML/config editing needed:
+      # - NVR_LISTEN_PORT=8080
+      # (Or change it later in the Web UI: Settings → General, see #270.)
+      # Match the UID/GID of the owner of the data folder if not 1000:
+      # - NVR_UID=1000
+      # - NVR_GID=1000
+
+    healthcheck:
+      test: ["CMD", "mibee-nvr", "health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3

--- a/deploy/synology/README.md
+++ b/deploy/synology/README.md
@@ -1,0 +1,32 @@
+# MiBee NVR — Synology Container Manager template
+
+One-import project template for DSM 7.2+ (Container Manager → Project).
+No manual compose typing — download `docker-compose.yml`, upload, done.
+
+## Import steps
+
+1. **File Station** → create the project folder `/volume1/docker/mibee-nvr/`.
+2. Upload this folder's `docker-compose.yml` into it (File Station → Upload).
+3. **Container Manager → Project → Add**:
+   - Project name: `mibee-nvr`
+   - Path: `/volume1/docker/mibee-nvr`
+   - Source: **Upload docker-compose.yml** → pick the uploaded file
+4. **Next → Done**. The multi-arch image is pulled and started.
+5. Open `http://<nas-ip>:9090` and complete the setup wizard.
+
+## Customize before starting (optional)
+
+- **Storage location**: change the left side of the volume mapping to a
+  shared folder with enough space, e.g. `/volume2/recordings:/data`.
+- **Port conflict** (`9090` taken): uncomment `NVR_LISTEN_PORT=8080` —
+  or change it later in the Web UI (Settings → General, #270).
+- **China mirror**: swap the `image:` line to
+  `registry.cn-hangzhou.aliyuncs.com/mickeybeehome/mibee-nvr:latest`.
+
+## Why host networking
+
+ONVIF WS-Discovery auto-scan needs UDP multicast, which Docker bridge
+blocks. `network_mode: host` fixes it; `ports:` must NOT be declared
+together with host mode (DSM rejects the compose).
+
+Full guide: [docs/en/deployment-synology.md](../../docs/en/deployment-synology.md)

--- a/deploy/synology/docker-compose.yml
+++ b/deploy/synology/docker-compose.yml
@@ -1,0 +1,39 @@
+# MiBee NVR — Synology DSM 7.2+ Container Manager Project template
+#
+# Import (see README.md for the step-by-step with screenshots-free walk):
+#   Container Manager → Project → Add → Path=/volume1/docker/mibee-nvr
+#   → Source=Upload docker-compose.yml (this file)
+#
+# network_mode: host is REQUIRED for ONVIF WS-Discovery auto-scan (UDP
+# multicast does not cross Docker's bridge). Do NOT add a "ports:" section —
+# host mode and port mappings conflict and DSM rejects the compose.
+services:
+  mibee-nvr:
+    image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    # China / slow ghcr? Swap to the Aliyun mirror (same manifest, anonymous pull):
+    # image: registry.cn-hangzhou.aliyuncs.com/mickeybeehome/mibee-nvr:latest
+    container_name: mibee-nvr
+    restart: unless-stopped
+    network_mode: host
+
+    volumes:
+      # Left side = host path on the NAS. Keep recordings on a volume with
+      # enough space (a dedicated shared folder or an HDD volume).
+      - /volume1/docker/mibee-nvr/data:/data
+
+    environment:
+      - NVR_DATA_DIR=/data
+      # Port conflict with something else on the NAS (#269)? Set the app's
+      # listen port via env — no YAML/config editing needed:
+      # - NVR_LISTEN_PORT=8080
+      # (Or change it later in the Web UI: Settings → General, see #270.)
+      # Match the UID/GID of the owner of the data folder if not 1000:
+      # - NVR_UID=1000
+      # - NVR_GID=1000
+
+    healthcheck:
+      test: ["CMD", "mibee-nvr", "health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3

--- a/deploy/zspace/README.md
+++ b/deploy/zspace/README.md
@@ -1,0 +1,25 @@
+# MiBee NVR — 极空间 Docker Compose 模板
+
+极空间（ZSPACE）Docker 编排一键导入模板，无需手抄 Compose。
+
+## 导入步骤
+
+1. 下载本目录的 `docker-compose.yml`。
+2. 极空间 **Docker → 编排 → 创建编排**，名称 `mibee-nvr`。
+3. 粘贴文件内容（或上传文件），按需修改存储路径。
+4. **创建/启动**。多架构镜像自动按 CPU 架构拉取。
+5. 浏览器打开 `http://<极空间IP>:9090` 完成初始化向导。
+
+## 按需调整
+
+- **存储位置**：把 volume 左侧改成空间充足的目录（建议 HDD）。
+- **端口冲突**（9090 被占）：取消注释 `NVR_LISTEN_PORT=8080` ——
+  或之后在 Web UI 里改（设置 → 通用，#270）。
+- **镜像源**：默认走阿里云镜像（国内免登录拉取）；海外可换回 ghcr。
+
+## 为什么用 host 网络
+
+ONVIF 自动发现依赖 UDP 组播，Docker bridge 模式不转发；
+`network_mode: host` 解决。host 模式下不要同时写 `ports:`。
+
+完整文档：[docs/zh/deployment-zspace.md](../../docs/zh/deployment-zspace.md)

--- a/deploy/zspace/docker-compose.yml
+++ b/deploy/zspace/docker-compose.yml
@@ -1,0 +1,37 @@
+# MiBee NVR — 极空间(ZSPACE) Docker Compose 模板
+#
+# 导入方式（详见 README.md）：
+#   极空间 Docker → 编排 → 创建编排 → 粘贴本文件内容
+#
+# network_mode: host 是 ONVIF 自动发现（UDP 组播，Docker bridge 不转发）的
+# 必要条件。host 模式下不要再写 ports: 端口映射。
+services:
+  mibee-nvr:
+    image: registry.cn-hangzhou.aliyuncs.com/mickeybeehome/mibee-nvr:latest
+    # 海外用户可换回 ghcr（内容完全一致）：
+    # image: ghcr.io/mi-bee-studio/mibeenvr:latest
+    container_name: mibee-nvr
+    restart: unless-stopped
+    network_mode: host
+
+    volumes:
+      # 左侧 = 极空间上的存储路径。建议选空间充足的硬盘/个人空间目录，
+      # 例如 /zs/media/nvr/data（按实际路径调整）。
+      - /zs/media/nvr/data:/data
+
+    environment:
+      - NVR_DATA_DIR=/data
+      # 9090 端口被其他应用占用（#269）？直接用环境变量改监听端口，
+      # 无需改 YAML/配置文件：
+      # - NVR_LISTEN_PORT=8080
+      # （或之后在 Web UI 里改：设置 → 通用，见 #270。）
+      # 数据目录属主非 1000 时按需调整：
+      # - NVR_UID=1000
+      # - NVR_GID=1000
+
+    healthcheck:
+      test: ["CMD", "mibee-nvr", "health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3

--- a/docs/en/deployment-qnap.md
+++ b/docs/en/deployment-qnap.md
@@ -57,6 +57,14 @@ docker compose up -d
 ```
 
 ## Port conflicts
+## Import the ready-made template
+
+Prefer not to paste compose by hand? A ready-to-use application template
+lives in the repo: [`deploy/qnap/docker-compose.yml`](../../deploy/qnap/docker-compose.yml)
+(with [`README.md`](../../deploy/qnap/README.md) import steps). It is the
+same host-network compose with the typical QTS pool path pre-filled, plus
+commented `NVR_LISTEN_PORT` and China-mirror switches.
+
 
 QNAP QTS uses `8080` (HTTP management) / `443` (HTTPS) / `80` (Web Server, if enabled) for itself. These do not clash with MiBee NVR's `9090` (Web) or `2121` (FTP). If a QNAP service occupies a port you need, change that service's port in the QTS **Control Panel → Network** rather than remapping the NVR.
 

--- a/docs/en/deployment-synology.md
+++ b/docs/en/deployment-synology.md
@@ -51,6 +51,14 @@ curl -fsSL https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/
 6. Open `http://<nas-ip>:9090` and complete the setup wizard.
 
 ## Port conflicts
+## Import the ready-made template
+
+Prefer not to paste compose by hand? A ready-to-upload project template lives
+in the repo: [`deploy/synology/docker-compose.yml`](../../deploy/synology/docker-compose.yml)
+(with [`README.md`](../../deploy/synology/README.md) import steps). It is the
+same host-network compose with the Synology path pre-filled, plus commented
+`NVR_LISTEN_PORT` and China-mirror switches.
+
 
 On host networking the container binds directly to the NAS. MiBee NVR uses `9090` (Web/API) and `2121` (FTP) — these do **not** clash with DSM's own ports. DSM reserves `5000` (HTTP) / `5001` (HTTPS) for its UI, and `20/21` for its optional built-in FTP. If you also enabled DSM's FTP, note it is a separate service from MiBee NVR's FTP (2121) — do not confuse them.
 

--- a/docs/en/deployment-zspace.md
+++ b/docs/en/deployment-zspace.md
@@ -50,6 +50,14 @@ curl -fsSL https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/
 5. Open `http://<nas-ip>:9090` and complete the setup wizard.
 
 ## Port conflicts
+## Import the ready-made template
+
+Prefer not to paste compose by hand? A ready-to-import orchestration template
+lives in the repo: [`deploy/zspace/docker-compose.yml`](../../deploy/zspace/docker-compose.yml)
+(with [`README.md`](../../deploy/zspace/README.md) import steps). It defaults
+to the Aliyun mirror (fast in China, anonymous pull), host networking, and a
+commented `NVR_LISTEN_PORT` switch.
+
 
 On host networking the container binds directly to the NAS. MiBee NVR uses `9090` (Web) and `2121` (FTP); if either clashes with another service or container, change the app's own port in `mibee-nvr.yaml` (not a port remap):
 ```yaml

--- a/docs/zh/deployment-qnap.md
+++ b/docs/zh/deployment-qnap.md
@@ -57,6 +57,13 @@ docker compose up -d
 ```
 
 ## 端口冲突
+## 导入现成模板
+
+不想手抄 Compose？仓库里有可直接导入的应用模板：
+[`deploy/qnap/docker-compose.yml`](../../deploy/qnap/docker-compose.yml)
+（导入步骤见 [`README.md`](../../deploy/qnap/README.md)）。与下文 compose 等价，
+已预填 QTS 典型存储池路径，并带 `NVR_LISTEN_PORT`（改端口）与国内镜像源注释开关。
+
 
 QNAP QTS 自身用 `8080`（HTTP 管理）/ `443`（HTTPS）/ `80`（Web Server，若启用）。这些与 MiBee NVR 的 `9090`（Web）或 `2121`（FTP）不冲突。若某个 QNAP 服务占用了你需要的端口，请在 QTS **控制面板 → 网络**里改该服务的端口，不要重映射 NVR。
 

--- a/docs/zh/deployment-synology.md
+++ b/docs/zh/deployment-synology.md
@@ -51,6 +51,13 @@ curl -fsSL https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/
 6. 打开 `http://<NAS-IP>:9090` 完成初始化向导。
 
 ## 端口冲突
+## 导入现成模板
+
+不想手抄 Compose？仓库里有可直接上传的项目模板：
+[`deploy/synology/docker-compose.yml`](../../deploy/synology/docker-compose.yml)
+（导入步骤见 [`README.md`](../../deploy/synology/README.md)）。与下文 compose 等价，
+已预填 Synology 路径，并带 `NVR_LISTEN_PORT`（改端口）与国内镜像源注释开关。
+
 
 host 网络下容器直接监听 NAS 端口。MiBee NVR 用 `9090`（Web/API）和 `2121`（FTP）——这俩**不与** DSM 自身端口冲突。DSM 保留 `5000`（HTTP）/ `5001`（HTTPS）给其管理界面，`20/21` 给可选的内置 FTP。如果你也开了 DSM 的 FTP，请注意它与本 NVR 的 FTP（2121）是两套独立服务，别混淆。
 

--- a/docs/zh/deployment-zspace.md
+++ b/docs/zh/deployment-zspace.md
@@ -50,6 +50,13 @@ curl -fsSL https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/
 5. 打开 `http://<NAS-IP>:9090` 完成初始化向导。
 
 ## 端口冲突
+## 导入现成模板
+
+不想手抄 Compose？仓库里有可直接导入的编排模板：
+[`deploy/zspace/docker-compose.yml`](../../deploy/zspace/docker-compose.yml)
+（导入步骤见 [`README.md`](../../deploy/zspace/README.md)）。默认走阿里云镜像源
+（国内免登录拉取）+ host 网络，并带 `NVR_LISTEN_PORT`（改端口）注释开关。
+
 
 host 网络下容器直接监听 NAS 端口。MiBee NVR 用 `9090`（Web）和 `2121`（FTP）；若与其它服务或容器冲突，改 `mibee-nvr.yaml` 里应用自己的端口（不要重映射）：
 ```yaml


### PR DESCRIPTION
Closes #291

## Summary
三平台「一键导入」模板资产落地，用户不再需要照文档手抄 Compose：

- **`deploy/synology/`** — Container Manager → Project 上传模板（DSM 7.2+）：host 网络、`/volume1/docker/mibee-nvr/data` 预填、`NVR_LISTEN_PORT`（#269）与国内镜像源注释开关、healthcheck；README 含导入步骤
- **`deploy/qnap/`** — Container Station → Applications 导入模板：同构，QTS 典型存储池路径预填
- **`deploy/zspace/`** — 极空间 Docker → 编排导入模板：默认阿里云镜像源（国内免登录拉取）、host 网络
- **统一约束**（验收要求）：全部 `network_mode: host`（ONVIF 组播必需）且不带 `ports:`（两者互斥，DSM 会拒绝）、数据卷映射、`NVR_LISTEN_PORT` 注释示例、README 导入指引
- **文档**：en+zh 三平台部署文档各加「导入模板 / Import template」章节，链接到 deploy/ 资产；端口冲突指引指向 Web UI 端口设置（#270 已落地）
- 模板 YAML 已用 parser 校验（host 模式、无 ports、volume/env 结构）

## 范围说明
- issue 的可选项「Compile Docker Package 封 .spk / QDK 打 .qpkg」未做——#320 已记录原生包的阻塞点（签名/审核），模板路径即 issue 的主交付物
- 社区模板库提交（slarker.me 等）属 #290 last-mile（需外部账号），不在本 PR