### PR TITLE
fix(config): setup 向导增量 patch 已加载配置，保留预置字段 (#388)

### DIFF
--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -54,47 +54,44 @@ func (h *Handler) handleSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build minimal valid config (mirrors cmdInit pattern)
+	// Storage path: only a wizard-provided path overrides the loaded config.
+	// When absent, keep the existing root_dir; fall back to Docker env detection
+	// only if the loaded config has none (it normally went through ApplyDefaults,
+	// which already sets /var/lib/mibee-nvr).
 	dataDir := strings.TrimSpace(req.StoragePath)
-	if dataDir == "" {
-		// Prefer existing config value, then Docker env detection
-		if h.config.Storage.RootDir != "" {
-			dataDir = h.config.Storage.RootDir
-		} else if envDir := os.Getenv("NVR_DATA_DIR"); envDir != "" {
-			dataDir = envDir
-		} else if info, err := os.Stat("/data"); err == nil && info.IsDir() {
-			dataDir = "/data"
-		} else {
-			dataDir = "/var/lib/mibee-nvr"
+	if dataDir == "" && strings.TrimSpace(h.config.Storage.RootDir) == "" {
+		switch {
+		case os.Getenv("NVR_DATA_DIR") != "":
+			dataDir = os.Getenv("NVR_DATA_DIR")
+		default:
+			if info, err := os.Stat("/data"); err == nil && info.IsDir() {
+				dataDir = "/data"
+			} else {
+				dataDir = "/var/lib/mibee-nvr"
+			}
 		}
 	}
 
-	cfg := config.Config{
-		Server:  config.ServerConfig{Listen: ":9090"},
-		Storage: config.StorageConfig{RootDir: dataDir, SegmentDuration: "30s"},
-		Auth:    config.AuthConfig{Username: req.Username, PasswordHash: hash},
-		Cameras: []config.CameraConfig{},
-		Cleanup: config.CleanupConfig{RetentionDays: 30, CheckInterval: "1h", DiskThresholdPercent: 85},
-		FTP:     config.FTPConfig{Port: 2121, PassivePortRange: "2122-2140"},
-		WebDAV:  config.WebDAVConfig{PathPrefix: "/dav"},
-		Observability: config.ObservabilityConfig{
-			LogLevel:  "info",
-			LogFormat: "text",
-		},
-		Version: "1.0",
+	// Patch the ALREADY-LOADED config in place — never rebuild from defaults
+	// (#388): a hand-preconfigured YAML (listen, vision, api_keys, cameras, …)
+	// completed through the setup wizard must keep every non-auth field. The
+	// loaded config already carries ApplyDefaults values, so a fresh install
+	// still materializes the same defaults the old rebuild wrote.
+	h.config.Auth.Username = req.Username
+	h.config.Auth.PasswordHash = hash
+	if dataDir != "" {
+		h.config.Storage.RootDir = dataDir
+	}
+	if strings.TrimSpace(h.config.Version) == "" {
+		h.config.Version = "1.0"
 	}
 
 	// Atomic save
-	if err := config.Save(h.configPath, &cfg); err != nil {
+	if err := config.Save(h.configPath, h.config); err != nil {
 		logger.Error("failed to save config", "error", err, "path", r.URL.Path)
 		WriteError(w, http.StatusInternalServerError, "failed to save config")
 		return
 	}
-
-	// Update in-memory config so middleware picks up the new password hash
-	h.config.Auth.Username = req.Username
-	h.config.Auth.PasswordHash = hash
-	h.config.Storage.RootDir = dataDir
 
 	// Issue a stateless signed session token (same scheme as /api/auth/login) so
 	// the just-initialized browser session never carries a reversible password.

--- a/internal/api/handlers_setup_test.go
+++ b/internal/api/handlers_setup_test.go
@@ -140,6 +140,50 @@ func TestHandleSetup_CustomStoragePath(t *testing.T) {
 	require.Equal(t, "/tmp/custom-nvr", saved.Storage.RootDir)
 }
 
+// TestHandleSetup_PreservesPreconfiguredFields locks in the #388 fix: setup
+// must patch auth (plus an explicit wizard storage path) on the already-loaded
+// config — never rewrite the file from defaults. A hand-preconfigured YAML
+// (listen / vision / api_keys / cameras) completed through the setup wizard
+// previously had every non-auth field silently reset.
+func TestHandleSetup_PreservesPreconfiguredFields(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	cfgPath := filepath.Join(t.TempDir(), "test-config.yaml")
+
+	cfg := &config.Config{
+		Version: "1.0",
+		Server:  config.ServerConfig{Listen: "127.0.0.1:9777"},
+		Storage: config.StorageConfig{RootDir: "/mnt/preconfigured"},
+		Vision:  config.VisionConfig{Enabled: true, URL: "http://192.168.63.110:9091"},
+		APIKeys: []config.APIKeyConfig{{Key: "mbv_abcdef0123456789", Name: "vision"}},
+		Cameras: []config.CameraConfig{{ID: "test-cam", Name: "Test", Protocol: "rtsp", URL: "rtsp://example/stream", Encoding: "h264"}},
+	}
+	h := NewHandler(db, store, noopAuthMW(), cfg, nil, nil, cfgPath, nil, nil, nil, nil, nil)
+
+	body := setupRequest{Username: "admin", Password: "testpassword123"}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.handleSetup(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	saved, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:9777", saved.Server.Listen)
+	require.Equal(t, "/mnt/preconfigured", saved.Storage.RootDir)
+	require.True(t, saved.Vision.Enabled)
+	require.Equal(t, "http://192.168.63.110:9091", saved.Vision.URL)
+	require.Len(t, saved.APIKeys, 1)
+	require.Equal(t, "mbv_abcdef0123456789", saved.APIKeys[0].Key)
+	require.Len(t, saved.Cameras, 1)
+	require.Equal(t, "test-cam", saved.Cameras[0].ID)
+	require.Equal(t, "admin", saved.Auth.Username)
+	require.NotEmpty(t, saved.Auth.PasswordHash)
+}
+
 func TestHandleSetup_TokenIsValid(t *testing.T) {
 	t.Parallel()
 	h, _ := setupTestHandlerForSetup(t)

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1250,7 +1250,7 @@
   "setup.passwordPlaceholder": "At least 8 characters",
   "setup.secureNote": "Your password is stored securely and cannot be recovered",
   "setup.storagePath": "Storage Path",
-  "setup.storagePathHint": "Directory where recordings will be stored",
+  "setup.storagePathHint": "Directory where recordings will be stored; leave empty to keep the server's current setting",
   "setup.submit": "Complete Setup",
   "setup.submitting": "Setting up...",
   "setup.subtitle": "Create your admin account to get started",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1209,7 +1209,7 @@
   "setup.passwordPlaceholder": "至少 8 个字符",
   "setup.secureNote": "密码安全存储，无法恢复，请妥善保管",
   "setup.storagePath": "存储路径",
-  "setup.storagePathHint": "录像文件的存储目录",
+  "setup.storagePathHint": "录像文件的存储目录；留空则沿用服务端当前配置",
   "setup.submit": "完成设置",
   "setup.submitting": "正在设置...",
   "setup.subtitle": "创建管理员账户以开始使用",

--- a/web/src/routes/Setup.svelte
+++ b/web/src/routes/Setup.svelte
@@ -12,7 +12,10 @@
   let showPassword = $state(false);
   let showConfirmPassword = $state(false);
   let language = $state('en');
-  let storagePath = $state('/var/lib/mibee-nvr');
+  // Empty = keep the server-side storage.root_dir (pre-configured YAML or its
+  // default). Only a user-entered path is submitted — the wizard must never
+  // clobber a pre-configured root_dir with its own default (#388).
+  let storagePath = $state('');
   let error = $state('');
   let loading = $state(false);
 


### PR DESCRIPTION
## 问题 (#388)

`POST /api/setup` 完成向导时用一份**默认构造的 Config** 整体重写配置文件，静默丢失所有预置字段：
`server.listen` 重置回 `:9090`、`vision.enabled` 重置回 `false`、`api_keys` 清空、摄像头列表清空。
影响"先写配置再初始化"的路径（预配置部署 / IaC）。

同时修复前端半边：Setup 向导硬编码 `storagePath='/var/lib/mibee-nvr'` 且无条件提交，即使后端修好也会把预置的 `storage.root_dir` 覆盖成默认值。

## 修复

**后端** `internal/api/handlers_setup.go`：
- 在已加载的 `h.config` 上增量 patch（username + password_hash + 用户显式填写的 storage path），不再整体重建
- 全新安装行为不变：加载时 `ApplyDefaults` 已填的默认值与旧手写块一致
- RootDir 为空时保留 Docker 环境探测回退链（NVR_DATA_DIR → /data → /var/lib/mibee-nvr）

**前端** `web/src/routes/Setup.svelte`：
- 存储路径默认改为空 + placeholder，留空不提交 → 服务端沿用当前 root_dir
- i18n 提示更新（中英）："留空则沿用服务端当前配置"

## 测试

- [x] 新增回归测试 `TestHandleSetup_PreservesPreconfiguredFields`（listen/vision/api_keys/cameras 全保留）
- [x] M5 真机浏览器实测（PR 准入）：
  - 预置 yaml（listen :9777 / vision.enabled+url / api_keys mbv_*）→ 浏览器完成向导 →
    配置文件全部字段保留，`root_dir` 未被覆盖
  - 预置 API key Bearer 鉴权 200，无鉴权 401（key 功能完好）
  - 二次 `POST /api/setup` 返回 409
- [x] `GOOS=linux GOARCH=arm64` 交叉编译通过；完整套件由 CI 验证

Closes #388