### PR TITLE
fix(ci): 禁用 provenance/SBOM 附带物 — ACR 拒收 oci.empty manifest class

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,13 @@ jobs:
             VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # No provenance/SBOM attestations: buildx attaches them as extra
+          # manifest-list entries (application/vnd.oci.empty.v1+json), which the
+          # Alibaba Cloud ACR mirror rejects with
+          # "denied: unknown manifest class" — breaking mirror-to-acr. ghcr
+          # works with or without them; ACR compatibility wins.
+          provenance: false
+          sbom: false
 
   # ---- Offline fnOS .fpk -------------------------------------------------------
   # Produces the self-contained fnOS installer (both arch images docker-saved


### PR DESCRIPTION
v0.11.0 第二次流水线：skopeo 同步在 4/6 清单处被 ACR 拒绝：`denied: unknown manifest class for application/vnd.oci.empty.v1+json`——buildx 默认附带的 attestation 清单。构建改为 provenance: false + sbom: false，清单列表只含三个真实平台镜像。

合并后第三次移动 v0.11.0 tag 重触发。