### PR TITLE
fix(fnos): 在线后缀判定用非空而非真值 — 离线包覆盖了在线 .fpk

### DIFF
--- a/deploy/fnos/build.sh
+++ b/deploy/fnos/build.sh
@@ -29,7 +29,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ONLINE=1 builds the online .fpk: no bundled image tars — cmd/main probes
 # ghcr vs the ACR mirror at start and pulls the matching arch. The online
 # package is tiny (~KB) but requires the NAS to reach a registry on install.
-ONLINE=0
+# ONLINE uses EMPTY/1 (not 0/1): the canonical-name suffix below relies on
+# ${ONLINE:+-online}, which tests NON-EMPTY — a literal "0" would wrongly add
+# the suffix to offline builds too (v0.11.0: both jobs emitted -online- names
+# and the offline upload clobbered the small online package).
+ONLINE=""
 if [ "${1:-}" = "--online" ]; then ONLINE=1; shift; fi
 VERSION="${1:-${VERSION:-}}"
 # fnpack binary; on Windows set FNPACK_BIN to the path of fnpack.exe.


### PR DESCRIPTION
${ONLINE:+-online} 对任何非空值都展开，OFFLINE 的 ONLINE=0 同样拼出 -online- 名字。v0.11.0 两个 job 产出同名资产，离线的 153MB 上传覆盖了在线的小包，且纯离线名从未存在。改为空串/1 语义。合并后第四次移 tag 重跑。