### PR TITLE
fix(config): xiaomi empty encoding no longer bricks startup (#402)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -328,7 +328,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !validProtocols[body.Protocol] {
-		WriteError(w, http.StatusBadRequest, fmt.Sprintf("invalid protocol %q, must be one of: rtsp, http, onvif, srt, rtmp, xiaomi, timelapse, gb28181", body.Protocol))
+		WriteError(w, http.StatusBadRequest, fmt.Sprintf("invalid protocol %q, must be one of: rtsp, http, onvif, srt, rtmp, whip, xiaomi, timelapse, gb28181", body.Protocol))
 		return
 	}
 	// Push/ingest cameras (srt/rtmp/whip): no URL — the publisher connects to us.
@@ -435,6 +435,13 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		case "gb28181":
 			// Hint only — the recorder detects the real codec from PS stream NALUs.
 			enc = "h264"
+		case "xiaomi":
+			// Hint only — the Xiaomi recorder probes H264/H265 from the MISS
+			// stream at runtime; the list/get probe backfill corrects the label
+			// for H.265 devices. Without this default the UI's deliberate
+			// encoding omission (auto-detect protocols send none) persisted an
+			// empty encoding that failed startup validation fatally (#402).
+			enc = "h264"
 		case "onvif":
 			// Auto-detect encoding from ONVIF device profiles
 			if body.StreamEncoding == "" {
@@ -447,6 +454,14 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 				enc = strings.ToLower(body.StreamEncoding)
 			}
 		}
+	}
+	// Guard the API write boundary with the same protocol+encoding validation
+	// the startup path enforces: an invalid combo saved here (e.g. rtmp+h265
+	// from a non-UI client) bricks the NEXT restart with a fatal config
+	// validation error (#402 bug class).
+	if err := model.ValidateProtocolEncoding(proto, enc); err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
 	}
 
 	cam := config.CameraConfig{
@@ -751,6 +766,34 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		}
 		if updates.ONVIFEndpoint != nil && *updates.ONVIFEndpoint != "" {
 			updates.URL = updates.ONVIFEndpoint
+		}
+	}
+
+	// When protocol or encoding is being changed, validate the RESULTING combo
+	// against the same rules startup enforces — otherwise a partial update
+	// (e.g. encoding h265 on an rtmp camera) saves a config that fails fatally
+	// on the next restart (#402 bug class).
+	if body.Protocol != nil || body.Encoding != nil {
+		proto, enc := "", ""
+		managed := false
+		if cur := h.camMgr.GetCameraConfig(id); cur != nil {
+			proto, enc = cur.Protocol, cur.Encoding
+			managed = true
+		}
+		if body.Protocol != nil {
+			proto = *body.Protocol
+		}
+		if body.Encoding != nil {
+			enc = *body.Encoding
+		}
+		// Validate only when the effective protocol is known: from the body, or
+		// from the camera's config entry. Orphaned DB-only cameras (no YAML
+		// entry) keep the legacy no-validation behavior.
+		if managed || body.Protocol != nil {
+			if err := model.ValidateProtocolEncoding(proto, enc); err != nil {
+				WriteError(w, http.StatusBadRequest, fmt.Sprintf("camera %q: %s", id, err.Error()))
+				return
+			}
 		}
 	}
 

--- a/internal/api/handlers_camera_test.go
+++ b/internal/api/handlers_camera_test.go
@@ -622,3 +622,73 @@ func TestHandleListCameras_GB28181_EncodingBackfill(t *testing.T) {
 	require.Equal(t, "cam-gb28181-backfill", cameras[0].ID)
 	require.Equal(t, "h264", cameras[0].Encoding, "GB28181 recorder must backfill encoding via HLSProvider")
 }
+
+// --- protocol+encoding write-boundary validation (#402) ---
+
+// TestCreateCamera_XiaomiDefaultsEncodingHint: the UI omits encoding for
+// auto-detect protocols (xiaomi) — the API must persist the h264 hint, not an
+// empty encoding. An empty encoding passed the API write path since v0.10.0
+// but failed startup validation fatally on the next restart (Docker update
+// brick, #402).
+func TestCreateCamera_XiaomiDefaultsEncodingHint(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"Xiaomi Cam","protocol":"xiaomi","url":"xiaomi://123456789"}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	parseJSON(t, rr, &created)
+	cfg := h.camMgr.GetCameraConfig(created.ID)
+	require.NotNil(t, cfg, "created camera must be in the manager config")
+	require.Equal(t, "h264", cfg.Encoding, "xiaomi cameras must get the h264 hint, never an empty encoding")
+}
+
+// TestCreateCamera_RejectsInvalidEncodingCombo: the create API enforces the
+// same protocol+encoding rules as startup validation, so a non-UI client
+// cannot save a combo (rtmp+h265) that bricks the next restart.
+func TestCreateCamera_RejectsInvalidEncodingCombo(t *testing.T) {
+	h := setupDedupHandler(t)
+
+	body := `{"name":"RTMP Cam","protocol":"rtmp","encoding":"h265","stream_key":"k1"}`
+	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
+	require.Contains(t, rr.Body.String(), "not valid for protocol")
+}
+
+// TestUpdateCamera_RejectsInvalidEncodingCombo: updating the encoding alone is
+// validated against the camera's current protocol; a valid combo passes.
+func TestUpdateCamera_RejectsInvalidEncodingCombo(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{RootDir: store.RootDir(), SegmentDuration: "30s"},
+		Cameras: []config.CameraConfig{{
+			ID:       "cam-xiaomi-update",
+			Name:     "Xiaomi",
+			Protocol: "xiaomi",
+			Encoding: "h264",
+			URL:      "xiaomi://123456789",
+		}},
+	}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, camMgr.Start(ctx))
+	t.Cleanup(func() { _ = camMgr.Stop() })
+
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, nil, nil)
+
+	// jpeg is not a valid xiaomi encoding → 400, nothing persisted.
+	rr := doRequest(t, h.Routes(), "PUT", "/api/cameras/cam-xiaomi-update", bytes.NewReader([]byte(`{"encoding":"jpeg"}`)), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
+	require.Equal(t, "h264", camMgr.GetCameraConfig("cam-xiaomi-update").Encoding)
+
+	// h265 is a valid hint for xiaomi → accepted.
+	rr = doRequest(t, h.Routes(), "PUT", "/api/cameras/cam-xiaomi-update", bytes.NewReader([]byte(`{"encoding":"h265"}`)), "", "")
+	require.Equal(t, http.StatusOK, rr.Code, "body: %s", rr.Body.String())
+	require.Equal(t, "h265", camMgr.GetCameraConfig("cam-xiaomi-update").Encoding)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -411,6 +411,27 @@ func TestXiaomiConfigValidationWithToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestXiaomiEmptyEncodingBackfilled (#402): configs written since v0.10.0
+// store encoding:"" for xiaomi cameras (the UI deliberately omits it for
+// auto-detect protocols; the add handler lacked a xiaomi default). The strict
+// protocol/encoding validation rejected that fatally at startup — Validate
+// must instead backfill the h264 hint so the next start succeeds, while still
+// rejecting a genuinely wrong encoding value.
+func TestXiaomiEmptyEncodingBackfilled(t *testing.T) {
+	cfg := &Config{Cameras: []CameraConfig{{ID: "c1", Protocol: "xiaomi", Encoding: "", URL: "xiaomi://device"}}}
+	cfg.ApplyDefaults()
+	err := Validate(cfg)
+	require.NoError(t, err)
+	require.Equal(t, "h264", cfg.Cameras[0].Encoding, "empty xiaomi encoding must be backfilled to the h264 hint")
+}
+
+func TestXiaomiInvalidEncodingStillRejected(t *testing.T) {
+	cfg := &Config{Cameras: []CameraConfig{{ID: "c1", Protocol: "xiaomi", Encoding: "jpeg", URL: "xiaomi://device"}}}
+	cfg.ApplyDefaults()
+	err := Validate(cfg)
+	require.Error(t, err, "backfill must only heal the empty value, not loosen validation for garbage")
+}
+
 func TestCameraConfigXiaomiFields(t *testing.T) {
 	cfg := &Config{
 		Cameras: []CameraConfig{{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -125,6 +125,20 @@ func validateConfigDetails(cfg *Config) error {
 				return fmt.Errorf("camera[%d].onvif_endpoint has invalid format: %s", i, c.ONVIFEndpoint)
 			}
 		}
+		// Self-heal legacy xiaomi configs with an empty encoding (#402): since
+		// v0.10.0 the UI deliberately omits encoding for xiaomi cameras (the
+		// recorder probes H264/H265 from the MISS stream at runtime), but the
+		// add handler only started defaulting it — configs written in between
+		// hold encoding:"" which the strict protocol/encoding validation below
+		// rejects fatally at startup. Backfill the same h264 hint the add path
+		// now writes; the runtime codec probe corrects the label for H.265
+		// devices. Mirrors the onvif_endpoint auto-populate above.
+		if c.Protocol == string(model.ProtoXiaomi) && c.Encoding == "" {
+			// Write through the loop index — c is a copy (the onvif_endpoint
+			// auto-populate above mutates only its copy and never persists).
+			cfg.Cameras[i].Encoding = string(model.FormatH264)
+			c.Encoding = string(model.FormatH264)
+		}
 		// 0.10.0+: combined protocol strings (e.g. "rtsp_h264") are no longer
 		// accepted. protocol and encoding must be specified separately.
 		proto := c.Protocol


### PR DESCRIPTION
Fixes #402

## Root cause

Since v0.10.0 (#171) the UI deliberately omits `encoding` for auto-detect protocols (xiaomi — the recorder probes H264/H265 from the MISS stream at runtime). But `handleAddCamera`'s default-encoding switch had **no `xiaomi` case**, so the empty value was persisted to `mibee-nvr.yaml`. Startup's strict protocol/encoding validation then rejected it **fatally**:

```
config validation: camera[0].encoding "" not valid for protocol "xiaomi"
```

Any restart — Docker update, reboot, `docker compose up -d` — after adding a xiaomi camera via the UI bricked the NVR. The validation rule itself dates back to v0.10.0; only the window between "camera added" and "next restart" made it look update-triggered (#402).

## Fix (three layers)

1. **Self-heal existing configs** — `config.Validate` backfills `encoding:"" → "h264"` for xiaomi cameras (mirrors the onvif_endpoint auto-populate in the same function; writes through the loop index — `range` copies would silently drop the fix). The hint is display-only: the list/get handlers already resolve the shown encoding from the live recorder probe, so H.265 xiaomi devices display correctly.
2. **Root cause at the write path** — `handleAddCamera` now defaults xiaomi to the same h264 hint (identical semantics to the existing gb28181 case).
3. **API write-boundary guard** — both create and update now run `ValidateProtocolEncoding`, so an invalid combo (e.g. rtmp+h265 from a non-UI client) is rejected with 400 instead of being saved and bricking the next restart. Same bug class, closed while here. Update-path guard validates the *resulting* combo (current config + partial body) and skips orphaned DB-only cameras with no YAML entry.

Also: stale protocol list in the create error message now includes `whip`.

## Tests

- `TestXiaomiEmptyEncodingBackfilled` — legacy shape validates + backfills
- `TestXiaomiInvalidEncodingStillRejected` — backfill heals only empty, not garbage
- `TestCreateCamera_XiaomiDefaultsEncodingHint` — add via API persists h264, never ""
- `TestCreateCamera_RejectsInvalidEncodingCombo` — rtmp+h265 → 400
- `TestUpdateCamera_RejectsInvalidEncodingCombo` — jpeg→400 (nothing persisted), h265→200

## Verification

Full suite `go test -race ./...` green, lint 0 issues. End-to-end: built the binary and booted it against a config with the exact issue shape (xiaomi + empty encoding) — starts and serves `/api/health`; on the previous release this config exits at `config validation`.