### PR TITLE
fix(storage): vanished temp segment must not trip I/O health

### DIFF
--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -2,7 +2,10 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -134,12 +137,27 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 	return tempPath, finalPath, nil
 }
 
+// recordFinalizeFailure feeds a finalize-path error into health tracking —
+// unless the temp segment simply vanished. A missing .tmp is a stale-segment
+// cleanup or restart-window artifact, not an I/O error: counting it escalates
+// a healthy camera to Failed on every restart, and the recorders' skip-before-
+// write behavior then blocks the successful write that would reset the state,
+// deadlocking the camera out of recording until the process restarts.
+func (m *Manager) recordFinalizeFailure(tempPath string, err error) {
+	if errors.Is(err, fs.ErrNotExist) {
+		slog.Warn("storage: temp segment vanished before finalize — segment lost, storage healthy",
+			"path", tempPath)
+		return
+	}
+	m.RecordWriteFailureForPath(tempPath)
+}
+
 // CloseSegment atomically finalizes a segment by syncing and renaming .tmp to final path.
 func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 	// Check if temp is a directory (MJPEG) or file (H.264)
 	info, err := os.Stat(tempPath)
 	if err != nil {
-		m.RecordWriteFailureForPath(tempPath)
+		m.recordFinalizeFailure(tempPath, err)
 		m.unregisterTempPath(tempPath)
 		return fmt.Errorf("storage: temp path not found: %w", err)
 	}
@@ -148,7 +166,7 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 		// Sync the directory for MJPEG
 		dirFd, err := os.Open(tempPath)
 		if err != nil {
-			m.RecordWriteFailureForPath(tempPath)
+			m.recordFinalizeFailure(tempPath, err)
 			m.unregisterTempPath(tempPath)
 			return fmt.Errorf("storage: cannot open temp dir for sync: %w", err)
 		}
@@ -169,7 +187,7 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 		// Sync and close the file for H.264
 		f, err := os.OpenFile(tempPath, os.O_WRONLY, 0)
 		if err != nil {
-			m.RecordWriteFailureForPath(tempPath)
+			m.recordFinalizeFailure(tempPath, err)
 			m.unregisterTempPath(tempPath)
 			return fmt.Errorf("storage: cannot open temp file for sync: %w", err)
 		}

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -1365,3 +1365,40 @@ func TestInsertOrphanRecordingsBatching(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, inserted, "second insert should find no new records")
 }
+
+// A vanished temp segment (removed by the stale-segment cleanup or lost in a
+// restart window) must NOT count toward storage health. Counting it drove a
+// production deadlock: three vanished-tmp closes during restart ramp-up
+// escalated a healthy camera to Failed, the recorders' skip-before-write
+// behavior then blocked the successful write that resets the state, and the
+// camera stopped recording until the next restart.
+func TestCloseSegment_VanishedTempDoesNotTripHealth(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := NewManager(dir)
+	m.EnsureCameraDir("cam-latch")
+
+	// Create and register a real segment, then delete the temp file out from
+	// under the closer — the observed production scenario.
+	tempPath, finalPath, err := m.CreateSegment("cam-latch", "h264")
+	if err != nil {
+		t.Fatalf("CreateSegment error: %v", err)
+	}
+	if err := os.Remove(tempPath); err != nil {
+		t.Fatalf("Remove temp: %v", err)
+	}
+
+	if err := m.CloseSegment(tempPath, finalPath); err == nil {
+		t.Fatal("CloseSegment must still report the lost segment")
+	}
+
+	// Repeat far past the failure threshold: health must stay clean.
+	for range maxConsecutiveFailures * 2 {
+		_ = m.CloseSegment(tempPath, finalPath)
+	}
+	if m.StorageFailedLegacy() {
+		t.Fatal("vanished temp segments must not trip storage health")
+	}
+	if m.StorageHealth("cam-latch") != HealthHealthy {
+		t.Fatal("camera health must remain healthy after vanished-tmp closes")
+	}
+}


### PR DESCRIPTION
Fixes #413.

`CloseSegment` counted a missing `.tmp` (`os.Stat` → NotExist) toward per-camera write-failure health. That turns a normal restart/cleanup artifact into a recording deadlock:

1. restart → orphaned `.tmp`s from the old process;
2. recorder ramp-up finalizes them → 3 NotExist closes (the `maxConsecutiveFailures` threshold) → camera escalates healthy → degraded → failed **within seconds**;
3. recorders check `StorageFailed` before writing → skip recording → no successful write ever resets the state → the camera is out of recording until the next process restart.

Observed in production today (M5): a healthy jpeg camera lost 11+ minutes of recording after a routine restart; kernel log completely clean — never a real disk error. `GET /api/health` meanwhile reports `storage: I/O errors detected`.

## Fix

Finalize-path NotExist (`os.Stat`/open failures where `errors.Is(err, fs.ErrNotExist)`) now logs a segment-lost WARN and returns the error unchanged — the segment is genuinely lost and callers already handle that — but does **not** feed the health tracker. Genuine I/O failures (sync errors, non-NotExist open/rename errors) still count exactly as before.

## Test

`TestCloseSegment_VanishedTempDoesNotTripHealth` — creates + registers a real segment, deletes the temp file under the closer, and asserts: CloseSegment still errors, and hammering it far past the failure threshold leaves both `StorageFailedLegacy` false and the camera `HealthHealthy`.