### PR TITLE
fix(storage,recorder): vanished tmp on WriteFrame must not trip health or tear down the stream

### DIFF
--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -503,6 +505,20 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 		} else {
 			n, err := r.store.WriteFrame(r.curTempPath, data)
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// The segment tmp vanished (rotated away or cleaned while
+					// this stream loop held it). The camera and HTTP stream
+					// are healthy — drop the stale path so the next frame
+					// opens a fresh segment instead of tearing down and
+					// reconnecting into the same dead path (which also fed
+					// the storage-health failure counter, #413).
+					httpJpegLogger.Warn("segment temp vanished — restarting segment",
+						"camera_id", r.cfg.CameraID, "path", r.curTempPath)
+					r.curTempPath = ""
+					r.curFinalPath = ""
+					r.frameCount = 0
+					continue
+				}
 				return fmt.Errorf("write frame: %w", err), true
 			}
 			r.frameCount++

--- a/internal/recorder/http_jpeg_test.go
+++ b/internal/recorder/http_jpeg_test.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"image/jpeg"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -288,4 +289,64 @@ func TestMemAvailableMB(t *testing.T) {
 	require.Greater(t, mb, 0, "memAvailableMB must be positive")
 	// Any real Linux host has at least 128MB available; the fallback is 1024.
 	require.Less(t, mb, 1024*1024, "memAvailableMB should be <1TB (sanity check)")
+}
+
+// vanishedTmpStore simulates a segment tmp that disappears mid-stream
+// (rotation/cleanup race): WriteFrame fails with fs.ErrNotExist until told
+// otherwise. Everything else succeeds.
+type vanishedTmpStore struct {
+	createCount int
+	failFirst   int
+	writes      []string
+}
+
+func (s *vanishedTmpStore) CreateSegment(cameraID, format string) (string, string, error) {
+	s.createCount++
+	return fmt.Sprintf("seg-%d.tmp", s.createCount), fmt.Sprintf("seg-%d.final", s.createCount), nil
+}
+
+func (s *vanishedTmpStore) WriteFrame(tempPath string, data []byte) (int, error) {
+	if s.failFirst > 0 {
+		s.failFirst--
+		return 0, fmt.Errorf("storage: temp path not accessible: %w", fs.ErrNotExist)
+	}
+	s.writes = append(s.writes, tempPath)
+	return len(data), nil
+}
+
+func (s *vanishedTmpStore) CloseSegment(tempPath, finalPath string) error { return nil }
+
+// A vanished segment tmp must restart the segment in-loop: keep the HTTP
+// stream, open a fresh segment on the next frame — NOT tear down and
+// reconnect into the same dead path (#413; the reconnect loop previously
+// hammered the missing tmp until storage health escalated to Failed).
+func TestHTTPJPEGVanishedTempRestartsSegment(t *testing.T) {
+	srv, handler := newMJPEGStreamServer()
+	defer srv.Close()
+
+	store := &vanishedTmpStore{failFirst: 1}
+	rec := NewHTTPJPEGRecorder(HTTPJPEGConfig{
+		CameraID:   "cam-vanished-tmp",
+		URL:        srv.URL,
+		SegmentDur: time.Hour,
+	}, store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, rec.Start(ctx))
+	require.Equal(t, model.StatusRecording, rec.Status())
+
+	time.Sleep(200 * time.Millisecond)
+	handler.sendFrames(5, 20*time.Millisecond)
+	time.Sleep(300 * time.Millisecond)
+
+	require.NoError(t, rec.Stop())
+	require.Equal(t, model.StatusStopped, rec.Status())
+
+	require.GreaterOrEqual(t, store.createCount, 2, "recorder must open a fresh segment after the tmp vanished")
+	require.NotEmpty(t, store.writes, "frames must land in the replacement segment")
+	for _, w := range store.writes {
+		require.Equal(t, "seg-2.tmp", w, "frames must go to the replacement segment only")
+	}
 }

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -220,6 +220,15 @@ func (m *Manager) WriteFrame(tempPath string, data []byte) (int, error) {
 
 	info, err := os.Stat(tempPath)
 	if err != nil {
+		// A vanished temp is a rotation/cleanup artifact, not an I/O error —
+		// same rationale as the CloseSegment gate: counting it escalates a
+		// healthy camera to Failed and the skip-before-write recorders then
+		// never record the successful write that would reset the state.
+		if errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("storage: temp segment vanished before write — frame dropped, storage healthy",
+				"path", tempPath)
+			return 0, fmt.Errorf("storage: temp path not accessible: %w", err)
+		}
 		m.RecordWriteFailureForPath(tempPath)
 		return 0, fmt.Errorf("storage: temp path not accessible: %w", err)
 	}

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -1402,3 +1402,32 @@ func TestCloseSegment_VanishedTempDoesNotTripHealth(t *testing.T) {
 		t.Fatal("camera health must remain healthy after vanished-tmp closes")
 	}
 }
+
+// WriteFrame on a vanished temp must not feed the health tracker either —
+// the recorder-side reconnect loop used to hammer the missing tmp until the
+// camera escalated to Failed (#413).
+func TestWriteFrame_VanishedTempDoesNotTripHealth(t *testing.T) {
+	dir := t.TempDir()
+	m, _ := NewManager(dir)
+	m.EnsureCameraDir("cam-wf")
+
+	tempPath, _, err := m.CreateSegment("cam-wf", "h264")
+	if err != nil {
+		t.Fatalf("CreateSegment error: %v", err)
+	}
+	if err := os.Remove(tempPath); err != nil {
+		t.Fatalf("Remove temp: %v", err)
+	}
+
+	for range maxConsecutiveFailures * 2 {
+		if _, err := m.WriteFrame(tempPath, []byte("x")); err == nil {
+			t.Fatal("WriteFrame must still report the missing temp")
+		}
+	}
+	if m.StorageFailedLegacy() {
+		t.Fatal("vanished temp segments must not trip storage health on write")
+	}
+	if m.StorageHealth("cam-wf") != HealthHealthy {
+		t.Fatal("camera health must remain healthy after vanished-tmp writes")
+	}
+}


### PR DESCRIPTION
Second half of #413 / follow-up to #414.

While validating #414 live on production, the SAME camera latched again — through a different path this time:

```
15:01:04 storage health state changed cam-a8031f83 healthy → degraded failures=1
             ERROR stream error … error="write frame: storage: temp path not accessible: stat …/xxx.tmp: no such file or directory"
15:01:08 storage health state changed cam-a8031f83 degraded → failed  failures=3   (same error ×3)
15:02:11 ERROR failed to close segment … temp path not found        ← #414's gate fired correctly here, no health count
```

Root cause: the http-jpeg frame loop's `WriteFrame` stats the segment tmp, gets NotExist (the tmp was rotated/cleaned while the stream loop held it), and the recorder treats that as a **stream** failure — it tears down the HTTP connection and reconnects into the SAME dead temp path, once per reconnect, until the failure counter trips `HealthFailed` and skip-before-write deadlocks the camera out of recording. #414 fixed the identical miscounting on the CloseSegment path only.

## Fix

- `storage.Manager.WriteFrame`: the stat gate exempts `fs.ErrNotExist` from health counting (logs a segment-lost WARN; the error is still returned so callers can react). Real I/O errors still count. Mirrors #414's CloseSegment gate.
- `HTTPJPEGRecorder`: on a NotExist write the loop clears the stale segment paths in place and `continue`s — the next frame opens a **fresh segment** and the healthy HTTP stream is never torn down.

## Tests

- `TestWriteFrame_VanishedTempDoesNotTripHealth` — vanished tmp hammered past the failure threshold leaves health clean while WriteFrame keeps erroring.
- `TestHTTPJPEGVanishedTempRestartsSegment` — fake store injects one NotExist write; the recorder must open a replacement segment and all subsequent frames must land in it.