### PR TITLE
fix(web): rtmp/srt push camera create silently blocked by URL validation

### DIFF
--- a/web/src/__tests__/CameraForm.test.ts
+++ b/web/src/__tests__/CameraForm.test.ts
@@ -329,6 +329,54 @@ describe('CameraForm - transcode policy', () => {
   });
 });
 
+describe('CameraForm - push camera URL exemption', () => {
+  afterEach(() => {
+    cleanup();
+    mockApiRequest.mockReset();
+  });
+
+  // rtmp/srt/whip push cameras are identified by stream key / stream-id and
+  // the form shows no URL field for them. validate() used to require a URL
+  // for rtmp/srt anyway — the hidden-field error silently blocked save.
+  it('submits a create for an rtmp push camera without a URL', async () => {
+    mockApiRequest.mockImplementation((path: string) => {
+      if (path === '/relay-presets') return Promise.resolve(mockPresets);
+      return Promise.resolve(null);
+    });
+
+    const { container } = render(CameraForm, { props: defaultProps() });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('#cam-name')).toBeTruthy();
+    });
+
+    const nameInput = container.querySelector('#cam-name') as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: 'Push Cam' } });
+
+    const protoSelect = container.querySelector('#cam-protocol') as HTMLSelectElement;
+    await fireEvent.change(protoSelect, { target: { value: 'rtmp' } });
+    await vi.waitFor(() => {
+      expect(container.querySelector('#cam-stream-key')).toBeTruthy();
+      expect(container.querySelector('#cam-url')).toBeFalsy();
+    });
+
+    const keyInput = container.querySelector('#cam-stream-key') as HTMLInputElement;
+    await fireEvent.input(keyInput, { target: { value: 'push-key-1' } });
+
+    const saveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('cameras.save'),
+    );
+    await fireEvent.click(saveBtn!);
+
+    await vi.waitFor(() => {
+      const create = mockApiRequest.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0] === '/cameras',
+      );
+      expect(create, 'POST /cameras should have been issued').toBeTruthy();
+    });
+  });
+});
+
 describe('CameraForm - preset override panel', () => {
   afterEach(() => {
     cleanup();

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -438,7 +438,11 @@ let validationErrors = $state<Record<string, string>>({});
     if (!formName.trim()) validationErrors['name'] = t('cameras.nameRequired');
     if (!formProtocol) validationErrors['protocol'] = t('cameras.protocolRequired');
     // gb28181 cameras are identified by SIP DeviceID/ChannelID — no URL.
-    if (formProtocol !== 'gb28181' && formProtocol !== 'whip' && !formUrl.trim()) validationErrors['url'] = t('cameras.urlRequired');
+    // rtmp/srt/whip push cameras are identified by stream key / stream-id —
+    // the form shows no URL field for them, so the requirement must not apply
+    // (a hidden-field validation error silently blocked save with no UI hint).
+    const urlNotRequired = formProtocol === 'gb28181' || formProtocol === 'whip' || formProtocol === 'rtmp' || formProtocol === 'srt';
+    if (!urlNotRequired && !formUrl.trim()) validationErrors['url'] = t('cameras.urlRequired');
     if (formProtocol === 'gb28181') {
       if (!formGB28181DeviceID.trim()) validationErrors['gb28181_device_id'] = t('cameras.gb28181DeviceIdRequired');
       if (!formGB28181ChannelID.trim()) validationErrors['gb28181_channel_id'] = t('cameras.gb28181ChannelIdRequired');


### PR DESCRIPTION
## Bug

Creating an **RTMP (push)** or **SRT (push)** camera from the web UI silently does nothing: clicking 保存 keeps the form open, no request is issued, and no error is visible.

## Root cause

`CameraForm.validate()` required a non-empty URL for every protocol except `gb28181` and `whip`. But rtmp/srt push cameras have **no URL field at all** (they are identified by stream key / stream-id), so validation failed on a hidden field — the error rendered nowhere and `handleSubmit` returned before `performCameraSave`.

Found while configuring RTMP ingest cameras on the fnOS gateway test box (2026-08-19).

## Fix

Exempt `rtmp` and `srt` from the URL requirement (same as `whip`/`gb28181`), with a regression test that renders the form, selects rtmp, fills name + stream key, submits, and asserts the `POST /cameras` call fires.