### PR TITLE
fix(api): streaming settings silently dropped RTMP/SRT fields

### DIFF
--- a/internal/api/handlers_system.go
+++ b/internal/api/handlers_system.go
@@ -897,6 +897,20 @@ func (h *Handler) handleGetStreamingSettings(w http.ResponseWriter, r *http.Requ
 		"hls": map[string]any{
 			"low_latency": h.config.HLS.LowLatency,
 		},
+		// RTMP/SRT ingest settings. The streaming panel persisted nothing for
+		// them before: the PUT body had no rtmp/srt fields, so the UI switches
+		// silently no-op'd while still toasting success (found configuring the
+		// fnOS test box, 2026-08-19).
+		"rtmp": map[string]any{
+			"enabled":     h.config.RTMP.Enabled != nil && *h.config.RTMP.Enabled,
+			"port":        h.config.RTMP.Port,
+			"stream_keys": h.config.RTMP.StreamKeys, // camera_id → stream_key (legacy map; per-camera stream_key takes precedence)
+		},
+		"srt": map[string]any{
+			"enabled": h.config.SRT.Enabled != nil && *h.config.SRT.Enabled,
+			"port":    h.config.SRT.Port,
+			"streams": h.config.SRT.Streams,
+		},
 	})
 }
 
@@ -921,6 +935,16 @@ func (h *Handler) handleUpdateStreamingSettings(w http.ResponseWriter, r *http.R
 		HLS *struct {
 			LowLatency *bool `json:"low_latency"`
 		} `json:"hls"`
+		RTMP *struct {
+			Enabled    *bool             `json:"enabled"`
+			Port       *int              `json:"port"`
+			StreamKeys map[string]string `json:"stream_keys"` // camera_id → stream_key
+		} `json:"rtmp"`
+		SRT *struct {
+			Enabled *bool              `json:"enabled"`
+			Port    *int               `json:"port"`
+			Streams []config.SRTStream `json:"streams"`
+		} `json:"srt"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -963,6 +987,36 @@ func (h *Handler) handleUpdateStreamingSettings(w http.ResponseWriter, r *http.R
 
 	if body.HLS != nil && body.HLS.LowLatency != nil {
 		h.config.HLS.LowLatency = *body.HLS.LowLatency
+	}
+
+	if body.RTMP != nil {
+		if body.RTMP.Enabled != nil {
+			if h.config.RTMP.Enabled == nil {
+				h.config.RTMP.Enabled = new(bool)
+			}
+			*h.config.RTMP.Enabled = *body.RTMP.Enabled
+		}
+		if body.RTMP.Port != nil {
+			h.config.RTMP.Port = *body.RTMP.Port
+		}
+		if body.RTMP.StreamKeys != nil {
+			h.config.RTMP.StreamKeys = body.RTMP.StreamKeys
+		}
+	}
+
+	if body.SRT != nil {
+		if body.SRT.Enabled != nil {
+			if h.config.SRT.Enabled == nil {
+				h.config.SRT.Enabled = new(bool)
+			}
+			*h.config.SRT.Enabled = *body.SRT.Enabled
+		}
+		if body.SRT.Port != nil {
+			h.config.SRT.Port = *body.SRT.Port
+		}
+		if body.SRT.Streams != nil {
+			h.config.SRT.Streams = body.SRT.Streams
+		}
 	}
 
 	// Persist config to disk

--- a/internal/api/handlers_system_test.go
+++ b/internal/api/handlers_system_test.go
@@ -415,13 +415,13 @@ func TestStreamingSettings_RTMPAndSRT(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	var got struct {
 		RTMP struct {
-			Enabled     bool              `json:"enabled"`
-			Port        int               `json:"port"`
-			StreamKeys  map[string]string `json:"stream_keys"`
+			Enabled    bool              `json:"enabled"`
+			Port       int               `json:"port"`
+			StreamKeys map[string]string `json:"stream_keys"`
 		} `json:"rtmp"`
 		SRT struct {
-			Enabled bool             `json:"enabled"`
-			Port    int              `json:"port"`
+			Enabled bool               `json:"enabled"`
+			Port    int                `json:"port"`
 			Streams []config.SRTStream `json:"streams"`
 		} `json:"srt"`
 	}

--- a/internal/api/handlers_system_test.go
+++ b/internal/api/handlers_system_test.go
@@ -383,3 +383,53 @@ func TestUpdateFeatures_InvalidBody(t *testing.T) {
 	rr := doRequest(t, h.Routes(), "PUT", "/api/features", bytes.NewReader([]byte("not json")), "", "")
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
+
+// --- streaming settings RTMP/SRT persistence (regression: the PUT body used
+// to have no rtmp/srt fields, so the UI switches silently no-op'd) ---
+
+func TestStreamingSettings_RTMPAndSRT(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := newHandlerWithConfig(db, store, &config.Config{})
+	h.config.RTMP.Port = 1935
+	h.config.SRT.Port = 9000
+
+	body := `{"rtmp":{"enabled":true,"port":1936,"stream_keys":{"cam-1":"front-door"}},"srt":{"enabled":true,"port":9001,"streams":[{"camera_id":"cam-2","mode":"listener","address":"","passphrase":"pw","stream_id":"s1"}]}}`
+	rr := doRequest(t, h.Routes(), "PUT", "/api/settings/streaming", bytes.NewReader([]byte(body)), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.NotNil(t, h.config.RTMP.Enabled)
+	require.True(t, *h.config.RTMP.Enabled)
+	require.Equal(t, 1936, h.config.RTMP.Port)
+	require.Equal(t, map[string]string{"cam-1": "front-door"}, h.config.RTMP.StreamKeys)
+
+	require.NotNil(t, h.config.SRT.Enabled)
+	require.True(t, *h.config.SRT.Enabled)
+	require.Equal(t, 9001, h.config.SRT.Port)
+	require.Len(t, h.config.SRT.Streams, 1)
+	require.Equal(t, "cam-2", h.config.SRT.Streams[0].CameraID)
+
+	// GET must round-trip what was stored.
+	rr = doRequest(t, h.Routes(), "GET", "/api/settings/streaming", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var got struct {
+		RTMP struct {
+			Enabled     bool              `json:"enabled"`
+			Port        int               `json:"port"`
+			StreamKeys  map[string]string `json:"stream_keys"`
+		} `json:"rtmp"`
+		SRT struct {
+			Enabled bool             `json:"enabled"`
+			Port    int              `json:"port"`
+			Streams []config.SRTStream `json:"streams"`
+		} `json:"srt"`
+	}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&got))
+	require.True(t, got.RTMP.Enabled)
+	require.Equal(t, 1936, got.RTMP.Port)
+	require.Equal(t, "front-door", got.RTMP.StreamKeys["cam-1"])
+	require.True(t, got.SRT.Enabled)
+	require.Equal(t, 9001, got.SRT.Port)
+	require.Equal(t, "cam-2", got.SRT.Streams[0].CameraID)
+}

--- a/internal/config/config_ingest.go
+++ b/internal/config/config_ingest.go
@@ -24,10 +24,10 @@ type SRTConfig struct {
 // SRTStream configures a single SRT stream mapping.
 type SRTStream struct {
 	CameraID   string `yaml:"camera_id" json:"camera_id"`
-	Mode       string `yaml:"mode" json:"mode"`                 // "listener" (receive pushes) or "caller" (pull from remote)
-	Address    string `yaml:"address" json:"address"`           // For caller mode: remote SRT address (e.g. "192.168.1.100:9000")
-	Passphrase string `yaml:"passphrase" json:"passphrase"`     // AES encryption passphrase (optional)
-	StreamID   string `yaml:"stream_id" json:"stream_id"`       // SRT stream ID for caller mode (optional)
+	Mode       string `yaml:"mode" json:"mode"`             // "listener" (receive pushes) or "caller" (pull from remote)
+	Address    string `yaml:"address" json:"address"`       // For caller mode: remote SRT address (e.g. "192.168.1.100:9000")
+	Passphrase string `yaml:"passphrase" json:"passphrase"` // AES encryption passphrase (optional)
+	StreamID   string `yaml:"stream_id" json:"stream_id"`   // SRT stream ID for caller mode (optional)
 }
 
 // RTMPConfig configures the RTMP ingest server.

--- a/internal/config/config_ingest.go
+++ b/internal/config/config_ingest.go
@@ -23,11 +23,11 @@ type SRTConfig struct {
 
 // SRTStream configures a single SRT stream mapping.
 type SRTStream struct {
-	CameraID   string `yaml:"camera_id"`
-	Mode       string `yaml:"mode"`       // "listener" (receive pushes) or "caller" (pull from remote)
-	Address    string `yaml:"address"`    // For caller mode: remote SRT address (e.g. "192.168.1.100:9000")
-	Passphrase string `yaml:"passphrase"` // AES encryption passphrase (optional)
-	StreamID   string `yaml:"stream_id"`  // SRT stream ID for caller mode (optional)
+	CameraID   string `yaml:"camera_id" json:"camera_id"`
+	Mode       string `yaml:"mode" json:"mode"`                 // "listener" (receive pushes) or "caller" (pull from remote)
+	Address    string `yaml:"address" json:"address"`           // For caller mode: remote SRT address (e.g. "192.168.1.100:9000")
+	Passphrase string `yaml:"passphrase" json:"passphrase"`     // AES encryption passphrase (optional)
+	StreamID   string `yaml:"stream_id" json:"stream_id"`       // SRT stream ID for caller mode (optional)
 }
 
 // RTMPConfig configures the RTMP ingest server.

--- a/web/src/__tests__/CameraForm.test.ts
+++ b/web/src/__tests__/CameraForm.test.ts
@@ -329,6 +329,54 @@ describe('CameraForm - transcode policy', () => {
   });
 });
 
+describe('CameraForm - push camera URL exemption', () => {
+  afterEach(() => {
+    cleanup();
+    mockApiRequest.mockReset();
+  });
+
+  // rtmp/srt/whip push cameras are identified by stream key / stream-id and
+  // the form shows no URL field for them. validate() used to require a URL
+  // for rtmp/srt anyway — the hidden-field error silently blocked save.
+  it('submits a create for an rtmp push camera without a URL', async () => {
+    mockApiRequest.mockImplementation((path: string) => {
+      if (path === '/relay-presets') return Promise.resolve(mockPresets);
+      return Promise.resolve(null);
+    });
+
+    const { container } = render(CameraForm, { props: defaultProps() });
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('#cam-name')).toBeTruthy();
+    });
+
+    const nameInput = container.querySelector('#cam-name') as HTMLInputElement;
+    await fireEvent.input(nameInput, { target: { value: 'Push Cam' } });
+
+    const protoSelect = container.querySelector('#cam-protocol') as HTMLSelectElement;
+    await fireEvent.change(protoSelect, { target: { value: 'rtmp' } });
+    await vi.waitFor(() => {
+      expect(container.querySelector('#cam-stream-key')).toBeTruthy();
+      expect(container.querySelector('#cam-url')).toBeFalsy();
+    });
+
+    const keyInput = container.querySelector('#cam-stream-key') as HTMLInputElement;
+    await fireEvent.input(keyInput, { target: { value: 'push-key-1' } });
+
+    const saveBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('cameras.save'),
+    );
+    await fireEvent.click(saveBtn!);
+
+    await vi.waitFor(() => {
+      const create = mockApiRequest.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0] === '/cameras',
+      );
+      expect(create, 'POST /cameras should have been issued').toBeTruthy();
+    });
+  });
+});
+
 describe('CameraForm - preset override panel', () => {
   afterEach(() => {
     cleanup();

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -41,7 +41,7 @@ export interface HLSStreamingConfig {
 export interface RTMPConfig {
   enabled: boolean;
   port: number;
-  stream_keys?: Record<string, string>; // stream_key → camera_id
+  stream_keys?: Record<string, string>; // camera_id → stream_key (legacy map; per-camera stream_key takes precedence)
 }
 
 export interface SRTStreamConfig {

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -438,7 +438,11 @@ let validationErrors = $state<Record<string, string>>({});
     if (!formName.trim()) validationErrors['name'] = t('cameras.nameRequired');
     if (!formProtocol) validationErrors['protocol'] = t('cameras.protocolRequired');
     // gb28181 cameras are identified by SIP DeviceID/ChannelID — no URL.
-    if (formProtocol !== 'gb28181' && formProtocol !== 'whip' && !formUrl.trim()) validationErrors['url'] = t('cameras.urlRequired');
+    // rtmp/srt/whip push cameras are identified by stream key / stream-id —
+    // the form shows no URL field for them, so the requirement must not apply
+    // (a hidden-field validation error silently blocked save with no UI hint).
+    const urlNotRequired = formProtocol === 'gb28181' || formProtocol === 'whip' || formProtocol === 'rtmp' || formProtocol === 'srt';
+    if (!urlNotRequired && !formUrl.trim()) validationErrors['url'] = t('cameras.urlRequired');
     if (formProtocol === 'gb28181') {
       if (!formGB28181DeviceID.trim()) validationErrors['gb28181_device_id'] = t('cameras.gb28181DeviceIdRequired');
       if (!formGB28181ChannelID.trim()) validationErrors['gb28181_channel_id'] = t('cameras.gb28181ChannelIdRequired');

--- a/web/src/routes/settings/StreamingPanel.svelte
+++ b/web/src/routes/settings/StreamingPanel.svelte
@@ -61,8 +61,10 @@
       streamingRtmpEnabled = config.rtmp?.enabled ?? false;
       streamingRtmpPort = config.rtmp?.port ?? 1935;
       const rtmpKeys = config.rtmp?.stream_keys;
+      // Backend map is camera_id → stream_key (legacy global map; per-camera
+      // stream_key fields take precedence at publish time).
       rtmpStreamKeys = rtmpKeys
-        ? Object.entries(rtmpKeys).map(([key, cameraId]) => ({ key, cameraId: String(cameraId) }))
+        ? Object.entries(rtmpKeys).map(([cameraId, key]) => ({ key: String(key), cameraId }))
         : [];
       streamingSrtEnabled = config.srt?.enabled ?? false;
       streamingSrtPort = config.srt?.port ?? 9000;
@@ -105,7 +107,7 @@
         rtmp: {
           enabled: streamingRtmpEnabled,
           port: streamingRtmpPort,
-          stream_keys: Object.fromEntries(rtmpStreamKeys.map((sk) => [sk.key, sk.cameraId])),
+          stream_keys: Object.fromEntries(rtmpStreamKeys.map((sk) => [sk.cameraId, sk.key])),
         },
         srt: {
           enabled: streamingSrtEnabled,


### PR DESCRIPTION
## Bug

The 直播 (Streaming) settings panel's **RTMP 接入** and **SRT 接收器** switches never persisted anything: clicking 保存 showed 设置保存成功, but `rtmp.enabled` stayed `false` in the config, and after a restart the ingest listener was still down — push publishers got `connection refused`.

## Root cause

`PUT /api/settings/streaming` (`handleUpdateStreamingSettings`) decoded only `webrtc`/`flv`/`hls` from the request body. The panel also sends `rtmp`/`srt` objects, but Go's `json.Decode` silently ignores unknown fields, so they were dropped — a silent no-op behind a success toast. `GET` was equally blind, which is why the panel could never show real RTMP/SRT state.

Found 2026-08-19 while wiring live-push ingest on the fnOS test box.

## Fix

- Decode + apply `rtmp {enabled, port, stream_keys}` and `srt {enabled, port, streams}`, persist with the rest.
- Return `rtmp`/`srt` in `GET /api/settings/streaming`.
- Fix the panel's `stream_keys` mapping direction (backend legacy map is **camera_id → stream_key**; the panel read/wrote it reversed).
- Add json tags to `SRTStream` (API now marshals snake_case).
- Regression test round-trips PUT → GET for both protocols.

Note: the RTMP/SRT listeners start at boot; toggling them needs a service restart to take effect (same as the listen-port fields).