### PR TITLE
fix(flv): ingest keyframes marked as inter frames — au[0]-only IDR check

### DIFF
--- a/internal/flv/manager.go
+++ b/internal/flv/manager.go
@@ -230,7 +230,13 @@ func (m *Manager) writeFrame(camID string, pts int64, au [][]byte) {
 		return // stream not active, silently ignore
 	}
 
-	isKeyframe := isKeyframeNALU(au[0], entry.codec == model.FormatH265)
+	// Scan the WHOLE AU, not just au[0]: ingest push paths (RTMP/SRT/WHIP)
+	// prepend the cached SPS/PPS to IDR frames before broadcasting, so au[0]
+	// is a parameter set, never the IDR itself — an au[0]-only check marked
+	// every ingest keyframe as an inter frame (GOP cache never filled, FLV
+	// viewers got a P-frame-only stream, players waited for a keyframe and
+	// gave up; found on the fnOS live-push topology, 2026-08-19).
+	isKeyframe := nalutil.IsIDR(au, entry.codec == model.FormatH265)
 
 	traceID := "no-trace"
 	if isKeyframe {
@@ -257,11 +263,6 @@ func (m *Manager) writeFrame(camID string, pts int64, au [][]byte) {
 			"queue_depth", len(entry.frameCh),
 		)
 	}
-}
-
-// isKeyframeNALU checks if the first NALU is an IDR frame.
-func isKeyframeNALU(nalu []byte, isH265 bool) bool {
-	return nalutil.IsKeyframeNALU(nalu, isH265)
 }
 
 // writeLoop drains frames from the channel and distributes to all viewers.

--- a/internal/flv/manager_test.go
+++ b/internal/flv/manager_test.go
@@ -742,3 +742,31 @@ var (
 
 // ensure io.Writer is satisfied
 var _ io.Writer = (*bytes.Buffer)(nil)
+
+// Ingest push paths (RTMP/SRT/WHIP) prepend the cached SPS/PPS to IDR frames
+// before hub broadcast — au[0] is a parameter set, never the IDR. writeFrame
+// used to check only au[0], marking every ingest keyframe as an inter frame:
+// the GOP cache never filled and FLV viewers got a P-frame-only stream that
+// no player could start from (fnOS live-push topology, 2026-08-19).
+func TestWriteFrame_IngestStyleAU_KeyframeDetected(t *testing.T) {
+	mgr := newTestManager(t)
+	require.NoError(t, mgr.RegisterStream("cam1", model.FormatH264, minimalSPS, minimalPPS, nil, nil))
+
+	mgr.mu.RLock()
+	entry := mgr.streams["cam1"]
+	mgr.mu.RUnlock()
+	require.NotNil(t, entry)
+
+	// [SPS, PPS, IDR] — ingest-style AU with prepended param sets.
+	idr := append([]byte{0x65}, make([]byte, 16)...)
+	au := [][]byte{append([]byte{0x67}, minimalSPS[1:]...), append([]byte{0x68}, minimalPPS[1:]...), idr}
+	mgr.writeFrame("cam1", 9000, au)
+
+	// writeLoop consumes frameCh and updates the GOP cache on keyframes —
+	// before the fix this AU was flagged inter and the cache stayed empty.
+	require.Eventually(t, func() bool {
+		entry.gopMu.RLock()
+		defer entry.gopMu.RUnlock()
+		return len(entry.gopCache.frames) == 1 && entry.gopCache.frames[0].isKeyframe
+	}, 2*time.Second, 20*time.Millisecond, "ingest-style [SPS,PPS,IDR] AU must land in the GOP cache as a keyframe")
+}


### PR DESCRIPTION
## Bug

RTMP/SRT/WHIP push cameras could not be viewed over HTTP-FLV: the stream served its AVC sequence header correctly, but **every subsequent tag was flagged frameType=inter** — the GOP cache never filled and players received a P-frame-only stream with no decodable entry point. mpegts.js waited ~1s for a keyframe and gave up; the orchestrator degraded through the whole chain.

## Root cause

`Manager.writeFrame` decided keyframe-ness from `au[0]` alone. Ingest recorders prepend the cached SPS/PPS to IDR access units before hub broadcast (`IngestRecorder.WriteNALU`), so for push cameras `au[0]` is a **parameter set**, never the IDR — every keyframe was misflagged as an inter frame. The WS (`wsstream`) and WebRTC consumers already scan the whole AU; only FLV had the `au[0]` shortcut.

## Fix

`nalutil.IsIDR(au, isH265)` over the whole AU (same as the other consumers), plus a regression test feeding an ingest-style `[SPS, PPS, IDR]` AU.

Found wiring the fnOS live-push topology (2026-08-19): all RTMP-forwarded cameras were unwatchable in every player mode.