### PR TITLE
fix(ingest): regroup per-NALU push deliveries into picture-complete AUs

### DIFF
--- a/internal/model/nalutil/au_assembler.go
+++ b/internal/model/nalutil/au_assembler.go
@@ -1,0 +1,146 @@
+package nalutil
+
+import "sync"
+
+// AUAssembler regroups pushed H.264/H.265 NAL units into picture-complete
+// access units.
+//
+// Push publishers do not agree on AU granularity. FFmpeg's RTMP/FLV muxer sends
+// one message per picture, but restreamer-style publishers emit one message per
+// NAL unit — which splits multi-slice pictures (libx264 sliced-threads encodes
+// 1080p frames as 4 slice NALUs) into several "AUs" that no decoder can decode
+// individually: every downstream consumer (FLV/MSE, HLS/fMP4, WebRTC) showed
+// permanently black video. MPEG-TS (SRT) and RTP (WHIP) sources already deliver
+// picture-complete AUs; for them the assembler is a pass-through that delays
+// each emission by at most one picture.
+//
+// Picture boundary detection is header-only and needs no RBSP unescaping — the
+// inspected byte directly follows the NAL header and cannot itself be an
+// emulation-prevention byte:
+//
+//	H.264: a VCL NAL (types 1-5) whose slice header starts with
+//	       first_mb_in_slice == 0 — the first bit of the byte after the 1-byte
+//	       NAL header (ue(v)==0 encodes to a single 1 bit) — begins a new
+//	       picture; continuation slices carry a nonzero first_mb_in_slice.
+//	       (For types 1-5 the header byte is never 0x00, so the following byte
+//	       is raw RBSP.)
+//	H.265: a VCL NAL (types 0-31) whose first_slice_segment_in_pic_flag — the
+//	       first bit of the byte after the 2-byte NAL header — is set begins a
+//	       new picture. (nuh_layer_id and nuh_temporal_id_plus1 keep byte 1
+//	       nonzero, so byte 2 is raw RBSP.)
+//
+// Non-VCL NALUs (SPS/PPS/VPS/SEI) arriving before slices become the picture's
+// prefix; arriving after VCL they belong to the NEXT picture and flush the
+// pending one. An AUD is an explicit boundary. A pending AU that never receives
+// a VCL NALU (e.g. the out-of-band RTMP sequence-header feed) is never emitted.
+//
+// The emitted picture's PTS comes from the call that delivered its first VCL
+// NALU — prefix NALUs may arrive earlier on a publisher's own clock.
+//
+// Safe for concurrent use. emit runs while the assembler's internal lock is
+// held, in decode order; it must not call back into the assembler.
+type AUAssembler struct {
+	mu      sync.Mutex
+	isH265  bool
+	pending [][]byte
+	pts     int64
+	valid   bool // pending is non-empty
+	hasVCL  bool // pending contains at least one VCL NALU
+}
+
+// NewAUAssembler returns an assembler for the given codec family.
+func NewAUAssembler(isH265 bool) *AUAssembler {
+	return &AUAssembler{isH265: isH265}
+}
+
+// Add absorbs one delivered AU (any granularity) and invokes emit for each
+// picture that just became complete.
+func (a *AUAssembler) Add(au [][]byte, pts int64, emit func(au [][]byte, pts int64)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		if isAudNALU(nalu, a.isH265) {
+			a.flushLocked(emit)
+			a.appendLocked(nalu, pts)
+			continue
+		}
+		if !a.isVCLNALU(nalu) {
+			if a.hasVCL {
+				// Parameter sets / SEI after VCL slices prefix the next picture.
+				a.flushLocked(emit)
+			}
+			a.appendLocked(nalu, pts)
+			continue
+		}
+		if a.hasVCL && a.startsPicture(nalu) {
+			a.flushLocked(emit)
+		}
+		if !a.hasVCL {
+			// First VCL NALU of the picture: its delivery time is the picture's
+			// PTS (a prefix may have arrived with a stale one).
+			a.pts = pts
+		}
+		a.appendLocked(nalu, pts)
+		a.hasVCL = true
+	}
+}
+
+// Flush emits the pending picture, if any (call on publisher disconnect/stop).
+func (a *AUAssembler) Flush(emit func(au [][]byte, pts int64)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.flushLocked(emit)
+}
+
+func (a *AUAssembler) flushLocked(emit func(au [][]byte, pts int64)) {
+	if a.valid && a.hasVCL && emit != nil {
+		out := make([][]byte, len(a.pending))
+		copy(out, a.pending)
+		emit(out, a.pts)
+	}
+	a.pending = nil
+	a.valid = false
+	a.hasVCL = false
+}
+
+func (a *AUAssembler) appendLocked(nalu []byte, pts int64) {
+	if !a.valid {
+		a.pts = pts
+		a.valid = true
+	}
+	a.pending = append(a.pending, nalu)
+}
+
+func (a *AUAssembler) isVCLNALU(nalu []byte) bool {
+	if a.isH265 {
+		return (nalu[0]>>1)&0x3F <= 31
+	}
+	t := nalu[0] & 0x1F
+	return t >= 1 && t <= 5
+}
+
+// startsPicture reports whether nalu is the first VCL NALU of a new picture.
+// Undersized NALUs are treated as picture starts (they cannot be verified as
+// continuations; emitting early is the safer failure mode).
+func (a *AUAssembler) startsPicture(nalu []byte) bool {
+	if a.isH265 {
+		if len(nalu) < 3 {
+			return true
+		}
+		return nalu[2]&0x80 != 0 // first_slice_segment_in_pic_flag
+	}
+	if len(nalu) < 2 {
+		return true
+	}
+	return nalu[1]&0x80 != 0 // first_mb_in_slice == 0
+}
+
+func isAudNALU(nalu []byte, isH265 bool) bool {
+	if isH265 {
+		return (nalu[0]>>1)&0x3F == 35 // AUD_NUT
+	}
+	return nalu[0]&0x1F == 9
+}

--- a/internal/model/nalutil/au_assembler_test.go
+++ b/internal/model/nalutil/au_assembler_test.go
@@ -1,0 +1,189 @@
+package nalutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+// h264Slice builds a VCL slice NALU. first selects the first_mb_in_slice bit
+// (0x80 in the byte after the NAL header = new picture).
+func h264Slice(idr, first bool) []byte {
+	nalu := []byte{0x01, 0x00, 0x84, 0x00, 0x10}
+	if idr {
+		nalu[0] = 0x05
+	}
+	if first {
+		nalu[1] = 0x88 // first_mb_in_slice == 0 (first bit set)
+	}
+	return nalu
+}
+
+// h264Param builds a parameter-set NALU (7=SPS, 8=PPS).
+func h264Param(t byte) []byte { return []byte{t, 0x42, 0x00, 0x0a} }
+
+type emitted struct {
+	au  [][]byte
+	pts int64
+}
+
+func collector(out *[]emitted) func([][]byte, int64) {
+	return func(au [][]byte, pts int64) { *out = append(*out, emitted{au, pts}) }
+}
+
+// TestAUAssembler_PerSliceMessagesGrouped feeds the restreamer shape — one
+// message per NAL unit, multi-slice picture — and expects one complete AU.
+func TestAUAssembler_PerSliceMessagesGrouped(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	s1, s2, s3, s4 := h264Slice(true, true), h264Slice(true, false), h264Slice(true, false), h264Slice(true, false)
+	a.Add([][]byte{h264Param(7), h264Param(8), s1}, 100, emit)
+	a.Add([][]byte{s2}, 110, emit)
+	a.Add([][]byte{s3}, 120, emit)
+	a.Add([][]byte{s4}, 130, emit)
+	if len(got) != 0 {
+		t.Fatalf("picture must not emit before the next one starts, got %d", len(got))
+	}
+
+	// Next picture (a P frame) flushes the complete IDR picture.
+	a.Add([][]byte{h264Slice(false, true)}, 200, emit)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one emitted picture, got %d", len(got))
+	}
+	want := [][]byte{h264Param(7), h264Param(8), s1, s2, s3, s4}
+	if !reflect.DeepEqual(got[0].au, want) {
+		t.Fatalf("emitted AU mismatch:\n got  %v\n want %v", got[0].au, want)
+	}
+	if got[0].pts != 100 {
+		t.Fatalf("picture PTS must come from the first VCL delivery, got %d", got[0].pts)
+	}
+}
+
+// TestAUAssembler_CompleteAUsPassThrough feeds the FFmpeg shape — one complete
+// AU per call — and expects one emission per picture (one picture of lag).
+func TestAUAssembler_CompleteAUsPassThrough(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	a.Add([][]byte{h264Param(7), h264Param(8), h264Slice(true, true), h264Slice(true, false)}, 0, emit)
+	a.Add([][]byte{h264Slice(false, true), h264Slice(false, false)}, 3000, emit)
+	a.Add([][]byte{h264Slice(false, true)}, 6000, emit)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 emitted pictures, got %d", len(got))
+	}
+	if got[0].pts != 0 || got[1].pts != 3000 {
+		t.Fatalf("pts mismatch: %v", got)
+	}
+}
+
+// TestAUAssembler_NonVCLAfterVCLStartsNextPicture verifies SPS/PPS/SEI arriving
+// after slices flush the pending picture and prefix the next one.
+func TestAUAssembler_NonVCLAfterVCLStartsNextPicture(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	s1 := h264Slice(false, true)
+	a.Add([][]byte{s1}, 10, emit)
+	a.Add([][]byte{h264Param(7), h264Param(8)}, 20, emit) // flushes picture 1
+	a.Add([][]byte{h264Slice(true, true)}, 30, emit)      // completes picture 2
+	a.Flush(emit)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 emitted pictures, got %d", len(got))
+	}
+	if len(got[0].au) != 1 || !reflect.DeepEqual(got[0].au[0], s1) {
+		t.Fatalf("picture 1 mismatch: %v", got[0].au)
+	}
+	want2 := [][]byte{h264Param(7), h264Param(8), h264Slice(true, true)}
+	if !reflect.DeepEqual(got[1].au, want2) || got[1].pts != 30 {
+		t.Fatalf("picture 2 mismatch: au=%v pts=%d", got[1].au, got[1].pts)
+	}
+}
+
+// TestAUAssembler_ParamOnlyNeverEmits: the RTMP out-of-band sequence-header
+// feed carries no VCL NALU and must never surface as an AU.
+func TestAUAssembler_ParamOnlyNeverEmits(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	a.Add([][]byte{h264Param(7), h264Param(8)}, 0, emit)
+	a.Flush(emit)
+	if len(got) != 0 {
+		t.Fatalf("param-only feed must not emit, got %d", len(got))
+	}
+}
+
+// TestAUAssembler_AUDBoundary treats an AUD as an explicit picture boundary.
+func TestAUAssembler_AUDBoundary(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	aud := []byte{0x09, 0xf0}
+	a.Add([][]byte{h264Slice(false, true), h264Slice(false, false)}, 0, emit)
+	a.Add([][]byte{aud, h264Slice(false, true)}, 3000, emit)
+	a.Flush(emit)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 pictures (AUD boundary + flush), got %d", len(got))
+	}
+	if got[0].pts != 0 || got[1].pts != 3000 {
+		t.Fatalf("pts mismatch: %v", got)
+	}
+}
+
+// TestAUAssembler_PTSFromFirstVCLNotStalePrefix: a prefix arriving with a stale
+// PTS must not stamp the picture.
+func TestAUAssembler_PTSFromFirstVCLNotStalePrefix(t *testing.T) {
+	a := NewAUAssembler(false)
+	var got []emitted
+	emit := collector(&got)
+
+	a.Add([][]byte{h264Param(7), h264Param(8)}, 0, emit) // out-of-band feed
+	a.Add([][]byte{h264Slice(true, true)}, 9000, emit)   // picture VCL at 9000
+	a.Add([][]byte{h264Slice(false, true)}, 9300, emit)  // next picture → flush
+	if len(got) != 1 || got[0].pts != 9000 {
+		t.Fatalf("expected 1 picture with pts=9000, got %+v", got)
+	}
+}
+
+// TestAUAssembler_H265 groups per-slice H.265 messages using
+// first_slice_segment_in_pic_flag.
+func TestAUAssembler_H265(t *testing.T) {
+	a := NewAUAssembler(true)
+	var got []emitted
+	emit := collector(&got)
+
+	h265Slice := func(idr, first bool) []byte {
+		t := byte(1) // TRAIL_R
+		if idr {
+			t = 19 // IDR_W_RADL
+		}
+		b2 := byte(0x00)
+		if first {
+			b2 = 0x80 // first_slice_segment_in_pic_flag
+		}
+		return []byte{t << 1, 0x01, b2, 0x01, 0x5a}
+	}
+	vps := []byte{(32 << 1), 0x01, 0x01}
+	sps := []byte{(33 << 1), 0x01, 0x01}
+	pps := []byte{(34 << 1), 0x01, 0x01}
+
+	a.Add([][]byte{vps, sps, pps, h265Slice(true, true)}, 0, emit)
+	a.Add([][]byte{h265Slice(true, false)}, 10, emit)
+	a.Add([][]byte{h265Slice(true, false)}, 20, emit)
+	a.Add([][]byte{h265Slice(false, true)}, 100, emit)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 grouped IDR picture, got %d", len(got))
+	}
+	want := [][]byte{vps, sps, pps, h265Slice(true, true), h265Slice(true, false), h265Slice(true, false)}
+	if !reflect.DeepEqual(got[0].au, want) {
+		t.Fatalf("H.265 grouped AU mismatch:\n got  %v\n want %v", got[0].au, want)
+	}
+}

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -64,6 +64,10 @@ type IngestRecorder struct {
 	// Hub is set by camera.initStreamHub (same pattern as H264Recorder.Hub).
 	Hub *model.StreamHub
 
+	// auAsm regroups delivered NALUs into picture-complete AUs before fan-out
+	// (push publishers disagree on delivery granularity; see AUAssembler).
+	auAsm *nalutil.AUAssembler
+
 	// connected reflects whether a publisher is currently pushing frames.
 	// Drives the Idle ↔ Recording status transitions.
 	connected atomic.Bool
@@ -101,7 +105,10 @@ func NewIngestRecorder(cfg IngestConfig) *IngestRecorder {
 	if cfg.SegmentDur <= 0 {
 		cfg.SegmentDur = DefaultSegmentDur
 	}
-	return &IngestRecorder{cfg: cfg}
+	return &IngestRecorder{
+		cfg:   cfg,
+		auAsm: nalutil.NewAUAssembler(cfg.Encoding == "h265"),
+	}
 }
 
 // GetHub returns the StreamHub for frame fan-out (satisfies the hubber interface
@@ -254,6 +261,9 @@ func (r *IngestRecorder) Start(_ context.Context) error {
 
 // Stop closes any in-flight segment and marks the recorder stopped.
 func (r *IngestRecorder) Stop() error {
+	// Emit the pending picture before closing the segment (the assembler holds
+	// it back until the next picture starts, which will never come).
+	r.auAsm.Flush(r.writeAssembledAU)
 	r.mu.Lock()
 	if r.cancel != nil {
 		r.cancel()
@@ -280,17 +290,25 @@ func (r *IngestRecorder) WriteConnected() {
 	r.connected.Store(true)
 }
 
-// WriteNALU ingests one H.264 access unit (slice of NAL units, WITHOUT start
-// codes) delivered by an ingest server (SRT tsdemux / RTMP reader).
+// WriteNALU ingests H.264 NAL units (WITHOUT start codes) delivered by an
+// ingest server (SRT tsdemux / RTMP reader / WHIP track handler).
+//
+// Delivery granularity varies by publisher: FFmpeg sends picture-complete AUs
+// per message, while restreamer-style publishers emit one NAL unit per message
+// — splitting multi-slice pictures (libx264 sliced-threads) into fragments no
+// decoder can decode. An AUAssembler regroups everything into picture-complete
+// AUs before fan-out, so the isIDR hint from the transport is ignored and IDR
+// is recomputed on the assembled picture.
 //
 // ptsTicks is a 90 kHz clock value (matching the RTP/StreamHub convention used
-// by the pull recorders). isIDR indicates the AU contains a keyframe.
+// by the pull recorders).
 //
 // It performs three jobs:
-//  1. Broadcasts the AU to the StreamHub for live consumers (HLS/WebRTC/FLV/WS).
+//  1. Broadcasts the assembled AU to the StreamHub for live consumers
+//     (HLS/WebRTC/FLV/WS).
 //  2. Captures SPS/PPS and rolls the MP4 segment when they change.
 //  3. Writes VCL NALUs (types 1, 5) to the rolling MP4 segment for recordings.
-func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
+func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, _ bool) {
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
 			buf := make([]byte, 4096)
@@ -300,15 +318,23 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 		}
 	}()
 
-	// ---- Lock scope 1: status transition, SPS/PPS update, segment rotation ----
-	r.mu.Lock()
-	if r.status != model.StatusRecording {
-		r.status = model.StatusRecording
-		r.incActive()
-		ingestLogger.Info("ingest publisher streaming", "camera_id", r.cfg.CameraID)
-	}
+	// Assembly runs first so a completing picture is written under the PREVIOUS
+	// codec parameters; the incoming AU's parameter sets are cached afterwards
+	// and rotate the recording segment before the next picture opens one.
+	r.auAsm.Add(au, ptsTicks, r.writeAssembledAU)
+	r.cacheParamSets(au)
+}
 
+// cacheParamSets extracts SPS/PPS from an incoming delivery (any granularity)
+// and rotates the recording segment when they change. Runs on every WriteNALU
+// call so out-of-band parameter-set deliveries (the RTMP sequence-header feed,
+// which carries no VCL NALU and is never emitted by the assembler) are still
+// captured in time for HLS/FLV/WebRTC initialization. H.264 only — H.265 push
+// ingest is a follow-up (see IngestConfig.Encoding).
+func (r *IngestRecorder) cacheParamSets(au [][]byte) {
 	sps, pps := nalutil.ExtractParamSetsH264(au)
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if sps != nil {
 		if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) {
 			ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
@@ -323,6 +349,29 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 		}
 		r.pps = append([]byte(nil), pps...)
 	}
+}
+
+// writeAssembledAU fans one picture-complete AU out to the StreamHub and the
+// rolling segment. Called synchronously by the AUAssembler.
+func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
+	defer func() {
+		if panicErr := recover(); panicErr != nil {
+			buf := make([]byte, 4096)
+			buf = buf[:runtime.Stack(buf, false)]
+			ingestLogger.Error("PANIC recovered in writeAssembledAU",
+				"camera_id", r.cfg.CameraID, "panic", panicErr, "stack", string(buf))
+		}
+	}()
+
+	isIDR := nalutil.IsIDR(au, r.cfg.Encoding == "h265")
+
+	// ---- Lock scope 1: status transition, shared-state snapshot ----
+	r.mu.Lock()
+	if r.status != model.StatusRecording {
+		r.status = model.StatusRecording
+		r.incActive()
+		ingestLogger.Info("ingest publisher streaming", "camera_id", r.cfg.CameraID)
+	}
 
 	// Copy shared state to locals while holding lock.
 	hub := r.Hub
@@ -331,18 +380,21 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 	r.mu.Unlock()
 
 	// ---- Hub broadcast (outside lock, non-blocking by design) ----
-	// RTMP/SRT publishers send SPS/PPS out-of-band (RTMP sequence header), so a
-	// keyframe AU typically does NOT contain the param sets that downstream
-	// consumers need — notably gohlslib's DTS extractor scans the AU for an SPS
-	// NAL and fails with "SPS not received yet" otherwise. Match the RTSP path
-	// (which inlines SPS/PPS in every IDR AU) by ALWAYS prepending the cached
-	// param sets to IDR frames (idempotent if the AU already has them).
+	// Downstream consumers need param sets in-band on keyframes — notably
+	// gohlslib's DTS extractor scans the AU for an SPS NAL and fails with
+	// "SPS not received yet" otherwise. Match the RTSP path by prepending the
+	// cached param sets to IDR AUs that don't already carry them inline
+	// (restreamer publishers inline them; FFmpeg delivers them out-of-band
+	// only, via the sequence-header feed cached in cacheParamSets).
 	if hub != nil {
 		broadcastAU := au
 		if isIDR && localSPS != nil && localPPS != nil {
-			broadcastAU = make([][]byte, 0, len(au)+2)
-			broadcastAU = append(broadcastAU, localSPS, localPPS)
-			broadcastAU = append(broadcastAU, au...)
+			inSPS, inPPS := nalutil.ExtractParamSetsH264(au)
+			if inSPS == nil || inPPS == nil {
+				broadcastAU = make([][]byte, 0, len(au)+2)
+				broadcastAU = append(broadcastAU, localSPS, localPPS)
+				broadcastAU = append(broadcastAU, au...)
+			}
 		}
 		hub.Broadcast(ptsTicks, broadcastAU, isIDR)
 	}
@@ -487,6 +539,8 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 // accept the next publisher without being restarted.
 func (r *IngestRecorder) OnDisconnect() {
 	r.connected.Store(false)
+	// Emit the pending picture before flushing the segment (see Stop).
+	r.auAsm.Flush(r.writeAssembledAU)
 	r.mu.Lock()
 	wasRecording := r.status == model.StatusRecording
 	r.closeCurrentSegmentLocked()

--- a/internal/recorder/ingest_test.go
+++ b/internal/recorder/ingest_test.go
@@ -82,14 +82,16 @@ func TestIngestRecorder_WriteNALU_RecordsSegment(t *testing.T) {
 	rec, store, db := newIngestRecorder(t, 10*time.Minute)
 	t.Cleanup(func() { _ = rec.Stop() })
 
-	// First access unit: SPS + PPS + IDR. Should open a segment + write the IDR.
+	// First access unit: SPS + PPS + IDR. Held by the AU assembler until the
+	// next picture starts (one-picture assembly lag by design).
 	rec.WriteNALU([][]byte{testSPS, testPPS, testIDR}, 0, true)
-	require.Equal(t, model.StatusRecording, rec.Status())
 
-	// A few non-IDR VCL frames.
+	// A few non-IDR VCL frames. The first flushes the pending IDR picture,
+	// opening a segment + writing the IDR.
 	for i := 1; i <= 5; i++ {
 		rec.WriteNALU([][]byte{testPFrame}, int64(i)*90, false)
 	}
+	require.Equal(t, model.StatusRecording, rec.Status())
 
 	// Stop closes the in-flight segment → one recording row + one file.
 	require.NoError(t, rec.Stop())
@@ -114,6 +116,8 @@ func TestIngestRecorder_OnDisconnect_ClosesSegment(t *testing.T) {
 
 	rec.WriteConnected()
 	rec.WriteNALU([][]byte{testSPS, testPPS, testIDR}, 0, true)
+	// Flush the pending IDR picture (one-picture assembly lag).
+	rec.WriteNALU([][]byte{testPFrame}, 90, false)
 	require.Equal(t, model.StatusRecording, rec.Status())
 
 	rec.OnDisconnect()
@@ -146,9 +150,12 @@ func TestIngestRecorder_IgnoresNonIDRBeforeKeyframe(t *testing.T) {
 	rec, store, db := newIngestRecorder(t, 10*time.Minute)
 	t.Cleanup(func() { _ = rec.Stop() })
 
-	// P-frame only (no SPS/PPS/IDR) → status flips to recording (live pusher
-	// active) but NO segment is opened (no SPS/PPS, not IDR).
+	// P-frames only (no SPS/PPS/IDR) → once the first picture completes (the
+	// second delivery flushes the first; one-picture assembly lag), status
+	// flips to recording (live pusher active) but NO segment is opened (no
+	// SPS/PPS, not IDR).
 	rec.WriteNALU([][]byte{testPFrame}, 0, false)
+	rec.WriteNALU([][]byte{testPFrame}, 90, false)
 	require.Equal(t, model.StatusRecording, rec.Status(), "publisher is live, but no segment yet")
 	require.Empty(t, db.recordings, "no recording row until IDR opens a segment")
 
@@ -158,6 +165,59 @@ func TestIngestRecorder_IgnoresNonIDRBeforeKeyframe(t *testing.T) {
 
 // testPFrame is a minimal H.264 non-IDR slice NAL (type 1).
 var testPFrame = []byte{0x41, 0x9a, 0x10, 0x00}
+
+// TestIngestRecorder_GroupsPerSliceDeliveries reproduces the fnOS live-push
+// topology failure (2026-08-20): a restreamer publisher emits one NAL unit per
+// RTMP message, so libx264 sliced-threads frames (1080p = 4 slices) arrived as
+// four separate "AUs" and every downstream consumer showed black video. The
+// recorder must regroup them into ONE picture-complete hub broadcast, keyed on
+// the assembled picture (IDR), keeping the publisher's inline param sets
+// without a duplicate cached prepend.
+func TestIngestRecorder_GroupsPerSliceDeliveries(t *testing.T) {
+	rec, _, _ := newIngestRecorder(t, 10*time.Minute)
+	t.Cleanup(func() { _ = rec.Stop() })
+
+	type hubFrame struct {
+		pts int64
+		au  [][]byte
+	}
+	ch := make(chan hubFrame, 4)
+	require.NoError(t, rec.Hub.Subscribe("test-grouping", func(pts int64, au [][]byte) {
+		ch <- hubFrame{pts, au}
+	}))
+
+	// IDR picture split across four deliveries: header param sets + first
+	// slice (first_mb_in_slice==0 → testIDR's 0x88), then three continuation
+	// slices (first_mb_in_slice!=0 → first header byte 0x00, i.e. ue(v) with
+	// leading zero bits).
+	s2 := []byte{0x65, 0x08, 0x84, 0x00, 0x10}
+	s3 := []byte{0x65, 0x08, 0x84, 0x00, 0x11}
+	s4 := []byte{0x65, 0x08, 0x84, 0x00, 0x12}
+
+	rec.WriteNALU([][]byte{testSPS, testPPS, testIDR}, 0, true)
+	rec.WriteNALU([][]byte{s2}, 30, true)
+	rec.WriteNALU([][]byte{s3}, 60, true)
+	rec.WriteNALU([][]byte{s4}, 90, true)
+
+	// Nothing may surface before the picture completes.
+	select {
+	case f := <-ch:
+		t.Fatalf("partial picture leaked to the hub: %+v", f)
+	default:
+	}
+
+	// The next picture's first slice flushes the grouped IDR picture.
+	rec.WriteNALU([][]byte{testPFrame}, 3000, false)
+
+	select {
+	case f := <-ch:
+		require.Equal(t, int64(0), f.pts, "picture PTS comes from its first VCL delivery")
+		require.Equal(t, [][]byte{testSPS, testPPS, testIDR, s2, s3, s4}, f.au,
+			"one picture-complete AU with all four slices and no duplicate param prepend")
+	case <-time.After(2 * time.Second):
+		t.Fatal("grouped IDR picture never reached the hub")
+	}
+}
 
 // TestIngestRecorder_ConcurrentLockNarrowing verifies that WriteNALU, Status,
 // and Stop can be called concurrently without data races.


### PR DESCRIPTION
## Problem

On the fnOS live-push topology (remote NVR restreaming cameras into this NVR via RTMP 直播推流), every pushed camera rendered **permanently black** in the web UI while degrading through the full player chain (wasm → webrtc → flv → hls). Single-slice streams played fine, multi-slice streams never did.

## Root cause

Restreamer-style publishers emit **one RTMP message per NAL unit**. libx264 sliced-threads encodes 1080p frames as 4 slice NALUs, so one picture surfaced as four separate "access units" — each individually undecodable:

- FLV: 4 consecutive keyframe tags per 8s GOP, each `[SPS,PPS,SPS,PPS,one-slice]` (both publisher and ingest prepended param sets) — MSE waits for a decodable picture forever
- HLS: the packager never cut a real segment — media playlist contained **only `#EXT-X-GAP` / 0-byte `gap.mp4`** entries (GAP interval == exactly one GOP)
- WebRTC: partial AUs, no picture

Verified by FLV tag dissection on-device; ffprobe confirmed the NALU chains were structurally valid — the split itself was the bug. FFmpeg-style publishers (one message per picture) and hardware-encoder streams (single slice) were unaffected, which made the failure look random.

## Fix

- **`nalutil.AUAssembler`** (new): regroups delivered NALUs into picture-complete AUs. Boundary detection is header-only and unescape-free:
  - H.264: `first_mb_in_slice == 0` — first bit of the byte after the NAL header (ue(v)==0 encodes to a single 1 bit)
  - H.265: `first_slice_segment_in_pic_flag` — first bit of the byte after the 2-byte NAL header
  - non-VCL after VCL prefixes the next picture (flush); AUD is an explicit boundary; param-set-only deliveries never emit
- **`IngestRecorder.WriteNALU`** (RTMP/SRT/WHIP paths): every delivery passes through the assembler before hub fan-out and segment writes. IDR is recomputed on the assembled picture; the transport's isIDR hint is ignored.
  - Assembly runs *before* param-set caching so a completing picture is written under the previous codec parameters and an SPS change rotates the segment at the right boundary
  - Out-of-band sequence-header feeds still seed `r.sps/r.pps` immediately (HLS/FLV/WebRTC init), but no longer produce a spurious pts=0 broadcast
  - Cached SPS/PPS prepend now skips AUs that already carry identical inline sets (no more duplicate param pairs)
  - `Stop()`/`OnDisconnect()` flush the pending picture

SRT (MPEG-TS) and WHIP (RTP) already deliver picture-complete AUs — for them the assembler is a pass-through with at most one picture of added latency (~33–66 ms).

## Tests

- `nalutil`: per-slice grouping, complete-AU pass-through, non-VCL-after-VCL flush, AUD boundary, param-only never emits, PTS-from-first-VCL, H.265 variant
- `recorder`: `TestIngestRecorder_GroupsPerSliceDeliveries` reproduces the exact per-slice push shape and asserts ONE picture-complete hub broadcast with all slices; existing tests adjusted for the one-picture assembly lag
- All green with `-race` on nalutil/recorder/rtmp + camera/srt/whip/flv/hls/gb28181 consumer suites

## Follow-up (separate)

The republish side (this repo's relay publisher) should ideally emit one message per picture too — ingest-side grouping makes the NVR robust either way. The GB28181 half-green-frame artifact reported alongside this is under separate investigation (different path: PS demuxer / RTP transport).