### PR TITLE
fix(relay): keep multi-slice pictures whole in the transcode Annex-B splitter

### DIFF
--- a/internal/livetranscode/annexb_splitter.go
+++ b/internal/livetranscode/annexb_splitter.go
@@ -237,10 +237,19 @@ func extractNalus(buf []byte, codes []startCode, codec Codec) ([]naluInfo, error
 //
 // An AU boundary is determined when:
 //   - An AUD (access unit delimiter) NALU is encountered
-//   - An IDR NALU is encountered (starts a new GOP/picture)
-//   - A VPS NALU is encountered in H.265 (starts a new sequence)
-//   - An SPS or PPS is encountered after VCL data (param set change mid-stream)
-//   - A VCL NALU (non-IDR) follows another VCL NALU (new picture)
+//   - A VCL slice with first_mb_in_slice == 0 (H.264) /
+//     first_slice_segment_in_pic_flag set (H.265) follows VCL data — the first
+//     slice of a new picture
+//   - A VPS/SPS/PPS NALU is encountered after VCL data (param set change
+//     mid-stream prefixes the next picture)
+//
+// A picture may span several slice NALUs: every slice of an IDR picture is NAL
+// type 5 (H.264) / 19|20 (H.265) and every P-picture slice is type 1 (H.264) /
+// 0|1 (H.265), so "VCL follows VCL" is NOT a picture boundary — libx264
+// sliced-threads emits 1080p frames as 4 slice NALUs, and a VCL-follows-VCL
+// rule shreds each such frame into per-slice AUs that no decoder can decode
+// individually (found via the RTMP relay publishing one message per NALU,
+// 2026-08-20).
 func groupAccessUnits(nalus []naluInfo, codec Codec) []AccessUnit {
 	if len(nalus) == 0 {
 		return nil
@@ -267,19 +276,14 @@ func groupAccessUnits(nalus []naluInfo, codec Codec) []AccessUnit {
 
 		switch codec {
 		case CodecH264:
-			if typ == h264NALUTypeAUD || typ == h264NALUTypeIDR {
-				// AUD and IDR always start a new AU.
-				// Flush previous AU only if it has VCL data (we have a complete picture).
+			if typ == h264NALUTypeAUD {
+				// AUD always starts a new AU.
 				if seenVCL {
 					flushAU()
 				}
 				currentAU = append(currentAU, nalu)
-				if typ == h264NALUTypeIDR {
-					seenVCL = true
-				}
 			} else if isVCLH264(typ) {
-				// Non-IDR VCL (type 1-4): if we already have a VCL, this is a new picture.
-				if seenVCL {
+				if seenVCL && h264StartsPicture(nalu.data) {
 					flushAU()
 				}
 				currentAU = append(currentAU, nalu)
@@ -296,21 +300,18 @@ func groupAccessUnits(nalus []naluInfo, codec Codec) []AccessUnit {
 			}
 
 		case CodecH265:
-			if typ == h265NALUTypeAUD || typ == h265NALUTypeIDR_W_RADL || typ == h265NALUTypeIDR_N_LP {
+			if typ == h265NALUTypeAUD {
 				if seenVCL {
 					flushAU()
 				}
 				currentAU = append(currentAU, nalu)
-				if typ == h265NALUTypeIDR_W_RADL || typ == h265NALUTypeIDR_N_LP {
-					seenVCL = true
-				}
 			} else if typ == h265NALUTypeVPS || typ == h265NALUTypeSPS || typ == h265NALUTypePPS {
 				if seenVCL {
 					flushAU()
 				}
 				currentAU = append(currentAU, nalu)
 			} else if isVCLH265(typ) {
-				if seenVCL {
+				if seenVCL && h265StartsPicture(nalu.data) {
 					flushAU()
 				}
 				currentAU = append(currentAU, nalu)
@@ -325,6 +326,32 @@ func groupAccessUnits(nalus []naluInfo, codec Codec) []AccessUnit {
 	flushAU()
 
 	return aus
+}
+
+// h264StartsPicture reports whether an H.264 VCL NALU is the first slice of a
+// new picture: first_mb_in_slice == 0 — the first bit of the byte after the
+// NAL header (ue(v)==0 encodes to a single 1 bit). Continuation slices of a
+// multi-slice picture carry first_mb_in_slice != 0 (leading zero bits). The
+// inspected byte follows the NAL header byte, which is nonzero for VCL types,
+// so it can never be an emulation-prevention byte. Undersized NALUs are
+// treated as picture starts: they cannot be verified as continuations, and
+// emitting early is the safer failure mode.
+func h264StartsPicture(nalu []byte) bool {
+	if len(nalu) < 2 {
+		return true
+	}
+	return nalu[1]&0x80 != 0
+}
+
+// h265StartsPicture reports whether an H.265 VCL NALU is the first slice
+// segment of a new picture: first_slice_segment_in_pic_flag — the first bit of
+// the byte after the 2-byte NAL header. nuh_temporal_id_plus1 keeps header
+// byte 1 nonzero, so the inspected byte is never an emulation-prevention byte.
+func h265StartsPicture(nalu []byte) bool {
+	if len(nalu) < 3 {
+		return true
+	}
+	return nalu[2]&0x80 != 0
 }
 
 // --------------- Param set extraction ---------------

--- a/internal/livetranscode/annexb_splitter_test.go
+++ b/internal/livetranscode/annexb_splitter_test.go
@@ -85,12 +85,13 @@ func TestSplitH264Basic(t *testing.T) {
 
 func TestSplitH265Basic(t *testing.T) {
 	// Stream: [VPS SPS PPS IDR] [P] [P] -> 3 AUs
+	// Slice payloads start with first_slice_segment_in_pic_flag set (0x80 bit).
 	vps := h265NAL(32, []byte{0x01, 0x02, 0x03})
 	sps := h265NAL(33, []byte{0x04, 0x05, 0x06})
 	pps := h265NAL(34, []byte{0x07, 0x08})
-	idr := h265NAL(19, []byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19})
-	p1 := h265NAL(1, []byte{0x20, 0x21, 0x22})
-	p2 := h265NAL(1, []byte{0x30, 0x31, 0x32})
+	idr := h265NAL(19, []byte{0x90, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19})
+	p1 := h265NAL(1, []byte{0xa0, 0x21, 0x22})
+	p2 := h265NAL(1, []byte{0xb0, 0x31, 0x32})
 
 	data := annexB(CodecH265, vps, sps, pps, idr, p1, p2)
 	aus, ps, err := SplitAnnexB(data, CodecH265)
@@ -113,6 +114,56 @@ func TestSplitH265Basic(t *testing.T) {
 	require.Equal(t, vps, ps.VPS)
 	require.Equal(t, sps, ps.SPS)
 	require.Equal(t, pps, ps.PPS)
+}
+
+// TestSplitH264MultiSlicePicture reproduces the 2026-08-20 relay failure:
+// libx264 sliced-threads emits each 1080p frame as 4 slice NALUs (every IDR
+// slice is NAL type 5, every P slice type 1). The pictures must stay whole —
+// the old VCL-follows-VCL boundary split them into per-slice AUs, which the
+// RTMP relay then published as separate messages that no receiver could
+// decode.
+func TestSplitH264MultiSlicePicture(t *testing.T) {
+	sps := h264NAL(7, []byte{0x64, 0x00})
+	pps := h264NAL(8, []byte{0xe8, 0x43})
+	// IDR picture: first slice first_mb==0 (0x88), three continuations (0x08).
+	idrS1 := h264NAL(5, []byte{0x88, 0x84, 0x01})
+	idrS2 := h264NAL(5, []byte{0x08, 0x84, 0x02})
+	idrS3 := h264NAL(5, []byte{0x08, 0x84, 0x03})
+	idrS4 := h264NAL(5, []byte{0x08, 0x84, 0x04})
+	// P picture: same multi-slice shape with type-1 NALUs.
+	pS1 := h264NAL(1, []byte{0x88, 0x11})
+	pS2 := h264NAL(1, []byte{0x08, 0x12})
+
+	data := annexB(CodecH264, sps, pps, idrS1, idrS2, idrS3, idrS4, pS1, pS2)
+	aus, _, err := SplitAnnexB(data, CodecH264)
+	require.NoError(t, err)
+
+	requireAULen(t, aus, 2)
+	// AU[0]: SPS + PPS + all four IDR slices in one picture.
+	requireAUNALUCount(t, aus[0], 6)
+	require.Equal(t, idrS4, aus[0][5], "last IDR slice stays in the same AU")
+	// AU[1]: both P slices.
+	requireAUNALUCount(t, aus[1], 2)
+}
+
+// TestSplitH265MultiSlicePicture is the H.265 counterpart: multi-slice
+// pictures (first_slice_segment_in_pic_flag set only on the first slice).
+func TestSplitH265MultiSlicePicture(t *testing.T) {
+	vps := h265NAL(32, []byte{0x01})
+	sps := h265NAL(33, []byte{0x02})
+	pps := h265NAL(34, []byte{0x03})
+	idrS1 := h265NAL(19, []byte{0x80, 0x11})
+	idrS2 := h265NAL(19, []byte{0x00, 0x12})
+	pS1 := h265NAL(1, []byte{0x80, 0x21})
+	pS2 := h265NAL(1, []byte{0x00, 0x22})
+
+	data := annexB(CodecH265, vps, sps, pps, idrS1, idrS2, pS1, pS2)
+	aus, _, err := SplitAnnexB(data, CodecH265)
+	require.NoError(t, err)
+
+	requireAULen(t, aus, 2)
+	requireAUNALUCount(t, aus[0], 5) // VPS+SPS+PPS+2 IDR slices
+	requireAUNALUCount(t, aus[1], 2) // 2 P slices
 }
 
 func TestSplitH264EmulationPrevention(t *testing.T) {
@@ -145,11 +196,12 @@ func TestSplitH264EmulationPrevention(t *testing.T) {
 }
 
 func TestSplitH264MixedStartCodes(t *testing.T) {
-	// Mixed 3-byte and 4-byte start codes
+	// Mixed 3-byte and 4-byte start codes. Slice payloads start with
+	// first_mb_in_slice == 0 (top bit of the byte after the NAL header).
 	sps := h264NAL(7, []byte{0x01, 0x02})
 	pps := h264NAL(8, []byte{0x03, 0x04})
-	idr := h264NAL(5, []byte{0x05, 0x06})
-	p := h264NAL(1, []byte{0x07, 0x08})
+	idr := h264NAL(5, []byte{0x85, 0x06})
+	p := h264NAL(1, []byte{0x87, 0x08})
 
 	// Manually build buffer with alternating start codes
 	// 4-byte then 3-byte then 4-byte then 3-byte
@@ -234,8 +286,8 @@ func TestSplitParamSetsExtractionH265(t *testing.T) {
 	vps := h265NAL(32, []byte{0x01, 0x02})
 	sps := h265NAL(33, []byte{0x03, 0x04})
 	pps := h265NAL(34, []byte{0x05, 0x06})
-	idr := h265NAL(19, []byte{0x07, 0x08, 0x09, 0x0a})
-	p := h265NAL(1, []byte{0x0b, 0x0c})
+	idr := h265NAL(19, []byte{0x87, 0x88, 0x89, 0x8a})
+	p := h265NAL(1, []byte{0x8b, 0x8c})
 
 	data := annexB(CodecH265, vps, sps, pps, idr, p)
 	aus, ps, err := SplitAnnexB(data, CodecH265)
@@ -253,12 +305,12 @@ func TestSplitH264MultipleIDR(t *testing.T) {
 	// Stream: [SPS PPS IDR1] [P] [SPS PPS IDR2] [P] -> 4 AUs
 	sps1 := h264NAL(7, []byte{0x01})
 	pps1 := h264NAL(8, []byte{0x02})
-	idr1 := h264NAL(5, []byte{0x03, 0x04})
-	p1 := h264NAL(1, []byte{0x05, 0x06})
+	idr1 := h264NAL(5, []byte{0x83, 0x04})
+	p1 := h264NAL(1, []byte{0x85, 0x06})
 	sps2 := h264NAL(7, []byte{0x07})
 	pps2 := h264NAL(8, []byte{0x08})
-	idr2 := h264NAL(5, []byte{0x09, 0x0a})
-	p2 := h264NAL(1, []byte{0x0b, 0x0c})
+	idr2 := h264NAL(5, []byte{0x89, 0x0a})
+	p2 := h264NAL(1, []byte{0x8b, 0x0c})
 
 	data := annexB(CodecH264, sps1, pps1, idr1, p1, sps2, pps2, idr2, p2)
 	aus, ps, err := SplitAnnexB(data, CodecH264)
@@ -279,13 +331,13 @@ func TestSplitH265MultipleIDR(t *testing.T) {
 	vps1 := h265NAL(32, []byte{0x01})
 	sps1 := h265NAL(33, []byte{0x02})
 	pps1 := h265NAL(34, []byte{0x03})
-	idr1 := h265NAL(19, []byte{0x04, 0x05})
-	p1 := h265NAL(1, []byte{0x06, 0x07})
+	idr1 := h265NAL(19, []byte{0x84, 0x05})
+	p1 := h265NAL(1, []byte{0x86, 0x07})
 	vps2 := h265NAL(32, []byte{0x08})
 	sps2 := h265NAL(33, []byte{0x09})
 	pps2 := h265NAL(34, []byte{0x0a})
-	idr2 := h265NAL(20, []byte{0x0b, 0x0c})
-	p2 := h265NAL(1, []byte{0x0d, 0x0e})
+	idr2 := h265NAL(20, []byte{0x8b, 0x0c})
+	p2 := h265NAL(1, []byte{0x8d, 0x0e})
 
 	data := annexB(CodecH265, vps1, sps1, pps1, idr1, p1, vps2, sps2, pps2, idr2, p2)
 	aus, ps, err := SplitAnnexB(data, CodecH265)
@@ -423,8 +475,8 @@ func TestStreamParserH265Chunked(t *testing.T) {
 	vps := h265NAL(32, []byte{0x01, 0x02})
 	sps := h265NAL(33, []byte{0x03, 0x04})
 	pps := h265NAL(34, []byte{0x05, 0x06})
-	idr := h265NAL(19, []byte{0x07, 0x08, 0x09, 0x0a})
-	p := h265NAL(1, []byte{0x0b, 0x0c})
+	idr := h265NAL(19, []byte{0x87, 0x88, 0x89, 0x8a})
+	p := h265NAL(1, []byte{0x8b, 0x8c})
 
 	data := annexB(CodecH265, vps, sps, pps, idr, p)
 


### PR DESCRIPTION
## Problem

The transcode relay path (H.265→H.264 via FFmpeg stdout) split **multi-slice pictures** into per-slice access units, and the RTMP relay then published **one message per NAL unit**.

## Root cause

`groupAccessUnits` in `internal/livetranscode/annexb_splitter.go` treated "VCL follows VCL" as a picture boundary. But a picture may span several slice NALUs:

- every slice of an **IDR** picture is NAL type 5 (H.264) / 19|20 (H.265)
- every slice of a **P** picture is NAL type 1 (H.264) / 0|1 (H.265)

libx264 sliced-threads encodes 1080p frames as 4 slice NALUs, so each frame became 4 "AUs" — undecodable fragments for any receiver. Verified live: an RTMP relay target fed by this path emitted per-slice messages; the receiving side showed permanently black video on all protocols (FLV/MSE, HLS, WebRTC) until #427 made the ingest regroup defensively.

This also affects strict third-party RTMP receivers (the relay feature's primary use case) — they have no ingest-side assembler to save them.

## Fix

Picture boundary detection now uses the slice header itself — header-only, no RBSP unescaping (the inspected byte follows the NAL header, which is nonzero for VCL types, so it can never be an emulation-prevention byte):

- H.264: `first_mb_in_slice == 0` — the top bit of the byte after the 1-byte NAL header (`ue(v)==0` encodes to a single 1 bit)
- H.265: `first_slice_segment_in_pic_flag` — the top bit of the byte after the 2-byte NAL header

AUD / param-sets-after-VCL boundaries are unchanged. Undersized NALUs are treated as picture starts (cannot be verified as continuations; emitting early is the safer failure mode).

## Tests

- Test slice payloads updated to carry realistic slice headers (first-slice bit set) so each intended picture actually starts one
- New `TestSplitH264MultiSlicePicture` / `TestSplitH265MultiSlicePicture`: 4-slice IDR + 2-slice P frames stay whole
- All livetranscode + relay suites green with `-race`

Companion to #427 (ingest-side regrouping — keeps the NVR robust against any publisher).