### PR TITLE
fix(gb28181): enlarge media UDP read buffer + surface transit-loss counter

### DIFF
--- a/internal/gb28181/rtp.go
+++ b/internal/gb28181/rtp.go
@@ -180,9 +180,19 @@ func (r *Receiver) Stop() error {
 		"camera_id", r.cameraID,
 		"packets_received", r.rtpPacketsReceived.Load(),
 		"packets_dropped", r.rtpPacketsDropped.Load(),
+		"gap_skipped_packets", r.gapSkippedPackets(),
 		"foreign_ssrc_dropped", r.foreignDrops.Load(),
 		"au_emitted", r.auEmitted.Load())
 	return nil
+}
+
+// gapSkippedPackets returns the count of packets lost in transit (sequence
+// gaps the jitter drain had to skip). Guarded by jitterBufferMu — the only
+// writer increments under the same lock.
+func (r *Receiver) gapSkippedPackets() uint64 {
+	r.jitterBufferMu.Lock()
+	defer r.jitterBufferMu.Unlock()
+	return r.packetsDroppedU
 }
 
 // Running returns whether the receiver is active.
@@ -591,9 +601,10 @@ func (r *Receiver) flushJitterBuffer() {
 // Metrics returns receiver metrics.
 func (r *Receiver) Metrics() map[string]int64 {
 	return map[string]int64{
-		"packets_received": r.rtpPacketsReceived.Load(),
-		"packets_dropped":  r.rtpPacketsDropped.Load(),
-		"au_emitted":       r.auEmitted.Load(),
+		"packets_received":    r.rtpPacketsReceived.Load(),
+		"packets_dropped":     r.rtpPacketsDropped.Load(),
+		"gap_skipped_packets": int64(r.gapSkippedPackets()),
+		"au_emitted":          r.auEmitted.Load(),
 	}
 }
 

--- a/internal/gb28181/session.go
+++ b/internal/gb28181/session.go
@@ -277,6 +277,7 @@ func (sm *SessionManager) Invite(channel *Channel, serverIP string, deviceAddr s
 			sm.portManager.Recycle(port)
 			return nil, fmt.Errorf("gb28181: failed to bind UDP port %d: %w", port, err)
 		}
+		setUDPReadBuffer(conn)
 		sess.conn = conn
 		ctx, cancel := context.WithCancel(context.Background())
 		if err := receiver.Start(ctx, conn); err != nil {
@@ -644,6 +645,7 @@ func (sm *SessionManager) inviteFetch(channel *Channel, serverIP string, start, 
 		sm.portManager.Recycle(port)
 		return nil, fmt.Errorf("gb28181: failed to bind UDP port %d: %w", port, err)
 	}
+	setUDPReadBuffer(conn)
 
 	// Feed complete AUs to the sink (AU grouping preserved for muxing)
 	receiver.AUCallback = func(au [][]byte, ptsTicks int64, isIDR bool) {

--- a/internal/gb28181/udp_buffer.go
+++ b/internal/gb28181/udp_buffer.go
@@ -1,0 +1,14 @@
+package gb28181
+
+import "net"
+
+// setUDPReadBuffer enlarges the SO_RCVBUF of a GB28181 media socket. 2K IDRs
+// arrive as multi-hundred-KB RTP bursts; the default buffer
+// (net.core.rmem_default, typically 212KB) overflows mid-burst and the kernel
+// silently drops packets — the receiver then gap-skips inside the keyframe and
+// every downstream decoder error-conceals (green frames) until the next IDR.
+// 4MB matches common net.core.rmem_max ceilings; the kernel silently caps the
+// request when rmem_max is lower, so this is safe everywhere.
+func setUDPReadBuffer(conn *net.UDPConn) {
+	_ = conn.SetReadBuffer(4 << 20)
+}


### PR DESCRIPTION
## Problem

While chasing the reported **green half-frames** on GB28181-forwarded cameras, two observability/robustness gaps turned up on the platform-side RTP receiver:

1. **Media UDP sockets use the default SO_RCVBUF** (`net.core.rmem_default`, typically 212KB). 2K IDR frames arrive as multi-hundred-KB RTP bursts — the kernel buffer overflows mid-burst and packets are silently dropped. The receiver gap-skips inside the keyframe and downstream decoders error-conceal (green) until the next IDR.
2. **Transit loss was invisible**: the gap-skip counter (`packetsDroppedU`) only logged at debug level and was absent from the session-stop log and `Metrics()`. The stop line's `packets_dropped` field counts **foreign-SSRC drops only**, so it read a reassuring `0` while packets were being lost on the wire.

(The root cause of the observed green frames was the *source-side* psmux writing a wrapped 16-bit `PES_packet_length` for >64KB IDRs — already fixed on main by the bounded-PES chunking; this PR hardens the receiving side and makes residual loss measurable.)

## Changes

- `setUDPReadBuffer(4MB)` on both media-socket `ListenUDP` sites (kernel silently caps where `rmem_max` is lower — safe everywhere)
- `gap_skipped_packets` added to the receiver stop log and `Metrics()`, read under `jitterBufferMu` (same lock as the only writer)

## Tests

`internal/gb28181` + `internal/gb28181/cascade` green with `-race` (one pre-existing flake in cascade observed once on the VM, unrelated to this diff, passed on rerun).