### PR TITLE
feat(cascade): per-camera catalog exposure gate (目录收敛)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -72,6 +72,7 @@ func injectYAMLConfigFields(row *storage.CameraRow, cfg *config.Config) {
 		row.DarkFrameFilterEnabled = cam.DarkFrameFilterEnabled
 		row.DarkFrameThreshold = cam.DarkFrameThreshold
 		row.RecordingEnabled = cam.RecordingEnabled
+		row.CascadeEnabled = cam.CascadeEnabled
 		row.RecordingSchedule = cam.RecordingSchedule
 		if cam.Protocol == "gb28181" {
 			gb := cam.GB28181
@@ -292,6 +293,9 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		AudioEnabled   *bool                         `json:"audio_enabled"`
 		// Recording gate: false = live-only (no segments written). nil = record.
 		RecordingEnabled *bool `json:"recording_enabled"`
+		// Cascade gate: false = hidden from the GB28181 cascade catalog and
+		// INVITEs refused. nil = default (exposed).
+		CascadeEnabled *bool `json:"cascade_enabled"`
 		// Push/ingest fields (SRT/RTMP)
 		StreamKey     string `json:"stream_key"`
 		SRTPassphrase string `json:"srt_passphrase"`
@@ -478,6 +482,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		Channel:           body.Channel,
 		AudioEnabled:      body.AudioEnabled != nil && *body.AudioEnabled,
 		RecordingEnabled:  body.RecordingEnabled,
+		CascadeEnabled:    body.CascadeEnabled,
 		StreamKey:         body.StreamKey,
 		SRTPassphrase:     body.SRTPassphrase,
 		SRTStreamID:       body.SRTStreamID,
@@ -663,6 +668,9 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		DarkFrameThreshold     *int  `json:"dark_frame_threshold"`
 		// Recording gate: false = live-only (no segments written). nil = unchanged.
 		RecordingEnabled *bool `json:"recording_enabled"`
+		// Cascade gate: false = hidden from the GB28181 cascade catalog and
+		// INVITEs refused. nil = unchanged.
+		CascadeEnabled *bool `json:"cascade_enabled"`
 		// Recording schedule
 		RecordingSchedule *config.ScheduleConfig `json:"recording_schedule"`
 		// Push/ingest fields (SRT/RTMP)
@@ -735,6 +743,7 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		DarkFrameFilterEnabled: body.DarkFrameFilterEnabled,
 		DarkFrameThreshold:     body.DarkFrameThreshold,
 		RecordingEnabled:       body.RecordingEnabled,
+		CascadeEnabled:         body.CascadeEnabled,
 		RecordingSchedule:      body.RecordingSchedule,
 		StreamKey:              body.StreamKey,
 		SRTPassphrase:          body.SRTPassphrase,

--- a/internal/camera/cascade_source.go
+++ b/internal/camera/cascade_source.go
@@ -33,6 +33,9 @@ func (s cascadeSource) Cameras() []cascade.CameraInfo {
 			ID:       cfg.ID,
 			Name:     cfg.Name,
 			Encoding: cfg.Encoding,
+			// Catalog convergence: cascade_enabled=false hides the camera from
+			// the upper platform entirely (catalog + INVITE gate).
+			CascadeHidden: cfg.CascadeEnabled != nil && !*cfg.CascadeEnabled,
 			// Brand/Model live only in DB rows (config.CameraConfig has no
 			// such fields); the catalog falls back to MiBee/MiBeeNvr.
 		})

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -606,6 +606,9 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 		}
 		cam.RecordingEnabled = updates.RecordingEnabled
 	}
+	if updates.CascadeEnabled != nil {
+		cam.CascadeEnabled = updates.CascadeEnabled
+	}
 	if updates.RecordingSchedule != nil {
 		cam.RecordingSchedule = updates.RecordingSchedule
 	}

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -59,6 +59,10 @@ type CameraUpdate struct {
 	DarkFrameThreshold     *int
 	// RecordingEnabled gates segment writes (false = live-only). nil = unchanged.
 	RecordingEnabled *bool
+	// CascadeEnabled gates GB28181 cascade exposure (false = hidden from the
+	// upper platform's catalog and INVITEs refused). nil = unchanged. Takes
+	// effect at the next catalog response / INVITE — no recorder restart.
+	CascadeEnabled *bool
 	// Recording schedule
 	RecordingSchedule *config.ScheduleConfig
 	// Push/ingest camera fields (SRT/RTMP). nil = unchanged.

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -86,6 +86,15 @@ type CameraConfig struct {
 	// See internal/autodiscover/ for the discovery engine.
 	ActivationState string `yaml:"activation_state,omitempty" json:"activation_state,omitempty"`
 
+	// CascadeEnabled gates this camera's participation in the GB28181 cascade
+	// catalog (lower-platform role): nil or true (default) = advertised to the
+	// upper platform and forwardable on INVITE; false = hidden from the
+	// aggregated catalog and INVITEs for its channel are refused ("目录收敛" —
+	// expose only a chosen subset of cameras to the upper platform). The
+	// persisted channel-ID allocation is kept, so re-enabling restores the
+	// same channel code and the upper's bindings survive.
+	CascadeEnabled *bool `yaml:"cascade_enabled,omitempty" json:"cascade_enabled,omitempty"`
+
 	// Push-out targets (relay): forward this camera's live stream to remote
 	// destinations (another NVR's RTMP/SRT ingest, a live platform, a backup).
 	// Applies to ANY camera protocol — the engine subscribes to the camera's

--- a/internal/gb28181/cascade/cascade_test.go
+++ b/internal/gb28181/cascade/cascade_test.go
@@ -73,6 +73,48 @@ func TestCatalogItemsAllocatesAndPersists(t *testing.T) {
 	require.Equal(t, "34020000001320000003", items3[2].DeviceID)
 }
 
+// TestCatalogHiddenCamerasExcluded verifies catalog convergence: cameras with
+// CascadeHidden are absent from the aggregated catalog, while their persisted
+// channel allocation is kept — re-enabling restores the same channel code.
+func TestCatalogHiddenCamerasExcluded(t *testing.T) {
+	db := newCascadeTestDB(t)
+	svc := New(testCfg(), fakeSource{cams: []CameraInfo{
+		{ID: "front", Name: "Front"},
+		{ID: "back", Name: "Back"},
+	}}, db)
+
+	// First pass: both cameras visible, channels allocated.
+	items, err := svc.catalogItems()
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	// Hide "back": it disappears from the catalog...
+	svcHidden := New(testCfg(), fakeSource{cams: []CameraInfo{
+		{ID: "front", Name: "Front"},
+		{ID: "back", Name: "Back", CascadeHidden: true},
+	}}, db)
+	itemsHidden, err := svcHidden.catalogItems()
+	require.NoError(t, err)
+	require.Len(t, itemsHidden, 1)
+	require.Equal(t, "34020000001320000001", itemsHidden[0].DeviceID, "front keeps its channel")
+
+	// ...and re-enabling restores the SAME channel (allocation persisted).
+	svcAgain := New(testCfg(), fakeSource{cams: []CameraInfo{
+		{ID: "front", Name: "Front"},
+		{ID: "back", Name: "Back"},
+	}}, db)
+	itemsAgain, err := svcAgain.catalogItems()
+	require.NoError(t, err)
+	require.Len(t, itemsAgain, 2)
+	require.Equal(t, "34020000001320000002", itemsAgain[1].DeviceID, "back's channel is stable across hide/show")
+
+	// The hidden camera's channel still resolves to its camera — the INVITE
+	// gate must refuse it with 404 rather than silently forwarding.
+	camID, ok := svcHidden.cameraOfChannel("34020000001320000002")
+	require.True(t, ok)
+	require.Equal(t, "back", camID)
+}
+
 func TestCameraOfChannel(t *testing.T) {
 	db := newCascadeTestDB(t)
 	svc := New(testCfg(), fakeSource{cams: []CameraInfo{{ID: "front", Name: "Front"}}}, db)

--- a/internal/gb28181/cascade/catalog.go
+++ b/internal/gb28181/cascade/catalog.go
@@ -41,6 +41,12 @@ func (s *Service) catalogItems() ([]manscdp.Item, error) {
 
 	items := make([]manscdp.Item, 0, len(cams))
 	for _, cam := range cams {
+		if cam.CascadeHidden {
+			// Catalog convergence: hidden cameras are not advertised. Their
+			// persisted channel allocation is kept so re-enabling restores the
+			// same channel code (upper-side bindings survive).
+			continue
+		}
 		chID, ok := alloc[cam.ID]
 		if !ok {
 			maxSerial++

--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -167,6 +167,14 @@ func (s *Service) onInvite(req sip.Request, _ sip.ServerTransaction) {
 		_, _ = s.srv.RespondOnRequest(req, 404, "Unknown Channel", "", nil)
 		return
 	}
+	if cam, ok := s.cameraInfo(cameraID); ok && cam.CascadeHidden {
+		// Catalog convergence: the channel was allocated once (allocation rows
+		// persist) but the camera is now hidden — the upper may still hold the
+		// stale binding and INVITE it. Refuse like an unknown channel.
+		slog.Info("gb28181-cascade: INVITE for hidden camera refused", "channel", channelID, "camera", cameraID)
+		_, _ = s.srv.RespondOnRequest(req, 404, "Unknown Channel", "", nil)
+		return
+	}
 	hub := s.src.Hub(cameraID)
 	if hub == nil {
 		_, _ = s.srv.RespondOnRequest(req, 500, "Stream Unavailable", "", nil)

--- a/internal/gb28181/cascade/service.go
+++ b/internal/gb28181/cascade/service.go
@@ -40,6 +40,10 @@ type CameraInfo struct {
 	// Encoding is the camera's configured codec ("h264"|"h265"|"" unknown) —
 	// the preferred PSM type; sniffed from the first NAL when empty.
 	Encoding string
+	// CascadeHidden excludes the camera from the aggregated catalog and makes
+	// INVITEs for its channel fail with 404 (catalog convergence: expose only
+	// a chosen subset to the upper platform).
+	CascadeHidden bool
 }
 
 // CameraSource supplies the local camera list and their stream hubs. The

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -72,6 +72,9 @@ type CameraRow struct {
 	RecordingEnabled *bool `json:"recording_enabled,omitempty"`
 	// Recording schedule (injected from YAML at API response time)
 	RecordingSchedule *config.ScheduleConfig `json:"recording_schedule,omitempty"`
+	// Cascade gate (injected from YAML at API response time): false = hidden
+	// from the GB28181 cascade catalog, INVITEs refused. nil = exposed.
+	CascadeEnabled *bool `json:"cascade_enabled,omitempty"`
 	// ActivationState: "active" (recorder runs) or "pending_activation"
 	// (persisted + visible but recorder not started — awaiting credentials).
 	// "" is treated as "active". Set by auto-discover for authenticated devices.

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -39,6 +39,9 @@ export interface Camera {
   // Recording gate: false = live-only (no segments written to disk; the recorder
   // stays connected for live preview + relay + health). undefined = record.
   recording_enabled?: boolean | null;
+  // Cascade gate: false = hidden from the GB28181 cascade catalog (upper
+  // platform cannot see or invite it). undefined = exposed.
+  cascade_enabled?: boolean | null;
   // Xiaomi two-way audio enable flag
   two_way_audio_enabled?: boolean;
   // Push/ingest fields (SRT/RTMP cameras)
@@ -144,6 +147,8 @@ export interface CreateCameraRequest {
   channel?: string;
   // Recording gate: false = live-only (no segments written). Omit = record.
   recording_enabled?: boolean | null;
+  // Cascade gate: false = hidden from the GB28181 cascade catalog. Omit = exposed.
+  cascade_enabled?: boolean | null;
   // Push/ingest fields (SRT/RTMP)
   stream_key?: string;
   srt_passphrase?: string;
@@ -185,6 +190,8 @@ export interface UpdateCameraRequest {
   channel?: string;
   // Recording gate: false = live-only (no segments written). Omit = unchanged.
   recording_enabled?: boolean | null;
+  // Cascade gate: false = hidden from the GB28181 cascade catalog. Omit = unchanged.
+  cascade_enabled?: boolean | null;
   // Push/ingest fields (SRT/RTMP)
   stream_key?: string;
   srt_passphrase?: string;

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -87,6 +87,7 @@
   // Recording gate — when off, the recorder stays connected for live preview
   // and relay but writes NO segments to disk (live-only / stream-forward mode).
   let formRecordingEnabled = $state(true);
+  let formCascadeEnabled = $state(true);
   // Xiaomi two-way audio
   let formTwoWayAudioEnabled = $state(false);
   // IP self-healing: candidate CIDRs to scan when this camera's IP changes.
@@ -293,6 +294,7 @@ let validationErrors = $state<Record<string, string>>({});
     formChannel = camera.channel || '';
     formAudioEnabled = camera.audio_enabled ?? false;
     formRecordingEnabled = camera.recording_enabled ?? true;
+    formCascadeEnabled = camera.cascade_enabled ?? true;
     formTwoWayAudioEnabled = camera.two_way_audio_enabled ?? false;
     formSubnetHints = (camera.subnet_hints ?? []).join('\n');
     formStreamKey = camera.stream_key || '';
@@ -561,6 +563,7 @@ async function performCameraSave() {
             channel: formProtocol === 'xiaomi' ? (formChannel || undefined) : undefined,
             audio_enabled: formAudioEnabled,
             recording_enabled: formRecordingEnabled,
+            cascade_enabled: formCascadeEnabled,
             two_way_audio_enabled: formProtocol === 'xiaomi' ? formTwoWayAudioEnabled : undefined,
             subnet_hints: formProtocol === 'onvif' ? parseSubnetHints(formSubnetHints) : undefined,
             stream_key: (formProtocol === 'rtmp' || formProtocol === 'whip') ? (formStreamKey || undefined) : undefined,
@@ -623,6 +626,7 @@ async function performCameraSave() {
             channel: formProtocol === 'xiaomi' ? (formChannel || undefined) : undefined,
             audio_enabled: formAudioEnabled,
             recording_enabled: formRecordingEnabled,
+            cascade_enabled: formCascadeEnabled,
             two_way_audio_enabled: formProtocol === 'xiaomi' ? formTwoWayAudioEnabled : undefined,
             subnet_hints: formProtocol === 'onvif' ? parseSubnetHints(formSubnetHints) : undefined,
             stream_key: (formProtocol === 'rtmp' || formProtocol === 'whip') ? (formStreamKey || undefined) : undefined,
@@ -803,6 +807,23 @@ async function performCameraSave() {
     </div>
     {#if !formRecordingEnabled}
       <p class="text-xs th-text-muted -mt-1">{t('cameras.recordingDisabledHint')}</p>
+    {/if}
+
+    <!-- Cascade catalog toggle: when off, the camera is hidden from the
+         GB28181 cascade upper platform (catalog + INVITE). -->
+    <div class="flex items-center gap-2">
+      <input
+        id="cam-cascade"
+        type="checkbox"
+        class="checkbox"
+        bind:checked={formCascadeEnabled}
+      />
+      <label for="cam-cascade" class="input-label cursor-pointer">
+        {t('cameras.cascadeEnabled')}
+      </label>
+    </div>
+    {#if !formCascadeEnabled}
+      <p class="text-xs th-text-muted -mt-1">{t('cameras.cascadeDisabledHint')}</p>
     {/if}
 
     <!-- Audio recording toggle (not supported for MJPEG/JPEG cameras) -->

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -269,6 +269,8 @@
   "cameras.recordFrom": "Record from",
   "cameras.recordTo": "to",
   "cameras.recordingDisabledHint": "Live-only mode: the camera stays connected for live preview and relay, but no recordings are saved (saves SD-card wear).",
+  "cameras.cascadeEnabled": "Expose to GB28181 cascade",
+  "cameras.cascadeDisabledHint": "When off, this camera is hidden from the cascade catalog — the upper platform cannot see or request it (the channel allocation is kept; re-enabling restores the same code)",
   "cameras.recordingEnabled": "Record video to disk",
   "cameras.recordingSchedule": "Recording schedule",
   "cameras.recordingScheduleHint": "time-based recording",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -262,6 +262,8 @@
   "cameras.recordFrom": "录制起始",
   "cameras.recordTo": "至",
   "cameras.recordingDisabledHint": "仅直播模式：摄像头保持连接用于实时预览和转发，但不保存录像（减少 SD 卡损耗）。",
+  "cameras.cascadeEnabled": "国标级联上报此摄像头",
+  "cameras.cascadeDisabledHint": "关闭后此摄像头不上报国标级联目录，上级平台无法看到或点播它（通道号保留，重新开启后绑定关系不变）",
   "cameras.recordingEnabled": "录制视频到磁盘",
   "cameras.recordingSchedule": "录制时间表",
   "cameras.recordingScheduleHint": "按时段录制",


### PR DESCRIPTION
## Problem

The GB28181 cascade catalog advertises **every** local camera (`catalogItems` enumerates `Cameras()` unconditionally) with no way to exclude any. An upper platform sees — and can INVITE — the full camera list even when only a subset should be exposed. Media is still lazy (nothing streams until invited), but there is no way to shrink the catalog itself.

## Change

Per-camera `cascade_enabled` gate, default **exposed** (nil/true — existing deployments unchanged):

- **Catalog**: hidden cameras are omitted from the aggregated catalog. Their persisted `cascade_channels` allocation is kept, so re-enabling restores the same channel code and the upper's bindings survive hide/show cycles.
- **INVITE gate**: the upper may hold a stale binding for a hidden channel — such INVITEs answer `404 Unknown Channel` instead of forwarding (mirror of the unknown-channel path).
- **API**: `cascade_enabled` on camera create/update bodies and the list/get response.
- **UI**: checkbox in the camera form next to the recording toggle — 「国标级联上报此摄像头」/ "Expose to GB28181 cascade" — with a hint about the semantics.

## Tests

- `TestCatalogHiddenCamerasExcluded`: hidden camera absent from catalog; channel allocation persists; re-enable restores the same code; hidden channel still resolves (the INVITE gate refuses rather than silently forwarding)
- Full gb28181 + camera suites green with `-race`; CameraForm vitest 17/17
- (3 pre-existing env-sensitive api failures on the local VM — disk 98% full; verified identical on pristine main and green in CI)