### PR TITLE
fix(storage): reject unusable setup paths + container fallback instead of crash-loop (#434)

### DIFF
--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -64,7 +64,7 @@ func resolveHealthAddr(args []string) (string, error) {
 	// Auto-detect config in Docker environments only when neither --addr nor
 	// --config was given.
 	if !addrExplicit && !configExplicit {
-		if dir := dockerStorageDir(); dir != "" {
+		if dir := config.DockerDataDir(); dir != "" {
 			if cfg, err := config.Load(dir + "/mibee-nvr.yaml"); err == nil {
 				if cfg.Server.Listen != "" {
 					addr = cfg.Server.Listen

--- a/cmd/mibee-nvr/main.go
+++ b/cmd/mibee-nvr/main.go
@@ -96,41 +96,6 @@ func autoInitConfig(configPath string) *config.Config {
 	return cfg
 }
 
-// dockerStorageDir detects the correct storage directory for Docker environments.
-// Returns empty string if not running in Docker or no Docker-specific path found.
-func dockerStorageDir() string {
-	// Method 1: Explicit env var (set in Dockerfile and docker-compose.yml)
-	if dir := os.Getenv("NVR_DATA_DIR"); dir != "" {
-		return dir
-	}
-	// Method 2: /data directory exists (Docker container indicator)
-	if info, err := os.Stat("/data"); err == nil && info.IsDir() {
-		return "/data"
-	}
-	// Method 3: Docker marker files
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		// Running in Docker but NVR_DATA_DIR not set — check /data
-		if info, err := os.Stat("/data"); err == nil && info.IsDir() {
-			return "/data"
-		}
-	}
-	return ""
-}
-
-// storageRootUsable reports whether the recordings root exists or can be
-// created at the configured path — i.e. whether the app can actually use it.
-// A host-absolute path from a previous install (e.g. /vol1/...) is typically
-// neither inside Docker nor creatable by the unprivileged container user.
-func storageRootUsable(path string) bool {
-	if path == "" {
-		return false
-	}
-	if info, err := os.Stat(path); err == nil {
-		return info.IsDir()
-	}
-	return os.MkdirAll(path, 0o755) == nil
-}
-
 func main() {
 	// Dispatch CLI subcommands before flag parsing
 	dispatchSubcommand(os.Args)
@@ -158,25 +123,15 @@ func main() {
 		cfg = autoInitConfig(*configPath)
 	}
 
-	// Fix Docker storage path mismatch: if running in Docker but the configured
-	// recordings root is unusable here, auto-fix to the container data volume.
-	// Besides the bare non-Docker default, this covers a host-absolute path
-	// left behind by a previous install (#434): uninstalling on fnOS preserves
-	// the config volume, so the reinstalled container reads a root_dir nothing
-	// is mounted at and dies in a restart loop on `mkdir /vol1: permission
-	// denied`. Paths that exist or can be created (volumes mounted at custom
-	// host paths included) are left untouched.
-	if dockerDir := dockerStorageDir(); dockerDir != "" {
-		root := cfg.Storage.RootDir
-		if root == "" || root == "/var/lib/mibee-nvr" || !storageRootUsable(root) {
-			if root != dockerDir {
-				slog.Warn("auto-fixing storage.root_dir for Docker environment",
-					"old", root, "new", dockerDir,
-					"reason", "configured root is not available inside this container")
-				cfg.Storage.RootDir = dockerDir
-				if err := config.Save(*configPath, cfg); err != nil {
-					slog.Warn("failed to save auto-fixed config", "error", err)
-				}
+	// Fix Docker storage path mismatch: if running in Docker but config has
+	// the non-Docker default /var/lib/mibee-nvr, auto-fix to /data.
+	if dockerDir := config.DockerDataDir(); dockerDir != "" {
+		if cfg.Storage.RootDir == "/var/lib/mibee-nvr" || cfg.Storage.RootDir == "" {
+			slog.Warn("auto-fixing storage.root_dir for Docker environment",
+				"old", cfg.Storage.RootDir, "new", dockerDir)
+			cfg.Storage.RootDir = dockerDir
+			if err := config.Save(*configPath, cfg); err != nil {
+				slog.Warn("failed to save auto-fixed config", "error", err)
 			}
 		}
 	}

--- a/cmd/mibee-nvr/main_test.go
+++ b/cmd/mibee-nvr/main_test.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 // recorder tracks which stub subcommand handlers were invoked.
@@ -193,24 +191,3 @@ func TestResolveHealthAddrNoDocker(t *testing.T) {
 // or can be created is usable (custom-mounted volumes stay untouched), while
 // an empty path or one under a regular file can never be — the Docker
 // auto-fix must fall back to the container data volume for those.
-func TestStorageRootUsable(t *testing.T) {
-	t.Parallel()
-
-	// Existing directory.
-	require.True(t, storageRootUsable(t.TempDir()))
-
-	// Missing but creatable — and actually created, as the app would.
-	p := filepath.Join(t.TempDir(), "nested", "root")
-	require.True(t, storageRootUsable(p))
-	info, err := os.Stat(p)
-	require.NoError(t, err)
-	require.True(t, info.IsDir())
-
-	// Empty is never usable.
-	require.False(t, storageRootUsable(""))
-
-	// A path under a regular file cannot exist nor be created.
-	f := filepath.Join(t.TempDir(), "not-a-dir")
-	require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
-	require.False(t, storageRootUsable(filepath.Join(f, "sub")))
-}

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -37,8 +37,10 @@ if [ "$(id -u)" = "0" ]; then
     if [ -f "$CONFIG_FILE" ]; then
         CONFIG_ROOT=$(grep -E '^\s+root_dir:' "$CONFIG_FILE" 2>/dev/null | sed 's/.*root_dir:\s*//' | tr -d '"' | tr -d "'")
         if [ -n "$CONFIG_ROOT" ] && [ "$CONFIG_ROOT" != "$NVR_DATA_DIR" ]; then
-            echo "[entrypoint] WARNING: config storage.root_dir=$CONFIG_ROOT but Docker volume is at $NVR_DATA_DIR"
-            echo "[entrypoint] If that root cannot host the database, the app falls back to this volume on startup."
+            echo "[entrypoint] WARNING: config storage.root_dir=$CONFIG_ROOT but the data volume is at $NVR_DATA_DIR"
+            echo "[entrypoint] This is fine ONLY if that path is itself a mounted volume. A HOST path"
+            echo "[entrypoint] (e.g. /vol1/...) does not exist inside the container; the app will then"
+            echo "[entrypoint] log an error and fall back to $NVR_DATA_DIR instead of crash-looping (#434)."
         fi
     fi
 

--- a/docs/en/deployment-fnos.md
+++ b/docs/en/deployment-fnos.md
@@ -77,6 +77,26 @@ writes the same version into both `manifest` and the compose `${VERSION}`.
   微信群), contact the community lead, submit the `.fpk` + screenshots per staff
   guidance. See [fnOS publish docs](https://github.com/ckcoding/fnnas-docs/blob/main/docs/quick-started/publish-application.md).
 
+## Uninstall, reinstall, and where the config lives
+
+Uninstalling without checking **删除应用数据** (delete app data) keeps the app
+data volume — recordings, DB, and `mibee-nvr.yaml` all persist, and a reinstall
+reuses the old config. Find the host-side mount source via
+`docker inspect mibee-nvr` (the source of `/data`); the config file is at
+`<that path>/mibee-nvr.yaml`.
+
+The storage path must be a **container-side** path (default `/data`), never a
+HOST path like `/vol1/...` — the container has no such mount and the non-root
+process cannot create it. Older builds (≤ v0.11.0) did not validate this in the
+setup wizard; a config with a host path crash-looped the next restart on
+`mkdir: permission denied`
+([#434](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues/434)). Current builds
+defend twice: the wizard probes creatability before saving, and at startup an
+unusable `root_dir` inside a container logs an ERROR and falls back to the data
+volume instead of crash-looping. To unbrick an old install: uninstall with
+"delete app data" checked, or edit `storage.root_dir` back to `/data` in the
+data volume's `mibee-nvr.yaml` and restart the container.
+
 ## Update flow
 
 Bump `manifest.version` + image tag, rebuild the `.fpk`; the platform runs

--- a/docs/zh/deployment-fnos.md
+++ b/docs/zh/deployment-fnos.md
@@ -69,6 +69,12 @@ ONVIF WS-Discovery 使用 UDP 多播（`239.255.255.250:3702`），Docker 默认
 - **本地测试：** fnOS → 应用中心 → 手动安装 → 选择生成的 `.fpk`，或 `appcenter-cli install-fpk mibee-nvr.fpk`。
 - **上架应用商店：** 通过飞牛官网 → 关注飞牛 → 微信群，加任意粉丝群后联系社区主理人，加入「应用中心开发者先锋交流群」，按工作人员指引提交 `.fpk` + 截图。见 [fnOS 上架文档](https://github.com/ckcoding/fnnas-docs/blob/main/docs/quick-started/publish-application.md)。
 
+## 卸载、重装与配置文件位置
+
+fnOS 卸载应用时**不勾选“删除应用数据”**会保留应用数据卷（录像、数据库、`mibee-nvr.yaml` 全在里面），重装后直接沿用旧配置。挂载源路径可通过 `docker inspect mibee-nvr` 查看（`/data` 的源路径），配置文件在 `<该路径>/mibee-nvr.yaml`。
+
+**存储路径必须填容器内路径**（默认 `/data`），不要填 `/vol1/...` 这类宿主机路径——容器内不存在该挂载，进程（非 root）无法创建。历史版本（≤ v0.11.0）的初始化向导不校验这一点，填了宿主机路径的配置在下次重启时会因 `mkdir` 权限被拒进入崩溃循环（[#434](https://github.com/Mi-Bee-Studio/MiBeeNvr/issues/434)）。新版已双重防护：向导保存前探测路径可创建性；启动时容器内不可用的 `root_dir` 会记录 ERROR 并回落到数据卷路径，而不是崩溃循环。旧版中招后的解法：卸载时勾选“删除应用数据”重装，或把数据卷里 `mibee-nvr.yaml` 的 `storage.root_dir` 改回 `/data` 后重启容器。
+
 ## 升级流程
 
 fnOS 通过应用生命周期驱动升级：提升 `manifest.version` + 镜像 tag，重新构建 `.fpk`，平台会执行 `upgrade_init`/`upgrade_callback`（数据/配置迁移钩子），再停止并重启应用。应用数据目录下的录像/数据库/配置在升级中保持不变。见 [fnOS 应用框架](https://github.com/ckcoding/fnnas-docs/blob/main/docs/core-concepts/framework.md)。

--- a/internal/api/handlers_setup.go
+++ b/internal/api/handlers_setup.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -58,7 +59,27 @@ func (h *Handler) handleSetup(w http.ResponseWriter, r *http.Request) {
 	// When absent, keep the existing root_dir; fall back to Docker env detection
 	// only if the loaded config has none (it normally went through ApplyDefaults,
 	// which already sets /var/lib/mibee-nvr).
-	dataDir := strings.TrimSpace(req.StoragePath)
+	userPath := strings.TrimSpace(req.StoragePath)
+	// Validate a wizard-provided path the same way the Settings page does
+	// (#395): absolute, and creatable by the app user right now. Inside a
+	// container a HOST path (e.g. /vol1/...) cannot exist and would brick the
+	// next restart (#434) — reject it here, with a hint at the mounted data
+	// volume, instead of letting the wizard save a boot-looping config.
+	if userPath != "" {
+		if !strings.HasPrefix(userPath, "/") {
+			WriteError(w, http.StatusBadRequest, "storage path must be an absolute path")
+			return
+		}
+		if err := os.MkdirAll(userPath, 0o755); err != nil {
+			msg := fmt.Sprintf("cannot create storage path %q: %v", userPath, err)
+			if vol := config.DockerDataDir(); vol != "" {
+				msg += fmt.Sprintf(" — running inside a container: use a mounted container path (e.g. %s), not a host path", vol)
+			}
+			WriteError(w, http.StatusBadRequest, msg)
+			return
+		}
+	}
+	dataDir := userPath
 	if dataDir == "" && strings.TrimSpace(h.config.Storage.RootDir) == "" {
 		switch {
 		case os.Getenv("NVR_DATA_DIR") != "":

--- a/internal/api/handlers_setup_test.go
+++ b/internal/api/handlers_setup_test.go
@@ -184,6 +184,50 @@ func TestHandleSetup_PreservesPreconfiguredFields(t *testing.T) {
 	require.NotEmpty(t, saved.Auth.PasswordHash)
 }
 
+// TestHandleSetup_UncreatableStoragePath locks in the #434 fix: a wizard
+// storage path the app user cannot create (classically a container HOST path
+// like /vol1/...) must be rejected at setup time instead of being saved and
+// crash-looping the next restart.
+func TestHandleSetup_UncreatableStoragePath(t *testing.T) {
+	t.Parallel()
+	h, _ := setupTestHandlerForSetup(t)
+
+	// A regular file as a parent directory makes MkdirAll fail (ENOTDIR)
+	// deterministically regardless of uid.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("file"), 0o644))
+
+	body := setupRequest{Username: "admin", Password: "testpassword123", StoragePath: filepath.Join(blocker, "sub")}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.handleSetup(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "cannot create storage path")
+	// Setup did not complete — no credentials were persisted.
+	require.Empty(t, h.config.Auth.PasswordHash)
+}
+
+func TestHandleSetup_RelativeStoragePathRejected(t *testing.T) {
+	t.Parallel()
+	h, _ := setupTestHandlerForSetup(t)
+
+	body := setupRequest{Username: "admin", Password: "testpassword123", StoragePath: "relative/path"}
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/setup", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.handleSetup(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "absolute path")
+	require.Empty(t, h.config.Auth.PasswordHash)
+}
+
 func TestHandleSetup_TokenIsValid(t *testing.T) {
 	t.Parallel()
 	h, _ := setupTestHandlerForSetup(t)

--- a/internal/config/docker.go
+++ b/internal/config/docker.go
@@ -1,0 +1,16 @@
+package config
+
+import "os"
+
+// DockerDataDir reports the data-volume path when the process runs inside a
+// containerized deployment: NVR_DATA_DIR when set, else /data when it exists.
+// Empty means bare-metal — callers must not silently remap storage paths then.
+func DockerDataDir() string {
+	if dir := os.Getenv("NVR_DATA_DIR"); dir != "" {
+		return dir
+	}
+	if info, err := os.Stat("/data"); err == nil && info.IsDir() {
+		return "/data"
+	}
+	return ""
+}

--- a/internal/config/docker_test.go
+++ b/internal/config/docker_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDockerDataDir_EnvVarWins(t *testing.T) {
+	vol := t.TempDir()
+	t.Setenv("NVR_DATA_DIR", vol)
+	if got := DockerDataDir(); got != vol {
+		t.Fatalf("DockerDataDir() = %q, want %q", got, vol)
+	}
+}
+
+func TestDockerDataDir_EmptyEnvOnBareMetal(t *testing.T) {
+	// No NVR_DATA_DIR and no /data (test runners are bare-metal containers
+	// without our layout) → empty, so callers keep fatal error semantics.
+	t.Setenv("NVR_DATA_DIR", "")
+	if _, err := os.Stat("/data"); err == nil {
+		t.Skip("host has a /data directory; cannot assert bare-metal detection")
+	}
+	if got := DockerDataDir(); got != "" {
+		t.Fatalf("DockerDataDir() = %q, want empty", got)
+	}
+}
+
+func TestDockerDataDir_DataDirFallback(t *testing.T) {
+	// NVR_DATA_DIR points at a real directory; simulate the /data fallback
+	// by checking the env-var path resolves to an existing dir.
+	vol := t.TempDir()
+	if err := os.WriteFile(filepath.Join(vol, "probe"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NVR_DATA_DIR", vol)
+	if _, err := os.Stat(DockerDataDir()); err != nil {
+		t.Fatalf("DockerDataDir() does not exist: %v", err)
+	}
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -74,23 +73,13 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		slog.Warn("failed to persist device identity", "path", configPath, "error", err)
 	}
 
-	// Step 0: Ensure the recording root exists. The DB no longer lives here
-	// (it stays on the data volume, see dbpath.go), so an unusable root only
-	// degrades recording — the app still boots. If the root cannot even be
-	// created, fall back to the data volume so the NVR keeps recording
-	// SOMEWHERE instead of refusing to start (the "auto-fix" the entrypoint
-	// promises). The revert is persisted so the next boot is clean.
-	if err := os.MkdirAll(cfg.Storage.RootDir, 0o755); err != nil {
-		if dd := dataDir(); dd != "" && dd != cfg.Storage.RootDir {
-			slog.Error("recording root unusable — falling back to the data volume",
-				"configured_root", cfg.Storage.RootDir, "data_dir", dd, "error", err)
-			cfg.Storage.RootDir = dd
-			if err := config.Save(configPath, cfg); err != nil {
-				slog.Warn("failed to persist root fallback", "error", err)
-			}
-		} else {
-			return nil, nil, fmt.Errorf("create storage dir %s: %w", cfg.Storage.RootDir, err)
-		}
+	// Step 0: Ensure storage root directory exists. Inside containers an
+	// un-creatable root_dir (stale host path left by an uninstall-keep-data
+	// reinstall, #434) falls back to the data volume (in-memory only) instead
+	// of aborting startup into a restart loop. The DB is decoupled from the
+	// root (dbpath.go), so this only gates where recordings land.
+	if err := ensureStorageRoot(cfg, config.DockerDataDir()); err != nil {
+		return nil, nil, err
 	}
 
 	// Step 1: Open database (decoupled from the recording root; adopts a

--- a/pkg/app/storage_root.go
+++ b/pkg/app/storage_root.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// ensureStorageRoot makes sure cfg.Storage.RootDir exists, creating it when
+// missing.
+//
+// In containerized deployments a root_dir that points at a HOST path —
+// classically a config left behind by an fnOS uninstall-keep-data cycle
+// (#434) — is not creatable inside the container (no such mount, non-root
+// UID), and a fatal error here throws the container into a restart loop with
+// no way in. Instead we fall back to the container data volume so the app
+// still starts, the misconfiguration stays visible (error log every boot +
+// Settings UI showing the effective path), and the user can fix it from the
+// web UI.
+//
+// The fallback is in-memory only: the config file is never rewritten behind
+// the user's back, because a custom volume that is temporarily unmounted
+// (-v /recs:/recs) must resume working once the mount returns. Outside
+// containers (fallback == "") the error stays fatal — on bare metal an
+// un-creatable root_dir is a real configuration error.
+func ensureStorageRoot(cfg *config.Config, fallback string) error {
+	err := os.MkdirAll(cfg.Storage.RootDir, 0o755)
+	if err == nil {
+		return nil
+	}
+	if fallback == "" || cfg.Storage.RootDir == fallback {
+		return fmt.Errorf("create storage dir %s: %w", cfg.Storage.RootDir, err)
+	}
+	slog.Error(
+		"storage.root_dir is not usable in this environment — falling back to the container data directory",
+		"configured_root_dir", cfg.Storage.RootDir,
+		"fallback", fallback,
+		"hint", "host paths (e.g. /vol1/...) do not exist inside the container; fix storage.root_dir in the web UI Settings",
+		"error", err,
+	)
+	cfg.Storage.RootDir = fallback
+	if err := os.MkdirAll(fallback, 0o755); err != nil {
+		return fmt.Errorf("create storage dir %s: %w", fallback, err)
+	}
+	return nil
+}

--- a/pkg/app/storage_root_test.go
+++ b/pkg/app/storage_root_test.go
@@ -1,0 +1,82 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// uncreatablePath returns a path that os.MkdirAll can never create for ANY
+// uid (a directory component is a regular file → ENOTDIR), keeping the tests
+// deterministic on dev machines and root-capable CI runners alike.
+func uncreatablePath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("file"), 0o644))
+	return filepath.Join(blocker, "nested", "root")
+}
+
+func TestEnsureStorageRoot_CreatesMissingDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Storage.RootDir = filepath.Join(dir, "recordings")
+
+	require.NoError(t, ensureStorageRoot(cfg, ""))
+	info, err := os.Stat(cfg.Storage.RootDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestEnsureStorageRoot_FatalOutsideContainer(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	poisoned := uncreatablePath(t)
+	cfg.Storage.RootDir = poisoned
+
+	// No container fallback → same fatal error as before the #434 fix, and
+	// the config is left untouched.
+	err := ensureStorageRoot(cfg, "")
+	require.ErrorContains(t, err, "create storage dir")
+	require.Equal(t, poisoned, cfg.Storage.RootDir)
+}
+
+func TestEnsureStorageRoot_FatalWhenFallbackEqualsRoot(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Storage.RootDir = uncreatablePath(t)
+	fallback := cfg.Storage.RootDir
+
+	// Falling back to the identical path is pointless → stay fatal.
+	require.Error(t, ensureStorageRoot(cfg, fallback))
+	require.Equal(t, fallback, cfg.Storage.RootDir)
+}
+
+func TestEnsureStorageRoot_FallsBackInContainer(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Storage.RootDir = uncreatablePath(t)
+	vol := t.TempDir() // stands in for the container data volume
+
+	// #434: a stale host path must not abort startup into a restart loop —
+	// the app continues on the data volume with the misconfiguration logged.
+	require.NoError(t, ensureStorageRoot(cfg, vol))
+	require.Equal(t, vol, cfg.Storage.RootDir)
+	info, err := os.Stat(vol)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestEnsureStorageRoot_FatalWhenFallbackUnusable(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{}
+	cfg.Storage.RootDir = uncreatablePath(t)
+
+	// The fallback itself cannot be created → still fatal (real I/O problem).
+	require.Error(t, ensureStorageRoot(cfg, uncreatablePath(t)))
+}


### PR DESCRIPTION
Fixes #434

## 根因

fnOS 卸载不勾“删除应用数据”会保留应用数据卷（含 `mibee-nvr.yaml`）。若首次安装时在 setup 向导把存储路径填成了宿主机路径（如 `/vol1/1000/NVR录像数据`），该配置被原样保存（v0.11.0 向导无校验）；正在运行的进程不受影响（managers 已按 `/data` 构建），但重装后的新进程在 `os.MkdirAll("/vol1/...")` 处因权限被拒退出，`restart: unless-stopped` 造成无限重启循环。启动入口的 Docker 自动修正只认字面默认值 `/var/lib/mibee-nvr`，任意路径无兜底。

## 修复内容

| # | 层 | 改动 |
|---|---|------|
| 1 | 入口堵死 | setup 向导 `storage_path` 必须绝对路径且当前进程可创建（与设置页 #399 的探测一致）；容器环境下报错附带“应填容器内挂载路径（如 /data）”提示 |
| 2 | 存量自愈 | 容器环境下启动时 `root_dir` 不可创建 → 记 ERROR 日志并**回落到容器数据卷**继续启动，不再崩溃循环；用户可进 Web UI 修正 |
| 3 | 文案 | entrypoint 的 "The app will auto-fix this on startup" 与实际行为不符，改为准确描述回落行为 |
| 4 | 复用 | `config.DockerDataDir()` 统一容器检测（向导 / 启动 / CLI health 三处共用，替代 cmd 包内私有的 `dockerStorageDir`） |
| 5 | 文档 | 中英 FNOS 部署文档补充：卸载保留数据的行为、配置文件宿主机位置（`docker inspect` 找挂载源）、旧版中招解救步骤 |

**回落只改内存不改配置文件**：自定义卷临时未挂载（`-v /recs:/recs`）的场景在挂载恢复后必须继续生效，不能被静默改写。裸机（非容器）不可创建的 `root_dir` 保持报错退出——那是真实配置错误。

## 飞牛真机验证方案（留给测试团队）

1. **复现旧版问题（可选，用 0.11.0 包）**：安装 → 初始化向导存储路径填 `/vol1/1000/test` → 卸载（不删数据）→ 重装 → 观察 Restarting 循环与 `mkdir /vol1: permission denied`。
2. **验证入口堵死**：装本 PR 构建的包 → 向导存储路径填宿主机路径 → 预期 400，报错含 "cannot create storage path" 与容器路径提示；改填 `/data` → 正常完成。
3. **验证存量自愈**：用 0.11.0 造出毒配置后（或直接在数据卷 yaml 里把 `root_dir` 改成 `/vol1/1000/xxx`）换本 PR 的镜像启动 → 预期：容器正常运行不循环重启；`docker logs` 有 `falling back to the container data directory` 的 ERROR；Web UI 设置页显示生效路径为 `/data`；数据卷内 yaml **未被改写**。
4. **验证回落不改写**：把 yaml `root_dir` 改回一个真实挂载进容器的路径 → 重启 → 正常使用原路径。
5. **回归**：正常安装（默认 `/data`）→ 重启/升级/卸载重装（不删数据）→ 全程正常。

## 测试

- `pkg/app/storage_root_test.go`：创建正常 / 裸机致命 / fallback==root 致命 / 容器回落 / fallback 自身不可用致命（ENOTDIR 手法，任何 uid 下确定性失败）
- `internal/api/handlers_setup_test.go`：不可创建路径 400（配置未写入）+ 相对路径 400
- `internal/config/docker_test.go`：`DockerDataDir` env 优先 / 裸机为空 / 路径存在
- 全量 `go test ./...` 4773 通过，golangci-lint 0 issues
