### PR TITLE
fix(player): honest degradation for overloaded wasm H.265 decode + plane strides

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1786964047361';
+const CACHE_VERSION = 'mibee-nvr-1787238042105';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
+++ b/web/src/lib/webcodecs-player/wasm-h265-decoder.ts
@@ -46,6 +46,25 @@ export class WasmH265Decoder {
   private _width = 0;
   private _height = 0;
 
+  // ── Throughput & integrity degradation ──────────────────────────────
+  // wasm H.265 on weak CPUs decodes high resolutions at a small fraction of
+  // the source frame rate (measured ~0.2fps for 4K vs 15-25fps input on an
+  // ARM-class box). An ever-growing backlog then corrupts output (users see
+  // bottom-half green/white concealment). Two guards keep the picture honest:
+  //  - _skipUntilKeyframe: after a failed push the reference chain is broken;
+  //    P-frames decoded against missing references display as concealment.
+  //    Skip everything until the next IDR.
+  //  - _keyframeOnly: when decode cost persistently exceeds the frame budget,
+  //    decode keyframes only — a stable still image per GOP instead of a
+  //    backlog of corrupted halves. Releases if decoding becomes cheap again
+  //    (e.g. the stream resolution dropped).
+  private _skipUntilKeyframe = false;
+  private _keyframeOnly = false;
+  private _decodeMsEma = 0;
+  private _decodeCount = 0;
+  private _frameIntervalMs = 0;
+  private _lastPts = 0;
+
   /**
    * Initialize the WASM decoder with codec parameters.
    * Loads the WASM module lazily on first call.
@@ -92,8 +111,30 @@ export class WasmH265Decoder {
    *          WasmFrame (raw RGBA + dimensions) so the caller can render via
    *          Canvas2D putImageData without depending on the VideoFrame API.
    */
-  decode(nalus: Uint8Array[], pts: number, _isKeyframe: boolean): VideoFrame | WasmFrame | null {
+  decode(nalus: Uint8Array[], pts: number, isKeyframe: boolean): VideoFrame | WasmFrame | null {
     if (!this._initialized || !this._decoder || !this._module) return null;
+
+    // Track the source frame interval (90kHz PTS → ms) as the decode budget.
+    if (this._lastPts > 0 && pts > this._lastPts) {
+      const interval = (pts - this._lastPts) / 90;
+      if (interval > 1 && interval < 10000) {
+        this._frameIntervalMs = this._frameIntervalMs
+          ? this._frameIntervalMs * 0.9 + interval * 0.1
+          : interval;
+      }
+    }
+    this._lastPts = pts;
+
+    if (this._skipUntilKeyframe && !isKeyframe) return null;
+    if (this._keyframeOnly && !isKeyframe) return null;
+
+    const t0 = performance.now();
+    const produced = this._decodePushed(nalus, pts);
+    this._noteDecodeMs(performance.now() - t0);
+    return produced;
+  }
+
+  private _decodePushed(nalus: Uint8Array[], pts: number): VideoFrame | WasmFrame | null {
 
     // Push each NAL unit. pushNal() expects ONE NAL WITHOUT a start code — the
     // decoder treats the whole buffer as a single NAL payload (whereas pushData()
@@ -105,12 +146,19 @@ export class WasmH265Decoder {
     for (const nalu of nalus) {
       const err = this._decoder.pushNal(nalu, BigInt(pts));
       if (!this._module.isOk(err)) {
-        // Push failed — likely need more data or parameter sets
+        // Push failed: the reference chain is now broken — decoding subsequent
+        // P-frames displays as bottom-half concealment. Skip to the next IDR.
+        this._skipUntilKeyframe = true;
         return null;
       }
       this._decoder.pushEndOfNal();
     }
     this._decoder.pushEndOfFrame();
+
+    // In degraded mode damaged pictures are worse than a stale one: suppress
+    // warned pictures (they carry concealed regions) so the tile keeps the
+    // last clean frame instead of flashing corruption.
+    const suppressWarned = this._keyframeOnly || this._skipUntilKeyframe;
 
     // Decode and extract frame
     let more = true;
@@ -128,8 +176,12 @@ export class WasmH265Decoder {
           // Still try to retrieve any picture produced before the warning.
           const warnImage = this._decoder.getNextPicture();
           if (warnImage) {
-            const produced = this._emitFrame(warnImage, pts);
-            if (produced) return produced;
+            if (suppressWarned) {
+              warnImage.delete();
+            } else {
+              const produced = this._emitFrame(warnImage, pts);
+              if (produced) return produced;
+            }
           }
           continue;
         }
@@ -142,10 +194,28 @@ export class WasmH265Decoder {
 
       // Must delete image to prevent ERROR_IMAGE_BUFFER_FULL — done by _emitFrame
       const produced = this._emitFrame(image, pts);
-      if (produced) return produced;
+      if (produced) {
+        // A clean picture proves the chain recovered.
+        this._skipUntilKeyframe = false;
+        return produced;
+      }
     }
 
     return null;
+  }
+
+  /** Update decode-cost EMA and toggle keyframe-only mode on sustained overload. */
+  private _noteDecodeMs(ms: number): void {
+    this._decodeCount++;
+    this._decodeMsEma = this._decodeMsEma ? this._decodeMsEma * 0.8 + ms * 0.2 : ms;
+    if (this._decodeCount < 4) return; // let the EMA and frame interval settle
+    const budget = this._frameIntervalMs || 66;
+    if (!this._keyframeOnly && this._decodeMsEma > budget * 1.5) {
+      this._keyframeOnly = true;
+    } else if (this._keyframeOnly && this._decodeMsEma < budget * 0.5) {
+      // Cheap again (resolution drop / faster machine) — try full rate back.
+      this._keyframeOnly = false;
+    }
   }
 
   /** Reset decoder state (discard pending data, keep config). */
@@ -172,7 +242,12 @@ export class WasmH265Decoder {
         const y = image.getImagePlane(0);
         const u = image.getImagePlane(1);
         const v = image.getImagePlane(2);
-        const rgba = yuv420ToRgba(y.bytes, u.bytes, v.bytes, this._width, this._height);
+        // Plane strides: libde265 may pad rows beyond width; reading with
+        // tight strides on padded planes skews or corrupts the image.
+        const rgba = yuv420ToRgba(
+          y.bytes, u.bytes, v.bytes, this._width, this._height,
+          y.stride || this._width, u.stride || (this._width >> 1), v.stride || (this._width >> 1),
+        );
         if (typeof VideoFrame !== 'undefined') {
           // WebCodecs available (HTTPS/localhost): wrap in a synthetic VideoFrame
           // for compatibility with the WebGL2/WebGPU rendering pipeline.

--- a/web/src/lib/webcodecs-player/yuv-rgba.test.ts
+++ b/web/src/lib/webcodecs-player/yuv-rgba.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { yuv420ToRgba } from './yuv-rgba';
+
+// Build a YUV420P frame with per-plane strides and poison bytes in the
+// padding columns — a tight-stride read would pick the poison up.
+function frame(width: number, height: number, yStride: number, uvStride: number) {
+  const y = new Uint8Array(yStride * height).fill(0xaa); // padding poison
+  const u = new Uint8Array(uvStride * (height >> 1)).fill(0xaa);
+  const v = new Uint8Array(uvStride * (height >> 1)).fill(0xaa);
+  // Neutral chroma (128) → grayscale output driven purely by Y.
+  for (let row = 0; row < height >> 1; row++) {
+    for (let col = 0; col < width >> 1; col++) {
+      u[row * uvStride + col] = 128;
+      v[row * uvStride + col] = 128;
+    }
+  }
+  return { y, u, v };
+}
+
+describe('yuv420ToRgba strides', () => {
+  it('reads luma with the provided yStride (padding ignored)', () => {
+    // 4x4, yStride 8 (4 padding bytes per row): row 0 dark, row 3 bright.
+    const { y, u, v } = frame(4, 4, 8, 4);
+    for (let col = 0; col < 4; col++) {
+      y[col] = 16; // near-black
+      y[3 * 8 + col] = 235; // near-white
+    }
+    const rgba = yuv420ToRgba(y, u, v, 4, 4, 8, 4, 4);
+    expect(rgba[0]).toBeLessThanOrEqual(5); // row 0 ≈ black
+    expect(rgba[(3 * 4 + 0) * 4]).toBeGreaterThanOrEqual(250); // row 3 ≈ white
+    // Alpha always opaque.
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('handles independent chroma strides (u vs v)', () => {
+    // 4x4 with different U/V strides and distinct chroma so a wrong-stride
+    // read would flip the color.
+    const { y, u, v } = frame(4, 4, 4, 6);
+    for (let col = 0; col < 4; col++) y[col] = 128; // mid gray
+    for (let row = 0; row < 2; row++)
+      for (let col = 0; col < 2; col++) {
+        u[row * 6 + col] = 180; // strong Cb → blue-ish
+        v[row * 6 + col] = 90; // weak Cr
+      }
+    const rgba = yuv420ToRgba(y, u, v, 4, 4, 4, 6, 6);
+    // With Cb>128 and Cr<128, blue must exceed red.
+    expect(rgba[2]).toBeGreaterThan(rgba[0]);
+  });
+
+  it('defaults to tight strides (backwards compatibility)', () => {
+    const { y, u, v } = frame(2, 2, 1, 1); // strides below width on purpose
+    for (let col = 0; col < 2; col++) y[col] = 235;
+    u[0] = 128;
+    v[0] = 128;
+    // Tight default: width 2 → yStride 2 — write via the same assumption.
+    const y2 = new Uint8Array([235, 235, 235, 235]);
+    const u2 = new Uint8Array([128]);
+    const v2 = new Uint8Array([128]);
+    const rgba = yuv420ToRgba(y2, u2, v2, 2, 2);
+    expect(rgba[0]).toBeGreaterThan(240);
+    expect(rgba.length).toBe(2 * 2 * 4);
+  });
+});

--- a/web/src/lib/webcodecs-player/yuv-rgba.ts
+++ b/web/src/lib/webcodecs-player/yuv-rgba.ts
@@ -22,14 +22,18 @@ export function yuv420ToRgba(
   vPlane: Uint8Array,
   width: number,
   height: number,
+  yStride: number = width,
+  uStride: number = width >> 1,
+  vStride: number = width >> 1,
 ): Uint8ClampedArray {
+  // Strides are the ROW BYTE LENGTHS of the source planes — decoders may pad
+  // rows beyond width (alignment). Passing the real stride is mandatory for
+  // padded planes; the defaults keep the historical tight-packing behavior.
   const rgba = new Uint8ClampedArray(width * height * 4);
-  const yStride = width;
-  const uvStride = width >> 1;
 
   for (let row = 0; row < height; row++) {
     const yRowOffset = row * yStride;
-    const uvRowOffset = (row >> 1) * uvStride;
+    const uvRowOffset = (row >> 1) * uStride;
     const rgbaRowOffset = row * width * 4;
 
     for (let col = 0; col < width; col++) {
@@ -39,7 +43,7 @@ export function yuv420ToRgba(
       // BT.601 full-range YUV → RGB
       const y = yPlane[yIdx] - 16;
       const u = uPlane[uvIdx] - 128;
-      const v = vPlane[uvIdx] - 128;
+      const v = vPlane[(row >> 1) * vStride + (col >> 1)] - 128;
 
       let r = 1.164 * y + 1.596 * v;
       let g = 1.164 * y - 0.392 * u - 0.813 * v;


### PR DESCRIPTION
## Problem

On plain-HTTP deployments the SPA decodes H.265 via libde265 WASM. For 4K cameras this cannot keep up: measured **~0.2fps decode vs 15-25fps input** on ARM-class CPUs. The backlog breaks the decoder's reference chain and libde265 emits pictures whose undecoded regions are error-concealed — users see **bottom-half green (day) / white (night B&W)** with a smooth fade at the boundary and no console errors.

Server side verified bit-clean end-to-end (FLV + WS captures decode with zero errors; WS messages up to 420KB structurally intact) — the corruption is introduced entirely by the overloaded browser decoder.

## Fix

1. **Throughput-aware keyframe-only mode** — track source frame interval (PTS deltas) + EMA of decode cost; on sustained >1.5× budget overload, decode keyframes only (stable still image per GOP instead of corrupted halves); auto-release when decode becomes cheap (<0.5× budget).
2. **Reference-chain integrity** — a failed `pushNal` sets skip-until-IDR (never feed P-frames against a broken chain); in degraded modes warned/concealed pictures are suppressed (stale-but-clean beats flashing corruption).
3. **Plane strides** — `yuv420ToRgba` now accepts per-plane strides from libde265 image planes (rows may be padded beyond width); defaults keep the old tight-packing behavior. New unit tests cover padded luma, independent chroma strides, and default-stride compatibility.

## Tests

- 3 new `yuv-rgba` vitest cases; webcodecs-player suite 163/163 green.