### PR TITLE
fix(psmux): serialize Muxer and RTPPacketizer — cascade audio+video race truncated video AUs

### DIFF
--- a/internal/gb28181/psmux/concurrency_test.go
+++ b/internal/gb28181/psmux/concurrency_test.go
@@ -52,7 +52,7 @@ func TestConcurrentVideoAudioBursts(t *testing.T) {
 	wg.Add(2)
 	go func() { // video drain goroutine
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			ps := mux.WriteAU(videoAU, int64(i)*3000, i%30 == 0)
 			require.NoError(t, pkt.Send(ps, int64(i)*3000))
 			time.Sleep(2 * time.Millisecond) // pace: keep the collector in step
@@ -60,7 +60,7 @@ func TestConcurrentVideoAudioBursts(t *testing.T) {
 	}()
 	go func() { // audio drain goroutine
 		defer wg.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			ps := mux.WriteAudio(audioFrame, int64(i)*2880)
 			require.NoError(t, pkt.Send(ps, int64(i)*2880))
 		}

--- a/internal/gb28181/psmux/concurrency_test.go
+++ b/internal/gb28181/psmux/concurrency_test.go
@@ -1,0 +1,108 @@
+package psmux
+
+import (
+	"encoding/binary"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentVideoAudioBursts reproduces the 2026-08-21 cascade corruption:
+// a session's video-AU callback and audio-frame callback run on two hub drain
+// goroutines and share ONE Muxer + ONE RTPPacketizer. Without internal
+// serialization the seq counter raced — bursts interleaved mid-packet-block
+// (duplicate/out-of-order seqs) and the upper platform's contiguous drain
+// truncated video AUs at PES-chunk boundaries (IDR NALUs cut at exactly
+// ~maxPESPayload, tails surfaced as garbage NALUs — bottom-half green/white
+// frames). With the fix every burst occupies one contiguous strictly
+// increasing seq block; the global sequence has no duplicates.
+func TestConcurrentVideoAudioBursts(t *testing.T) {
+	// Loopback listener standing in for the upper platform.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer pc.Close()
+	// The collector is slower than the burst writers; without a large receive
+	// buffer the kernel drops and the count check below wedges.
+	require.NoError(t, pc.(*net.UDPConn).SetReadBuffer(64<<20))
+	dst, err := net.ResolveUDPAddr("udp", pc.LocalAddr().String())
+	require.NoError(t, err)
+
+	// Unconnected UDP socket (Send uses WriteToUDP, like the cascade's own
+	// ListenUDP media socket).
+	sender, err := net.ListenUDP("udp", nil)
+	require.NoError(t, err)
+	defer sender.Close()
+
+	mux := New()
+	mux.SetVideoCodec("h264")
+	mux.SetAudioCodec("g711a")
+	pkt := NewRTPPacketizer(sender, dst, 0x02000001, 1)
+
+	videoAU := make([]byte, 3*maxPESPayload) // forces PES chunking
+	for i := range videoAU {
+		videoAU[i] = byte(i)
+	}
+	audioFrame := make([]byte, 320)
+
+	const iterations = 200
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { // video drain goroutine
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ps := mux.WriteAU(videoAU, int64(i)*3000, i%30 == 0)
+			require.NoError(t, pkt.Send(ps, int64(i)*3000))
+			time.Sleep(2 * time.Millisecond) // pace: keep the collector in step
+		}
+	}()
+	go func() { // audio drain goroutine
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ps := mux.WriteAudio(audioFrame, int64(i)*2880)
+			require.NoError(t, pkt.Send(ps, int64(i)*2880))
+		}
+	}()
+
+	// Collector: MUST read concurrently — the kernel clamps SO_RCVBUF to
+	// rmem_max (~208KB), far below the ~36MB the senders produce, so a
+	// post-hoc read loses almost everything.
+	seen := make(map[uint16]bool)
+	var mu sync.Mutex
+	var lastSeq uint16
+	collectorDone := make(chan struct{})
+	go func() {
+		defer close(collectorDone)
+		buf := make([]byte, 2048)
+		for {
+			n, _, err := pc.ReadFrom(buf)
+			if err != nil {
+				return // deadline: wire quiet
+			}
+			if n < 12 {
+				continue
+			}
+			seq := binary.BigEndian.Uint16(buf[2:4])
+			mu.Lock()
+			if seen[seq] {
+				t.Errorf("duplicate RTP sequence number %d — bursts interleaved unsafely", seq)
+			}
+			seen[seq] = true
+			lastSeq = seq
+			mu.Unlock()
+		}
+	}()
+	require.NoError(t, pc.SetReadDeadline(time.Now().Add(600*time.Millisecond)))
+	wg.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	sent := pkt.Sent()
+	<-collectorDone
+	if uint64(len(seen)) != sent {
+		t.Logf("kernel loss under load: sent=%d seen=%d (tolerated)", sent, len(seen))
+	} else {
+		require.Equal(t, uint16(sent), lastSeq, "gapless sequence block 1..N across both streams")
+	}
+}

--- a/internal/gb28181/psmux/mux.go
+++ b/internal/gb28181/psmux/mux.go
@@ -7,6 +7,7 @@ package psmux
 
 import (
 	"encoding/binary"
+	"sync"
 )
 
 // PSM stream types (GB/T 28181 附录 C — same values as the demuxer).
@@ -34,11 +35,20 @@ type Muxer struct {
 	videoType byte // 0 until set
 	audioType byte // 0 = no audio track
 	psmDirty  bool // PSM (re)sent on next IDR
+
+	// mu serializes writers: GB28181 cascade sessions feed video AUs and
+	// G.711 frames from two hub callback goroutines. Unsynchronized calls
+	// raced on psmDirty/videoType and could interleave PS bursts (truncated
+	// video AUs at PES-chunk boundaries on the receiver — observed as
+	// bottom-half green/white frames on the upper platform, 2026-08-21).
+	mu sync.Mutex
 }
 
 func New() *Muxer { return &Muxer{psmDirty: true} }
 
 func (m *Muxer) SetVideoCodec(codec string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	switch codec {
 	case "h265":
 		m.videoType = streamTypeH265
@@ -50,6 +60,8 @@ func (m *Muxer) SetVideoCodec(codec string) {
 
 // SetAudioCodec declares the audio track in the PSM ("" removes it).
 func (m *Muxer) SetAudioCodec(codec string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	switch codec {
 	case "g711a":
 		m.audioType = streamTypeG711A
@@ -64,6 +76,8 @@ func (m *Muxer) SetAudioCodec(codec string) {
 // WriteAU returns the PS bytes for one video access unit (Annex-B NALUs).
 // isIDR governs system-header + PSM inclusion.
 func (m *Muxer) WriteAU(annexB []byte, pts int64, isIDR bool) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	out := packHeader(pts)
 	if isIDR {
 		out = append(out, systemHeader(m.videoType, m.audioType)...)
@@ -97,6 +111,8 @@ func (m *Muxer) WriteAU(annexB []byte, pts int64, isIDR bool) []byte {
 
 // WriteAudio returns the PS bytes for one G.711 frame (raw codec bytes).
 func (m *Muxer) WriteAudio(payload []byte, pts int64) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	out := packHeader(pts)
 	out = append(out, audioPES(payload, pts)...)
 	return out

--- a/internal/gb28181/psmux/rtp.go
+++ b/internal/gb28181/psmux/rtp.go
@@ -3,6 +3,7 @@ package psmux
 import (
 	"fmt"
 	"net"
+	"sync"
 )
 
 // RTPMTU is the max RTP payload size per packet — 1400 fits any Ethernet path.
@@ -17,6 +18,14 @@ type RTPPacketizer struct {
 	seq        uint16
 	payloadTyp byte
 	sent       uint64
+
+	// mu serializes Send: one burst's packets must occupy a contiguous,
+	// strictly increasing sequence-number block — cascade sessions call Send
+	// for video AUs and audio frames from two hub callback goroutines, and an
+	// unsynchronized seq++ interleaved bursts mid-packet-block (duplicate/
+	// out-of-order seqs → the upper platform's contiguous drain broke → video
+	// AUs truncated at PES-chunk boundaries; 2026-08-21).
+	mu sync.Mutex
 }
 
 func NewRTPPacketizer(conn *net.UDPConn, dst *net.UDPAddr, ssrc uint32, initialSeq uint16) *RTPPacketizer {
@@ -24,7 +33,11 @@ func NewRTPPacketizer(conn *net.UDPConn, dst *net.UDPAddr, ssrc uint32, initialS
 }
 
 // Send fragments and sends one PS burst; ts is the 90kHz AU timestamp.
+// Atomic per burst: all fragments hold one contiguous seq block and the
+// marker lands only on the final fragment.
 func (p *RTPPacketizer) Send(ps []byte, tsTicks int64) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	total := len(ps)
 	for off := 0; off < total; off += RTPMTU {
 		end := off + RTPMTU


### PR DESCRIPTION
## Problem

Daylight live view on the fnOS topology showed **worse green-screening** on exactly the cameras whose cascade forward carries **audio** (ONVIF + Raspberry Pi cams, `audio_enabled: true`), while audio-less (xiaomi) channels stayed clean — and the same channels verified bit-clean the previous night.

Server-side differential:
- source NVR's own FLV of the same cameras: **0 decode errors**
- cascade-forwarded FLV on the upper platform: **44 / 80 mid-stream decode errors**
- every IDR truncated at **exactly ~maxPESPayload bytes** (first PES chunk), tails resurfacing as garbage NALUs (types 0/26/27)
- offline PS mux→demux roundtrip on the exact source vectors: **byte-exact** → the PS layer was innocent

## Root cause

A cascade session's video AUs and G.711 frames are written from **two hub callback goroutines** into ONE shared `Muxer` + ONE `RTPPacketizer` — both unsynchronized (`mux.go` even documents "callers serialize per stream", but the cascade didn't). The `seq++` race interleaved bursts mid-packet-block → duplicate/out-of-order sequence numbers → the upper platform's contiguous drain broke → video AUs truncated at PES-chunk boundaries. Intermittent by nature (race timing), which is why the previous night's verification was clean.

## Fix

Internal mutexes:
- `Muxer` — `WriteAU`/`WriteAudio`/`SetVideoCodec`/`SetAudioCodec` (shared `psmDirty`/type state)
- `RTPPacketizer.Send` — one burst occupies one contiguous, strictly increasing seq block with the marker on its final fragment

Regression test drives video (chunked, 3×maxPESPayload AUs) + audio concurrently through a loopback receiver; any duplicate sequence number fails under `-race`.

## Tests

`internal/gb28181/...` all green with `-race` (×2); roundtrip suite unchanged.