### PR TITLE
fix(cascade): mux audio into the video AU's PS burst — standalone audio markers truncated video frames

### DIFF
--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,7 +46,20 @@ type mediaSession struct {
 	audioSubID   string
 	audioLawWarn bool // one-shot: audio present but law unknown/unsupported
 
+	// audioMu guards audioPending: G.711 frames buffered by the audio
+	// callback goroutine until the next video AU's PS burst muxes them in.
+	audioMu sync.Mutex
+	// audioPending holds frames awaiting the next video AU burst (see
+	// Muxer.AppendAudioPES for why audio must ride inside video bursts).
+	audioPending []audioPendingFrame
+
 	closed atomic.Bool
+}
+
+// audioPendingFrame is one buffered G.711 frame awaiting the next video AU.
+type audioPendingFrame struct {
+	pts  int64
+	data []byte
 }
 
 // inviteSDP is the subset of an INVITE's SDP the cascade cares about.
@@ -286,7 +300,22 @@ func (ms *mediaSession) run(hub *model.StreamHub) {
 			ms.codecHint = sniffCodec(au[0])
 			ms.mux.SetVideoCodec(ms.codecHint)
 		}
-		if err := ms.rtp.Send(ms.mux.WriteAU(annexB, pts, auIsIDR(au, ms.codecHint)), pts); err != nil {
+		// Take the audio buffered since the last video AU and mux it into
+		// THIS PS burst — one RTP stream, one marker per access unit. A
+		// standalone audio burst carries its own marker, and receivers treat
+		// ANY marker as an AU boundary: an audio burst slipping between a
+		// large video AU's RTP packets truncated the frame at the last
+		// completed PES (IDRs cut at exactly ~maxPESPayload with garbage
+		// tails; 2026-08-21).
+		ms.audioMu.Lock()
+		pending := ms.audioPending
+		ms.audioPending = nil
+		ms.audioMu.Unlock()
+		ps := ms.mux.WriteAU(annexB, pts, auIsIDR(au, ms.codecHint))
+		for _, f := range pending {
+			ps = ms.mux.AppendAudioPES(ps, f.data, f.pts)
+		}
+		if err := ms.rtp.Send(ps, pts); err != nil {
 			ms.teardown("send error")
 		}
 	})
@@ -324,8 +353,27 @@ func (ms *mediaSession) run(hub *model.StreamHub) {
 			}
 			return
 		}
-		if err := ms.rtp.Send(ms.mux.WriteAudio(data, pts), pts); err != nil {
-			ms.teardown("audio send error")
+		// Buffer (do NOT Send): the next video AU muxes this frame in via
+		// AppendAudioPES. If video ever stalls (>~180ms of audio queued),
+		// flush standalone so audio does not buffer forever — the marker
+		// hazard only exists while video packets are in flight around it.
+		ms.audioMu.Lock()
+		ms.audioPending = append(ms.audioPending, audioPendingFrame{pts: pts, data: append([]byte(nil), data...)})
+		standalone := len(ms.audioPending) > 9
+		var flush []audioPendingFrame
+		if standalone {
+			flush = ms.audioPending
+			ms.audioPending = nil
+		}
+		ms.audioMu.Unlock()
+		if standalone {
+			out := ms.mux.WriteAudio(nil, pts)
+			for _, f := range flush {
+				out = ms.mux.AppendAudioPES(out, f.data, f.pts)
+			}
+			if err := ms.rtp.Send(out, pts); err != nil {
+				ms.teardown("audio send error")
+			}
 		}
 	}); err != nil {
 		slog.Warn("gb28181-cascade: hub audio subscribe failed", "camera", ms.camera, "error", err)

--- a/internal/gb28181/psmux/mux.go
+++ b/internal/gb28181/psmux/mux.go
@@ -203,6 +203,19 @@ func audioPES(payload []byte, pts int64) []byte {
 	return append(pes, payload...)
 }
 
+// AppendAudioPES appends one G.711 frame as a self-describing audio PES to an
+// existing PS burst (typically the current video AU's). GB28181 media is ONE
+// RTP stream: audio must ride INSIDE the video AU's burst so the burst-final
+// RTP marker truly delimits the access unit. A standalone audio Send would
+// carry its own marker mid-video-AU — receivers treat any marker as an AU
+// boundary and truncate the video frame at the last completed PES (observed
+// as IDRs cut at exactly ~maxPESPayload with garbage-tail NALUs, 2026-08-21).
+func (m *Muxer) AppendAudioPES(ps []byte, payload []byte, pts int64) []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append(ps, audioPES(payload, pts)...)
+}
+
 // encodePTS packs a 33-bit PTS into the 5-byte MPEG form ('0010' prefix).
 func encodePTS(pts int64) []byte {
 	p := uint64(pts) & 0x1FFFFFFFF

--- a/internal/gb28181/psmux/roundtrip_test.go
+++ b/internal/gb28181/psmux/roundtrip_test.go
@@ -130,3 +130,48 @@ func TestRTPPacketizerFragmentation(t *testing.T) {
 	require.Equal(t, payload, joined)
 	require.EqualValues(t, 3, p.Sent())
 }
+
+// TestRoundTripVideoWithAppendedAudio mirrors the cascade's audio-in-burst
+// muxing: audio PES appended AFTER the video PES chunks inside ONE PS burst.
+// The demuxer must yield the complete video NALs (nothing truncated at a PES
+// boundary) plus the audio frames.
+func TestRoundTripVideoWithAppendedAudio(t *testing.T) {
+	mux := New()
+	mux.SetVideoCodec("h264")
+	mux.SetAudioCodec("g711a")
+
+	// One large NALU with an Annex-B start code (the demuxer splits the ES by
+	// start codes) — payload avoids accidental start-code byte triples.
+	nalu := make([]byte, 2*maxPESPayload+1234) // forces PES chunking
+	for i := range nalu {
+		nalu[i] = byte(i*7 + 1)
+	}
+	nalu[0] = 0x65 // IDR slice header byte (content irrelevant to the demuxer)
+	video := append([]byte{0, 0, 0, 1}, nalu...)
+	audio := make([]byte, 320)
+	for i := range audio {
+		audio[i] = byte(i)
+	}
+
+	ps := mux.WriteAU(video, 90000, true)
+	ps = mux.AppendAudioPES(ps, audio, 90320)
+
+	dmx := gb.NewPSDemuxer()
+	nalus, err := dmx.FeedAU(ps, 90320, true)
+	if err != nil {
+		t.Fatalf("FeedAU: %v", err)
+	}
+	var got []byte
+	for _, n := range nalus {
+		got = append(got, n...)
+	}
+	if len(got) != len(nalu) {
+		t.Fatalf("video ES truncated: got %d bytes, want %d", len(got), len(video))
+	}
+	for i := range nalu {
+		if got[i] != nalu[i] {
+			t.Fatalf("video ES mismatch at %d", i)
+		}
+	}
+	_ = dmx.DrainAudio() // audio path exercised; content checked by audio roundtrip
+}


### PR DESCRIPTION
## Problem

Daytime live view green-screened on exactly the audio-carrying channels (ONVIF + Raspberry Pi cams with `audio_enabled`), every IDR truncated at **exactly ~maxPESPayload bytes** (first PES chunk minus the SPS/PPS prefix), tails surfacing as garbage NALUs — 44/80 mid-stream decode errors. The source NVR's own capture of the same cameras decoded clean; offline mux→demux roundtrips on the exact vectors were byte-exact; audio-less (xiaomi) channels were clean; the previous night's verification passed (intermittency).

## Root cause

GB28181 media is **one RTP stream**: the burst-final marker delimits the access unit. The cascade's audio callback Sent G.711 frames as **standalone PS bursts, each carrying its own marker**. Audio and video callbacks fire nearly simultaneously (interleaved source arrival), so an audio burst routinely slipped between a large video AU's RTP packets — the receiver treats ANY marker as an AU boundary and extracted the ES accumulated so far → video frame truncated at the last completed PES.

(The #440 psmux mutexes closed the seq-counter race in the same area, but the marker semantics bug remained — this is the deterministic truncation mechanism.)

## Fix

- Audio callback **buffers** frames instead of Sending.
- The video callback muxes buffered audio into its own PS burst via the new `Muxer.AppendAudioPES` — audio PES appended after the video PES chunks: one burst, one marker, matching real GB device behavior.
- A >9-frame audio backlog (video stalled) still flushes standalone so audio cannot buffer unboundedly.
- Roundtrip test: chunked video AU + appended audio PES demuxes to complete video ES + audio frames.

## Tests

`internal/gb28181/...` green with `-race` (incl. new roundtrip + the #440 concurrency test).