### PR TITLE
feat(cascade): TCP media client — survive lossy UDP paths for cascade forwarding

### DIFF
--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -31,8 +31,8 @@ type mediaSession struct {
 	camera  string // local camera ID
 	upper   *upper // owning upper platform (#370 dialog routing)
 
-	conn *net.UDPConn
-	dst  *net.UDPAddr
+	conn net.Conn     // UDP socket or the dialed TCP media connection
+	dst  *net.UDPAddr // nil for TCP media
 	ssrc uint32
 
 	mux       *psmux.Muxer
@@ -66,6 +66,7 @@ type audioPendingFrame struct {
 type inviteSDP struct {
 	host  string
 	port  int
+	tcp   bool // m= line negotiated TCP/RTP/AVP (upper's tcp-passive offer)
 	ssrc  uint32
 	name  string // s= session name ("Play"|"Playback")
 	t0    int64  // t= start, Unix seconds (NTP-era values normalized)
@@ -88,6 +89,9 @@ func sdpFromInvite(body []byte) (inviteSDP, error) {
 			sd.host = strings.TrimSpace(strings.TrimPrefix(line, "c=IN IP4"))
 		case strings.HasPrefix(line, "m=video "):
 			fields := strings.Fields(line)
+			if len(fields) >= 3 && fields[2] == "TCP/RTP/AVP" {
+				sd.tcp = true
+			}
 			if len(fields) >= 2 {
 				sd.port, _ = strconv.Atoi(fields[1])
 			}
@@ -211,11 +215,28 @@ func (s *Service) onInvite(req sip.Request, _ sip.ServerTransaction) {
 	}
 	s.mu.Unlock()
 
-	dst := &net.UDPAddr{IP: net.ParseIP(sd.host), Port: sd.port}
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
-	if err != nil {
-		_, _ = s.srv.RespondOnRequest(req, 500, "Internal Error", "", nil)
-		return
+	// Media transport: the upper's tcp-passive offer (TCP/RTP/AVP +
+	// a=setup:passive) means WE connect — TCP retransmission survives lossy
+	// hops that shred back-to-back UDP bursts (4K IDR bursts lost ~10% of
+	// packets on one deployment's switch, truncating every keyframe at a PES
+	// boundary; 2026-08-21). UDP offers keep the classic socket.
+	var conn net.Conn
+	var dst *net.UDPAddr
+	if sd.tcp {
+		conn, err = net.DialTimeout("tcp", net.JoinHostPort(sd.host, strconv.Itoa(sd.port)), 5*time.Second)
+		if err != nil {
+			slog.Warn("gb28181-cascade: TCP media dial failed", "channel", channelID, "upper", sd.host, "error", err)
+			_, _ = s.srv.RespondOnRequest(req, 500, "Internal Error", "", nil)
+			return
+		}
+		slog.Info("gb28181-cascade: TCP media connected", "channel", channelID, "upper", conn.RemoteAddr())
+	} else {
+		dst = &net.UDPAddr{IP: net.ParseIP(sd.host), Port: sd.port}
+		conn, err = net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+		if err != nil {
+			_, _ = s.srv.RespondOnRequest(req, 500, "Internal Error", "", nil)
+			return
+		}
 	}
 
 	ms := &mediaSession{
@@ -229,11 +250,23 @@ func (s *Service) onInvite(req sip.Request, _ sip.ServerTransaction) {
 		ms.codecHint = cam.Encoding
 		ms.mux.SetVideoCodec(cam.Encoding)
 	}
-	ms.rtp = psmux.NewRTPPacketizer(conn, dst, sd.ssrc, uint16(time.Now().UnixNano()&0xFFFF))
+	if sd.tcp {
+		ms.rtp = psmux.NewRTPPacketizerTCP(conn, sd.ssrc, uint16(time.Now().UnixNano()&0xFFFF))
+	} else {
+		ms.rtp = psmux.NewRTPPacketizer(conn, dst, sd.ssrc, uint16(time.Now().UnixNano()&0xFFFF))
+	}
 	ms.sdpBody = fmt.Sprintf(
 		"v=0\r\no=- 0 0 IN IP4 %s\r\ns=Play\r\nc=IN IP4 %s\r\nt=0 0\r\n"+
 			"m=video %d RTP/AVP 96\r\na=sendonly\r\na=rtpmap:96 PS/90000\r\ny=%d\r\n",
 		ms.localHost(), ms.localHost(), ms.localPort(), sd.ssrc)
+	if sd.tcp {
+		// Answer as the TCP-active side: we dialed, per the offer's setup:passive.
+		ms.sdpBody = fmt.Sprintf(
+			"v=0\r\no=- 0 0 IN IP4 %s\r\ns=Play\r\nc=IN IP4 %s\r\nt=0 0\r\n"+
+				"m=video %d TCP/RTP/AVP 96\r\na=sendonly\r\na=setup:active\r\na=connection:new\r\n"+
+				"a=rtpmap:96 PS/90000\r\ny=%d\r\n",
+			ms.localHost(), ms.localHost(), ms.localPort(), sd.ssrc)
+	}
 
 	s.mu.Lock()
 	s.sessions[callID] = ms

--- a/internal/gb28181/psmux/rtp.go
+++ b/internal/gb28181/psmux/rtp.go
@@ -1,6 +1,7 @@
 package psmux
 
 import (
+	"encoding/binary"
 	"fmt"
 	"net"
 	"sync"
@@ -12,8 +13,8 @@ const RTPMTU = 1400
 // RTPPacketizer fragments a PS byte stream across RTP/UDP packets: PT 96,
 // 90kHz timestamps, marker on the last packet of each PS burst (access unit).
 type RTPPacketizer struct {
-	conn       *net.UDPConn
-	dst        *net.UDPAddr
+	conn       net.Conn
+	dst        *net.UDPAddr // nil → TCP media (RFC 4571 framing)
 	ssrc       uint32
 	seq        uint16
 	payloadTyp byte
@@ -28,8 +29,15 @@ type RTPPacketizer struct {
 	mu sync.Mutex
 }
 
-func NewRTPPacketizer(conn *net.UDPConn, dst *net.UDPAddr, ssrc uint32, initialSeq uint16) *RTPPacketizer {
+func NewRTPPacketizer(conn net.Conn, dst *net.UDPAddr, ssrc uint32, initialSeq uint16) *RTPPacketizer {
 	return &RTPPacketizer{conn: conn, dst: dst, ssrc: ssrc, seq: initialSeq, payloadTyp: 96}
+}
+
+// NewRTPPacketizerTCP builds a TCP-media packetizer: dst is nil, each RTP
+// packet is framed with a 2-byte big-endian length prefix (RFC 4571 — the
+// platform-side receiver auto-detects RFC4571 and 0x24 framings).
+func NewRTPPacketizerTCP(conn net.Conn, ssrc uint32, initialSeq uint16) *RTPPacketizer {
+	return &RTPPacketizer{conn: conn, ssrc: ssrc, seq: initialSeq, payloadTyp: 96}
 }
 
 // Send fragments and sends one PS burst; ts is the 90kHz AU timestamp.
@@ -63,8 +71,18 @@ func (p *RTPPacketizer) Send(ps []byte, tsTicks int64) error {
 		pkt[11] = byte(p.ssrc)
 		pkt = append(pkt, ps[off:end]...)
 		p.seq++
-		if _, err := p.conn.WriteToUDP(pkt, p.dst); err != nil {
-			return fmt.Errorf("psmux: rtp send: %w", err)
+		if p.dst != nil {
+			if _, err := p.conn.(*net.UDPConn).WriteToUDP(pkt, p.dst); err != nil {
+				return fmt.Errorf("psmux: rtp send: %w", err)
+			}
+		} else {
+			// TCP media: RFC 4571 framing (2-byte length prefix).
+			framed := make([]byte, 2+len(pkt))
+			binary.BigEndian.PutUint16(framed, uint16(len(pkt)))
+			copy(framed[2:], pkt)
+			if _, err := p.conn.Write(framed); err != nil {
+				return fmt.Errorf("psmux: rtp send (tcp): %w", err)
+			}
 		}
 		p.sent++
 	}


### PR DESCRIPTION
## Motivation

Cascade media over UDP is at the mercy of every hop's burst handling. On the fnOS test topology the M5→R4S path drops a large fraction of back-to-back UDP bursts (measured with controlled floods: up to 83% loss on full-speed bursts; receiver counters showed 6–12% gap-skips on ALL forwarded channels during real traffic). Large IDR bursts get shredded mid-frame — keyframes truncate at PES-chunk boundaries and every decoder downstream error-conceals (green/white halves), no matter what the muxer does.

## Change

- **Cascade client (lower platform)**: when the upper's INVITE offers `TCP/RTP/AVP` + `a=setup:passive` (the NVR's `media_transport: tcp-passive`), dial the offered address and send media over TCP; the 200 OK answers `a=setup:active`. UDP offers keep the classic socket — zero behavior change for existing deployments.
- **RTPPacketizer**: generalized to `net.Conn`; TCP mode frames each RTP packet with a 2-byte big-endian length prefix (**RFC 4571**) — the platform-side receiver already auto-detects RFC4571 and 0x24 framings. Playback path stays UDP-only (unchanged).

The upper side needed no change: `buildLiveSDP` already emits proper TCP offers and `acceptTCP` + framed reading are in place.

## Tests

`internal/gb28181/...` green with `-race` (incl. the #440 concurrency and #441 roundtrip suites).