### PR TITLE
fix(gb28181): drain jitter buffer fully and never emit an AU with a pending PES

### DIFF
--- a/internal/gb28181/psdemux.go
+++ b/internal/gb28181/psdemux.go
@@ -364,11 +364,38 @@ feedLoop:
 	// boundary (RTP marker): the trailing NALU ends exactly there. Mid-AU
 	// flushes keep accumulating — emitting a truncated trailing NALU would
 	// corrupt the frame and desync the stream.
-	if complete && len(d.esBuf) > 0 {
-		nalus = append(nalus, extractNALUs(d.esBuf, d.naluType)...)
-		d.esBuf = nil
+	//
+	// A marker with a video PES still pending means the burst ended mid-PES —
+	// its bytes never arrived (wire loss truncated the burst, or a sender bug
+	// ended the burst early). The pending PES can never complete: emitting the
+	// esBuf would hand downstream a partial frame (decoders conceal the missing
+	// half — the half-green/half-white screen class), and carrying the stale
+	// PES forward splices unrelated bursts. Drop the partial AU and resync at
+	// the next marker.
+	if complete {
+		if len(d.videoPesBuf) > 0 {
+			logger.Warn("gb28181: AU ended mid-PES — dropping partial frame and resyncing",
+				"pending_pes_bytes", len(d.videoPesBuf), "es_bytes", len(d.esBuf))
+			d.videoPesBuf = nil
+			d.esBuf = nil
+			return nil, nil
+		}
+		if len(d.esBuf) > 0 {
+			nalus = append(nalus, extractNALUs(d.esBuf, d.naluType)...)
+			d.esBuf = nil
+		}
 	}
 	return nalus, nil
+}
+
+// DropPartialVideo discards the in-progress video AU (pending PES + ES
+// accumulation). Called by Stage 1 after detected packet loss: the
+// reassembled bytes have a hole, and PES reassembly would otherwise "complete"
+// a frame from mismatched halves — a decoded partial frame shows up as
+// half-frame corruption (green/white blocks) downstream.
+func (d *PSDemuxer) DropPartialVideo() {
+	d.videoPesBuf = nil
+	d.esBuf = nil
 }
 
 // Flush returns any remaining buffered NALUs from incomplete PES data.

--- a/internal/gb28181/rtp.go
+++ b/internal/gb28181/rtp.go
@@ -400,7 +400,7 @@ func (r *Receiver) feedJitterBuffer(pkt *rtp.Packet) error {
 	if len(r.jitterBuffer) >= r.maxJitterPackets {
 		// Force flush to make room. Mid-AU: the demuxer only accumulates
 		// (complete=false) — partial NALUs are never emitted.
-		r.emitAccessUnitsLocked(false)
+		r.emitAccessUnitsLocked()
 	}
 
 	// Store packet
@@ -409,30 +409,37 @@ func (r *Receiver) feedJitterBuffer(pkt *rtp.Packet) error {
 
 	// Marker bit indicates AU boundary - emit complete AU
 	if pkt.Header.Marker {
-		r.emitAccessUnitsLocked(true)
+		r.emitAccessUnitsLocked()
 	}
 
 	return nil
 }
 
 // emitAccessUnitsLocked reassembles packets in sequence order and emits
-// complete access units. Must be called with jitterBufferMu held. complete
-// marks whether this emission ends on a marker (real AU boundary).
+// complete access units. Must be called with jitterBufferMu held. An emission
+// ends an access unit only when the drained run's final packet carries the RTP
+// marker bit (see endedOnMarker below).
 //
 // Loss recovery: when the packet at baseSeq is missing (UDP loss), the
 // contiguous drain below would stall forever. Instead the gap is skipped —
 // baseSeq advances to the lowest buffered sequence number — so the stream
 // continues (the partial AU is dropped, which the PS demuxer tolerates)
 // instead of freezing and growing the buffer without bound.
-func (r *Receiver) emitAccessUnitsLocked(complete bool) {
+func (r *Receiver) emitAccessUnitsLocked() {
 	if len(r.jitterBuffer) == 0 {
 		return
 	}
 
-	// Build ordered list of packets by sequence number,
-	// starting from the oldest received (lowest seq number).
+	// Build the ordered, CONTIGUOUS run of packets by sequence number starting
+	// at baseSeq. The loop runs until the run breaks at a gap — comparing
+	// against len(r.jitterBuffer) as the bound would be wrong: entries are
+	// deleted as they are collected, so the bound shrinks in lockstep and the
+	// drain stops after half the run. Undersized mid-AU feeds delayed PES
+	// completion until after the marker packet, and the marker feed then
+	// extracted the AU with its final PES still pending — every large frame
+	// (H.264 IDR ≥ maxPESPayload) was cut at the first PES chunk (#444).
 	var packets []*rtp.Packet
-	for len(packets) < len(r.jitterBuffer) {
+	for {
 		targetSeq := r.baseSeq + uint16(len(packets))
 		pkt, ok := r.jitterBuffer[targetSeq]
 		if !ok {
@@ -452,14 +459,26 @@ func (r *Receiver) emitAccessUnitsLocked(complete bool) {
 		r.packetsDroppedU++
 		logger.Debug("gb28181: RTP packet loss — skipping gap",
 			"camera_id", r.cameraID, "from_seq", r.baseSeq, "to_seq", next)
+		// The AU in flight lost bytes on the wire — its pending PES/ES
+		// reassembly would complete from mismatched halves (a frame with a
+		// hole decodes as half-frame corruption). Drop it; the stream resyncs
+		// at the next AU boundary.
+		r.demuxer.DropPartialVideo()
 		r.baseSeq = next
 		// Re-run so the buffered packets above the gap are emitted now.
-		r.emitAccessUnitsLocked(complete)
+		r.emitAccessUnitsLocked()
 		return
 	}
 
 	// Advance base sequence to account for emitted packets
 	r.baseSeq += uint16(len(packets))
+
+	// A real AU boundary exists only when the drained run ENDS on the marker
+	// packet. Passing the caller's `complete` blindly was wrong twice: a
+	// force-flush run could end exactly on a burst-final marker (harmless), but
+	// a marker-triggered drain that stopped at a sequence gap mid-burst, or a
+	// teardown flush, claimed completeness for a run the wire never finished.
+	endedOnMarker := packets[len(packets)-1].Header.Marker
 
 	// Stitch payloads across packets (cross-packet byte stitching)
 	var auPayload []byte
@@ -478,7 +497,7 @@ func (r *Receiver) emitAccessUnitsLocked(complete bool) {
 	r.ptsClock.Store(ptsTicks)
 
 	// Feed to Stage 2: PS demuxer
-	nalus, err := r.demuxer.FeedAU(auPayload, ptsTicks, complete)
+	nalus, err := r.demuxer.FeedAU(auPayload, ptsTicks, endedOnMarker)
 	if err != nil {
 		logger.Debug("gb28181: PS demux error", "camera_id", r.cameraID, "error", err)
 		return
@@ -570,9 +589,10 @@ func (r *Receiver) flushJitterBuffer() {
 	r.jitterBufferMu.Lock()
 	defer r.jitterBufferMu.Unlock()
 
-	// Emit any remaining packets as one AU (stream end = boundary)
+	// Emit any remaining packets (a run ending without a marker extracts
+	// nothing here — the demuxer.Flush below drains the residual bytes).
 	if len(r.jitterBuffer) > 0 {
-		r.emitAccessUnitsLocked(true)
+		r.emitAccessUnitsLocked()
 	}
 
 	// Flush demuxer residual data

--- a/internal/gb28181/rtp_reassembly_test.go
+++ b/internal/gb28181/rtp_reassembly_test.go
@@ -1,0 +1,228 @@
+package gb28181
+
+import (
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/psmux"
+)
+
+// Regression coverage for #444: a large H.264 access unit spans multiple PES
+// packets (PES_packet_length is 16-bit, psmux chunks at 60KB) and therefore
+// dozens of RTP packets — more than the jitter buffer holds at once, so the
+// AU reaches the PS demuxer across several mid-AU force-flush feeds. Two bugs
+// combined to truncate every such AU at its first PES chunk: the drain loop
+// stopped after half the contiguous run (its bound shrank as packets were
+// collected), and the marker feed then extracted the AU while its final PES
+// was still pending reassembly.
+
+// pseudoRandomNALU builds an n-byte NALU body that contains no Annex-B start
+// codes (bytes 1..255, never runs of zeros), so false NALU boundaries cannot
+// mask the PES/RTP reassembly behavior under test.
+func pseudoRandomNALU(hdr, firstPayload byte, n int, seed int64) []byte {
+	body := make([]byte, n)
+	body[0] = hdr
+	if n > 1 {
+		body[1] = firstPayload
+	}
+	rng := rand.New(rand.NewSource(seed))
+	for i := 2; i < n; i++ {
+		body[i] = byte(rng.Intn(255) + 1)
+	}
+	return body
+}
+
+// largeH264Stream builds SPS/PPS and one 122KB IDR slice — the PiCameraV1
+// shape from the field report (#444): three NALUs, the IDR alone spanning
+// three PES packets.
+func largeH264Stream() (sps, pps, idr []byte) {
+	sps = make([]byte, 30)
+	sps[0], sps[1], sps[2], sps[3] = 0x67, 0x64, 0x00, 0xAC
+	for i := 4; i < len(sps); i++ {
+		sps[i] = byte(0x20 + i)
+	}
+	pps = make([]byte, 10)
+	pps[0] = 0x68
+	for i := 1; i < len(pps); i++ {
+		pps[i] = 0xAA
+	}
+	idr = pseudoRandomNALU(0x65, 0x88, 122000, 7) // first_mb_in_slice == 0
+	return sps, pps, idr
+}
+
+func annexBJoin(nalus ...[]byte) []byte {
+	var out []byte
+	for _, nalu := range nalus {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, nalu...)
+	}
+	return out
+}
+
+// TestReceiverReassemblesMultiPESAU drives the real production path —
+// psmux.Muxer chunking, the TCP media packetizer (RFC 4571 framing), and the
+// Receiver's framing/jitter/demux stages — and requires the emitted AU to be
+// byte-complete.
+func TestReceiverReassemblesMultiPESAU(t *testing.T) {
+	sps, pps, idr := largeH264Stream()
+	mux := psmux.New()
+	mux.SetVideoCodec("h264")
+
+	idrPTS := int64(3600)
+	idrPS := mux.WriteAU(annexBJoin(sps, pps, idr), idrPTS, true)
+	pSlice := pseudoRandomNALU(0x41, 0x88, 8000, 11)
+	pPS := func(pts int64) []byte { return mux.WriteAU(annexBJoin(pSlice), pts, false) }
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close(); _ = server.Close() })
+	pktr := psmux.NewRTPPacketizerTCP(client, 0x11223344, 1000)
+
+	sendErr := make(chan error, 1)
+	go func() {
+		var err error
+		for g := 0; g < 2 && err == nil; g++ {
+			base := int64(g * 11 * 3600)
+			if err = pktr.Send(idrPS, idrPTS+base); err != nil {
+				break
+			}
+			for j := 1; j <= 10; j++ {
+				if err = pktr.Send(pPS(idrPTS+base+int64(j)*3600), idrPTS+base+int64(j)*3600); err != nil {
+					break
+				}
+			}
+		}
+		_ = client.Close() // signals the reader loop to stop
+		sendErr <- err
+	}()
+
+	recv := NewReceiver("test-cam", nil, nil)
+	recv.conn = server
+	recv.isTCP.Store(true)
+
+	type emittedAU struct {
+		size  int
+		isIDR bool
+		pts   int64
+	}
+	var aus []emittedAU
+	recv.AUCallback = func(au [][]byte, ptsTicks int64, isIDR bool) {
+		total := 0
+		for _, n := range au {
+			total += len(n)
+		}
+		aus = append(aus, emittedAU{total, isIDR, ptsTicks})
+	}
+
+	buf := make([]byte, rtpReadBufSize)
+	for {
+		n, err := recv.readTCP(buf)
+		if err != nil {
+			break // sender closed the pipe
+		}
+		var pkt rtp.Packet
+		require.NoError(t, pkt.Unmarshal(buf[:n]))
+		pkt.Payload = append([]byte(nil), pkt.Payload...)
+		require.NoError(t, recv.feedJitterBuffer(&pkt))
+	}
+	require.NoError(t, <-sendErr)
+
+	// 2 GOPs of (IDR + 10 P). Every AU must carry its own timestamp — no
+	// doubled frames, no leftovers spliced from the previous AU.
+	wantAU := 22
+	require.Len(t, aus, wantAU, "emitted AUs")
+	for i, au := range aus {
+		if au.isIDR {
+			require.Equal(t, len(sps)+len(pps)+len(idr), au.size,
+				"AU[%d]: IDR must reassemble byte-complete, not truncate at the first PES chunk", i)
+		} else {
+			require.Equal(t, len(pSlice), au.size, "AU[%d]: P frame size", i)
+		}
+		require.Equal(t, idrPTS+int64(i)*3600, au.pts, "AU[%d]: pts", i)
+	}
+	require.True(t, aus[0].isIDR && aus[11].isIDR, "GOP headers must be flagged IDR")
+	require.Equal(t, int64(wantAU), recv.auEmitted.Load())
+}
+
+// TestReceiverPacketLossDropsHoledAU verifies UDP-loss handling: when a
+// sequence gap holes a large AU mid-burst, the receiver must DROP the partial
+// AU — never emit a frame truncated at the last completed PES, and never
+// splice the pending PES into the next burst's AU.
+func TestReceiverPacketLossDropsHoledAU(t *testing.T) {
+	sps, pps, idr := largeH264Stream()
+	mux := psmux.New()
+	mux.SetVideoCodec("h264")
+
+	idrPTS := int64(3600)
+	idrPS := mux.WriteAU(annexBJoin(sps, pps, idr), idrPTS, true)
+	pSlice := pseudoRandomNALU(0x41, 0x88, 8000, 11)
+
+	fragment := func(ps []byte, seq uint16, ts int64) []*rtp.Packet {
+		var pkts []*rtp.Packet
+		for off := 0; off < len(ps); off += psmux.RTPMTU {
+			end := off + psmux.RTPMTU
+			if end > len(ps) {
+				end = len(ps)
+			}
+			pkts = append(pkts, &rtp.Packet{
+				Header: rtp.Header{
+					SequenceNumber: seq + uint16(len(pkts)),
+					Timestamp:      uint32(ts),
+					SSRC:           0x11223344,
+					Marker:         end == len(ps),
+				},
+				Payload: append([]byte(nil), ps[off:end]...),
+			})
+		}
+		return pkts
+	}
+
+	recv := NewReceiver("test-cam", nil, nil)
+	var idrEmitted, pEmitted int
+	recv.AUCallback = func(au [][]byte, ptsTicks int64, isIDR bool) {
+		if isIDR {
+			idrEmitted++
+			return
+		}
+		total := 0
+		for _, n := range au {
+			total += len(n)
+		}
+		require.Equal(t, len(pSlice), total, "P frame after loss must be clean")
+		require.Equal(t, pEmitted*3600+7200, int(ptsTicks), "P frame pts")
+		pEmitted++
+	}
+
+	feed := func(pkts []*rtp.Packet) {
+		for _, p := range pkts {
+			require.NoError(t, recv.feedJitterBuffer(p))
+		}
+	}
+
+	// Drop one packet from the middle of the large IDR burst.
+	idrPkts := fragment(idrPS, 1000, idrPTS)
+	require.Greater(t, len(idrPkts), 40, "IDR burst must span many packets")
+	for i, p := range idrPkts {
+		if i == 40 {
+			continue // lost on the wire
+		}
+		require.NoError(t, recv.feedJitterBuffer(p))
+	}
+
+	// Following P frames must arrive intact and on time.
+	nextSeq := uint16(1000 + len(idrPkts))
+	for j := 1; j <= 3; j++ {
+		pts := idrPTS + int64(j)*3600
+		pkts := fragment(mux.WriteAU(annexBJoin(pSlice), pts, false), nextSeq, pts)
+		nextSeq += uint16(len(pkts))
+		feed(pkts)
+	}
+
+	require.Zero(t, idrEmitted,
+		"a holed IDR must be dropped, never emitted truncated at a PES chunk")
+	require.Equal(t, 3, pEmitted, "stream must resync cleanly at the next AU")
+	require.Positive(t, int(recv.gapSkippedPackets()), "the gap must be accounted as loss")
+}

--- a/internal/gb28181/rtp_test.go
+++ b/internal/gb28181/rtp_test.go
@@ -137,7 +137,11 @@ func TestReceiverUDPBasic(t *testing.T) {
 		return receivedFrames.Load() > 0
 	}, 2*time.Second, 10*time.Millisecond, "consumer should receive frame")
 
-	require.Equal(t, int64(1), receivedFrames.Load())
+	// The first burst carries no marker, so both bursts drain as one run on
+	// the marker packet and splitAUsByFrame recovers one AU per frame (the
+	// documented lost-marker recovery). Both frames share the marker packet's
+	// timestamp — the drain ends there.
+	require.Equal(t, int64(2), receivedFrames.Load())
 	require.True(t, receivedPTS.Load() > 0)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the cascade green-screen arc (#440/#441/#443). After those fixes, H.264 channels still showed half-frame corruption (green by day / white at night): every large access unit was truncated at exactly its first PES chunk (`maxPESPayload` = 60000 bytes minus inline parameter sets — #444).

Root cause (receiver-side, two coupled bugs in `emitAccessUnitsLocked` + `FeedAU`):

1. **Half-drain**: the jitter drain loop was bounded by `len(packets) < len(r.jitterBuffer)`, but entries are deleted as they are collected — the bound shrank in lockstep and the drain stopped after **half** the contiguous run. Large AUs (> 32 packets ≈ 45KB, i.e. any 2K+ IDR) therefore reached the PS demuxer in undersized mid-AU feeds, and their final PES was still pending when the marker packet arrived.
2. **Marker = extract, blindly**: the marker feed passed `complete=true` into `FeedAU`, which extracted the accumulated `esBuf` (only the first PES chunk) as a full AU and rolled the pending PES tail into the *next* AU (doubled/garbled frames downstream).

Whether a channel visibly broke depended on where the half-drains landed relative to PES boundaries — which is why some H.265 channels looked fine while others (H.264 720p with 122KB IDRs) truncated every keyframe.

## Changes

- `rtp.go`: drain the contiguous run to its gap; derive completeness from the drained run itself (`endedOnMarker`) instead of the caller's claim — force-flushes, gap-stalled drains and teardown flushes no longer claim completeness. On sequence-gap loss recovery, drop the demuxer's in-progress video reassembly (`DropPartialVideo`) — a PES "completed" from mismatched halves decodes as corruption.
- `psdemux.go`: `FeedAU` drops the partial AU when a marker arrives with a video PES still pending (the burst ended mid-PES: wire loss or sender bug) instead of emitting a holed frame; new `DropPartialVideo`.
- Tests: `rtp_reassembly_test.go` drives the **real production path** (psmux chunking → TCP media packetizer with RFC 4571 framing → `readTCP` → jitter buffer → PS demuxer) with a 122KB H.264 IDR and asserts byte-complete reassembly; a UDP-loss case asserts holed AUs are dropped and the stream resyncs at the next AU. `TestReceiverUDPBasic` updated: it previously asserted the half-drain side effect (1 frame) where the documented lost-marker recovery now correctly emits both frames.

Fixes #444