### PR TITLE
fix(gb28181): INVITE wiring race at boot leaves channels streaming into an orphan hub

### DIFF
--- a/internal/camera/autoinvite_test.go
+++ b/internal/camera/autoinvite_test.go
@@ -1,0 +1,65 @@
+package camera
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeInviterEnder records the recycle + INVITE sequence fired by
+// autoInviteGB28181, mutex-guarded because the helper runs detached.
+type fakeInviterEnder struct {
+	mu      sync.Mutex
+	byes    []string
+	invites []string
+}
+
+func (f *fakeInviterEnder) ByeChannelByID(channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.byes = append(f.byes, channelID)
+	return nil
+}
+
+func (f *fakeInviterEnder) InviteChannel(deviceID, channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.invites = append(f.invites, deviceID+"/"+channelID)
+	return nil
+}
+
+// TestAutoInviteGB28181: starting a GB28181 recorder must recycle the
+// channel's live session (its AU callback may point at a dead recorder or an
+// orphan hub) and re-INVITE so media binds the fresh instance.
+func TestAutoInviteGB28181(t *testing.T) {
+	t.Parallel()
+
+	fe := &fakeInviterEnder{}
+	cm := &CameraManager{}
+	cm.SetGB28181Inviter(fe)
+	cm.SetGB28181SessionEnder(fe)
+
+	cm.autoInviteGB28181(config.CameraConfig{
+		ID:       "gb-x",
+		Protocol: string(model.ProtoGB28181),
+		GB28181: config.GB28181ChannelConfig{
+			DeviceID:  "34020000012000000152",
+			ChannelID: "34020000011320000003",
+		},
+	})
+
+	require.Eventually(t, func() bool {
+		fe.mu.Lock()
+		defer fe.mu.Unlock()
+		return len(fe.invites) == 1
+	}, 2*time.Second, 10*time.Millisecond, "INVITE should fire after Bye")
+
+	fe.mu.Lock()
+	defer fe.mu.Unlock()
+	require.Equal(t, []string{"34020000011320000003"}, fe.byes, "session must be recycled before the INVITE")
+	require.Equal(t, []string{"34020000012000000152/34020000011320000003"}, fe.invites)
+}

--- a/internal/camera/lifecycle.go
+++ b/internal/camera/lifecycle.go
@@ -58,6 +58,12 @@ func (cm *CameraManager) Start(ctx context.Context) error {
 					}
 				} else {
 					logger.Info("started recorder", "camera_id", cam.ID, "protocol", cam.Protocol, "encoding", cam.Encoding)
+					// GB28181 recorders are passive — pull media with a SIP
+					// INVITE now that the recorder exists. This also heals a
+					// session wired before startup finished (catalog-driven
+					// INVITE racing camera-manager boot): the recycle inside
+					// replaces the orphan-hub binding with this recorder.
+					cm.autoInviteGB28181(cam)
 					// Notify health manager of new camera with per-camera overrides
 					var hOverrides *config.ResolvedHealthOverrides
 					if cm.cfg.Health.Enabled {

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -296,6 +296,40 @@ func initStreamHub(rec model.Recorder, cameraID string, protocol string, sampleC
 	}
 }
 
+// autoInviteGB28181 recycles any live session for the camera's channel and
+// re-INVITEs so the session's AU callback binds THIS recorder instance — GB
+// recorders are passive and produce no media without a SIP INVITE. Fired on
+// every GB28181 recorder start, including camera-manager boot: a lower
+// platform hammering re-REGISTER mid-boot can get its catalog-driven INVITE
+// in before the recorder exists, and that session's orphan-hub wiring would
+// stick forever (the receiver keeps draining, so no watchdog ever recycles
+// it). No-op for non-GB cameras or when the inviter isn't wired.
+func (cm *CameraManager) autoInviteGB28181(cam config.CameraConfig) {
+	if cam.Protocol != string(model.ProtoGB28181) || cm.gb28181Inviter == nil {
+		return
+	}
+	deviceID, channelID := cam.GB28181.DeviceID, cam.GB28181.ChannelID
+	if channelID == "" {
+		return // no channel binding to invite on
+	}
+	cameraID := cam.ID
+	inviter := cm.gb28181Inviter
+	ender := cm.gb28181SessionEnder
+	// Run detached: INVITE involves network I/O (and Bye + re-INVITE churn)
+	// that must not delay recorder startup.
+	go func() {
+		// A recorder restart replaces the recorder instance, but a live
+		// session's AU callback still feeds the OLD one — recycle the session
+		// first so the INVITE below binds the new recorder.
+		if ender != nil {
+			_ = ender.ByeChannelByID(channelID)
+		}
+		if err := inviter.InviteChannel(deviceID, channelID); err != nil {
+			logger.Warn("gb28181: auto-INVITE failed", "camera_id", cameraID, "error", err)
+		}
+	}()
+}
+
 // startRecorder creates and starts a recorder for the given camera config.
 //
 // Concurrency: safe to call from any goroutine. All registry mutations go
@@ -426,22 +460,7 @@ func (cm *CameraManager) startRecorderLocked(ctx context.Context, cam config.Cam
 	cm.healthMgr.OnCameraAdded(cam.ID, rec, overrides)
 	logger.Info("started recorder for camera", "camera_id", cam.ID)
 
-	// Auto-INVITE GB28181 cameras: the recorder is passive and needs the SIP
-	// server to send an INVITE before any RTP media flows. Run in a goroutine
-	// so the recorder start returns promptly (INVITE involves network I/O).
-	if cam.Protocol == string(model.ProtoGB28181) && cm.gb28181Inviter != nil {
-		go func() {
-			// A recorder restart replaces the recorder instance, but a live
-			// session's AU callback still feeds the OLD one — recycle the
-			// session first so the INVITE below binds the new recorder.
-			if cm.gb28181SessionEnder != nil {
-				_ = cm.gb28181SessionEnder.ByeChannelByID(cam.GB28181.ChannelID)
-			}
-			if err := cm.gb28181Inviter.InviteChannel(cam.GB28181.DeviceID, cam.GB28181.ChannelID); err != nil {
-				logger.Warn("gb28181: auto-INVITE failed", "camera_id", cam.ID, "error", err)
-			}
-		}()
-	}
+	cm.autoInviteGB28181(cam)
 
 	// For ONVIF cameras without a valid stable_id yet, auto-populate it
 	// asynchronously so IP self-healing (internal/rediscovery) can later

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -592,6 +592,18 @@ func (s *Server) InviteChannel(deviceID, channelID string) error {
 		}
 	}
 
+	// A bound camera whose recorder isn't running must not be INVITE'd: the
+	// media would feed an orphan hub nobody consumes, and since the receiver
+	// keeps draining packets the stall watchdog never fires — the session
+	// wedges with zero frames ever reaching the recorder. That is exactly the
+	// boot race where a lower platform hammering re-REGISTER gets its
+	// catalog-driven INVITE in before camera-manager startup finishes. Defer
+	// instead: the recorder-start auto-INVITE establishes the session (and
+	// recycles any wedged one) once the recorder exists.
+	if cameraID != "" && onAU == nil {
+		return fmt.Errorf("gb28181: recorder for camera %q not running — deferring INVITE for channel %s", cameraID, channelID)
+	}
+
 	// Allocate port, create SDP, start receiver.
 	sdp, err := s.sessionMgr.Invite(ch, serverHost, netAddr, nil, onAU, onAudio)
 	if err != nil {

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -781,3 +781,29 @@ func TestRetireDeviceSelfChannel_NoRealChannels(t *testing.T) {
 }
 
 func (f *fakeEnroller) GB28181RecordingWanted(deviceID, channelID string) bool { return false }
+
+// TestServer_InviteChannel_DefersWhenRecorderNotRunning: a channel bound to
+// a camera whose recorder isn't up yet must NOT be INVITE'd. The media would
+// feed an orphan hub nobody consumes while the receiver keeps draining, so no
+// watchdog ever recycles the dead-wired session (the boot race where a lower
+// platform hammering re-REGISTER gets its catalog-driven INVITE in before
+// camera-manager startup finishes).
+func TestServer_InviteChannel_DefersWhenRecorderNotRunning(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+
+	const chID = "34020000001320000021"
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: "127.0.0.1:9999"})
+	dm.RegisterChannel(testDeviceID, &gb28181.Channel{DeviceID: testDeviceID, ID: chID})
+
+	// Bound camera (fakeEnroller resolves the binding) but no recorder:
+	// GB28181NALUWriter always returns nil.
+	fe := &fakeEnroller{}
+	_ = fe.EnsureGB28181Camera(testDeviceID, chID, "", "")
+	srv.SetCameraEnroller(fe)
+
+	err := srv.InviteChannel(testDeviceID, chID)
+	require.ErrorContains(t, err, "not running")
+	// Nothing half-open must be left behind.
+	require.Nil(t, srv.sessionMgr.GetReceiver(chID))
+}


### PR DESCRIPTION
## Symptom (on-box, fresh-install first boot)

All 12 cascade TCP sessions established and M5 pushed full-rate media (~2-3 Mbps/channel at the socket, verified via `ss -tni bytes_received`), health stayed green — but **zero frames reached the recorders**: FLV/WS answered 503 `waiting for video stream`, `has_sps=false`. No warnings, no stall recycles. A manual `POST /channels/{id}/bye` + `/invite` instantly restored the stream.

Whether a channel wedged was a **millisecond coin flip per channel** (channels whose recorder started before the catalog INVITE were fine).

## Root cause

- `CameraManager.Start` (the **boot** path) starts GB28181 recorders **without** the auto-INVITE that `startRecorderLocked` (restart/create path) has — GB recorders are passive.
- The session therefore comes from the **catalog-driven auto-INVITE**, which fires the moment the lower platform re-REGISTERs. On a fresh install the lower platform is hammering retries through the outage, so its catalog can land **before camera-manager startup finishes**.
- `InviteChannel` then resolves the bound camera's recorder too early → `onAU == nil` → media feeds an **orphan hub** nobody consumes. And because the receiver keeps draining packets, the stall watchdog never fires — the dead-wired session sticks forever.

## Fix (ordering becomes irrelevant)

1. **`InviteChannel` guard** — refuses to INVITE a bound camera whose recorder isn't running (returns `recorder for camera %q not running — deferring INVITE`). Catalog-path failures log at Debug (`autoInviteDevice`), so this is quiet.
2. **`CameraManager.Start` now fires the same recycle + re-INVITE** as the restart path, via an extracted `autoInviteGB28181` helper (Bye old session, then INVITE — `SessionManager.Invite` already supersedes, so the late INVITE replaces the orphan-hub binding with the live recorder).

## Tests

- `TestServer_InviteChannel_DefersWhenRecorderNotRunning` — bound camera + no recorder → error, no session left behind
- `TestAutoInviteGB28181` — helper recycles the session before inviting, with the right device/channel IDs

Full `./internal/camera` + `./internal/gb28181/...` suites pass (Linux).

Verified on-box: the manual BYE+re-INVITE recovery (same supersede path the fix now automates) restored full FLV flow on the wedged channels.