### PR TITLE
fix(gb28181): default media_transport to tcp-passive — UDP measured 16% frame loss (#460)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -380,7 +380,10 @@ observability:
 #   realm: "3402000000"             # SIP digest auth realm (10-digit area code)
 #   password: ""                    # digest password; EMPTY = no auth (see guide)
 #   port_range: "30000-30050"       # RTP media port pool
-#   media_transport: "udp"          # udp | tcp-passive | tcp-active
+#   media_transport: "tcp-passive" # udp | tcp-passive | tcp-active
+#                                  # tcp-passive is the default: UDP media measured
+#                                  # ~16% frame loss on real GB cameras (macroblock
+#                                  # corruption until the next IDR) — see #460
 #   subscribe_catalog: true         # realtime channel-change NOTIFY
 #   subscribe_alarm: true           # alarm subscription
 #   subscribe_mobile_position: false

--- a/docs/en/gb28181-guide.md
+++ b/docs/en/gb28181-guide.md
@@ -33,7 +33,7 @@ gb28181:
   port_range: "30000-30050"
   heartbeat_interval: "60s"
   catalog_interval: "30m"
-  media_transport: "udp"        # udp | tcp-passive | tcp-active
+  media_transport: "tcp-passive"  # udp | tcp-passive | tcp-active (default tcp-passive, see below)
   subscribe_catalog: true       # real-time channel-change push
   subscribe_alarm: true         # alarm subscription
   subscribe_mobile_position: false
@@ -45,7 +45,7 @@ gb28181:
 - `server_id`: the NVR's 20-digit GB/T 28181 platform serial (must match the device side exactly)
 - `realm`: the SIP digest-auth realm (usually your 10-digit area code)
 - `password`: the SIP digest secret. **Empty = no authentication** (any device that can reach port 5060 can register — see Security)
-- `media_transport`: RTP transport — `udp` (default), `tcp-passive` (NVR listens, device connects — the Hikvision/Dahua NAT default), or `tcp-active` (NVR dials the device's answer address)
+- `media_transport`: RTP transport — `tcp-passive` (default; NVR listens, device connects — the Hikvision/Dahua NAT default), `udp`, or `tcp-active` (NVR dials the device's answer address). **Why TCP is the default (#460)**: UDP media measured ~16% frame loss on a real GB camera (IDR-sized bursts overflow the NIC/softirq path; each loss breaks the P-frame reference chain — macroblock corruption until the next IDR), while TCP measured <1% on the same LAN. Older devices without TCP media support can opt back into `udp`.
 
 ### Step 2: Configure the camera
 
@@ -120,7 +120,7 @@ Audio is off by default. Turn on the **Audio** toggle in the camera's edit page 
 | `port_range` | string | `"30000-30050"` | RTP media port pool (`"start-end"`) |
 | `heartbeat_interval` | string | `"60s"` | Expected device heartbeat interval |
 | `catalog_interval` | string | `"30m"` | Catalog poll interval (fallback when subscribed) |
-| `media_transport` | string | `"udp"` | `udp` / `tcp-passive` / `tcp-active` |
+| `media_transport` | string | `"tcp-passive"` | `tcp-passive` / `udp` / `tcp-active` (why TCP, see above — #460) |
 | `sip_transport` | string | `"udp"` | Signaling transport: `udp` (add `tcp` listener optionally) |
 | `tcp_framing` | string | `"auto"` | TCP framing: `rfc4571` / `0x24` / `auto` |
 | `subscribe_catalog` | bool | `true` | Catalog subscription (real-time channel push) |
@@ -129,7 +129,7 @@ Audio is off by default. Turn on the **Audio** toggle in the camera's edit page 
 | `subscribe_expires` | string | `"3600s"` | Subscription lifetime (auto-renewed at 80%) |
 | `allowed_device_ids` | `[]string` | `[]` | Registration allowlist (empty = allow all) |
 
-> `tcp_mode` (bool) is a legacy alias of `media_transport`, kept for YAML compatibility.
+> `tcp_mode` (bool) is a legacy alias of `media_transport`, kept for YAML compatibility. It no longer influences the default (tcp-passive since v0.12.0, #460) — set `media_transport: "udp"` explicitly for UDP.
 
 ### Camera
 
@@ -255,6 +255,14 @@ Directions: `up/down/left/right/up-left/up-right/down-left/down-right/zoom-in/zo
 2. Behind NAT, switch to `media_transport: tcp-passive`
 3. On TCP framing errors, try `tcp_framing: rfc4571 / 0x24 / auto`
 4. Codec: H.264/H.265 auto-detected, no configuration needed
+
+### Macroblock corruption / tearing (blurry bottom half)
+
+Typical symptom: a region of the frame (often the bottom half) turns into macroblock garbage, recovers with the next keyframe seconds later, then repeats. Root cause: **UDP media packet loss** (IDR-sized bursts overflow the path; each loss breaks the P-frame reference chain — #460 measured up to 16% frame loss):
+
+1. Confirm `media_transport` is the default `tcp-passive` (switch back if it was changed to `udp`)
+2. Still corrupted on TCP → check `tcp_framing` (try `rfc4571` / `0x24` / `auto` in turn)
+3. Cross-check the receiver logs' `gap_skipped` / `AU ended mid-PES` counters to locate the loss
 
 ### No audio
 

--- a/docs/zh/gb28181-guide.md
+++ b/docs/zh/gb28181-guide.md
@@ -33,7 +33,7 @@ gb28181:
   port_range: "30000-30050"
   heartbeat_interval: "60s"
   catalog_interval: "30m"
-  media_transport: "udp"        # udp | tcp-passive | tcp-active
+  media_transport: "tcp-passive"  # udp | tcp-passive | tcp-active（默认 tcp-passive，见下）
   subscribe_catalog: true       # 通道变更实时推送
   subscribe_alarm: true         # 报警订阅
   subscribe_mobile_position: false
@@ -45,7 +45,7 @@ gb28181:
 - `server_id`：NVR 的 20 位 GB/T 28181 平台编号（设备端需完全一致）
 - `realm`：SIP 摘要认证域（通常为 10 位区域码）
 - `password`：SIP 摘要认证密码。**留空 = 不鉴权**（任何能访问 5060 端口的设备都可注册，见"安全考虑"）
-- `media_transport`：RTP 媒体传输 —— `udp`（默认）、`tcp-passive`（NVR 监听、设备连接，海康/大华 NAT 默认）、`tcp-active`（NVR 拨向设备应答地址）
+- `media_transport`：RTP 媒体传输 —— `tcp-passive`（默认，NVR 监听、设备连接，海康/大华 NAT 默认）、`udp`、`tcp-active`（NVR 拨向设备应答地址）。**默认使用 TCP 的原因（#460）**：实测 UDP 媒体在真实 GB 相机上丢帧率约 16%（IDR 突发包触发网卡/软中断路径丢包，每次丢帧打断 P 帧参考链，表现为花屏/马赛克直到下个 IDR）；同一网络 TCP 丢帧 <1%。个别不支持 TCP 媒体的老设备可改回 `udp`。
 
 ### 步骤 2：配置摄像机
 
@@ -120,7 +120,7 @@ cameras:
 | `port_range` | string | `"30000-30050"` | RTP 媒体端口池（`"start-end"`） |
 | `heartbeat_interval` | string | `"60s"` | 期望的设备心跳间隔 |
 | `catalog_interval` | string | `"30m"` | 目录轮询间隔（订阅开启时仅作兜底） |
-| `media_transport` | string | `"udp"` | 媒体传输：`udp` / `tcp-passive` / `tcp-active` |
+| `media_transport` | string | `"tcp-passive"` | 媒体传输：`tcp-passive` / `udp` / `tcp-active`（默认 TCP 的原因见上文，#460） |
 | `sip_transport` | string | `"udp"` | 信令传输：`udp`（可叠加 `tcp` 监听） |
 | `tcp_framing` | string | `"auto"` | TCP 组帧：`"rfc4571"`、`"0x24"`、`"auto"` |
 | `subscribe_catalog` | bool | `true` | 目录订阅（通道变更实时推送） |
@@ -129,7 +129,7 @@ cameras:
 | `subscribe_expires` | string | `"3600s"` | 订阅有效期（80% 时自动续订） |
 | `allowed_device_ids` | `[]string` | `[]` | 注册白名单（空 = 允许所有） |
 
-> `tcp_mode`（bool）是 `media_transport` 的旧别名，保留仅为 YAML 兼容。
+> `tcp_mode`（bool）是 `media_transport` 的旧别名，保留仅为 YAML 兼容，**已不再影响默认值**（v0.12.0 起默认即 `tcp-passive`，#460）；需要 UDP 请显式设置 `media_transport: "udp"`。
 
 ### 相机配置
 
@@ -255,6 +255,14 @@ curl -X POST http://localhost:9090/api/gb28181/channels/34020000001320000001/ptz
 2. NAT 场景切换 `media_transport: tcp-passive`
 3. TCP 组帧报错时依次尝试 `tcp_framing: rfc4571 / 0x24 / auto`
 4. 编码：H.264/H.265 自动探测，无需配置
+
+### 花屏 / 马赛克（图像下半截模糊有码）
+
+典型症状：画面某区域（常见下半屏）出现马赛克/色块，数秒后随下一个关键帧恢复，周而复始。根因是 **UDP 媒体丢帧**（IDR 突发包触发丢包 → P 帧参考链断裂，#460 实测丢帧率可达 16%）：
+
+1. 确认 `media_transport` 为默认的 `tcp-passive`（若曾被改为 `udp` 请改回）
+2. 已是 TCP 仍花屏 → 检查 `tcp_framing`（依次尝试 `rfc4571` / `0x24` / `auto`）
+3. 服务器端可对照接收日志中的 `gap_skipped` / `AU ended mid-PES` 计数定位丢包位置
 
 ### 音频无声
 

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -348,11 +348,17 @@ func applyConfigDefaults(cfg *Config) {
 		cfg.GB28181.TCPFraming = "auto"
 	}
 	if strings.TrimSpace(cfg.GB28181.MediaTransport) == "" {
-		if cfg.GB28181.TCPMode {
-			cfg.GB28181.MediaTransport = "tcp-passive" // legacy tcp_mode alias
-		} else {
-			cfg.GB28181.MediaTransport = "udp"
-		}
+		// Default tcp-passive (#460): UDP media measured ~16% frame loss on a
+		// real GB camera (back-to-back IDR bursts overflow NIC/softirq paths —
+		// each loss breaks the P-frame reference chain until the next IDR,
+		// perceived as macroblock corruption), while tcp-passive delivered
+		// complete IDRs and <1% loss on the same LAN. tcp-passive is also the
+		// Hikvision/Dahua default across NAT. Devices without TCP media support
+		// can opt back with media_transport: "udp".
+		// The legacy tcp_mode alias no longer influences the choice: it is a
+		// bool, so an explicit `tcp_mode: false` is indistinguishable from
+		// unset and honoring it would reinstate the UDP default for everyone.
+		cfg.GB28181.MediaTransport = "tcp-passive"
 	}
 	if strings.TrimSpace(cfg.GB28181.SIPTransport) == "" {
 		cfg.GB28181.SIPTransport = "udp"

--- a/internal/config/config_gb28181.go
+++ b/internal/config/config_gb28181.go
@@ -34,10 +34,12 @@ type GB28181ServerConfig struct {
 	// CatalogInterval is how often the platform refreshes the device catalog.
 	CatalogInterval string `yaml:"catalog_interval"` // default "30m"
 
-	// TCPMode forces TCP media transport (passive). Default false (UDP).
+	// TCPMode forces TCP media transport (passive).
 	//
-	// Deprecated: superseded by MediaTransport — kept as a YAML-compat
-	// alias (true → "tcp-passive").
+	// Deprecated: superseded by MediaTransport — no longer influences the
+	// default (which is now "tcp-passive", #460) because an explicit
+	// `tcp_mode: false` is indistinguishable from unset. Kept as a YAML-compat
+	// no-op; set media_transport explicitly instead.
 	TCPMode bool `yaml:"tcp_mode"`
 
 	// TCPFraming selects the TCP-passive framing: "rfc4571" (2-byte length
@@ -45,10 +47,11 @@ type GB28181ServerConfig struct {
 	TCPFraming string `yaml:"tcp_framing"` // default "auto"
 
 	// MediaTransport selects the RTP media transport for INVITE sessions:
-	// "udp" (default), "tcp-passive" (NVR listens, device connects — the
-	// Hikvision/Dahua default), or "tcp-active" (NVR dials the device's
-	// answer address). Signaling transport is independent (SIPTransport).
-	MediaTransport string `yaml:"media_transport"` // default "udp"
+	// "tcp-passive" (default — NVR listens, device connects; UDP measured ~16%
+	// frame loss on real GB cameras, #460), "udp", or "tcp-active" (NVR dials
+	// the device's answer address). Signaling transport is independent
+	// (SIPTransport).
+	MediaTransport string `yaml:"media_transport"` // default "tcp-passive"
 
 	// SIPTransport selects the SIP signaling listener: "udp" (default) or
 	// "tcp". "tcp" adds a SIP-over-TCP listener alongside UDP — devices pick

--- a/internal/config/config_gb28181_test.go
+++ b/internal/config/config_gb28181_test.go
@@ -138,3 +138,39 @@ func TestValidate_GB28181(t *testing.T) {
 		require.Equal(t, "auto", cfg.GB28181.TCPFraming)
 	})
 }
+
+// TestApplyDefaults_GB28181MediaTransport locks the tcp-passive default (#460):
+// UDP media measured ~16% frame loss on a real GB camera, so tcp-passive is the
+// safe default. The legacy tcp_mode bool must NOT influence the choice (an
+// explicit false is indistinguishable from unset) and explicit values win.
+func TestApplyDefaults_GB28181MediaTransport(t *testing.T) {
+	t.Run("empty defaults to tcp-passive", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.ApplyDefaults()
+		require.Equal(t, "tcp-passive", cfg.GB28181.MediaTransport)
+	})
+
+	t.Run("legacy tcp_mode true or false does not override the default", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.GB28181.TCPMode = true
+		cfg.ApplyDefaults()
+		require.Equal(t, "tcp-passive", cfg.GB28181.MediaTransport)
+
+		cfg = &Config{}
+		cfg.GB28181.TCPMode = false
+		cfg.ApplyDefaults()
+		require.Equal(t, "tcp-passive", cfg.GB28181.MediaTransport)
+	})
+
+	t.Run("explicit media_transport is preserved", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.GB28181.MediaTransport = "udp"
+		cfg.ApplyDefaults()
+		require.Equal(t, "udp", cfg.GB28181.MediaTransport)
+
+		cfg = &Config{}
+		cfg.GB28181.MediaTransport = "tcp-active"
+		cfg.ApplyDefaults()
+		require.Equal(t, "tcp-active", cfg.GB28181.MediaTransport)
+	})
+}

--- a/internal/gb28181/session.go
+++ b/internal/gb28181/session.go
@@ -119,7 +119,8 @@ func (sm *SessionManager) SetTCPFraming(fn func() string) {
 	sm.mu.Unlock()
 }
 
-// MediaTransport snapshots the configured media transport (UDP default).
+// MediaTransport snapshots the configured media transport (tcp-passive
+// default since #460; falls back to MediaUDP for unknown values).
 func (sm *SessionManager) MediaTransport() string {
 	sm.mu.Lock()
 	fn := sm.mediaTransportFunc


### PR DESCRIPTION
Closes #460.

## What
- `gb28181.media_transport` now defaults to **tcp-passive** (was udp) for fresh/unset configs.
- The legacy `tcp_mode` bool no longer influences the default: an explicit `tcp_mode: false` is indistinguishable from unset, so honoring the alias would reinstate the UDP default for everyone. `tcp_mode` stays as a YAML-compat no-op; set `media_transport: "udp"` explicitly for UDP.
- Explicitly configured values always win — existing deployments with `media_transport: udp` in their yaml are untouched.
- Docs (zh+en guides): default updated, why-TCP rationale, and a new troubleshooting entry for the macroblock-corruption symptom (花屏/马赛克 → tcp-passive, tcp_framing, gap_skipped counters). `config.example.yaml` updated.

## Why
48h soak test (#435) measured ~16% frame loss over UDP media on a real GB camera (IDR-sized bursts overflow the NIC/softirq path; each loss breaks the P-frame reference chain until the next IDR — perceived as macroblock corruption). TCP-passive on the same LAN measured <1% and is also the Hikvision/Dahua NAT default.

## Verification
- Unit tests: `TestApplyDefaults_GB28181MediaTransport` (empty → tcp-passive; tcp_mode either value doesn't change it; explicit udp/tcp-active preserved).
- On-device (ARM64 test box, live): explicit `udp` in yaml resolves to udp after upgrade (back-compat); clearing the key resolves to tcp-passive via GET /api/settings; config restored afterwards.

Note for watchers: if you rely on UDP media on an unset config, set `media_transport: "udp"` before upgrading.