### PR TITLE
fix(relay): fail fast on MJPEG/JPEG push sources instead of a doomed transcode (#423)

### DIFF
--- a/internal/camera/status.go
+++ b/internal/camera/status.go
@@ -99,6 +99,48 @@ func (cm *CameraManager) GetSPS(cameraID string) (sps, pps []byte, isH264 bool) 
 	return nil, nil, false
 }
 
+// GetSourceCodec returns the source camera's current video encoding as a
+// model.Format string ("h264", "h265", "mjpeg", "jpeg"; "" = unknown — no
+// recorder, or a recorder type without a meaningful single codec). Used by the
+// relay manager so push targets can fail fast on sources the transcode path
+// cannot handle (MJPEG/JPEG, #423).
+func (cm *CameraManager) GetSourceCodec(cameraID string) string {
+	rec := cm.GetRecorder(cameraID)
+	if rec == nil {
+		return ""
+	}
+	switch r := rec.(type) {
+	case *recorder.H264Recorder:
+		return string(model.FormatH264)
+	case *recorder.H265Recorder:
+		return string(model.FormatH265)
+	case *recorder.MJPEGRecorder:
+		return string(model.FormatMJPEG)
+	case *recorder.HTTPJPEGRecorder:
+		return string(model.EncJPEG)
+	case *recorder.ONVIFRecorder:
+		if d := r.Delegate(); d != nil {
+			switch d.(type) {
+			case *recorder.H264Recorder:
+				return string(model.FormatH264)
+			case *recorder.H265Recorder:
+				return string(model.FormatH265)
+			case *recorder.HTTPJPEGRecorder:
+				return string(model.EncJPEG)
+			}
+		}
+		return ""
+	}
+	// Generic fallback: recorders that probe their codec at runtime (GB28181,
+	// Ingest/SRT, Xiaomi) implement model.HLSProvider.CodecParams.
+	if cp, ok := rec.(model.HLSProvider); ok {
+		if c, _, _, _ := cp.CodecParams(); c != "" {
+			return string(c)
+		}
+	}
+	return ""
+}
+
 // GetCodecInfo returns the source camera's current video and audio codec
 // parameters as a single CodecInfo struct. Used by the relay engine to
 // initialize target tracks with complete codec information.

--- a/internal/relay/connect_rtmp.go
+++ b/internal/relay/connect_rtmp.go
@@ -16,6 +16,13 @@ import (
 func (t *PushTarget) connectRTMP(ctx context.Context) error {
 	sps, pps, isH264 := t.spsProvider()
 	if !isH264 {
+		// MJPEG/JPEG sources can never feed the H.265 transcode path — fail
+		// fast with a clear per-target error instead of a doomed transcoder
+		// (#423).
+		if t.isJPEGSource() {
+			t.setStatus(StatusError, "source is "+t.sourceCodec()+"; RTMP push requires H.264/H.265")
+			return errPermanent
+		}
 		// H.265 source — transcode if policy allows.
 		if t.Config.TranscodePolicy == "off" {
 			t.setStatus(StatusError, "source is not H.264 (RTMP target requires H.264)")

--- a/internal/relay/connect_rtmp.go
+++ b/internal/relay/connect_rtmp.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -18,10 +19,13 @@ func (t *PushTarget) connectRTMP(ctx context.Context) error {
 	if !isH264 {
 		// MJPEG/JPEG sources can never feed the H.265 transcode path — fail
 		// fast with a clear per-target error instead of a doomed transcoder
-		// (#423).
+		// (#423). The sentinel is wrapped with the detail because the Run loop
+		// surfaces err.Error() in push-status/logs and would otherwise stomp
+		// the message set above with the generic "no retry" text.
 		if t.isJPEGSource() {
-			t.setStatus(StatusError, "source is "+t.sourceCodec()+"; RTMP push requires H.264/H.265")
-			return errPermanent
+			msg := "source is " + t.sourceCodec() + "; RTMP push requires H.264/H.265"
+			t.setStatus(StatusError, msg)
+			return fmt.Errorf("%w: %s", errPermanent, msg)
 		}
 		// H.265 source — transcode if policy allows.
 		if t.Config.TranscodePolicy == "off" {

--- a/internal/relay/connect_rtsp.go
+++ b/internal/relay/connect_rtsp.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -20,10 +21,12 @@ func (t *PushTarget) connectRTSP(ctx context.Context) error {
 	if !isH264 {
 		// MJPEG/JPEG sources can never feed the H.265 transcode path — fail
 		// fast with a clear per-target error instead of a doomed transcoder
-		// (#423).
+		// (#423). Wrapped so the detail survives the Run loop's err.Error()
+		// surfacing (see connect_rtmp.go).
 		if t.isJPEGSource() {
-			t.setStatus(StatusError, "source is "+t.sourceCodec()+"; RTSP push requires H.264/H.265")
-			return errPermanent
+			msg := "source is " + t.sourceCodec() + "; RTSP push requires H.264/H.265"
+			t.setStatus(StatusError, msg)
+			return fmt.Errorf("%w: %s", errPermanent, msg)
 		}
 		// H.265 source — transcode if policy allows.
 		if t.Config.TranscodePolicy == "off" {

--- a/internal/relay/connect_rtsp.go
+++ b/internal/relay/connect_rtsp.go
@@ -18,6 +18,13 @@ import (
 func (t *PushTarget) connectRTSP(ctx context.Context) error {
 	sps, pps, isH264 := t.spsProvider()
 	if !isH264 {
+		// MJPEG/JPEG sources can never feed the H.265 transcode path — fail
+		// fast with a clear per-target error instead of a doomed transcoder
+		// (#423).
+		if t.isJPEGSource() {
+			t.setStatus(StatusError, "source is "+t.sourceCodec()+"; RTSP push requires H.264/H.265")
+			return errPermanent
+		}
 		// H.265 source — transcode if policy allows.
 		if t.Config.TranscodePolicy == "off" {
 			t.setStatus(StatusError, "source is not H.264 (RTSP target currently requires H.264)")

--- a/internal/relay/engine.go
+++ b/internal/relay/engine.go
@@ -49,6 +49,12 @@ type VideoPresetOverrides struct {
 // source is H.264 (RTMP targets require H.264; H.265 sources are rejected).
 type SPSProvider func() (sps, pps []byte, isH264 bool)
 
+// SourceCodecProvider returns the source camera's current video encoding as a
+// model.Format string ("h264", "h265", "mjpeg", "jpeg", ...; "" = unknown).
+// The relay uses it to fail fast on sources the transcode path can never
+// handle (MJPEG/JPEG — #423) instead of engaging a doomed H.265 decoder.
+type SourceCodecProvider func() string
+
 // StreamURLProvider returns the source camera's stream URL (e.g. rtsp://...)
 // for FFmpeg relay mode. If it returns empty, SourceURL from config is used.
 type StreamURLProvider func(cameraID string) string
@@ -63,6 +69,7 @@ type PushTarget struct {
 	hub               *model.StreamHub
 	spsProvider       SPSProvider
 	codecInfoProvider func() model.CodecInfo
+	sourceCodec       SourceCodecProvider
 
 	mu     sync.RWMutex
 	status RelayStatus
@@ -106,6 +113,28 @@ func NewPushTarget(cameraID string, cfg PushTargetConfig, hub *model.StreamHub, 
 // targets. Should be set before Run.
 func (t *PushTarget) SetCodecInfoProvider(p func() model.CodecInfo) {
 	t.codecInfoProvider = p
+}
+
+// SetSourceCodecProvider wires an optional source-codec provider used to fail
+// fast on video encodings the transcode path cannot handle (#423). Should be
+// set before Run; unset keeps the legacy behavior (non-H.264 is treated as
+// H.265).
+func (t *PushTarget) SetSourceCodecProvider(p SourceCodecProvider) {
+	t.sourceCodec = p
+}
+
+// isJPEGSource reports whether the source video is MJPEG/JPEG. Unknown codec
+// ("" — provider unset or recorder not yet resolved) returns false so the
+// existing behavior is preserved.
+func (t *PushTarget) isJPEGSource() bool {
+	if t.sourceCodec == nil {
+		return false
+	}
+	switch t.sourceCodec() {
+	case string(model.FormatMJPEG), string(model.EncJPEG):
+		return true
+	}
+	return false
 }
 
 // SetPresetRegistry wires the preset registry for transcode path resolution.

--- a/internal/relay/engine_test.go
+++ b/internal/relay/engine_test.go
@@ -594,3 +594,55 @@ func TestPushTarget_Status_TranscodeRuntime(t *testing.T) {
 	st := target.Status()
 	assert.Equal(t, "idle", st.TranscodeStatus)
 }
+
+// JPEG sources (MJPEG/JPEG recorders) can never feed the H.265 transcode
+// path — connectRTMP/connectRTSP must fail fast with a clear per-target
+// error instead of engaging a doomed transcoder (#423).
+func TestConnectRTMP_JPEGSourceFailsFast(t *testing.T) {
+	for _, codec := range []string{"mjpeg", "jpeg"} {
+		target := NewPushTarget("test-cam", PushTargetConfig{
+			ID: "t1", URL: "rtmp://invalid/does/not/matter",
+			Protocol: "rtmp", TranscodePolicy: "auto",
+		}, nil, func() ([]byte, []byte, bool) {
+			return nil, nil, false // not H.264 — the JPEG trap path
+		})
+		target.SetSourceCodecProvider(func() string { return codec })
+
+		err := target.connectRTMP(context.Background())
+		require.Equal(t, errPermanent, err)
+		require.Equal(t, StatusError, target.status)
+		require.Contains(t, target.errMsg, "source is "+codec)
+		require.Contains(t, target.errMsg, "requires H.264/H.265")
+	}
+}
+
+func TestConnectRTSP_JPEGSourceFailsFast(t *testing.T) {
+	target := NewPushTarget("test-cam", PushTargetConfig{
+		ID: "t1", URL: "rtsp://invalid/does/not/matter",
+		Protocol: "rtsp", TranscodePolicy: "auto",
+	}, nil, func() ([]byte, []byte, bool) {
+		return nil, nil, false // not H.264 — the JPEG trap path
+	})
+	target.SetSourceCodecProvider(func() string { return "mjpeg" })
+
+	err := target.connectRTSP(context.Background())
+	require.Equal(t, errPermanent, err)
+	require.Equal(t, StatusError, target.status)
+	require.Contains(t, target.errMsg, "source is mjpeg")
+}
+
+// Without a source-codec provider the legacy behavior is preserved: a
+// non-H.264 source with TranscodePolicy "off" gets the generic message.
+func TestConnectRTMP_NoSourceCodecProviderKeepsLegacyBehavior(t *testing.T) {
+	target := NewPushTarget("test-cam", PushTargetConfig{
+		ID: "t1", URL: "rtmp://invalid/does/not/matter",
+		Protocol: "rtmp", TranscodePolicy: "off",
+	}, nil, func() ([]byte, []byte, bool) {
+		return nil, nil, false
+	})
+
+	err := target.connectRTMP(context.Background())
+	require.Equal(t, errPermanent, err)
+	require.Equal(t, StatusError, target.status)
+	require.Contains(t, target.errMsg, "source is not H.264")
+}

--- a/internal/relay/engine_test.go
+++ b/internal/relay/engine_test.go
@@ -609,7 +609,8 @@ func TestConnectRTMP_JPEGSourceFailsFast(t *testing.T) {
 		target.SetSourceCodecProvider(func() string { return codec })
 
 		err := target.connectRTMP(context.Background())
-		require.Equal(t, errPermanent, err)
+		require.ErrorIs(t, err, errPermanent)
+		require.Contains(t, err.Error(), "source is "+codec)
 		require.Equal(t, StatusError, target.status)
 		require.Contains(t, target.errMsg, "source is "+codec)
 		require.Contains(t, target.errMsg, "requires H.264/H.265")
@@ -626,7 +627,8 @@ func TestConnectRTSP_JPEGSourceFailsFast(t *testing.T) {
 	target.SetSourceCodecProvider(func() string { return "mjpeg" })
 
 	err := target.connectRTSP(context.Background())
-	require.Equal(t, errPermanent, err)
+	require.ErrorIs(t, err, errPermanent)
+	require.Contains(t, err.Error(), "source is mjpeg")
 	require.Equal(t, StatusError, target.status)
 	require.Contains(t, target.errMsg, "source is mjpeg")
 }

--- a/internal/relay/manager.go
+++ b/internal/relay/manager.go
@@ -28,14 +28,21 @@ type SPSCameraProvider func(cameraID string) (sps, pps []byte, isH264 bool)
 // Backed by CameraManager.GetCodecInfo in production.
 type CodecInfoProvider func(cameraID string) model.CodecInfo
 
+// SourceCameraCodecProvider returns the source camera's current video encoding
+// ("h264"/"h265"/"mjpeg"/"jpeg"; "" = unknown) by camera id. Backed by
+// CameraManager.GetSourceCodec in production; used by push targets to fail
+// fast on sources the transcode path cannot handle (#423).
+type SourceCameraCodecProvider func(cameraID string) string
+
 // Manager owns the lifecycle of all push-out targets across all cameras.
 // Each (cameraID, targetID) pair maps to at most one running *PushTarget.
 // Manager is nil-safe at the call sites: when no relays are configured, main.go
 // passes a no-op manager so camera Add/Update/Remove don't need nil checks.
 type Manager struct {
-	hubProvider       CameraHubProvider
-	spsProvider       SPSCameraProvider
-	codecInfoProvider CodecInfoProvider // optional, for audio-aware targets
+	hubProvider         CameraHubProvider
+	spsProvider         SPSCameraProvider
+	codecInfoProvider   CodecInfoProvider         // optional, for audio-aware targets
+	sourceCodecProvider SourceCameraCodecProvider // optional, for JPEG fail-fast (#423)
 
 	mu      sync.Mutex
 	targets map[string]*runningTarget // key = cameraID + "/" + targetID
@@ -68,6 +75,14 @@ func NewManager(hubProvider CameraHubProvider, spsProvider SPSCameraProvider) *M
 func (m *Manager) SetCodecInfoProvider(p CodecInfoProvider) {
 	m.mu.Lock()
 	m.codecInfoProvider = p
+	m.mu.Unlock()
+}
+
+// SetSourceCodecProvider wires an optional SourceCameraCodecProvider for use by
+// push targets (JPEG fail-fast, #423). Should be set before Start.
+func (m *Manager) SetSourceCodecProvider(p SourceCameraCodecProvider) {
+	m.mu.Lock()
+	m.sourceCodecProvider = p
 	m.mu.Unlock()
 }
 
@@ -211,6 +226,9 @@ func (m *Manager) SetCameraTargets(cameraID string, cfgs []config.PushTargetConf
 		t := NewPushTarget(cameraID, c, hub, sps)
 		if m.codecInfoProvider != nil {
 			t.SetCodecInfoProvider(func() model.CodecInfo { return m.codecInfoProvider(cameraID) })
+		}
+		if m.sourceCodecProvider != nil {
+			t.SetSourceCodecProvider(func() string { return m.sourceCodecProvider(cameraID) })
 		}
 		if m.presetRegistry != nil {
 			t.SetPresetRegistry(m.presetRegistry)

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -498,6 +498,10 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	}
 	relayMgr.SetFFmpegPath(relayFFmpegPath)
 	relayMgr.SetHardwareCap(relayHwCap)
+	// Wire the source-codec resolver so push targets fail fast on MJPEG/JPEG
+	// sources instead of engaging the H.265 transcode path that can never
+	// decode them (#423).
+	relayMgr.SetSourceCodecProvider(camMgr.GetSourceCodec)
 	// Wire the source-URL resolver used by FFmpeg relay mode. Without this,
 	// connectViaFFmpeg() sees an empty provider, cannot resolve the camera's
 	// RTSP URL, and returns errPermanent on every retry (the 'permanent relay


### PR DESCRIPTION
Closes #423.

## What
- `connectRTMP`/`connectRTSP` treated every non-H.264 source as H.265 and engaged the transcode path (`InputCodec: CodecH265`), so adding a push target on an MJPEG/JPEG camera spawned a decoder that can never work.
- New optional `SourceCodecProvider` (wired from `CameraManager.GetSourceCodec`, mirroring the existing `SetCodecInfoProvider` pattern) reports the recorder's live video encoding; when it resolves to mpeg/jpeg the target fails fast with `source is jpeg; RTMP push requires H.264/H.265`.
- The `errPermanent` sentinel is wrapped with the detail message so the Run loop's `err.Error()` surfacing (push-status + logs) doesn't stomp it back to the generic "permanent relay error (no retry)".
- Provider unset → legacy behavior unchanged (non-H.264 still treated as H.265).

## Verification
- Unit tests in `internal/relay/engine_test.go`: JPEG fail-fast for rtmp+rtmp+rtsp (`errors.Is(errPermanent)` + message), and no-provider keeps the legacy message.
- On-device: added an enabled RTMP target on the JPEG camera — push-status immediately reports `permanent relay error (no retry): source is jpeg; RTMP push requires H.264/H.265`; target removed afterwards. All 5 relay/engine + camera/manager package tests pass.