### PR TITLE
fix(merge): propagate motion_score + activity_flags into merged recordings (#458)

### DIFF
--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -67,6 +67,93 @@ func migrateAIEventsInTx(ctx context.Context, tx *sql.Tx, newRecordingID string,
 	return nil
 }
 
+// motionAgg accumulates motion info across recordings being merged so the
+// merged row inherits a duration-weighted motion_score and the union of
+// activity flags (#458). Unanalyzed sources (score < 0) contribute their
+// flags but not the average; a set of only-unanalyzed sources keeps the
+// merged row unanalyzed (-1) — treating them as 0 would mislabel a merged
+// hour as "static" and make motion-aware cleanup evict it first.
+type motionAgg struct {
+	weightedSum  float64
+	totalDur     float64
+	analyzed     int
+	simpleSum    float64
+	flags        map[string]struct{}
+	flagsOrdered []string
+}
+
+func (a *motionAgg) add(score float64, flags string, dur float64) {
+	if a.flags == nil {
+		a.flags = make(map[string]struct{})
+	}
+	for _, f := range strings.Split(flags, ",") {
+		if f = strings.TrimSpace(f); f != "" {
+			if _, dup := a.flags[f]; !dup {
+				a.flags[f] = struct{}{}
+				a.flagsOrdered = append(a.flagsOrdered, f)
+			}
+		}
+	}
+	if score < 0 {
+		return
+	}
+	if dur < 0 {
+		dur = 0
+	}
+	a.weightedSum += score * dur
+	a.totalDur += dur
+	a.simpleSum += score
+	a.analyzed++
+}
+
+// result returns the aggregated (score, flags). Score falls back to a simple
+// average when every analyzed source has zero duration.
+func (a *motionAgg) result() (float64, string) {
+	if a.analyzed == 0 {
+		return model.MotionScoreUnanalyzed, ""
+	}
+	var score float64
+	if a.totalDur > 0 {
+		score = a.weightedSum / a.totalDur
+	} else {
+		score = a.simpleSum / float64(a.analyzed)
+	}
+	return score, strings.Join(a.flagsOrdered, ",")
+}
+
+// aggregateSourceMotion loads the motion columns of the given recording IDs
+// within tx and folds them into agg.
+func aggregateSourceMotion(ctx context.Context, tx *sql.Tx, ids []string, agg *motionAgg) error {
+	for _, chunk := range chunkIDs(ids, batchUpdateChunkSize) {
+		placeholders := make([]string, len(chunk))
+		args := make([]interface{}, 0, len(chunk))
+		for i, id := range chunk {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		q := `SELECT motion_score, COALESCE(activity_flags, ''), COALESCE(duration, 0) FROM recordings WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+		rows, err := tx.QueryContext(ctx, q, args...)
+		if err != nil {
+			return fmt.Errorf("load source motion columns: %w", err)
+		}
+		for rows.Next() {
+			var score, dur float64
+			var flags string
+			if err := rows.Scan(&score, &flags, &dur); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan source motion columns: %w", err)
+			}
+			agg.add(score, flags, dur)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("iterate source motion columns: %w", err)
+		}
+		rows.Close()
+	}
+	return nil
+}
+
 // MergeAndReplaceRecordings atomically inserts a merged recording and deletes old recordings in a single transaction.
 // This reduces SQLITE_BUSY contention compared to separate INSERT + SetMerged + DeleteBatch calls.
 func (d *DB) MergeAndReplaceRecordings(ctx context.Context, merged *model.Recording, oldIDs []string) error {
@@ -79,8 +166,16 @@ func (d *DB) MergeAndReplaceRecordings(ctx context.Context, merged *model.Record
 	}
 	defer tx.Rollback()
 
-	q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?);`
-	_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format, timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize, merged.FrameCount, model.MergeStatusMerged, merged.MergeTier, 100, merged.MergeQuality)
+	// Propagate motion info from the source segments into the merged row
+	// (duration-weighted score + flag union) before they are deleted (#458).
+	var agg motionAgg
+	if err := aggregateSourceMotion(ctx, tx, oldIDs, &agg); err != nil {
+		return err
+	}
+	motionScore, motionFlags := agg.result()
+
+	q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
+	_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format, timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize, merged.FrameCount, model.MergeStatusMerged, merged.MergeTier, 100, merged.MergeQuality, motionScore, motionFlags)
 	if err != nil {
 		return err
 	}
@@ -162,20 +257,36 @@ func (d *DB) RollingReplaceRecordings(ctx context.Context, merged *model.Recordi
 	}
 	defer tx.Rollback()
 
+	// Propagate motion info into the merged row (#458):
+	// - create: fold the source segments' scores (duration-weighted) + flags
+	// - append: fold the EXISTING merged row's aggregate together with the
+	//   newly-appended sources, so a growing bucket keeps a representative
+	//   score for its whole content rather than only the latest append.
+	var agg motionAgg
+	if existingMergedID != "" {
+		if err := aggregateSourceMotion(ctx, tx, []string{existingMergedID}, &agg); err != nil {
+			return err
+		}
+	}
+	if err := aggregateSourceMotion(ctx, tx, sourceIDs, &agg); err != nil {
+		return err
+	}
+	motionScore, motionFlags := agg.result()
+
 	if existingMergedID == "" {
 		// Case 1: Create — INSERT new merged recording.
-		q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?);`
+		q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
 		_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format,
 			timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize,
-			merged.FrameCount, model.MergeStatusMerged, "rolling", 100, merged.MergeQuality)
+			merged.FrameCount, model.MergeStatusMerged, "rolling", 100, merged.MergeQuality, motionScore, motionFlags)
 		if err != nil {
 			return err
 		}
 	} else {
 		// Case 2: Append — UPDATE existing merged recording.
-		q := `UPDATE recordings SET file_path = ?, ended_at = ?, duration = ?, file_size = ?, frame_count = ?, merge_quality = ? WHERE id = ?;`
+		q := `UPDATE recordings SET file_path = ?, ended_at = ?, duration = ?, file_size = ?, frame_count = ?, merge_quality = ?, motion_score = ?, activity_flags = ? WHERE id = ?;`
 		_, err = tx.ExecContext(ctx, q, merged.FilePath, timeToDB(merged.EndedAt), merged.Duration,
-			merged.FileSize, merged.FrameCount, merged.MergeQuality, existingMergedID)
+			merged.FileSize, merged.FrameCount, merged.MergeQuality, motionScore, motionFlags, existingMergedID)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -125,31 +125,36 @@ func (a *motionAgg) result() (float64, string) {
 // within tx and folds them into agg.
 func aggregateSourceMotion(ctx context.Context, tx *sql.Tx, ids []string, agg *motionAgg) error {
 	for _, chunk := range chunkIDs(ids, batchUpdateChunkSize) {
-		placeholders := make([]string, len(chunk))
-		args := make([]interface{}, 0, len(chunk))
-		for i, id := range chunk {
-			placeholders[i] = "?"
-			args = append(args, id)
+		if err := aggregateSourceMotionChunk(ctx, tx, chunk, agg); err != nil {
+			return err
 		}
-		q := `SELECT motion_score, COALESCE(activity_flags, ''), COALESCE(duration, 0) FROM recordings WHERE id IN (` + strings.Join(placeholders, ",") + `)`
-		rows, err := tx.QueryContext(ctx, q, args...)
-		if err != nil {
-			return fmt.Errorf("load source motion columns: %w", err)
+	}
+	return nil
+}
+
+func aggregateSourceMotionChunk(ctx context.Context, tx *sql.Tx, chunk []string, agg *motionAgg) error {
+	placeholders := make([]string, len(chunk))
+	args := make([]interface{}, 0, len(chunk))
+	for i, id := range chunk {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	q := `SELECT motion_score, COALESCE(activity_flags, ''), COALESCE(duration, 0) FROM recordings WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := tx.QueryContext(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("load source motion columns: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var score, dur float64
+		var flags string
+		if err := rows.Scan(&score, &flags, &dur); err != nil {
+			return fmt.Errorf("scan source motion columns: %w", err)
 		}
-		for rows.Next() {
-			var score, dur float64
-			var flags string
-			if err := rows.Scan(&score, &flags, &dur); err != nil {
-				rows.Close()
-				return fmt.Errorf("scan source motion columns: %w", err)
-			}
-			agg.add(score, flags, dur)
-		}
-		if err := rows.Err(); err != nil {
-			rows.Close()
-			return fmt.Errorf("iterate source motion columns: %w", err)
-		}
-		rows.Close()
+		agg.add(score, flags, dur)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate source motion columns: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/db_motion_test.go
+++ b/internal/storage/db_motion_test.go
@@ -137,3 +137,108 @@ func TestTimelineSegmentsCarryMotionScore(t *testing.T) {
 	require.Equal(t, 1, total)
 	require.InDelta(t, 0.66, segs[0].MotionScore, 1e-9)
 }
+
+// Merge/rolling-merge must propagate motion info into the merged row before
+// the source rows are deleted (#458): duration-weighted score + flag union.
+// All-unanalyzed sources keep the merged row unanalyzed (-1) so motion-aware
+// cleanup does not mislabel it as static.
+func TestMergePropagatesMotionScore(t *testing.T) {
+	ctx := context.Background()
+	db := newMotionTestDB(t)
+
+	// Two analyzed sources: 30s @ 0.2 static + 60s @ 0.8 motion.
+	insertMotionTestRecording(t, db, "src-a", 2*time.Minute)
+	require.NoError(t, db.UpdateRecordingMotionScore(ctx, "src-a", 0.2, "static"))
+	r, err := db.GetRecording(ctx, "src-a")
+	require.NoError(t, err)
+	r.Duration = 30
+	require.NoError(t, db.UpdateRecording(ctx, r))
+
+	insertMotionTestRecording(t, db, "src-b", time.Minute)
+	require.NoError(t, db.UpdateRecordingMotionScore(ctx, "src-b", 0.8, "motion,scene_cut"))
+	r, err = db.GetRecording(ctx, "src-b")
+	require.NoError(t, err)
+	r.Duration = 60
+	require.NoError(t, db.UpdateRecording(ctx, r))
+
+	merged := &model.Recording{
+		ID: "merged-1", CameraID: "cam-1", FilePath: "/x/merged-1.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().UTC().Add(-3 * time.Minute),
+		EndedAt: time.Now().UTC(), Duration: 90, FileSize: 3000, FrameCount: 1800,
+	}
+	require.NoError(t, db.MergeAndReplaceRecordings(ctx, merged, []string{"src-a", "src-b"}))
+
+	got, err := db.GetRecording(ctx, "merged-1")
+	require.NoError(t, err)
+	// (0.2*30 + 0.8*60) / 90 = 0.6
+	require.InDelta(t, 0.6, got.MotionScore, 1e-9)
+	require.Contains(t, got.ActivityFlags, "static")
+	require.Contains(t, got.ActivityFlags, "motion")
+	require.Contains(t, got.ActivityFlags, "scene_cut")
+}
+
+func TestRollingMergePropagatesMotionScore(t *testing.T) {
+	ctx := context.Background()
+	db := newMotionTestDB(t)
+
+	// Bucket create from one analyzed + one unanalyzed source.
+	insertMotionTestRecording(t, db, "rs-1", 2*time.Minute)
+	require.NoError(t, db.UpdateRecordingMotionScore(ctx, "rs-1", 0.6, "motion"))
+	r, _ := db.GetRecording(ctx, "rs-1")
+	r.Duration = 30
+	require.NoError(t, db.UpdateRecording(ctx, r))
+	insertMotionTestRecording(t, db, "rs-2", time.Minute) // stays unanalyzed (-1)
+
+	merged := &model.Recording{
+		ID: "roll-1", CameraID: "cam-1", FilePath: "/x/roll-1.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().UTC().Add(-3 * time.Minute),
+		EndedAt: time.Now().UTC(), Duration: 60, FileSize: 2000, FrameCount: 1200,
+	}
+	require.NoError(t, db.RollingReplaceRecordings(ctx, merged, "", []string{"rs-1", "rs-2"}))
+
+	got, err := db.GetRecording(ctx, "roll-1")
+	require.NoError(t, err)
+	// Only the analyzed source weights the average: 0.6.
+	require.InDelta(t, 0.6, got.MotionScore, 1e-9)
+	require.Equal(t, "motion", got.ActivityFlags)
+
+	// Append: 60s of 0.6 existing + 30s of 0.3 new → (0.6*60+0.3*30)/90 = 0.5.
+	insertMotionTestRecording(t, db, "rs-3", 0)
+	require.NoError(t, db.UpdateRecordingMotionScore(ctx, "rs-3", 0.3, "static"))
+	r, _ = db.GetRecording(ctx, "rs-3")
+	r.Duration = 30
+	require.NoError(t, db.UpdateRecording(ctx, r))
+
+	merged2 := &model.Recording{
+		ID: "roll-1", CameraID: "cam-1", FilePath: "/x/roll-1.mp4",
+		Format: model.FormatH264, StartedAt: got.StartedAt, EndedAt: time.Now().UTC(),
+		Duration: 90, FileSize: 3000, FrameCount: 1800,
+	}
+	require.NoError(t, db.RollingReplaceRecordings(ctx, merged2, "roll-1", []string{"rs-3"}))
+
+	got, err = db.GetRecording(ctx, "roll-1")
+	require.NoError(t, err)
+	require.InDelta(t, 0.5, got.MotionScore, 1e-9)
+	require.Contains(t, got.ActivityFlags, "motion")
+	require.Contains(t, got.ActivityFlags, "static")
+}
+
+func TestMergeAllUnanalyzedStaysUnanalyzed(t *testing.T) {
+	ctx := context.Background()
+	db := newMotionTestDB(t)
+
+	insertMotionTestRecording(t, db, "un-1", 2*time.Minute)
+	insertMotionTestRecording(t, db, "un-2", time.Minute)
+
+	merged := &model.Recording{
+		ID: "merged-un", CameraID: "cam-1", FilePath: "/x/merged-un.mp4",
+		Format: model.FormatH264, StartedAt: time.Now().UTC().Add(-3 * time.Minute),
+		EndedAt: time.Now().UTC(), Duration: 60, FileSize: 2000, FrameCount: 1200,
+	}
+	require.NoError(t, db.MergeAndReplaceRecordings(ctx, merged, []string{"un-1", "un-2"}))
+
+	got, err := db.GetRecording(ctx, "merged-un")
+	require.NoError(t, err)
+	require.Equal(t, model.MotionScoreUnanalyzed, got.MotionScore)
+	require.Empty(t, got.ActivityFlags)
+}


### PR DESCRIPTION
Closes #458.

## What
- `MergeAndReplaceRecordings` and `RollingReplaceRecordings` (create AND append) now fold the source segments' motion info into the merged row **inside the same transaction**, before the source rows are deleted:
  - `motion_score` = duration-weighted average of the analyzed sources (sources with score -1 contribute flags only; if none are analyzed the merged row stays -1 — treating unanalyzed as 0 would mislabel a merged hour as "static" and make motion-aware cleanup evict it first).
  - `activity_flags` = ordered union of source flags.
  - Append case folds the existing merged row's aggregate together with the newly appended sources, so a growing rolling bucket keeps a representative score for its whole content.
- No model/schema changes — the columns exist since v33 (#435).

## Why
Rolling merge deletes the source rows; without propagation every merged segment degraded to "unanalyzed", defeating min_motion_score/activity filters and boring-first disk eviction for most of the library.

## Verification
- `internal/storage/db_motion_test.go`: weighted average across durations (0.2×30s + 0.8×60s → 0.6), flag union, append re-weighting (0.6×60s + 0.3×30s → 0.5), all-unanalyzed stays -1.
- On-device: rolling merges produced after this change carry propagated scores (e.g. 0.548/0.565/0.693 with `motion,scene_cut`) — verified via direct DB query on production data. storage/merge/cleanup/motion packages all green.