### PR TITLE
fix(recorder): make adaptive recording work on real cameras — spike noise calibration, burst calm reset, ONVIF/Xiaomi wiring, live GOP flush (#466, #467)

### DIFF
--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -21,21 +21,13 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 	// recorder's resolved form, defaulting unspecified fields (issue #435). The
 	// config layer has already validated ranges.
 	resolveAdaptiveConfig := func(a *config.AdaptiveRecordingConfig) *recorder.AdaptiveConfig {
-		ac := recorder.DefaultAdaptiveConfig()
+		var calm, interval string
+		var spike float64
+		var gop int64
 		if a != nil {
-			if d, err := time.ParseDuration(a.CalmThreshold); err == nil && d > 0 {
-				ac.CalmThreshold = d
-			}
-			if d, err := time.ParseDuration(a.TimelapseInterval); err == nil && d > 0 {
-				ac.TimelapseInterval = d
-			}
-			if a.SpikeFactor > 0 {
-				ac.SpikeFactor = a.SpikeFactor
-			}
-			if a.GOPBufferBytes > 0 {
-				ac.MaxGOPBuffer = a.GOPBufferBytes
-			}
+			calm, interval, spike, gop = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes
 		}
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop)
 		return &ac
 	}
 
@@ -143,6 +135,11 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 			AVI:            cam.HTTPJPEGAVI,
 			EventBus:       cm.eventBus,
 			RecordEnabled:  cam.RecordingEnabled,
+		}
+		if cam.RecordingMode == "adaptive" {
+			// Validated by config.ValidateCameraRecordingMode (h264/h265 only);
+			// createDelegate ignores it for MJPEG/JPEG encodings.
+			onvifCfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
 		}
 		if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
 			onvifCfg.FrameWatchdogTimeout = d

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -130,7 +130,8 @@ type AdaptiveRecordingConfig struct {
 	// Default "30s". Range 5s–10m.
 	TimelapseInterval string `yaml:"timelapse_interval,omitempty" json:"timelapse_interval,omitempty"`
 	// SpikeFactor is how many (MAD-floored) deviations above the P-frame size
-	// baseline count as an activity spike. Default 3.0. Range 1.5–10.
+	// baseline count as an activity spike. Default 5.0 (real-camera noise
+	// calibration, issue #466). Range 1.5–10.
 	SpikeFactor float64 `yaml:"spike_factor,omitempty" json:"spike_factor,omitempty"`
 	// GOPBufferBytes caps the in-memory GOP pre-buffer that makes the
 	// timelapse→normal transition seamless. Default 16MB. Range 1–64MB.

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -7,6 +7,11 @@
 //	NORMAL ──(activity signal calm for CalmThreshold)──▶ TIMELAPSE
 //	TIMELAPSE ──(single P-frame size spike)──▶ NORMAL + GOP flush
 //
+// While in NORMAL, only a spike BURST (2+ oversized P-frames within 2s) resets
+// the calm accumulation — real motion produces clustered spikes, while
+// encoders emit isolated oversized P-frames even in fully static scenes
+// (issue #466 field data). Exiting TIMELAPSE takes a single spike.
+//
 // In TIMELAPSE mode only one keyframe per TimelapseInterval reaches the muxer
 // (audio is dropped too); everything else is skipped on disk but retained in
 // an in-memory GOP ring — the frames since the last IDR, which form a
@@ -40,11 +45,19 @@ type AdaptiveConfig struct {
 }
 
 // DefaultAdaptiveConfig mirrors the validated ranges in config.validate.
+//
+// SpikeFactor 5.0 is calibrated on real-camera capture (issue #466): H.264/H.265
+// encoders emit isolated oversized P-frames in fully static scenes (noise /
+// intra-refresh / AEC adjustments), so a 3.0 threshold flags ~1.3% of P-frames
+// as spikes on a motionless indoor camera — combined with the single-spike
+// calm reset that made TIMELAPSE unreachable (max measured spike-free stretch
+// 50s < 60s CalmThreshold). 5.0 keeps a genuinely busy camera in NORMAL while
+// letting a static one go sparse.
 func DefaultAdaptiveConfig() AdaptiveConfig {
 	return AdaptiveConfig{
 		CalmThreshold:     60 * time.Second,
 		TimelapseInterval: 30 * time.Second,
-		SpikeFactor:       3.0,
+		SpikeFactor:       5.0,
 		MaxGOPBuffer:      16 << 20, // 16MB ≈ 64s @ 2Mbps — far above any sane GOP
 	}
 }
@@ -86,7 +99,14 @@ type adaptiveTracker struct {
 	median    float64
 	mad       float64
 	lastCalc  time.Time
-	calmSince time.Time // last spike (or start); sustained calm enters TIMELAPSE
+	calmSince time.Time // last motion burst (or start); sustained calm enters TIMELAPSE
+
+	// Spike-burst detection (issue #466): only CLUSTERED spikes (>=2 within
+	// adaptiveBurstWindow) reset the calm accumulation while in NORMAL — real
+	// motion produces runs of consecutive oversized P-frames, encoder noise
+	// produces isolated single spikes. Exiting TIMELAPSE still happens on any
+	// single spike (better to over-record than to miss an event start).
+	recentSpikes []time.Time
 
 	// Sparse-mode write cadence.
 	lastSparseWrite time.Time
@@ -104,7 +124,7 @@ type adaptiveTracker struct {
 // TIMELAPSE entry requires a full CalmThreshold of calm after connect.
 func newAdaptiveTracker(cfg AdaptiveConfig, camID string, log *slog.Logger) *adaptiveTracker {
 	if cfg.SpikeFactor <= 0 {
-		cfg.SpikeFactor = 3.0
+		cfg.SpikeFactor = 5.0
 	}
 	if cfg.CalmThreshold <= 0 {
 		cfg.CalmThreshold = 60 * time.Second
@@ -125,6 +145,18 @@ func newAdaptiveTracker(cfg AdaptiveConfig, camID string, log *slog.Logger) *ada
 
 const adaptivePWindow = 1200 // rolling baseline samples (~60s @ 20fps)
 
+const (
+	// adaptiveBurstWindow is how close two P-frame spikes must be to count as
+	// a motion burst (vs isolated encoder noise). Real motion produces
+	// consecutive/clustered spikes; static-scene encoder noise produces single
+	// spikes separated by seconds (issue #466 field data: isolated spikes up
+	// to 1.3% of P-frames on a motionless camera, max spike-free stretch 50s).
+	adaptiveBurstWindow = 2 * time.Second
+	// adaptiveBurstCount is the spike count within the window that resets the
+	// calm accumulation.
+	adaptiveBurstCount = 2
+)
+
 // observe ingests one VCL NALU (without start code), updates the activity
 // baseline and GOP ring, and executes mode transitions. It returns whether
 // this frame is an activity spike, and — on the TIMELAPSE→NORMAL transition —
@@ -142,23 +174,68 @@ func (t *adaptiveTracker) observe(nalu []byte, isIDR bool, now time.Time) (spike
 	if !isIDR {
 		spike = t.classify(size, now)
 		if spike {
-			t.calmSince = now
+			t.recordSpike(now)
 		}
 	}
 
 	switch t.mode {
 	case adaptiveNormal:
+		// Only a spike BURST (clustered oversized P-frames) counts as motion
+		// and resets the calm accumulation; an isolated spike is encoder
+		// noise and must not keep a static camera recording at full rate
+		// forever (issue #466).
+		if spike && t.spikeBurst(now) {
+			t.calmSince = now
+		}
 		if now.Sub(t.calmSince) >= t.cfg.CalmThreshold {
 			t.setMode(adaptiveTimelapse, now)
 			t.lastSparseWrite = now
 		}
 	case adaptiveTimelapse:
 		if spike {
+			// Any single spike exits sparse mode. The exit itself is evidence
+			// of activity, so a fresh CalmThreshold window is required before
+			// re-entering TIMELAPSE (prevents spike → exit → instant re-entry
+			// oscillation, since the burst rule above does not fire on
+			// isolated spikes).
+			t.calmSince = now
 			flush = t.takeGOP()
 			t.setMode(adaptiveNormal, now)
 		}
 	}
 	return spike, flush
+}
+
+// recordSpike appends a spike timestamp, trimming entries outside the burst
+// window.
+func (t *adaptiveTracker) recordSpike(now time.Time) {
+	cutoff := now.Add(-adaptiveBurstWindow)
+	drop := 0
+	for _, at := range t.recentSpikes {
+		if at.Before(cutoff) {
+			drop++
+			continue
+		}
+		break
+	}
+	t.recentSpikes = append(t.recentSpikes[drop:drop:drop], now)
+}
+
+// spikeBurst reports whether the recent spikes within the burst window reach
+// adaptiveBurstCount (a motion burst, not isolated noise).
+func (t *adaptiveTracker) spikeBurst(now time.Time) bool {
+	cutoff := now.Add(-adaptiveBurstWindow)
+	n := 0
+	for i := len(t.recentSpikes) - 1; i >= 0; i-- {
+		if t.recentSpikes[i].Before(cutoff) {
+			break
+		}
+		n++
+		if n >= adaptiveBurstCount {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldWriteSparse reports whether a frame observed in TIMELAPSE mode may
@@ -266,4 +343,88 @@ func (t *adaptiveTracker) setMode(m adaptiveMode, now time.Time) {
 		"mode", m.String(), "transitions", t.transitions,
 		"calm_threshold", t.cfg.CalmThreshold.String(),
 		"timelapse_interval", t.cfg.TimelapseInterval.String())
+}
+
+// AdaptiveFrame is one retained GOP frame exposed to plugin-style recorders
+// outside this package (see AdaptiveGate).
+type AdaptiveFrame struct {
+	Nalu  []byte
+	IsIDR bool
+	At    time.Time
+}
+
+// AdaptiveGate is the exported per-connection adaptive-recording gate for
+// recorders that do not inherit baseRecorder (e.g. the Xiaomi MISS recorder,
+// issue #468). It wraps adaptiveTracker with the same semantics as the
+// writeFrames gate: sustained calm drops write density to one keyframe per
+// TimelapseInterval; an activity spike flushes the retained GOP and resumes
+// full-rate writing. Rebuild per connection so a reconnect always starts in
+// NORMAL mode with a fresh baseline.
+type AdaptiveGate struct {
+	t *adaptiveTracker
+}
+
+// NewAdaptiveGate arms an adaptive gate; cfg is resolved camera config
+// (recorder.DefaultAdaptiveConfig for unset fields).
+func NewAdaptiveGate(cfg AdaptiveConfig, camID string, log *slog.Logger) *AdaptiveGate {
+	return &AdaptiveGate{t: newAdaptiveTracker(cfg, camID, log)}
+}
+
+// Observe classifies one VCL NALU (without start code) and returns the write
+// decision:
+//
+//	spike — the frame is an activity spike (diagnostics)
+//	skip  — drop the frame's DISK write (sparse mode); live fan-out is the
+//	        caller's business and must keep flowing
+//	flush — retained GOP frames to write BEFORE the current frame (non-empty
+//	        only on the timelapse→normal exit; starts with an IDR)
+//
+// After a non-skip sparse keyframe write, the caller need not stamp anything —
+// the cadence is stamped here, mirroring the base recorder.
+func (g *AdaptiveGate) Observe(nalu []byte, isIDR bool, now time.Time) (spike, skip bool, flush []AdaptiveFrame) {
+	spike, fl := g.t.observe(nalu, isIDR, now)
+	if len(fl) > 0 {
+		// Timelapse exit: hand the retained GOP to the caller to write BEFORE
+		// the current frame. Keyed on the flush return, not on mode — observe()
+		// has already switched to NORMAL (same fix as writeFrames).
+		for _, f := range fl {
+			flush = append(flush, AdaptiveFrame{Nalu: f.nalu, IsIDR: f.isIDR, At: f.at})
+		}
+	}
+	if g.t.mode == adaptiveTimelapse && !spike {
+		if !g.t.shouldWriteSparse(isIDR, now) {
+			return spike, true, flush
+		}
+		if isIDR {
+			g.t.lastSparseWrite = now
+		}
+	}
+	return spike, false, flush
+}
+
+// Timelapse reports whether the gate is in sparse mode (callers use it to
+// gate DISK audio writes, which sparse mode drops; live audio continues).
+func (g *AdaptiveGate) Timelapse() bool {
+	return g.t.mode == adaptiveTimelapse
+}
+
+// ResolveAdaptiveConfig builds a resolved AdaptiveConfig from optional
+// overrides, defaulting unset fields. Shared by the camera-manager factory
+// (RTSP/ONVIF paths) and plugin-style recorders (Xiaomi) so both resolve
+// identically. String durations follow the frame_watchdog_timeout convention.
+func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor float64, gopBufferBytes int64) AdaptiveConfig {
+	ac := DefaultAdaptiveConfig()
+	if d, err := time.ParseDuration(calmThreshold); err == nil && d > 0 {
+		ac.CalmThreshold = d
+	}
+	if d, err := time.ParseDuration(timelapseInterval); err == nil && d > 0 {
+		ac.TimelapseInterval = d
+	}
+	if spikeFactor > 0 {
+		ac.SpikeFactor = spikeFactor
+	}
+	if gopBufferBytes > 0 {
+		ac.MaxGOPBuffer = gopBufferBytes
+	}
+	return ac
 }

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -253,7 +253,7 @@ func TestAdaptiveTracker_SpikeBurstResetsCalm(t *testing.T) {
 	// resets calmSince, so the 60s threshold is never reached.
 	for elapsed := time.Duration(0); elapsed < 80*time.Second; elapsed += 10 * time.Second {
 		at := end.Add(elapsed)
-		for d := time.Duration(0); d < 10*time.Second; d += 50*time.Millisecond {
+		for d := time.Duration(0); d < 10*time.Second; d += 50 * time.Millisecond {
 			buf := make([]byte, 800)
 			buf[0] = 0x41
 			tr.observe(buf, false, at.Add(d))

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -196,3 +196,173 @@ func TestAdaptiveTracker_BaselineRingBounded(t *testing.T) {
 		t.Fatalf("baseline ring grew to %d, cap %d", len(tr.pSizes), adaptivePWindow)
 	}
 }
+
+// feedNoisyCalm simulates a static scene whose encoder still emits isolated
+// oversized P-frames (issue #466): every gapSeconds a single spike frame is
+// injected between small frames. Isolated spikes must NOT reset the calm
+// accumulation, so TIMELAPSE is still entered once CalmThreshold elapses.
+func feedNoisyCalm(t *testing.T, tr *adaptiveTracker, t0 time.Time, seconds int, gapSeconds time.Duration, spikeFactor float64) time.Time {
+	t.Helper()
+	step := 50 * time.Millisecond
+	end := t0
+	for elapsed := time.Duration(0); elapsed < time.Duration(seconds)*time.Second; elapsed += gapSeconds {
+		// small frames up to the spike point
+		for d := time.Duration(0); d < gapSeconds; d += step {
+			buf := make([]byte, 800)
+			buf[0] = 0x41
+			tr.observe(buf, false, end.Add(d))
+		}
+		end = end.Add(gapSeconds)
+		// one isolated spike well above the classify threshold
+		big := make([]byte, int(800*(spikeFactor+2)))
+		big[0] = 0x41
+		tr.observe(big, false, end)
+		end = end.Add(step)
+	}
+	return end
+}
+
+func TestAdaptiveTracker_IsolatedSpikesDoNotResetCalm(t *testing.T) {
+	cfg := DefaultAdaptiveConfig() // SpikeFactor 5.0, CalmThreshold 60s
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+
+	t0 := time.Now()
+	// Baseline must exist before classify produces spikes: warm up calmly.
+	end := feedCalm(t, tr, t0, 100) // 5s of small frames
+	// 50s with an isolated spike every 10s (last at ~55s). With the OLD
+	// single-spike rule the calm timer reset on every spike, pushing TIMELAPSE
+	// past ~115s; now the isolated spikes are ignored and calm accumulates
+	// across them. The window stays under the 60s threshold so entry happens
+	// only in the trailing calm stretch below.
+	end = feedNoisyCalm(t, tr, end, 50, 10*time.Second, cfg.SpikeFactor)
+	// Pure calm crosses the 60s mark and enters TIMELAPSE; with no spike after
+	// entry the mode holds (single-spike exit is exercised by its own test).
+	feedCalm(t, tr, end, 400) // 20s
+	if tr.mode != adaptiveTimelapse {
+		t.Fatalf("mode = %v, want timelapse — isolated noise spikes must not block entry", tr.mode)
+	}
+}
+
+func TestAdaptiveTracker_SpikeBurstResetsCalm(t *testing.T) {
+	cfg := DefaultAdaptiveConfig()
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+
+	t0 := time.Now()
+	end := feedCalm(t, tr, t0, 100) // warm up baseline
+	// Repeated bursts (2 spikes 100ms apart) every 10s for 80s — each burst
+	// resets calmSince, so the 60s threshold is never reached.
+	for elapsed := time.Duration(0); elapsed < 80*time.Second; elapsed += 10 * time.Second {
+		at := end.Add(elapsed)
+		for d := time.Duration(0); d < 10*time.Second; d += 50*time.Millisecond {
+			buf := make([]byte, 800)
+			buf[0] = 0x41
+			tr.observe(buf, false, at.Add(d))
+		}
+		for i := range 2 { // clustered spikes = motion burst
+			big := make([]byte, int(800*(cfg.SpikeFactor+2)))
+			big[0] = 0x41
+			tr.observe(big, false, at.Add(10*time.Second+time.Duration(i)*100*time.Millisecond))
+		}
+	}
+	if tr.mode != adaptiveNormal {
+		t.Fatalf("mode = %v, want normal — motion bursts must keep resetting calm", tr.mode)
+	}
+}
+
+func TestAdaptiveTracker_TimelapseExitRequiresFreshCalmWindow(t *testing.T) {
+	cfg := AdaptiveConfig{CalmThreshold: 10 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 3.0, MaxGOPBuffer: 16 << 20}
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+
+	t0 := time.Now()
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	tr.observe(idr, true, t0)
+	end := feedCalm(t, tr, t0.Add(50*time.Millisecond), 500) // 25s calm > 10s → TIMELAPSE
+	if tr.mode != adaptiveTimelapse {
+		t.Fatalf("mode = %v, want timelapse after sustained calm", tr.mode)
+	}
+
+	// Single isolated spike exits TIMELAPSE...
+	big := make([]byte, 300000)
+	big[0] = 0x41
+	_, flush := tr.observe(big, false, end)
+	if tr.mode != adaptiveNormal {
+		t.Fatalf("mode = %v, want normal after spike", tr.mode)
+	}
+	if flush == nil {
+		t.Fatal("expected GOP flush on timelapse exit")
+	}
+	// ...and the exit must reset the calm window: the very next calm frame
+	// must NOT re-enter TIMELAPSE instantly (no oscillation).
+	buf := make([]byte, 800)
+	buf[0] = 0x41
+	tr.observe(buf, false, end.Add(60*time.Millisecond))
+	if tr.mode != adaptiveNormal {
+		t.Fatalf("mode = %v, want normal — exit must require a fresh CalmThreshold before re-entry", tr.mode)
+	}
+}
+
+func TestDefaultAdaptiveConfig_SpikeFactorCalibrated(t *testing.T) {
+	cfg := DefaultAdaptiveConfig()
+	if cfg.SpikeFactor != 5.0 {
+		t.Fatalf("default SpikeFactor = %v, want 5.0 (issue #466 real-camera calibration)", cfg.SpikeFactor)
+	}
+}
+
+func TestAdaptiveGate_SparseSkipAndFlushFacade(t *testing.T) {
+	cfg := AdaptiveConfig{CalmThreshold: 10 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 3.0, MaxGOPBuffer: 16 << 20}
+	g := NewAdaptiveGate(cfg, "cam", testAdaptiveLogger())
+
+	// Warm up: IDR + 25s calm (> 10s) enters timelapse.
+	t0 := time.Now()
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	if _, skip, _ := g.Observe(idr, true, t0); skip {
+		t.Fatal("IDR in NORMAL must not be skipped")
+	}
+	end := t0
+	for i := range 500 { // 25s @ 20fps
+		buf := make([]byte, 800)
+		buf[0] = 0x41
+		g.Observe(buf, false, end.Add(time.Duration(i)*50*time.Millisecond))
+	}
+	end = end.Add(25 * time.Second)
+	if !g.Timelapse() {
+		t.Fatal("want timelapse after sustained calm")
+	}
+
+	// Sparse mode: P frames skipped, sparse keyframes pass.
+	p := make([]byte, 800)
+	p[0] = 0x41
+	if _, skip, _ := g.Observe(p, false, end); !skip {
+		t.Fatal("P frame in timelapse must be skipped")
+	}
+	// Entry stamped the cadence clock, so the first sparse keyframe passes only
+	// after a full TimelapseInterval (30s) from entry (~t0+10s).
+	if _, skip, _ := g.Observe(idr, true, end.Add(31*time.Second)); skip {
+		t.Fatal("sparse keyframe after a full interval must pass")
+	}
+
+	// Spike: no skip, GOP flush returned, back to NORMAL.
+	big := make([]byte, 300000)
+	big[0] = 0x41
+	_, skip, flush := g.Observe(big, false, end.Add(2*time.Second))
+	if skip {
+		t.Fatal("spike frame must be written")
+	}
+	if len(flush) == 0 || !flush[0].IsIDR {
+		t.Fatal("expected GOP flush starting with IDR")
+	}
+	if g.Timelapse() {
+		t.Fatal("spike must exit timelapse")
+	}
+}
+
+func TestResolveAdaptiveConfig_DefaultsAndOverrides(t *testing.T) {
+	ac := ResolveAdaptiveConfig("", "", 0, 0)
+	if ac != (AdaptiveConfig{CalmThreshold: 60 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 5.0, MaxGOPBuffer: 16 << 20}) {
+		t.Fatalf("defaults wrong: %+v", ac)
+	}
+	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20)
+	if ac.CalmThreshold != 2*time.Minute || ac.TimelapseInterval != 10*time.Second || ac.SpikeFactor != 7.5 || ac.MaxGOPBuffer != 1<<20 {
+		t.Fatalf("overrides wrong: %+v", ac)
+	}
+}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -571,13 +571,21 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 			now := time.Now()
 			isIDR := b.driver.isIDR(typ)
 			spike, flush := b.adaptive.observe(nalu, isIDR, now)
-			if b.adaptive.mode == adaptiveTimelapse {
-				if spike {
-					// Activity burst: resume full-rate writing. The flushed
-					// GOP (complete reference chain since the last IDR) is
-					// written first so the resume has no missing references.
-					b.writeFlushedGOP(flush)
-				} else if !b.adaptive.shouldWriteSparse(isIDR, now) {
+			if len(flush) > 0 {
+				// Activity burst exiting timelapse: resume full-rate writing with
+				// the flushed GOP (complete reference chain since the last IDR)
+				// FIRST, so the resume has no missing references. This must be
+				// keyed on the flush return, not on mode: observe() has already
+				// switched to NORMAL by the time it returns, so the previous
+				// `if mode == adaptiveTimelapse { if spike { writeFlushedGOP } }`
+				// never ran — the exit frame was written with dangling references
+				// (decode artifacts until the next IDR) and the retained pre-buffer
+				// was silently dropped (found via the AdaptiveGate facade test,
+				// issue #466 field test).
+				b.writeFlushedGOP(flush)
+			}
+			if b.adaptive.mode == adaptiveTimelapse && !spike {
+				if !b.adaptive.shouldWriteSparse(isIDR, now) {
 					// Sparse: the frame is retained in the GOP ring, not
 					// written; a later spike can still flush it.
 					if sa := b.adaptive.mode == adaptiveTimelapse; sa != sparseAudio {

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -43,6 +43,13 @@ type ONVIFConfig struct {
 	// Start time — without this, recording_enabled=false had no effect on ONVIF
 	// cameras (the delegate always recorded).
 	RecordEnabled *bool
+	// Adaptive enables dynamic-timelapse write density (issue #435) on the
+	// H.264/H.265 delegates. Without forwarding it here, recording_mode:
+	// adaptive on ONVIF cameras was silently ignored by the delegate (issue
+	// #467) — the config validated and the UI showed adaptive, but the
+	// recorder wrote continuously. Ignored for MJPEG/JPEG delegates (the
+	// compressed-domain signal requires differential encoding).
+	Adaptive *AdaptiveConfig
 }
 
 // ONVIFRecorder implements model.Recorder by resolving the RTSP stream URI
@@ -653,6 +660,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 			FrameWatchdogTimeout: r.cfg.FrameWatchdogTimeout,
 			EventBus:             r.cfg.EventBus,
 			RecordEnabled:        r.cfg.RecordEnabled,
+			Adaptive:             r.cfg.Adaptive,
 		}
 		rec := NewH265Recorder(cfg, r.store, r.metrics)
 		rec.Hub = r.Hub
@@ -741,6 +749,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 			FrameWatchdogTimeout: r.cfg.FrameWatchdogTimeout,
 			EventBus:             r.cfg.EventBus,
 			RecordEnabled:        r.cfg.RecordEnabled,
+			Adaptive:             r.cfg.Adaptive,
 		}
 		rec := NewH264Recorder(cfg, r.store, r.metrics)
 		rec.Hub = r.Hub

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/go-chi/chi/v5"
 )

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -67,6 +68,22 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 		Quality:       cfg.Quality,
 		EventBus:      p.eventBus,
 		RecordEnabled: cfg.RecordingEnabled,
+	}
+	// Adaptive write-density (issue #435/#468): recording_mode: adaptive was
+	// silently ignored by the Xiaomi recorder until the gate was ported.
+	// Config validation (ValidateCameraRecordingMode) already restricts it to
+	// h264/h265 cameras.
+	if cfg.RecordingMode == "adaptive" {
+		var a *config.AdaptiveRecordingConfig
+		if cfg.Adaptive != nil {
+			a = cfg.Adaptive
+		}
+		calm, interval, spike, gop := "", "", 0.0, int64(0)
+		if a != nil {
+			calm, interval, spike, gop = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes
+		}
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop)
+		recCfg.Adaptive = &ac
 	}
 	return NewXiaomiRecorder(recCfg, store, opts...)
 }

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -76,6 +77,10 @@ type XiaomiRecorderConfig struct {
 	// HLS) but no segments are written to disk. Matches baseRecorder.RecordEnabled
 	// semantics so recording_enabled=false takes effect on Xiaomi cameras.
 	RecordEnabled *bool
+	// Adaptive enables dynamic-timelapse write density (issue #435; wired for
+	// Xiaomi cameras in issue #468 — previously recording_mode: adaptive was
+	// silently ignored by this recorder). Nil = plain continuous recording.
+	Adaptive *recorder.AdaptiveConfig
 }
 
 // XiaomiRecorder records H.264/H.265 video from a Xiaomi camera via MISS protocol.
@@ -119,6 +124,15 @@ type XiaomiRecorder struct {
 	// MISS client reference for external commands (MotorControl, GetDeviceInfo).
 	missClient *MISSClient
 	missMu     sync.Mutex
+
+	// Adaptive write-density gate (issue #435/#468). Rebuilt per connection in
+	// connectAndRecord so a reconnect always starts in NORMAL mode; nil when
+	// adaptive recording is not configured. Owned by the video NALU processing
+	// path.
+	adaptive *recorder.AdaptiveGate
+	// audioSparse gates DISK writes of audio while the adaptive gate is in
+	// sparse (timelapse) mode; live audio broadcast continues.
+	audioSparse atomic.Bool
 }
 
 // Interface compliance check.
@@ -527,6 +541,13 @@ func (r *XiaomiRecorder) connectAndRecord(ctx context.Context, missURL string) (
 	r.pps = nil
 	r.vps = nil
 	r.audioCodecID = 0
+	// Rebuild the adaptive gate per connection: a reconnect always starts in
+	// NORMAL mode with a fresh activity baseline (a reconnect storm can't
+	// oscillate the mode).
+	if r.cfg.Adaptive != nil {
+		r.adaptive = recorder.NewAdaptiveGate(*r.cfg.Adaptive, r.cfg.CameraID, xiaomiLogger)
+		r.audioSparse.Store(false)
+	}
 
 	var lastTimestamp uint64
 
@@ -638,6 +659,21 @@ func (r *XiaomiRecorder) processH264NALU(nalu []byte, timestamp uint64, lastTime
 		return
 	}
 
+	// Adaptive write-density gate (issue #435/#468) — see processH265NALU.
+	if r.adaptive != nil {
+		now := time.Now()
+		isIDR := naluType == 5
+		_, skip, flush := r.adaptive.Observe(nalu, isIDR, now)
+		r.audioSparse.Store(r.adaptive.Timelapse())
+		if len(flush) > 0 {
+			r.writeFlushedGOP(flush)
+		}
+		if skip {
+			r.forwardHLS(nalu)
+			return
+		}
+	}
+
 	if r.muxer == nil {
 		tempPath, finalPath, err := r.store.CreateSegment(r.cfg.CameraID, string(model.FormatH264))
 		if err != nil {
@@ -741,6 +777,25 @@ func (r *XiaomiRecorder) processH265NALU(nalu []byte, timestamp uint64, lastTime
 	// Wait for IDR frame (types 19=IDR_W_RADL, 20=IDR_N_LP).
 	if r.muxer == nil && naluType != 19 && naluType != 20 {
 		return
+	}
+
+	// Adaptive write-density gate (issue #435/#468): while the compressed-domain
+	// activity signal is calm only sparse keyframes reach the disk; on a spike
+	// the retained GOP ring is flushed first so the resume has no missing
+	// references. Live fan-out (forwardHLS → StreamHub) keeps flowing for every
+	// frame — the gate changes write density, never the connection.
+	if r.adaptive != nil {
+		now := time.Now()
+		isIDR := naluType == 19 || naluType == 20
+		_, skip, flush := r.adaptive.Observe(nalu, isIDR, now)
+		r.audioSparse.Store(r.adaptive.Timelapse())
+		if len(flush) > 0 {
+			r.writeFlushedGOP(flush)
+		}
+		if skip {
+			r.forwardHLS(nalu)
+			return
+		}
 	}
 
 	if r.muxer == nil {
@@ -903,13 +958,43 @@ func (r *XiaomiRecorder) forwardAudio(codecID uint32, payload []byte) {
 	aid := r.audioTrackID
 	start := r.segStart
 	r.mu.Unlock()
-	if m != nil && aid > 0 {
+	// Sparse (adaptive-timelapse) mode drops DISK audio, live audio continues
+	// (mirrors the built-in H264/H265 recorders).
+	if m != nil && aid > 0 && !r.audioSparse.Load() {
 		pts := time.Since(start)
 		// Audio frame duration: 20ms (G.711 and Opus both use 20ms frames).
 		dur := 20 * time.Millisecond
 		if err := m.WriteAudioSample(aid, payload, pts, dur); err != nil {
 			xiaomiLogger.Error("failed to write audio sample", "camera_id", r.cfg.CameraID, "error", err)
 		}
+	}
+}
+
+// writeFlushedGOP writes the adaptive gate's retained GOP frames (complete
+// reference chain since the last IDR) into the current segment on the
+// timelapse→normal transition, mirroring baseRecorder.writeFlushedGOP. If the
+// segment just rotated (muxer == nil) the flush is dropped — the triggering
+// frame itself still creates a fresh segment on its IDR, so at worst one
+// pre-buffer is lost at a rotation boundary; no corrupt references result.
+func (r *XiaomiRecorder) writeFlushedGOP(frames []recorder.AdaptiveFrame) {
+	if r.muxer == nil {
+		return
+	}
+	for _, f := range frames {
+		pts := f.At.Sub(r.segStart)
+		if pts < 0 {
+			pts = 0
+		}
+		dur := f.At.Sub(r.lastFrameTime)
+		if dur < time.Millisecond {
+			dur = time.Millisecond
+		}
+		if err := r.muxer.WriteSample(r.trackID, f.Nalu, pts, dur); err != nil {
+			xiaomiLogger.Error("failed to write flushed sample", "camera_id", r.cfg.CameraID, "error", err)
+			continue
+		}
+		r.lastFrameTime = f.At
+		r.frameCount++
 	}
 }
 

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -78,7 +78,7 @@ export interface AdaptiveRecordingConfig {
   calm_threshold?: string;
   /** Keyframe cadence while sparse. Default '30s'. */
   timelapse_interval?: string;
-  /** Activity spike sensitivity (MAD deviations above baseline). Default 3.0. */
+  /** Activity spike sensitivity (MAD deviations above baseline). Default 5.0. */
   spike_factor?: number;
   /** Seamless-transition GOP pre-buffer cap in bytes. Default 16MB. */
   gop_buffer_bytes?: number;

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -934,7 +934,7 @@ async function performCameraSave() {
           </div>
           <div>
             <label for="cam-adaptive-spike" class="input-label">{t('cameras.adaptiveSpikeFactor')}</label>
-            <input id="cam-adaptive-spike" class="input" type="number" step="0.1" min="1.5" max="10" placeholder="3.0" bind:value={formAdaptiveSpikeFactor} />
+            <input id="cam-adaptive-spike" class="input" type="number" step="0.1" min="1.5" max="10" placeholder="5.0" bind:value={formAdaptiveSpikeFactor} />
           </div>
           <div>
             <label for="cam-adaptive-gop" class="input-label">{t('cameras.adaptiveGopBufferMB')}</label>


### PR DESCRIPTION
Field test of #435 Phase 3 on real hardware (M5, 2026-08-23) found the adaptive recording shipped in #438 never activated outside synthetic streams. Four fixes, all validated against real capture data before coding (per-frame size series extracted from actual recordings, classifier replayed offline):

## 1. Spike threshold miscalibrated for real encoders (#466)
Real H.265 encoders emit isolated oversized P-frames even in fully static scenes — measured 1.3% of P-frames on a motionless indoor camera, with the longest spike-free stretch at **50.2s < 60s CalmThreshold**. With the single-spike calm reset, TIMELAPSE was mathematically unreachable (13+ min observed, zero transitions, camera burning 2.7GB/h on a static scene).

- Default `SpikeFactor` 3.0 → **5.0** (noise-floor calibration; parameter sweep on capture data)
- Calm window now resets only on a **spike burst** (2+ spikes within 2s) — real motion produces clustered spikes, encoder noise produces isolated ones. A single spike still **exits** TIMELAPSE (over-record hysteresis from the #435 spec unchanged), and the exit itself requires a fresh CalmThreshold window before re-entry (no exit→re-entry oscillation).

Replay validation on real capture (exact classifier semantics): static indoor cam TL share 0% → 23% @factor 5 (44% @8, 59% @10); busy street cam 0% at every factor (correctly stays NORMAL).

## 2. ONVIF cameras silently ignored `recording_mode: adaptive` (#467)
The factory wired `Adaptive` only on direct-RTSP recorders; `ONVIFConfig` had no field and `createDelegate` never forwarded it. ONVIF is the most common real protocol — adaptive was a silent no-op for it. Now: factory ONVIF branch resolves + passes it; H264/H265 delegates forward it; MJPEG/JPEG delegates ignore it (compressed-domain signal needs differential encoding).

## 3. Xiaomi cameras likewise (#467)
`XiaomiRecorder` is a standalone implementation (no baseRecorder). Ported the gate via a new exported **`recorder.AdaptiveGate`** facade that encapsulates the same semantics as the writeFrames gate (sparse skip decisions, interval stamping, GOP flush on exit), rebuilt per connection; skipped frames keep live fan-out (forwardHLS); sparse mode drops disk audio only. Shared `recorder.ResolveAdaptiveConfig` replaces the duplicated factory closure.

## 4. `writeFrames` GOP flush on timelapse exit was dead code
`observe()` switches mode to NORMAL before returning, so the outer `if mode == adaptiveTimelapse { if spike { writeFlushedGOP } }` never ran: exit frames were written with dangling references (decode artifacts until the next IDR) and the retained pre-buffer was silently dropped. **Found by the new facade unit test.** Now keyed on the flush return value.

## Tests
`internal/recorder/adaptive_test.go`: isolated spikes don't block entry; spike bursts keep resetting calm; timelapse exit requires a fresh calm window; default calibration value; AdaptiveGate facade (sparse skip / interval cadence / exit flush — catches the dead-flush class); ResolveAdaptiveConfig defaults+overrides. Full recorder/camera/xiaomi suites pass.

## M5 live verification (pre-PR, per repo policy)
Deployed (`0.11.0-adaptive-fix-466-467`): static ONVIF H.265 camera enters TIMELAPSE within 60s of calm (write rate 2.7GB/h → ~0 in sparse windows, measured by directory growth), busy street camera correctly oscillates with real traffic (8 transitions in 3 min during afternoon activity), all 13 cameras healthy, zero ERROR lines. Backup at `mibee-nvr.bak-0823-pre467`.

Closes #466, closes #467. Related #435.