### PR TITLE
fix(web): orchestrator 测试夹具对齐 #332 线格式 + CI 补跑 vitest(574/574 绿)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,14 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
+      # Frontend unit tests (vitest). Without this step the suite rots silently —
+      # the orchestrator fixtures went stale for weeks after the /protocols JSON
+      # field casing changed (#332) because nothing in CI ran vitest.
+      - name: Test frontend
+        run: cd web && npm ci && npm test
+
       - name: Build frontend
-        run: cd web && npm ci && npm run build
+        run: cd web && npm run build
 
       - name: Build
         run: |

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -86,7 +86,15 @@ function setupCacheMock() {
     match: vi.fn().mockImplementation(async (url: string) => {
       const cached = mockCacheStore.get(url);
       if (cached) {
-        return new Response(new Blob([cached]), { status: 200 });
+        // Build the hit Response with an ArrayBuffer body, NOT a Blob: under
+        // Node 22's jsdom environment the global Blob is jsdom's, and undici's
+        // Response constructor stringifies it ("[object Blob]", 13 bytes) —
+        // the cache "hit" returns garbage, ORT session creation fails, and the
+        // runtime's self-heal path purges + re-fetches, breaking the
+        // caches-model test. Node 24+ accepts it, so this only failed in CI
+        // (which pins Node 22). ArrayBuffer bodies are native to undici on
+        // every version.
+        return new Response(cached.slice(0), { status: 200 });
       }
       return undefined;
     }),
@@ -380,9 +388,7 @@ describe('AiRuntime', () => {
 
     it('does NOT self-heal on non-corrupt session errors', async () => {
       // A generic WebGPU/runtime failure must NOT trigger a re-download.
-      mockOrtModule.InferenceSession.create = vi
-        .fn()
-        .mockRejectedValue(new Error('WebGPU adapter unavailable'));
+      mockOrtModule.InferenceSession.create = vi.fn().mockRejectedValue(new Error('WebGPU adapter unavailable'));
       setupFetchWithResponse(new ArrayBuffer(1024));
 
       const rt = new AiRuntime();

--- a/web/src/lib/player/__tests__/orchestrator.test.ts
+++ b/web/src/lib/player/__tests__/orchestrator.test.ts
@@ -9,19 +9,24 @@ import type { Camera, ProtocolsResponse } from '$lib/stream-selection';
 const H264_CAMERA: Camera = { id: 'cam-1', name: 'T', protocol: 'rtsp', encoding: 'h264' } as Camera;
 
 // Backend offers webrtc < flv < hls — a full chain for an H.264 camera.
+// NOTE: field names are lowercase snake_case, matching the /protocols JSON
+// (ProtocolDetail json tags, #332). An earlier fixture used Go's capitalized
+// default field names (Protocol/Available) — pre-#332 wire format — which
+// made `available` resolve to an empty set and the chain come out [] on
+// every registration (18 tests red, unnoticed because CI didn't run vitest).
 const H264_RESP: ProtocolsResponse = {
   encoding: 'h264',
   default: 'webrtc',
   protocols: [
-    { Protocol: 'webrtc', Available: true, Reason: '' },
-    { Protocol: 'flv', Available: true, Reason: '' },
-    { Protocol: 'll-hls', Available: true, Reason: '' },
-    { Protocol: 'hls', Available: true, Reason: '' },
+    { protocol: 'webrtc', available: true, reason: '' },
+    { protocol: 'flv', available: true, reason: '' },
+    { protocol: 'll-hls', available: true, reason: '' },
+    { protocol: 'hls', available: true, reason: '' },
     // wasm is advertised by the backend's WSStreamHandler (always registered,
     // see pkg/app/run.go). Including it here matches real /protocols output so
     // the wasm mode (gated on caps AND availability) can lead the chain when
     // the browser supports WebCodecs.
-    { Protocol: 'wasm', Available: true, Reason: '' },
+    { protocol: 'wasm', available: true, reason: '' },
   ],
 };
 
@@ -198,22 +203,29 @@ describe('PlayerOrchestrator — degrade', () => {
       sessionStorage.setItem(
         'mibee_nvr_device_caps',
         JSON.stringify({
-          webCodecs: true, hevcDecode: true, webgpu: true, webgl2: true,
-          mseH265: false, wasmH265: true, probedAt: Date.now(),
+          webCodecs: true,
+          hevcDecode: true,
+          webgpu: true,
+          webgl2: true,
+          mseH265: false,
+          wasmH265: true,
+          probedAt: Date.now(),
         }),
       );
-    } catch { /* sessionStorage may be unavailable */ }
+    } catch {
+      /* sessionStorage may be unavailable */
+    }
     const o = createPlayerOrchestrator();
     const H265_CAM: Camera = { id: 'cam-h80', name: 'H80', protocol: 'onvif', encoding: 'h265' } as Camera;
     const H265_RESP: ProtocolsResponse = {
       encoding: 'h265',
       default: 'hls',
       protocols: [
-        { Protocol: 'hls', Available: true, Reason: '' },
-        { Protocol: 'll-hls', Available: true, Reason: '' },
-        { Protocol: 'wasm', Available: true, Reason: '' },
-        { Protocol: 'webrtc', Available: false, Reason: 'H.265' },
-        { Protocol: 'flv', Available: false, Reason: 'H.265' },
+        { protocol: 'hls', available: true, reason: '' },
+        { protocol: 'll-hls', available: true, reason: '' },
+        { protocol: 'wasm', available: true, reason: '' },
+        { protocol: 'webrtc', available: false, reason: 'H.265' },
+        { protocol: 'flv', available: false, reason: 'H.265' },
       ],
     };
     // No MSE H.265 → only wasm is usable → single-element chain, like H80.


### PR DESCRIPTION
## 问题

main 上 `web/src/lib/player/__tests__/orchestrator.test.ts` 18/21 测试失败(前一会话用干净 main worktree 验证过,非 #470 引入)。

## 根因

两个因素叠加:

1. **测试夹具字段名过时**:夹具用 `{ Protocol: 'webrtc', Available: true }`(大写——Go 默认序列化的字段名)。#332 给后端 `ProtocolDetail` 加了 snake_case json tag 后,`/protocols` 实际输出小写 `protocol`/`available`,前端源码与 TS 类型也都是小写。大写夹具使 `buildCandidateChain` 里 `resp.protocols.filter(p => p.available)` 恒为空 → available 集合为空 → 每个协议都过不了后端可用性门 → 候选链恒为 `[]` → `activeMode` 恒 null → 18 个断言全红。
2. **CI 从不运行 vitest**(build job 只 `npm run build`)——所以后端 #332 改字段名后测试烂了几周无人发现。

## 修复

- 夹具两处(H264_RESP、H80 场景的 H265_RESP)字段名改为小写,并加注释说明线格式历史,防止再有人"改回去"
- CI 的 build job 新增 `Test frontend` 步骤(`cd web && npm ci && npm test`)——放在既有必需 workflow 内,失败即阻塞合并,无需改分支保护配置

## 验证

- `web` 全量 vitest:**574/574 通过**(修复前 556 通过 / 18 失败)
