### PR TITLE
chore(ci): 前端工具链统一 Node 24(workflows/Docker/engines 强制)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # ---- Stage 1: Build frontend SPA (native, no QEMU) ----
-FROM --platform=$BUILDPLATFORM node:22-slim AS frontend
+FROM --platform=$BUILDPLATFORM node:24-slim AS frontend
 
 WORKDIR /build/web
 

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,4 @@
+# Enforce the engines field (Node >= 24) — the toolchain is standardized on
+# Node 24 (CI, Docker frontend stage, dev machines). Node 22 had a jsdom/undici
+# Blob interop quirk that made test behavior version-dependent (#471).
+engine-strict=true

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/web/src/lib/ai-detection/runtime.test.ts
+++ b/web/src/lib/ai-detection/runtime.test.ts
@@ -91,9 +91,10 @@ function setupCacheMock() {
         // Response constructor stringifies it ("[object Blob]", 13 bytes) —
         // the cache "hit" returns garbage, ORT session creation fails, and the
         // runtime's self-heal path purges + re-fetches, breaking the
-        // caches-model test. Node 24+ accepts it, so this only failed in CI
-        // (which pins Node 22). ArrayBuffer bodies are native to undici on
-        // every version.
+        // caches-model test. CI and dev environments now standardize on
+        // Node 24 (which accepts a Blob), but anyone running the suite on
+        // Node 22 would hit this again. ArrayBuffer bodies are native to
+        // undici on every version.
         return new Response(cached.slice(0), { status: 200 });
       }
       return undefined;


### PR DESCRIPTION
## 变更

- `ci.yml` / `release.yml` 的 `setup-node` 22 → 24;`deploy/docker/Dockerfile` 前端构建阶段 `node:22-slim` → `node:24-slim`
- `web/package.json` 增加 `engines.node ">=24"`,`web/.npmrc` 增加 `engine-strict=true` —— Node 22 环境 `npm ci` 直接失败(notsup),从安装入口杜绝版本漂移
- `runtime.test.ts` 注释同步(不再表述为 "CI pins Node 22")

## 背景

#471 排查发现 Node 22 的 jsdom/undici Blob 互操作缺陷使测试行为随 Node 版本漂移(CI 22 红本地 24 绿)。按用户要求全线统一 Node 24,并以 engines 强制。

## 验证

- Node 24:全量 vitest 574/574 通过、`npm ci` 正常
- Node 22:`npm ci` 被 engine-strict 拦截(`EBADENGINE/notsup`)