### PR TITLE
fix(recorder): timelapse-exit GOP flush must skip frames already on disk (#473)

### DIFF
--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -83,6 +83,13 @@ type gopFrame struct {
 	nalu  []byte
 	isIDR bool
 	at    time.Time
+	// written marks frames already on disk in the CURRENT segment (normal-path
+	// writes and sparse keyframes). The timelapse-exit flush must skip them
+	// when writing into the existing segment — re-writing the sparse IDR (the
+	// ring's anchor) produced duplicate POC / dts collisions (issue #473).
+	// A flush that CREATES a fresh segment still writes the whole ring: the
+	// IDR there lands in a new file, which is not a duplicate.
+	written bool
 }
 
 // adaptiveTracker holds the live activity signal and mode state. It is owned
@@ -238,6 +245,13 @@ func (t *adaptiveTracker) spikeBurst(now time.Time) bool {
 	return false
 }
 
+// markTailWritten flags the newest retained frame as already on disk.
+func (t *adaptiveTracker) markTailWritten() {
+	if n := len(t.gop); n > 0 {
+		t.gop[n-1].written = true
+	}
+}
+
 // shouldWriteSparse reports whether a frame observed in TIMELAPSE mode may
 // reach the muxer: keyframes only, at most one per TimelapseInterval.
 func (t *adaptiveTracker) shouldWriteSparse(isIDR bool, now time.Time) bool {
@@ -269,7 +283,8 @@ func (t *adaptiveTracker) appendGOP(nalu []byte, isIDR bool, now time.Time) {
 
 // takeGOP detaches the retained GOP for flushing. Returns nil when the ring
 // is broken (overflowed) or does not start with an IDR (not independently
-// decodable).
+// decodable). Callers skip already-written frames when flushing into an
+// existing segment (issue #473).
 func (t *adaptiveTracker) takeGOP() []gopFrame {
 	frames := t.gop
 	t.gop = nil
@@ -351,6 +366,10 @@ type AdaptiveFrame struct {
 	Nalu  []byte
 	IsIDR bool
 	At    time.Time
+	// Written: the frame is already on disk in the current segment — skip it
+	// when flushing into the existing segment (issue #473); include it when
+	// the flush creates a fresh segment.
+	Written bool
 }
 
 // AdaptiveGate is the exported per-connection adaptive-recording gate for
@@ -388,7 +407,7 @@ func (g *AdaptiveGate) Observe(nalu []byte, isIDR bool, now time.Time) (spike, s
 		// the current frame. Keyed on the flush return, not on mode — observe()
 		// has already switched to NORMAL (same fix as writeFrames).
 		for _, f := range fl {
-			flush = append(flush, AdaptiveFrame{Nalu: f.nalu, IsIDR: f.isIDR, At: f.at})
+			flush = append(flush, AdaptiveFrame{Nalu: f.nalu, IsIDR: f.isIDR, At: f.at, Written: f.written})
 		}
 	}
 	if g.t.mode == adaptiveTimelapse && !spike {
@@ -406,6 +425,15 @@ func (g *AdaptiveGate) Observe(nalu []byte, isIDR bool, now time.Time) (spike, s
 // gate DISK audio writes, which sparse mode drops; live audio continues).
 func (g *AdaptiveGate) Timelapse() bool {
 	return g.t.mode == adaptiveTimelapse
+}
+
+// MarkLastWritten records that the most recently observed frame was
+// successfully written to the current segment, so a later timelapse-exit
+// flush skips it (issue #473). Callers invoke it after a successful muxer
+// write of the frame Observe just classified. No-op when the ring is empty
+// or was detached by a flush.
+func (g *AdaptiveGate) MarkLastWritten() {
+	g.t.markTailWritten()
 }
 
 // ResolveAdaptiveConfig builds a resolved AdaptiveConfig from optional

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -366,3 +366,54 @@ func TestResolveAdaptiveConfig_DefaultsAndOverrides(t *testing.T) {
 		t.Fatalf("overrides wrong: %+v", ac)
 	}
 }
+
+func TestAdaptiveGate_FlushSkipsWrittenFrames(t *testing.T) {
+	cfg := AdaptiveConfig{CalmThreshold: 10 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 3.0, MaxGOPBuffer: 16 << 20}
+	g := NewAdaptiveGate(cfg, "cam", testAdaptiveLogger())
+	t0 := time.Now()
+
+	// IDR + calm → timelapse.
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	g.Observe(idr, true, t0)
+	end := t0.Add(50 * time.Millisecond)
+	for i := range 500 { // 25s calm
+		buf := make([]byte, 800)
+		buf[0] = 0x41
+		g.Observe(buf, false, end.Add(time.Duration(i)*50*time.Millisecond))
+	}
+	end = end.Add(25 * time.Second)
+	if !g.Timelapse() {
+		t.Fatal("want timelapse")
+	}
+
+	// A sparse keyframe is written after the interval: the caller marks it.
+	g.Observe(idr, true, end)             // skipped (within interval)
+	if _, skip, _ := g.Observe(idr, true, end.Add(31*time.Second)); skip {
+		t.Fatal("sparse keyframe must pass")
+	}
+	g.MarkLastWritten() // caller wrote it successfully
+
+	// Skipped P frames accumulate unwritten.
+	p := make([]byte, 800)
+	p[0] = 0x41
+	for i := range 5 {
+		g.Observe(p, false, end.Add((31+time.Duration(i))*time.Second))
+	}
+
+	// Spike exits timelapse: the flush must carry the sparse IDR as Written
+	// (skip into the existing segment) and the skipped P frames as unwritten.
+	big := make([]byte, 300000)
+	big[0] = 0x41
+	_, _, flush := g.Observe(big, false, end.Add(37*time.Second))
+	if len(flush) < 6 {
+		t.Fatalf("flush = %d frames, want >= 6", len(flush))
+	}
+	if !flush[0].IsIDR || !flush[0].Written {
+		t.Fatal("flush anchor must be the written sparse IDR (skipped on disk re-write)")
+	}
+	for i, f := range flush[1:] {
+		if f.Written {
+			t.Fatalf("flush frame %d must be unwritten (it was skipped in sparse mode)", i+1)
+		}
+	}
+}

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -387,7 +387,7 @@ func TestAdaptiveGate_FlushSkipsWrittenFrames(t *testing.T) {
 	}
 
 	// A sparse keyframe is written after the interval: the caller marks it.
-	g.Observe(idr, true, end)             // skipped (within interval)
+	g.Observe(idr, true, end) // skipped (within interval)
 	if _, skip, _ := g.Observe(idr, true, end.Add(31*time.Second)); skip {
 		t.Fatal("sparse keyframe must pass")
 	}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -650,6 +650,11 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 			continue
 		}
 		b.frameCount++
+		if b.adaptive != nil {
+			// The frame just observed into the GOP ring is now on disk; a later
+			// timelapse-exit flush into this segment must skip it (issue #473).
+			b.adaptive.markTailWritten()
+		}
 
 		// Step 10: Check segment duration rollover.
 		if time.Since(b.segStart) >= b.cfg.SegmentDur {
@@ -675,6 +680,12 @@ func (b *baseRecorder) writeFlushedGOP(frames []gopFrame) {
 		return
 	}
 	for _, f := range frames {
+		if b.muxer != nil && f.written {
+			// Already on disk in the current segment (normal-path write or the
+			// sparse keyframe itself) — re-writing it duplicated the ring's IDR
+			// anchor (duplicate POC / dts collision, issue #473).
+			continue
+		}
 		if b.muxer == nil {
 			if !f.isIDR {
 				continue // never start a segment on a P frame

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -722,6 +722,10 @@ func (r *XiaomiRecorder) processH264NALU(nalu []byte, timestamp uint64, lastTime
 		return
 	}
 	r.frameCount++
+	if r.adaptive != nil {
+		// Frame now on disk; a later flush into this segment must skip it (#473).
+		r.adaptive.MarkLastWritten()
+	}
 
 	// Forward to HLS (non-blocking)
 	r.forwardHLS(nalu)
@@ -846,6 +850,10 @@ func (r *XiaomiRecorder) processH265NALU(nalu []byte, timestamp uint64, lastTime
 		return
 	}
 	r.frameCount++
+	if r.adaptive != nil {
+		// Frame now on disk; a later flush into this segment must skip it (#473).
+		r.adaptive.MarkLastWritten()
+	}
 
 	// Forward to HLS (non-blocking)
 	r.forwardHLS(nalu)
@@ -981,6 +989,11 @@ func (r *XiaomiRecorder) writeFlushedGOP(frames []recorder.AdaptiveFrame) {
 		return
 	}
 	for _, f := range frames {
+		if f.Written {
+			// Already on disk in this segment — re-writing duplicates the ring's
+			// IDR anchor (issue #473).
+			continue
+		}
 		pts := f.At.Sub(r.segStart)
 		if pts < 0 {
 			pts = 0


### PR DESCRIPTION
Found by the M5 #435 field test sparse-segment decode spot-check: the first sparse segment of the busy street camera failed decode with `Duplicate POC in a sequence` — the ring's IDR anchor appeared twice (pts 12.138/12.139, identical size).

Root cause: the GOP ring retains every observed frame without a written flag, so the #468 live flush re-wrote already-on-disk frames (the sparse keyframe itself, or a normal-phase GOP head) into the current segment. Latent until #468 made the flush run at all.

Fix: per-frame `written` flag stamped after successful normal-path writes (base + Xiaomi via the gate facade); `writeFlushedGOP` skips written frames when the segment already exists, and still writes the whole ring when the flush creates a fresh segment (cross-file IDR repeat is legal).

Tests: facade-level test asserting the flush carries the sparse IDR as Written and skipped P frames as unwritten; full recorder/xiaomi/camera suites pass. Deployed to M5 (`0.11.0-adaptive-fix-473`, backup `mibee-nvr.bak-0823-pre473`) — post-deploy sparse-segment decode spot-checks are being watched by the 2h field-test cron.

Closes #473.