### PR TITLE
feat(recorder): burst-gated timelapse exit with scene-cut guard; fix spike retention; widen spike_factor range (#475)

### DIFF
--- a/internal/config/config_adaptive_test.go
+++ b/internal/config/config_adaptive_test.go
@@ -56,7 +56,7 @@ func TestValidateRecordingMode_AdaptiveRanges(t *testing.T) {
 		{"interval too short", &AdaptiveRecordingConfig{TimelapseInterval: "1s"}, "timelapse_interval"},
 		{"interval too long", &AdaptiveRecordingConfig{TimelapseInterval: "11m"}, "timelapse_interval"},
 		{"spike too low", &AdaptiveRecordingConfig{SpikeFactor: 1.0}, "spike_factor"},
-		{"spike too high", &AdaptiveRecordingConfig{SpikeFactor: 11}, "spike_factor"},
+		{"spike too high", &AdaptiveRecordingConfig{SpikeFactor: 25}, "spike_factor"},
 		{"buffer too small", &AdaptiveRecordingConfig{GOPBufferBytes: 1 << 10}, "gop_buffer_bytes"},
 		{"buffer too large", &AdaptiveRecordingConfig{GOPBufferBytes: 128 << 20}, "gop_buffer_bytes"},
 		{"bad duration", &AdaptiveRecordingConfig{CalmThreshold: "abc"}, "calm_threshold"},

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -131,7 +131,9 @@ type AdaptiveRecordingConfig struct {
 	TimelapseInterval string `yaml:"timelapse_interval,omitempty" json:"timelapse_interval,omitempty"`
 	// SpikeFactor is how many (MAD-floored) deviations above the P-frame size
 	// baseline count as an activity spike. Default 5.0 (real-camera noise
-	// calibration, issue #466). Range 1.5–10.
+	// calibration, issue #466). Range 1.5–20 — values above ~10 are for
+	// high-noise scenes (e.g. constant cloud movement) where anything lower
+	// never goes sparse (issue #475 field data).
 	SpikeFactor float64 `yaml:"spike_factor,omitempty" json:"spike_factor,omitempty"`
 	// GOPBufferBytes caps the in-memory GOP pre-buffer that makes the
 	// timelapse→normal transition seamless. Default 16MB. Range 1–64MB.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -755,8 +755,8 @@ func ValidateCameraRecordingMode(cam CameraConfig) error {
 			return fmt.Errorf("cameras.%s.adaptive.timelapse_interval must be 5s–10m, got %s", cam.ID, a.TimelapseInterval)
 		}
 	}
-	if a.SpikeFactor != 0 && (a.SpikeFactor < 1.5 || a.SpikeFactor > 10) {
-		return fmt.Errorf("cameras.%s.adaptive.spike_factor must be 1.5–10, got %v", cam.ID, a.SpikeFactor)
+	if a.SpikeFactor != 0 && (a.SpikeFactor < 1.5 || a.SpikeFactor > 20) {
+		return fmt.Errorf("cameras.%s.adaptive.spike_factor must be 1.5–20, got %v", cam.ID, a.SpikeFactor)
 	}
 	if a.GOPBufferBytes != 0 && (a.GOPBufferBytes < 1<<20 || a.GOPBufferBytes > 64<<20) {
 		return fmt.Errorf("cameras.%s.adaptive.gop_buffer_bytes must be 1MB–64MB, got %d", cam.ID, a.GOPBufferBytes)

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -105,6 +105,7 @@ type adaptiveTracker struct {
 	pSizes    []float64
 	median    float64
 	mad       float64
+	floor     float64 // MAD-floored deviation floor from the last recompute
 	lastCalc  time.Time
 	calmSince time.Time // last motion burst (or start); sustained calm enters TIMELAPSE
 
@@ -162,6 +163,14 @@ const (
 	// adaptiveBurstCount is the spike count within the window that resets the
 	// calm accumulation.
 	adaptiveBurstCount = 2
+	// adaptiveMajorFactor scales the spike threshold for a MAJOR spike — a
+	// single frame large enough to exit timelapse on its own (scene cut,
+	// light-on, person appearing): size > median + majorFactor*threshold.
+	// Guards the burst-gated exit against missing one-frame scene changes
+	// (issue #475 field data: an empty room's noise spikes stay under 2x a
+	// factor-10 threshold while real scene cuts clear it by an order of
+	// magnitude).
+	adaptiveMajorFactor = 2.0
 )
 
 // observe ingests one VCL NALU (without start code), updates the activity
@@ -199,12 +208,18 @@ func (t *adaptiveTracker) observe(nalu []byte, isIDR bool, now time.Time) (spike
 			t.lastSparseWrite = now
 		}
 	case adaptiveTimelapse:
-		if spike {
-			// Any single spike exits sparse mode. The exit itself is evidence
-			// of activity, so a fresh CalmThreshold window is required before
-			// re-entering TIMELAPSE (prevents spike → exit → instant re-entry
-			// oscillation, since the burst rule above does not fire on
-			// isolated spikes).
+		// Exit is burst-gated like entry (issue #475 field data: on a camera
+		// confirmed recording an empty scene all day, every isolated noise
+		// spike exited sparse mode and cost a fresh CalmThreshold of full-rate
+		// writing — timelapse share 2% where the scene was 100% static). A
+		// single MAJOR spike (scene-cut scale) still exits alone: one-frame
+		// scene changes (light on, person appearing) must resume recording
+		// immediately. Real motion always clusters, so the burst path covers it.
+		if spike && (t.spikeBurst(now) || t.majorSpike(size)) {
+			// The exit itself is evidence of activity, so a fresh CalmThreshold
+			// window is required before re-entering TIMELAPSE (prevents spike →
+			// exit → instant re-entry oscillation, since the entry reset does
+			// not fire on isolated spikes).
 			t.calmSince = now
 			flush = t.takeGOP()
 			t.setMode(adaptiveNormal, now)
@@ -225,7 +240,18 @@ func (t *adaptiveTracker) recordSpike(now time.Time) {
 		}
 		break
 	}
-	t.recentSpikes = append(t.recentSpikes[drop:drop:drop], now)
+	// Shift retained spikes left in place, then append. The previous
+	// `append(t.recentSpikes[drop:drop:drop], now)` silently DISCARDED the
+	// retained tail when drop == 0 (full-slice expr caps capacity at 0), so
+	// only the newest spike ever survived and spikeBurst never saw a pair —
+	// the burst rules (entry calm-reset and, from #475, the timelapse exit)
+	// were dead in production from #468 until the burst-gated-exit unit test
+	// caught it.
+	if drop > 0 {
+		n := copy(t.recentSpikes, t.recentSpikes[drop:])
+		t.recentSpikes = t.recentSpikes[:n]
+	}
+	t.recentSpikes = append(t.recentSpikes, now)
 }
 
 // spikeBurst reports whether the recent spikes within the burst window reach
@@ -315,11 +341,17 @@ func (t *adaptiveTracker) classify(size int, now time.Time) bool {
 	if t.median <= 0 {
 		return false
 	}
-	floor := t.mad
-	if minFloor := t.median * 0.08; floor < minFloor {
-		floor = minFloor
+	t.floor = t.mad
+	if minFloor := t.median * 0.08; t.floor < minFloor {
+		t.floor = minFloor
 	}
-	return float64(size) > t.median+t.cfg.SpikeFactor*floor
+	return float64(size) > t.median+t.cfg.SpikeFactor*t.floor
+}
+
+// majorSpike reports whether the frame is a scene-cut-scale outlier: big
+// enough to leave timelapse on its own despite the burst-gated exit.
+func (t *adaptiveTracker) majorSpike(size int) bool {
+	return t.median > 0 && float64(size) > t.median+adaptiveMajorFactor*t.cfg.SpikeFactor*t.floor
 }
 
 // recomputeBaseline derives median and MAD over the retained size window.

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -417,3 +417,75 @@ func TestAdaptiveGate_FlushSkipsWrittenFrames(t *testing.T) {
 		}
 	}
 }
+
+func TestAdaptiveTracker_BurstGatedExit(t *testing.T) {
+	cfg := AdaptiveConfig{CalmThreshold: 10 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 3.0, MaxGOPBuffer: 16 << 20}
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+	t0 := time.Now()
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	tr.observe(idr, true, t0)
+	end := feedCalm(t, tr, t0.Add(50*time.Millisecond), 500) // 25s → TIMELAPSE
+	if tr.mode != adaptiveTimelapse {
+		t.Fatal("want timelapse")
+	}
+
+	// Thresholds for the 800-byte calm baseline: median=800, MAD=0 → floor=64.
+	// spike thr = 800+3*64 = 992; major thr = 800+2*3*64 = 1184.
+	isolated := make([]byte, 1100) // 992 < 1100 < 1184: spike but not major
+	isolated[0] = 0x41
+
+	// Isolated noise spikes (far apart) must NOT exit timelapse (#475).
+	tr.observe(isolated, false, end)
+	if tr.mode != adaptiveTimelapse {
+		t.Fatal("isolated non-major spike must not exit timelapse")
+	}
+	tr.observe(isolated, false, end.Add(61*time.Second))
+	if tr.mode != adaptiveTimelapse {
+		t.Fatal("still timelapse after a second isolated spike")
+	}
+
+	// A spike burst (two within 2s) exits.
+	tr.observe(isolated, false, end.Add(130*time.Second))
+	if tr.mode != adaptiveTimelapse {
+		t.Fatal("first spike of a pair must not exit alone")
+	}
+	tr.observe(isolated, false, end.Add(131*time.Second))
+	if tr.mode == adaptiveTimelapse {
+		t.Fatal("spike burst (2 within 2s) must exit timelapse")
+	}
+
+	// A MAJOR single spike (scene-cut scale) exits alone — the light-on /
+	// person-appearing guard.
+	feedCalm(t, tr, end.Add(131*time.Second), 800) // 40s > 10s calm → re-enter
+	if tr.mode != adaptiveTimelapse {
+		t.Fatal("want timelapse re-entry after calm")
+	}
+	major := make([]byte, 8000) // >> 1184
+	major[0] = 0x41
+	// Flush is nil here by design: the burst exit already detached the
+	// IDR-anchored ring and no IDR has arrived since, so there is nothing
+	// independently decodable to flush (takeGOP returns nil). Only the exit
+	// itself is asserted.
+	tr.observe(major, false, end.Add(175*time.Second))
+	if tr.mode == adaptiveTimelapse {
+		t.Fatal("major single spike must exit timelapse")
+	}
+}
+
+func TestAdaptiveTracker_SpikeRetention(t *testing.T) {
+	tr := &adaptiveTracker{}
+	now := time.Now()
+	tr.recordSpike(now)
+	tr.recordSpike(now.Add(100 * time.Millisecond))
+	if len(tr.recentSpikes) != 2 {
+		t.Fatalf("recentSpikes = %d entries, want 2 (retention must survive a zero-drop append)", len(tr.recentSpikes))
+	}
+	if !tr.spikeBurst(now.Add(100 * time.Millisecond)) {
+		t.Fatal("two spikes within the burst window must register as a burst")
+	}
+	// A spike after the window keeps only itself.
+	tr.recordSpike(now.Add(10 * time.Second))
+	if len(tr.recentSpikes) != 1 || !tr.recentSpikes[0].Equal(now.Add(10*time.Second)) {
+		t.Fatalf("recentSpikes = %v, want only the newest", tr.recentSpikes)
+	}
+}

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -934,7 +934,7 @@ async function performCameraSave() {
           </div>
           <div>
             <label for="cam-adaptive-spike" class="input-label">{t('cameras.adaptiveSpikeFactor')}</label>
-            <input id="cam-adaptive-spike" class="input" type="number" step="0.1" min="1.5" max="10" placeholder="5.0" bind:value={formAdaptiveSpikeFactor} />
+            <input id="cam-adaptive-spike" class="input" type="number" step="0.1" min="1.5" max="20" placeholder="5.0" bind:value={formAdaptiveSpikeFactor} />
           </div>
           <div>
             <label for="cam-adaptive-gop" class="input-label">{t('cameras.adaptiveGopBufferMB')}</label>


### PR DESCRIPTION
Ground truth from the M5 #435 field test: all three test cameras recorded **empty scenes** all day (user-confirmed) — so every full-rate NORMAL window was over-recording. On the static studio camera timelapse share was **2%**: isolated noise spikes kept exiting sparse mode, each exit costing a fresh 60s CalmThreshold of full-rate writing (~100 exits/day on an empty room).

## Changes

1. **Burst-gated timelapse exit** (`spike && (burst within 2s || single frame >= 2x spike threshold)`) — symmetric with the #466 entry rule. The major-spike guard keeps one-frame scene changes (light on, person appearing then freezing) resuming full-rate immediately; real motion always produces spike clusters. Replay on real capture: static cam at factor 10, TL share 60.1% → **90.1%**.
2. **Fixed `recordSpike` retention** — `append(recentSpikes[drop:drop:drop], now)` silently discarded the retained tail when drop==0 (full-slice expression caps capacity at 0), so `spikeBurst` never saw a pair: the #466 entry-side burst rule was dead in production, masked by the raised default factor and the exit-resets-calm path. Caught by the new burst-gated-exit unit test.
3. **spike_factor range 1.5–10 → 1.5–20** (default stays 5.0): a rooftop camera under constant cloud movement measured 0% TL at every factor ≤10 (clouds are real pixel change to the encoder); single-spike-exit at factor 20 reaches 72.8%. High-noise scenes need the headroom as a per-camera override.

## Tests
Retention regression test (pair retention + window trimming), burst-gated exit (isolated no-exit / burst exit / major exit), range-boundary update. recorder/xiaomi/camera/config suites pass.

## M5 live
Deployed `0.11.0-adaptive-fix-475` (backup `mibee-nvr.bak-0823-pre475`); per-camera tuning applied hot: studio camera `spike_factor=10`, rooftop `spike_factor=15`, patrolling stairwell cam left at defaults (its motion is the camera's own patrol — full-rate there is correct; ~18MB/h anyway). The 2h field-test cron continues watching TL share and sparse-segment decode health.

Closes #475.