### PR TITLE
fix(test): wsstream rebind test must assert decoded frame identity, not raw bytes

### DIFF
--- a/internal/wsstream/rebind_test.go
+++ b/internal/wsstream/rebind_test.go
@@ -57,26 +57,38 @@ func TestRebindHub(t *testing.T) {
 	// hub's, not the stale one.)
 	broadcastFrame(t, oldHub, 2000, [][]byte{{0xAA}})
 	broadcastFrame(t, newHub, 3000, [][]byte{{0xFF, 0xD8, 0x01}})
+	// Assert by DECODED identity (type + pts), never by scanning raw bytes:
+	// every video-frame message ends with the 8-byte IngestAt wallclock
+	// (#469), whose bytes cycle through 0x00-0xFF — a raw scan for the 0xAA
+	// marker false-positives ~0.4% of runs purely on timestamp luck (bit us on
+	// two consecutive main-branch CI runs).
 	msg, err := readMessage(t, conn)
 	if err != nil {
 		t.Fatalf("frame after rebind: %v", err)
 	}
-	for _, b := range msg {
-		if b == 0xAA {
-			t.Fatalf("stale frame from old hub leaked after rebind: % X", msg)
-		}
+	vf, err := decodeVideoFrame(msg)
+	if err != nil {
+		t.Fatalf("decode frame after rebind: %v", err)
 	}
-	// The next message (if any) also must not carry the stale marker.
+	if vf.PTS != 3000 {
+		t.Fatalf("first frame after rebind has pts=%d, want 3000 (new hub) — old-hub frame leaked", vf.PTS)
+	}
+	// Queued messages (if any) also must not be the stale frame.
 	conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
 	for {
 		_, msg2, err := conn.ReadMessage()
 		if err != nil {
 			break // timeout/closed — done
 		}
-		for _, b := range msg2 {
-			if b == 0xAA {
-				t.Fatalf("stale frame from old hub leaked after rebind (queued): % X", msg2)
-			}
+		if len(msg2) == 0 || msg2[0] != MsgTypeVideoFrame {
+			continue
+		}
+		vf2, err := decodeVideoFrame(msg2)
+		if err != nil {
+			t.Fatalf("decode queued frame: %v", err)
+		}
+		if vf2.PTS == 2000 {
+			t.Fatalf("stale frame from old hub leaked after rebind (queued): pts=%d", vf2.PTS)
 		}
 	}
 }


### PR DESCRIPTION
Un flakes the red main-branch CI after #474/#476: `TestRebindHub` scanned every raw message byte for the `0xAA` stale marker, but video-frame messages end with the 8-byte IngestAt wallclock added in #469 — its bytes cycle through the full 0x00-0xFF range, so the timestamp alone trips the scan ~0.4% of runs. Both main-branch pushes hit it (PR runs happened to land lucky timestamps); the merged recorder changes were unrelated.

The test now asserts decoded identity: first post-rebind frame must carry the new hub's pts (3000); queued frames must never carry the stale pts (2000). 30 consecutive runs + full wsstream suite green.