### PR TITLE
fix(recorder): GOP 预缓冲默认 16→32MB + 溢出 WARN（#485）

### DIFF
--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -144,7 +144,9 @@ type AdaptiveRecordingConfig struct {
 	// never goes sparse (issue #475 field data).
 	SpikeFactor float64 `yaml:"spike_factor,omitempty" json:"spike_factor,omitempty"`
 	// GOPBufferBytes caps the in-memory GOP pre-buffer that makes the
-	// timelapse→normal transition seamless. Default 16MB. Range 1–64MB.
+	// timelapse→normal transition seamless. Default 32MB (must hold one full
+	// camera GOP — 2K cameras with IDR intervals near the 30s timelapse
+	// cadence overflow 16MB and lose the flush, issue #485). Range 1–64MB.
 	GOPBufferBytes int64 `yaml:"gop_buffer_bytes,omitempty" json:"gop_buffer_bytes,omitempty"`
 }
 

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -64,7 +64,13 @@ func DefaultAdaptiveConfig() AdaptiveConfig {
 		CalmThreshold:     60 * time.Second,
 		TimelapseInterval: 30 * time.Second,
 		SpikeFactor:       5.0,
-		MaxGOPBuffer:      16 << 20, // 16MB ≈ 64s @ 2Mbps — far above any sane GOP
+		// 32MB: the ring must hold one full camera GOP. 16MB was sized for
+		// ~4s GOPs; a 2K H.265 camera whose IDR interval approaches the 30s
+		// timelapse cadence (~12-15MB average, more with motion spikes)
+		// overflows it, breaking the ring — the next timelapse exit then
+		// flushes nothing and its P-frames land with dangling references
+		// ("Could not find ref with POC" at decode, issue #485 field data).
+		MaxGOPBuffer: 32 << 20, // ≈ 75s @ 3.5Mbps — above a 30s GOP at 2K
 	}
 }
 
@@ -158,7 +164,7 @@ func newAdaptiveTracker(cfg AdaptiveConfig, camID string, log *slog.Logger) *ada
 		cfg.TimelapseInterval = 30 * time.Second
 	}
 	if cfg.MaxGOPBuffer <= 0 {
-		cfg.MaxGOPBuffer = 16 << 20
+		cfg.MaxGOPBuffer = 32 << 20
 	}
 	return &adaptiveTracker{
 		cfg:       cfg,
@@ -347,7 +353,15 @@ func (t *adaptiveTracker) appendGOP(nalu []byte, isIDR bool, now time.Time) {
 	size := int64(len(nalu))
 	if t.gopBytes+size > t.cfg.MaxGOPBuffer {
 		// Pathological GOP (e.g. intra-refresh encoders with no discrete
-		// IDR): retaining is pointless — degrade to no-flush transitions.
+		// IDR, or an IDR interval long enough to overflow the cap): retaining
+		// is pointless — degrade to no-flush transitions. The next exit
+		// writes its P-frames with dangling references (decode artifacts
+		// until the following IDR), so make the condition observable.
+		if !t.gopBroken {
+			t.log.Warn("adaptive GOP pre-buffer overflowed — timelapse exits will flush nothing until the next IDR",
+				"gop_bytes", t.gopBytes, "max_gop_buffer", t.cfg.MaxGOPBuffer,
+				"hint", "raise adaptive.gop_buffer_bytes for this camera")
+		}
 		t.gopBroken = true
 		t.gop = t.gop[:0]
 		t.gopBytes = 0

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -358,7 +358,7 @@ func TestAdaptiveGate_SparseSkipAndFlushFacade(t *testing.T) {
 
 func TestResolveAdaptiveConfig_DefaultsAndOverrides(t *testing.T) {
 	ac := ResolveAdaptiveConfig("", "", 0, 0)
-	if ac != (AdaptiveConfig{CalmThreshold: 60 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 5.0, MaxGOPBuffer: 16 << 20}) {
+	if ac != (AdaptiveConfig{CalmThreshold: 60 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 5.0, MaxGOPBuffer: 32 << 20}) {
 		t.Fatalf("defaults wrong: %+v", ac)
 	}
 	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20)


### PR DESCRIPTION
> 基于 #484（stacked，先合那个）。

Closes #485。2K H.265 相机 IDR 间隔接近 30s 稀疏节奏时，GOP 环均值 12–15MB（云层尖峰下更高）越过 16MB 默认上限：`gopBroken` 锁存 → `takeGOP()` 恒 nil → TL 退出 flush 为空 → 触发帧悬空参考（`Could not find ref with POC`，实机稀疏段 POC 4/18 两处）。溢出此前完全无日志。

- 默认 `MaxGOPBuffer` 16MB → 32MB（≈75s @ 3.5Mbps；校验范围 1–64MB 不变；每 adaptive 相机峰值内存 +16MB）
- `appendGOP` 首次溢出打一条 WARN（gop_bytes + 按相机上调提示）——若某相机仍缺 POC 且无此日志，即另有根因，日志是分界证据
- 复现：`gop_buffer_bytes: 1048576`（合法下限）可稳定复现