### PR TITLE
fix(web): Flow 双前缀 404 + 链路并入仪表盘 tab + 录像详情活动热力条

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787492645669';
+const CACHE_VERSION = 'mibee-nvr-1787526820896';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -16,7 +16,6 @@
     surveillance: () => import('./routes/Surveillance.svelte'),
     settings: () => import('./routes/Settings.svelte'),
     dashboard: () => import('./routes/Dashboard.svelte'),
-    flow: () => import('./routes/Flow.svelte'),
     'transcoding-history': () => import('./routes/TranscodingHistory.svelte'),
     'ai-events': () => import('./routes/AIEvents.svelte'),
   };
@@ -149,11 +148,18 @@ function parseRoute(hash: string) {
     }
 
     if (segments[0] === 'dashboard') {
-      const tab = segments[1] === 'health' ? 'health' : segments[1] === 'transcoding' ? 'transcoding' : 'storage';
+      const tab = segments[1] === 'health'
+        ? 'health'
+        : segments[1] === 'flow'
+          ? 'flow'
+          : segments[1] === 'transcoding'
+            ? 'transcoding'
+            : 'storage';
       return { route: 'dashboard', params: { tab } };
     }
+    // Legacy standalone flow route → dashboard tab.
     if (segments[0] === 'flow') {
-      return { route: 'flow', params: {} };
+      return { route: 'dashboard', params: { tab: 'flow' } };
     }
     if (segments[0] === 'surveillance') {
       return { route: 'surveillance', params: {} };

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -92,7 +92,6 @@
     { href: '#/cameras', labelKey: 'nav.cameras', route: '/cameras' },
     { href: '#/recordings', labelKey: 'nav.recordings', route: '/recordings' },
     ...(miBeeVisionConnected ? [{ href: '#/ai-events', labelKey: 'nav.aiEvents', route: '/ai-events' }] : []),
-    { href: '#/flow', labelKey: 'nav.flow', route: '/flow' },
     { href: '#/dashboard', labelKey: 'nav.dashboard', route: '/dashboard' },
     { href: '#/settings', labelKey: 'nav.settings', route: '/settings' },
   ]);

--- a/web/src/lib/api/flow.ts
+++ b/web/src/lib/api/flow.ts
@@ -50,5 +50,8 @@ export interface FlowStreamsResponse {
 
 /** Fetch the flow-path snapshot for all cameras. */
 export async function getFlowStreams(): Promise<FlowStreamsResponse> {
-  return apiRequest<FlowStreamsResponse>('/api/streams');
+  // NOTE: apiRequest prepends API_BASE which already ends in /api — the
+  // endpoint must NOT start with /api (the original '/api/streams' produced
+  // /api/api/streams → 404 in production).
+  return apiRequest<FlowStreamsResponse>('/streams');
 }

--- a/web/src/lib/components/FlowPanel.svelte
+++ b/web/src/lib/components/FlowPanel.svelte
@@ -5,7 +5,7 @@
   import type { FlowStream } from '$lib/api/flow';
   import type { Camera, HealthEvent } from '$lib/api';
   import { t } from '$lib/i18n';
-  import { Activity, Users, Gauge, Radio } from 'lucide-svelte';
+  import { Users, Gauge, Radio } from 'lucide-svelte';
 
   const POLL_INTERVAL = 2000;
   const EVENTS_REFRESH = 30_000;
@@ -120,9 +120,8 @@
   }
 </script>
 
-<div class="flow-page">
+<div class="flow-panel">
   <div class="flow-header">
-    <h1><Activity size={22} /> {t('flow.title')}</h1>
     <p class="subtitle">{t('flow.subtitle')}</p>
     {#if lastUpdated}
       <span class="updated">{t('flow.updatedAt')}: {lastUpdated.toLocaleTimeString()}</span>
@@ -225,10 +224,8 @@
 </div>
 
 <style>
-  .flow-page {
-    padding: 1.5rem;
-    max-width: 1200px;
-    margin: 0 auto;
+  .flow-panel {
+    margin-top: 1rem;
   }
   .flow-header {
     display: flex;

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1713,7 +1713,6 @@
   "settings.motionAwareCleanupOn": "Evicts boring segments first",
   "settings.motionAwareCleanupOff": "Evicts oldest first",
   "settings.motionAwareCleanupHint": "When the disk threshold is hit, delete the lowest-motion (calmest) recordings first; off = oldest-first.",
-  "nav.flow": "Flow",
   "flow.title": "Stream Flow",
   "flow.subtitle": "Live frame pipeline: producer → StreamHub → consumers (fps/bitrate derived by diffing polls)",
   "flow.updatedAt": "Updated",
@@ -1732,5 +1731,11 @@
   "flow.noViewers": "no viewers",
   "flow.liveLatency": "end-to-end latency",
   "health.stability.uptime": "24h uptime",
-  "health.stability.mtbf": "mean time between failures"
+  "health.stability.mtbf": "mean time between failures",
+  "dashboard.tab.flow": "Flow",
+  "detail.activity.title": "Activity",
+  "detail.activity.score": "activity score",
+  "detail.activity.noScore": "not analyzed",
+  "detail.activity.current": "current",
+  "detail.activity.hint": "green=calm → red=busy; click to jump to that recording"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1712,7 +1712,6 @@
   "settings.motionAwareCleanupOn": "优先删除安静片段",
   "settings.motionAwareCleanupOff": "按时间顺序删除",
   "settings.motionAwareCleanupHint": "磁盘达到阈值时，优先删除活动分最低（画面安静）的录像；关闭后按最旧优先删除。",
-  "nav.flow": "链路",
   "flow.title": "视频链路",
   "flow.subtitle": "实时帧流水线:采集 → StreamHub → 消费者(fps/码率由两次轮询差分计算)",
   "flow.updatedAt": "更新于",
@@ -1731,5 +1730,11 @@
   "flow.noViewers": "无观看者",
   "flow.liveLatency": "端到端延迟",
   "health.stability.uptime": "24h 在线率",
-  "health.stability.mtbf": "平均无故障时间"
+  "health.stability.mtbf": "平均无故障时间",
+  "dashboard.tab.flow": "链路",
+  "detail.activity.title": "活动热力",
+  "detail.activity.score": "活动分",
+  "detail.activity.noScore": "未分析",
+  "detail.activity.current": "本段",
+  "detail.activity.hint": "绿=平静 → 红=活跃;点击跳转该录像"
 }

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -4,9 +4,10 @@
   import type { StorageStats, Camera, HealthResponse, SystemStats, CameraHealthDetail } from '$lib/api';
   import { t } from '$lib/i18n';
   import { formatFileSize } from '$lib/format';
-  import { Cpu, MemoryStick, HardDrive, Wifi, Activity, CircleCheck, AlertCircle, CirclePause, BarChart3, Loader2 } from 'lucide-svelte';
+  import { Cpu, MemoryStick, HardDrive, Wifi, Activity, CircleCheck, AlertCircle, CirclePause, BarChart3, Loader2, Radio } from 'lucide-svelte';
   import { loadChart, createTrendChart } from '$lib/charts';
   import Tab from '$lib/components/Tab.svelte';
+  import FlowPanel from '$lib/components/FlowPanel.svelte';
   import HealthHistory from './HealthHistory.svelte';
   import TranscodingHistory from './TranscodingHistory.svelte';
   import AiStatusCard from '../components/AiStatusCard.svelte';
@@ -23,6 +24,7 @@
   let tabs = $derived([
     { id: 'storage', label: t('dashboard.tab.storage'), icon: HardDrive },
     { id: 'health', label: t('dashboard.tab.health'), icon: Activity },
+    { id: 'flow', label: t('dashboard.tab.flow'), icon: Radio },
     { id: 'transcoding', label: t('dashboard.tab.transcoding'), icon: Cpu },
   ]);
 
@@ -491,6 +493,8 @@
       <div class="health-tab-content">
         <HealthHistory />
       </div>
+    {:else if activeTab === 'flow'}
+      <FlowPanel />
     {:else if activeTab === 'transcoding'}
       <TranscodingHistory />
     {/if}

--- a/web/src/routes/RecordingDetail.svelte
+++ b/web/src/routes/RecordingDetail.svelte
@@ -22,6 +22,7 @@
   import MergePanel from './recordings/MergePanel.svelte';
   import PlaybackPanel from './recordings/PlaybackPanel.svelte';
   import MetaEditor from './recordings/MetaEditor.svelte';
+  import RecordingActivityStrip from './recordings/RecordingActivityStrip.svelte';
 
   let { recordingId = '' } = $props();
   let currentId = $state('');
@@ -348,6 +349,9 @@
             oncrosssegment={handleCrossSegment}
           />
         </div>
+
+        <!-- Activity heat strip: this recording's motion score in the day's context -->
+        <RecordingActivityStrip {recording} />
 
         <!-- Recording info + actions + transcode status -->
         <MetaEditor

--- a/web/src/routes/recordings/RecordingActivityStrip.svelte
+++ b/web/src/routes/recordings/RecordingActivityStrip.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  /**
+   * Per-recording activity heat strip (#470 follow-up): shows the recording's
+   * own motion score plus a day-wide heat strip of the SAME camera's segments
+   * (green = calm → red = busy, identical coloring to the Recordings day
+   * timeline), with the current recording outlined. Clicking another band
+   * navigates to that recording's detail page — the activity context the
+   * Recordings page has, now available while watching a specific recording.
+   */
+  import { onMount } from 'svelte';
+  import { getRecordingsTimeline } from '$lib/api';
+  import type { Recording, RecordingTimelineSegment } from '$lib/api';
+  import { t } from '$lib/i18n';
+  import { Flame } from 'lucide-svelte';
+
+  let { recording }: { recording: Recording } = $props();
+
+  let segments = $state<RecordingTimelineSegment[]>([]);
+  let dayStart = $state(0);
+  let dayEnd = $state(0);
+  let failed = $state(false);
+
+  // Same heat coloring as DayTimeline.svelte (green→red by motion_score).
+  function heatColor(score: number): string {
+    const hue = Math.max(0, Math.round(120 - Math.min(1, Math.max(0, score)) * 120));
+    return `hsl(${hue} 65% 42%)`;
+  }
+
+  function isVideo(fmt?: string): boolean {
+    return fmt === 'h264' || fmt === 'h265';
+  }
+
+  function bandStyle(seg: RecordingTimelineSegment): string {
+    const start = new Date(seg.started_at).getTime();
+    const end = new Date(seg.ended_at).getTime();
+    const left = ((start - dayStart) / (dayEnd - dayStart)) * 100;
+    const width = Math.max(0.15, ((end - start) / (dayEnd - dayStart)) * 100);
+    let bg = 'var(--text-tertiary, #9ca3af)';
+    if (isVideo(seg.format) && (seg.motion_score ?? -1) >= 0) {
+      bg = heatColor(seg.motion_score!);
+    } else if (isVideo(seg.format)) {
+      bg = 'rgba(96, 165, 250, 0.45)'; // analyzed-pending video band
+    }
+    return `left: ${left}%; width: ${width}%; background: ${bg};`;
+  }
+
+  function isCurrent(seg: RecordingTimelineSegment): boolean {
+    return seg.id === recording.id;
+  }
+
+  function fmtTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+
+  function go(seg: RecordingTimelineSegment): void {
+    if (!isCurrent(seg)) {
+      window.location.hash = `#/recordings/${seg.id}`;
+    }
+  }
+
+  onMount(async () => {
+    // Local-midight-to-midnight window containing this recording.
+    const d = new Date(recording.started_at);
+    const start = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const end = new Date(start.getTime() + 24 * 3600 * 1000);
+    dayStart = start.getTime();
+    dayEnd = end.getTime();
+    try {
+      const resp = await getRecordingsTimeline({
+        camera_id: recording.camera_id,
+        start: start.toISOString(),
+        end: end.toISOString(),
+      });
+      segments = resp.segments ?? [];
+    } catch {
+      failed = true; // strip silently hidden — non-critical context UI
+    }
+  });
+</script>
+
+{#if !failed && segments.length > 0}
+  <div class="card p-4 border th-border space-y-3">
+    <div class="flex items-center gap-3 flex-wrap">
+      <span class="text-sm font-medium th-text-primary flex items-center gap-1.5">
+        <Flame size={14} /> {t('detail.activity.title')}
+      </span>
+      {#if isVideo(recording.format)}
+        {#if (recording.motion_score ?? -1) >= 0}
+          <span
+            class="text-xs font-semibold px-2 py-0.5 rounded-full tabular-nums text-white"
+            style="background: {heatColor(recording.motion_score!)}"
+            title={t('detail.activity.score')}
+          >
+            {recording.motion_score!.toFixed(2)}
+          </span>
+          {#if recording.activity_flags}
+            <span class="text-xs th-text-secondary">{recording.activity_flags}</span>
+          {/if}
+        {:else}
+          <span class="text-xs th-text-muted">{t('detail.activity.noScore')}</span>
+        {/if}
+      {/if}
+      <span class="text-xs th-text-muted ml-auto">{t('detail.activity.hint')}</span>
+    </div>
+
+    <div class="heat-strip" role="img" aria-label={t('detail.activity.title')}>
+      {#each segments as seg (seg.id)}
+        <button
+          type="button"
+          class="band {isCurrent(seg) ? 'band-current' : ''}"
+          style={bandStyle(seg)}
+          title="{fmtTime(seg.started_at)}–{fmtTime(seg.ended_at)} · {t('detail.activity.score')}: {seg.motion_score != null && seg.motion_score >= 0 ? seg.motion_score.toFixed(2) : t('detail.activity.noScore')}{isCurrent(seg) ? ' · ' + t('detail.activity.current') : ''}"
+          onclick={() => go(seg)}
+        ></button>
+      {/each}
+      <div class="now-marker" style="left: {(Math.min(Date.now(), dayEnd) - dayStart) / (dayEnd - dayStart) * 100}%"></div>
+    </div>
+    <div class="flex justify-between text-[10px] th-text-muted tabular-nums">
+      <span>00:00</span><span>06:00</span><span>12:00</span><span>18:00</span><span>24:00</span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .heat-strip {
+    position: relative;
+    height: 22px;
+    border-radius: 6px;
+    background: rgba(128, 128, 128, 0.12);
+    overflow: hidden;
+  }
+  .band {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    min-width: 1px;
+    opacity: 0.85;
+  }
+  .band:hover {
+    opacity: 1;
+  }
+  .band-current {
+    outline: 2px solid currentColor;
+    outline-offset: -2px;
+    opacity: 1;
+    z-index: 2;
+    cursor: default;
+  }
+  .now-marker {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(255, 255, 255, 0.7);
+    z-index: 3;
+    pointer-events: none;
+  }
+</style>


### PR DESCRIPTION
## 修复与改进

真机验证反馈:链路页 404 打不开。复查后修复,并按要求完成两项 UX 调整。

### 1. 链路页 404(根因:API 客户端双前缀)

\`flow.ts\` 调 \`apiRequest('/api/streams')\`,而 \`apiRequest\` 已拼 \`API_BASE\`(=\`/api\`)→ 实际请求 \`/api/api/streams\` → 404。改为 \`'/streams'\`。已全局复查本会话新增的其它 API 调用,无同类问题。

### 2. 链路并入仪表盘(不再独立一页)

- \`Flow.svelte\` → \`FlowPanel.svelte\` 组件,作为 Dashboard 第四个 tab:**存储 / 健康 / 链路 / 转码**(\`#/dashboard/flow\`)
- 旧链接 \`#/flow\` 重定向到 \`#/dashboard/flow\`;移除顶部导航独立"链路"入口

### 3. 录像详情页活动热力条

新增 \`RecordingActivityStrip\`(插在播放器与信息卡之间):

- 本录像的 motion_score 徽章(与列表页同款绿→红配色)+ activity_flags
- 同相机当日 24h 热力条:相邻 segment 按分数着色、当前录像高亮描边、"现在"时间线、hover 显示时间段+分数,**点击相邻段直接跳转该录像详情**
- 数据复用 \`/api/recordings/timeline\`(轻量 7 字段),零新后端代码;加载失败静默隐藏

## 验证(Playwright 对 M5 实测,真机 5 相机在线)

- Dashboard → 链路 tab:**14 张相机卡片、15.1 fps、37 个消费者行**,无 \`/api/api\` 404
- 录像详情:热力条 **214 段、当前段高亮**
- 全量 vitest 574/574;截图见 PR 描述外链(tmp/flow-tab.png、tmp/detail-activity.png)
- 控制台剩余项均为已知良性:\`gateway-session\` 401(匿名探测,预期)、WHEP 卸载 DELETE 404(播放器销毁清理,代码已吞)
