### PR TITLE
fix(merge): 关键帧对齐缝合——合并产物每段必须从 IDR 开始 (#488)

### DIFF
--- a/internal/merge/manager.go
+++ b/internal/merge/manager.go
@@ -439,11 +439,37 @@ func (m *MergeManager) mergeFormatGroup(ctx context.Context, cameraID, format st
 			continue
 		}
 
-		if err := MergeMP4Segments(ctx, segmentInfos, tempPath); err != nil {
+		stats, err := MergeMP4Segments(ctx, segmentInfos, tempPath)
+		if err != nil {
 			logger.Error("failed to merge MP4 segments", "camera_id", cameraID, "error", err)
 			os.Remove(tempPath)
 			m.metrics.RecordMergeFailure("merge_error")
 			continue
+		}
+		// Keyframe-less segments were skipped by the merge (#488): mark them
+		// incompatible and exclude them from the replacement/deletion set —
+		// their samples are NOT in the output.
+		if len(stats.SkippedNoKeyframe) > 0 {
+			skipIDs := make([]string, 0, len(stats.SkippedNoKeyframe))
+			for _, idx := range stats.SkippedNoKeyframe {
+				skipIDs = append(skipIDs, recordings[idx].ID)
+			}
+			if err := storage.RetryOnBusy(ctx, func() error {
+				return m.db.SetMergeStatus(ctx, skipIDs, model.MergeStatusIncompatible)
+			}); err != nil {
+				logger.Warn("failed to mark keyframe-less segments", "error", err)
+			}
+			logger.Warn("periodic merge skipped keyframe-less segments",
+				"camera_id", cameraID, "skipped", len(skipIDs))
+			if len(stats.Included) > 0 {
+				keepRecs := make([]*model.Recording, 0, len(stats.Included))
+				keepInfos := make([]*SegmentInfo, 0, len(stats.Included))
+				for _, idx := range stats.Included {
+					keepRecs = append(keepRecs, recordings[idx])
+					keepInfos = append(keepInfos, segmentInfos[idx])
+				}
+				recordings, segmentInfos = keepRecs, keepInfos
+			}
 		}
 
 		// Verify merged file exists and has content.

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -44,13 +44,126 @@ type mergedSample struct {
 	isKeyFrame bool
 }
 
+// MergeStats reports how a merge consumed its inputs after keyframe alignment.
+type MergeStats struct {
+	// Included holds the input indexes whose samples are present in the output.
+	Included []int
+	// SkippedNoKeyframe holds input indexes dropped entirely: their video track
+	// had no keyframe sample, so they cannot join a merged reference chain (#488).
+	SkippedNoKeyframe []int
+	// LeadingDropped maps input index → count of leading video samples dropped
+	// to reach that segment's first keyframe.
+	LeadingDropped map[int]int
+}
+
+// ErrNoKeyframe is returned when no input segment carries a keyframe sample —
+// nothing decodable can be produced from the inputs.
+var ErrNoKeyframe = errors.New("no keyframe-bearing segments")
+
+// AlignToKeyframe trims seg's leading video samples up to (and including the
+// position of) its first keyframe and trims the audio head by the same wall
+// duration so A/V still start together. A segment that starts mid-GOP
+// references frames that live only in the PREVIOUS source file; once that file
+// is deleted after the merge, players conceal every such P-frame with gray
+// until the next IDR (#488: user-visible gray screens in downloaded merged
+// recordings). Mutates seg in place (Samples/SampleCount/TotalDuration and the
+// audio head). Returns the number of leading video samples dropped and false
+// when the segment has no keyframe at all — callers must then keep the segment
+// standalone (mark incompatible) instead of merging it.
+func AlignToKeyframe(seg *SegmentInfo) (dropped int, ok bool) {
+	first := -1
+	for i, s := range seg.Samples {
+		if s.IsKeyFrame {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return 0, false
+	}
+	if first == 0 {
+		return 0, true
+	}
+	var droppedDur uint64
+	for _, s := range seg.Samples[:first] {
+		droppedDur += uint64(s.Duration)
+	}
+	seg.Samples = seg.Samples[first:]
+	seg.SampleCount = len(seg.Samples)
+	if seg.Timescale > 0 {
+		droppedSec := float64(droppedDur) / float64(seg.Timescale)
+		seg.TotalDuration -= time.Duration(droppedSec * float64(time.Second))
+		trimAudioHead(seg, droppedSec)
+	}
+	return first, true
+}
+
+// trimAudioHead drops leading audio samples whose midpoint falls before the
+// video head moved by droppedSec, keeping A/V start roughly aligned after a
+// keyframe trim.
+func trimAudioHead(seg *SegmentInfo, droppedSec float64) {
+	if len(seg.AudioSamples) == 0 || seg.AudioTimescale == 0 || droppedSec <= 0 {
+		return
+	}
+	var cum float64
+	cut := 0
+	for i, s := range seg.AudioSamples {
+		d := float64(s.Duration) / float64(seg.AudioTimescale)
+		if cum+d/2 <= droppedSec {
+			cum += d
+			cut = i + 1
+		} else {
+			break
+		}
+	}
+	if cut > 0 {
+		seg.AudioSamples = seg.AudioSamples[cut:]
+		if seg.AudioSampleCount >= cut {
+			seg.AudioSampleCount -= cut
+		} else {
+			seg.AudioSampleCount = 0
+		}
+	}
+}
+
 // MergeMP4Segments performs a streaming merge of multiple MP4 segments into a single output file.
 // All segments must share the same codec and SPS/PPS (for H.264) or VPS/SPS/PPS (for H.265).
 // The output file is written to outputPath directly (caller handles temp→final rename).
-func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath string) error {
+//
+// Keyframe alignment (#488): before stitching, every segment's leading video
+// samples are dropped up to its first keyframe (audio head trimmed by the same
+// duration), and segments with no keyframe at all are skipped and reported in
+// the returned MergeStats. Without this, a segment that starts mid-GOP (e.g. an
+// adaptive TL-exit flush segment or a reconnect micro-segment) contributes
+// P-frames whose references exist only in an already-deleted source file —
+// players conceal them with gray until the next IDR. Input SegmentInfos are
+// mutated to their aligned state so callers' duration/frame metadata matches
+// what actually landed in the output.
+func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath string) (MergeStats, error) {
+	stats := MergeStats{LeadingDropped: map[int]int{}}
 	if len(segments) == 0 {
-		return fmt.Errorf("no segments to merge")
+		return stats, fmt.Errorf("no segments to merge")
 	}
+
+	aligned := make([]*SegmentInfo, 0, len(segments))
+	for i, seg := range segments {
+		dropped, ok := AlignToKeyframe(seg)
+		if !ok {
+			stats.SkippedNoKeyframe = append(stats.SkippedNoKeyframe, i)
+			logger.Warn("merge: skipping keyframe-less segment (would corrupt the merged reference chain)",
+				"path", seg.FilePath, "samples", seg.SampleCount)
+			continue
+		}
+		if dropped > 0 {
+			stats.LeadingDropped[i] = dropped
+		}
+		stats.Included = append(stats.Included, i)
+		aligned = append(aligned, seg)
+	}
+	if len(aligned) == 0 {
+		return stats, ErrNoKeyframe
+	}
+	segments = aligned
 
 	first := segments[0]
 	codec := first.Codec
@@ -58,14 +171,14 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	// Validate all segments share the same codec and SPS/PPS.
 	for i, seg := range segments {
 		if seg.Codec != codec {
-			return fmt.Errorf("segment %d: codec mismatch (%s vs %s)", i, seg.Codec, codec)
+			return stats, fmt.Errorf("segment %d: codec mismatch (%s vs %s)", i, seg.Codec, codec)
 		}
 		if i > 0 {
 			if !bytes.Equal(seg.SPS, first.SPS) || !bytes.Equal(seg.PPS, first.PPS) {
-				return fmt.Errorf("segment %d: SPS/PPS mismatch", i)
+				return stats, fmt.Errorf("segment %d: SPS/PPS mismatch", i)
 			}
 			if codec == "h265" && !bytes.Equal(seg.VPS, first.VPS) {
-				return fmt.Errorf("segment %d: VPS mismatch", i)
+				return stats, fmt.Errorf("segment %d: VPS mismatch", i)
 			}
 		}
 	}
@@ -104,19 +217,19 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 
 	// Validate that segments have samples.
 	if first.SampleCount == 0 && (!hasAudio || first.AudioSampleCount == 0) {
-		return fmt.Errorf("first segment has empty sample table")
+		return stats, fmt.Errorf("first segment has empty sample table")
 	}
 
 	out, err := os.Create(outputPath)
 	if err != nil {
-		return fmt.Errorf("create output: %w", err)
+		return stats, fmt.Errorf("create output: %w", err)
 	}
 	defer out.Close()
 
 	// Step 1: Write ftyp box.
 	ftypSize, err := writeMergeFtyp(out, codec)
 	if err != nil {
-		return fmt.Errorf("write ftyp: %w", err)
+		return stats, fmt.Errorf("write ftyp: %w", err)
 	}
 
 	// Step 2: Calculate moov size by writing to a buffer with placeholder offsets.
@@ -181,7 +294,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	moovBuf := &bytesWriter{}
 	moovW := mp4.NewWriter(moovBuf)
 	if err := writeMergeMoov(moovW, videoTrack, audioTrack, 0, 0); err != nil {
-		return fmt.Errorf("calculate moov size: %w", err)
+		return stats, fmt.Errorf("calculate moov size: %w", err)
 	}
 	moovSize := moovBuf.len()
 	// Add headroom for stts entry expansion — real video may have varying frame durations
@@ -202,7 +315,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	moovOffset := ftypSize
 	moovPlaceholder := make([]byte, moovSize)
 	if _, err := out.Write(moovPlaceholder); err != nil {
-		return fmt.Errorf("write moov placeholder: %w", err)
+		return stats, fmt.Errorf("write moov placeholder: %w", err)
 	}
 
 	// Step 4: Write mdat box header (size placeholder + "mdat").
@@ -210,7 +323,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	var mdatHeader [8]byte
 	copy(mdatHeader[4:8], "mdat")
 	if _, err := out.Write(mdatHeader[:]); err != nil {
-		return fmt.Errorf("write mdat header: %w", err)
+		return stats, fmt.Errorf("write mdat header: %w", err)
 	}
 	mdatDataStart := mdatHeaderOffset + 8
 
@@ -221,19 +334,19 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 
 	for _, seg := range segments {
 		if seg.FilePath == "" {
-			return fmt.Errorf("segment has empty FilePath")
+			return stats, fmt.Errorf("segment has empty FilePath")
 		}
 
 		src, err := os.Open(seg.FilePath)
 		if err != nil {
-			return fmt.Errorf("open segment %s: %w", seg.FilePath, err)
+			return stats, fmt.Errorf("open segment %s: %w", seg.FilePath, err)
 		}
 
 		for _, s := range seg.Samples {
 			select {
 			case <-ctx.Done():
 				src.Close()
-				return ctx.Err()
+				return stats, ctx.Err()
 			default:
 			}
 			sampleAbsOffset := currentOffset + mdatDataStart
@@ -241,7 +354,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 			_, copyErr := copySampleData(src, out, s.Offset, int64(s.Size), buf)
 			if copyErr != nil {
 				src.Close()
-				return fmt.Errorf("copy sample from %s at offset %d: %w", seg.FilePath, s.Offset, copyErr)
+				return stats, fmt.Errorf("copy sample from %s at offset %d: %w", seg.FilePath, s.Offset, copyErr)
 			}
 
 			allVideoSamples = append(allVideoSamples, mergedSample{
@@ -265,14 +378,14 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 			}
 			src, err := os.Open(seg.FilePath)
 			if err != nil {
-				return fmt.Errorf("open segment %s for audio: %w", seg.FilePath, err)
+				return stats, fmt.Errorf("open segment %s for audio: %w", seg.FilePath, err)
 			}
 
 			for _, s := range seg.AudioSamples {
 				select {
 				case <-ctx.Done():
 					src.Close()
-					return ctx.Err()
+					return stats, ctx.Err()
 				default:
 				}
 				sampleAbsOffset := currentOffset + mdatDataStart
@@ -280,7 +393,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 				_, copyErr := copySampleData(src, out, s.Offset, int64(s.Size), buf)
 				if copyErr != nil {
 					src.Close()
-					return fmt.Errorf("copy audio sample from %s at offset %d: %w", seg.FilePath, s.Offset, copyErr)
+					return stats, fmt.Errorf("copy audio sample from %s at offset %d: %w", seg.FilePath, s.Offset, copyErr)
 				}
 
 				allAudioSamples = append(allAudioSamples, mergedSample{
@@ -298,20 +411,20 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	// Step 6: Patch mdat box size.
 	mdatBoxSize := uint64(8 + currentOffset)
 	if mdatBoxSize > math.MaxUint32 {
-		return fmt.Errorf("mdat box size %d exceeds MaxUint32", mdatBoxSize)
+		return stats, fmt.Errorf("mdat box size %d exceeds MaxUint32", mdatBoxSize)
 	}
 	if _, err := out.Seek(mdatHeaderOffset, io.SeekStart); err != nil {
-		return fmt.Errorf("seek to mdat header: %w", err)
+		return stats, fmt.Errorf("seek to mdat header: %w", err)
 	}
 	var sizeBuf [4]byte
 	binary.BigEndian.PutUint32(sizeBuf[:], uint32(mdatBoxSize))
 	if _, err := out.Write(sizeBuf[:]); err != nil {
-		return fmt.Errorf("write mdat size: %w", err)
+		return stats, fmt.Errorf("write mdat size: %w", err)
 	}
 
 	// Step 7: Go back and write the real moov box at the placeholder position.
 	if _, err := out.Seek(moovOffset, io.SeekStart); err != nil {
-		return fmt.Errorf("seek to moov: %w", err)
+		return stats, fmt.Errorf("seek to moov: %w", err)
 	}
 
 	// Calculate total video duration in timescale units.
@@ -320,7 +433,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		totalVideoDuration += uint64(s.duration)
 	}
 	if totalVideoDuration > math.MaxUint32 {
-		return fmt.Errorf("DurationV0 overflow: video duration %d exceeds MaxUint32", totalVideoDuration)
+		return stats, fmt.Errorf("DurationV0 overflow: video duration %d exceeds MaxUint32", totalVideoDuration)
 	}
 	videoTrack.duration = uint32(totalVideoDuration)
 	videoTrack.samples = allVideoSamples
@@ -332,7 +445,7 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 			totalAudioDuration += uint64(s.duration)
 		}
 		if totalAudioDuration > math.MaxUint32 {
-			return fmt.Errorf("DurationV0 overflow: audio duration %d exceeds MaxUint32", totalAudioDuration)
+			return stats, fmt.Errorf("DurationV0 overflow: audio duration %d exceeds MaxUint32", totalAudioDuration)
 		}
 		audioTrack.duration = uint32(totalAudioDuration)
 		audioTrack.samples = allAudioSamples
@@ -351,11 +464,11 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		}
 	}
 	if err := writeMergeMoov(moovWriter, videoTrack, audioTrack, videoChunkOffset, audioChunkOffset); err != nil {
-		return fmt.Errorf("write moov: %w", err)
+		return stats, fmt.Errorf("write moov: %w", err)
 	}
 
 	if moovOut.remaining < 0 {
-		return fmt.Errorf("moov box overflow: calculated %d, actual %d", moovSize, moovSize-moovOut.remaining)
+		return stats, fmt.Errorf("moov box overflow: calculated %d, actual %d", moovSize, moovSize-moovOut.remaining)
 	}
 
 	// If the real moov is smaller than the reserved space, pad with a "free" box.
@@ -365,16 +478,16 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		binary.BigEndian.PutUint32(padBuf[0:4], uint32(moovOut.remaining))
 		copy(padBuf[4:8], "free")
 		if _, err := out.Write(padBuf); err != nil {
-			return fmt.Errorf("write moov padding: %w", err)
+			return stats, fmt.Errorf("write moov padding: %w", err)
 		}
 	}
 
 	// Sync and close.
 	if err := out.Sync(); err != nil {
-		return fmt.Errorf("sync output: %w", err)
+		return stats, fmt.Errorf("sync output: %w", err)
 	}
 
-	return nil
+	return stats, nil
 }
 
 // copySampleData copies size bytes from src at offset to dst using the provided buffer.

--- a/internal/merge/mp4merge_align_test.go
+++ b/internal/merge/mp4merge_align_test.go
@@ -1,0 +1,193 @@
+package merge
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// #488 regression tests: keyframe-aligned stitching. A segment that starts
+// mid-GOP references frames that only exist in the previous source file —
+// after the merge deletes it, players conceal those P-frames with gray until
+// the next IDR. The merge must drop each segment's leading non-keyframe
+// samples and skip keyframe-less segments entirely.
+
+func TestMergeMP4Segments_KeyframeAlignmentDropsLeadingNonKeyframe(t *testing.T) {
+	dir := t.TempDir()
+
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	idrNAL := []byte{0x65, 0x88, 0x80, 0x40}
+	pNAL := []byte{0x41, 0x10, 0x00, 0x0c}
+
+	// seg1 starts at an IDR (normal); seg2 starts with two P-frames — the
+	// TL-exit flush / reconnect-micro-segment shape from the field.
+	seg1 := createH264SegmentWithSamples(t, dir, "seg1.mp4", sps, pps, [][]byte{idrNAL, pNAL})
+	seg2 := createH264SegmentWithSamples(t, dir, "seg2.mp4", sps, pps, [][]byte{pNAL, pNAL, idrNAL, pNAL})
+
+	info1, err := ParseSegment(seg1)
+	require.NoError(t, err)
+	info2, err := ParseSegment(seg2)
+	require.NoError(t, err)
+	require.Equal(t, 4, info2.SampleCount)
+
+	outputPath := filepath.Join(dir, "merged.mp4")
+	stats, err := MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, stats.Included)
+	require.Empty(t, stats.SkippedNoKeyframe)
+	require.Equal(t, 2, stats.LeadingDropped[1], "seg2's two leading P-frames must be dropped")
+	require.Equal(t, 0, stats.LeadingDropped[0])
+
+	// Input infos are mutated to their aligned state (documented contract).
+	require.Equal(t, 2, info2.SampleCount)
+
+	merged, err := ParseSegment(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, 4, merged.SampleCount, "2 (seg1) + 2 (aligned seg2)")
+	require.Equal(t, 132*time.Millisecond, merged.TotalDuration)
+
+	// Every segment run in the output must start at a keyframe: exactly two
+	// keyframes — seg1's IDR and seg2's aligned IDR.
+	keyframes := 0
+	for _, s := range merged.Samples {
+		if s.IsKeyFrame {
+			keyframes++
+		}
+	}
+	require.Equal(t, 2, keyframes)
+}
+
+func TestMergeMP4Segments_SkipsKeyframelessSegment(t *testing.T) {
+	dir := t.TempDir()
+
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	idrNAL := []byte{0x65, 0x88, 0x80, 0x40}
+	pNAL := []byte{0x41, 0x10, 0x00, 0x0c}
+
+	seg1 := createH264SegmentWithSamples(t, dir, "seg1.mp4", sps, pps, [][]byte{idrNAL, pNAL})
+	seg2 := createH264SegmentWithSamples(t, dir, "seg2.mp4", sps, pps, [][]byte{pNAL, pNAL, pNAL})
+
+	info1, err := ParseSegment(seg1)
+	require.NoError(t, err)
+	info2, err := ParseSegment(seg2)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(dir, "merged.mp4")
+	stats, err := MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	require.NoError(t, err)
+	require.Equal(t, []int{0}, stats.Included)
+	require.Equal(t, []int{1}, stats.SkippedNoKeyframe)
+
+	merged, err := ParseSegment(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, 2, merged.SampleCount, "output carries only seg1's samples")
+}
+
+func TestMergeMP4Segments_ErrNoKeyframeWhenAllSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	pNAL := []byte{0x41, 0x10, 0x00, 0x0c}
+
+	seg := createH264SegmentWithSamples(t, dir, "seg.mp4", sps, pps, [][]byte{pNAL, pNAL})
+	info, err := ParseSegment(seg)
+	require.NoError(t, err)
+
+	outputPath := filepath.Join(dir, "merged.mp4")
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
+	require.ErrorIs(t, err, ErrNoKeyframe)
+	require.NoFileExists(t, outputPath)
+}
+
+func TestAlignToKeyframe_TrimsAudioHeadWithVideo(t *testing.T) {
+	// Video: timescale 90000, 4 samples × 33.33ms, first two are P-frames.
+	// Audio: timescale 8000, 10 samples × 23ms (dur 184).
+	// Dropped video head = 66.67ms → audio drops the samples whose midpoint
+	// falls before it: 11.5, 34.5 and 57.5ms (3 samples, 69ms ≥ 66.67ms —
+	// the midpoint rule keeps A/V starts within half a sample).
+	seg := &SegmentInfo{
+		Timescale:     90000,
+		SampleCount:   4,
+		TotalDuration: 4 * 33333 * time.Microsecond,
+		Samples: []SampleEntry{
+			{Offset: 100, Size: 10, Duration: 3000},
+			{Offset: 110, Size: 10, Duration: 3000},
+			{Offset: 120, Size: 10, Duration: 3000, IsKeyFrame: true},
+			{Offset: 130, Size: 10, Duration: 3000},
+		},
+		AudioTimescale:   8000,
+		AudioSampleCount: 10,
+	}
+	for i := 0; i < 10; i++ {
+		seg.AudioSamples = append(seg.AudioSamples, SampleEntry{Offset: int64(200 + i), Size: 4, Duration: 184})
+	}
+
+	dropped, ok := AlignToKeyframe(seg)
+	require.True(t, ok)
+	require.Equal(t, 2, dropped)
+	require.Len(t, seg.Samples, 2)
+	require.Equal(t, 2, seg.SampleCount)
+	require.True(t, seg.Samples[0].IsKeyFrame)
+	require.Equal(t, 7, seg.AudioSampleCount, "3 leading audio samples trimmed with the video head")
+	require.Len(t, seg.AudioSamples, 7)
+
+	// A segment already starting at a keyframe is untouched.
+	seg2 := &SegmentInfo{
+		Timescale:   90000,
+		SampleCount: 1,
+		Samples:     []SampleEntry{{Offset: 1, Size: 2, Duration: 3000, IsKeyFrame: true}},
+	}
+	dropped, ok = AlignToKeyframe(seg2)
+	require.True(t, ok)
+	require.Equal(t, 0, dropped)
+
+	// A segment with no keyframe reports !ok and is left for the caller to
+	// keep standalone (mutating it would silently drop its content).
+	seg3 := &SegmentInfo{
+		Timescale:   90000,
+		SampleCount: 2,
+		Samples:     []SampleEntry{{Offset: 1, Size: 2, Duration: 3000}, {Offset: 3, Size: 2, Duration: 3000}},
+	}
+	dropped, ok = AlignToKeyframe(seg3)
+	require.False(t, ok)
+	require.Equal(t, 0, dropped)
+	require.Len(t, seg3.Samples, 2)
+}
+
+func TestSplitRunsByCompatKey_SplitsOnCodecParamsAndAudio(t *testing.T) {
+	spsA := []byte{0x67, 0x01}
+	spsB := []byte{0x67, 0x02}
+	pps := []byte{0x68, 0x01}
+
+	info := func(sps []byte, hasAudio bool) *SegmentInfo {
+		si := &SegmentInfo{Codec: "h264", SPS: sps, PPS: pps}
+		if hasAudio {
+			si.HasAudio = true
+			si.AudioCodec = "g711"
+			si.G711MULaw = true
+			si.AudioTimescale = 8000
+		}
+		return si
+	}
+
+	recs := []*model.Recording{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}}
+	infos := []*SegmentInfo{
+		info(spsA, false), // run 1: alone (SPS A)
+		info(spsB, false), // run 2: SPS B, no audio
+		info(spsB, false), //        continues (same key)
+		info(spsB, true),  // run 3: audio appears → key change
+	}
+
+	runs := splitRunsByCompatKey(recs, infos)
+	require.Len(t, runs, 3)
+	require.Len(t, runs[0].infos, 1)
+	require.Len(t, runs[1].infos, 2)
+	require.Len(t, runs[2].infos, 1)
+}

--- a/internal/merge/mp4merge_align_test.go
+++ b/internal/merge/mp4merge_align_test.go
@@ -125,7 +125,7 @@ func TestAlignToKeyframe_TrimsAudioHeadWithVideo(t *testing.T) {
 		AudioTimescale:   8000,
 		AudioSampleCount: 10,
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		seg.AudioSamples = append(seg.AudioSamples, SampleEntry{Offset: int64(200 + i), Size: 4, Duration: 184})
 	}
 

--- a/internal/merge/mp4merge_bench_test.go
+++ b/internal/merge/mp4merge_bench_test.go
@@ -163,7 +163,7 @@ func BenchmarkMergeMP4Segments(b *testing.B) {
 			b.ResetTimer()
 			for i := range b.N {
 				outputPath := filepath.Join(dir, fmt.Sprintf("merged_%d.mp4", i))
-				if err := MergeMP4Segments(
+				if _, err := MergeMP4Segments(
 					context.Background(), infos, outputPath,
 				); err != nil {
 					b.Fatal(err)
@@ -250,7 +250,7 @@ func BenchmarkMergeMP4Segments_LargeNALs(b *testing.B) {
 		b.ResetTimer()
 		for i := range b.N {
 			outputPath := filepath.Join(dir, fmt.Sprintf("merged_%d.mp4", i))
-			if err := MergeMP4Segments(
+			if _, err := MergeMP4Segments(
 				context.Background(), infos, outputPath,
 			); err != nil {
 				b.Fatal(err)
@@ -316,7 +316,7 @@ func BenchmarkRollingMergeSimulation(b *testing.B) {
 
 			outputPath := filepath.Join(dir, fmt.Sprintf("rolling_%03d.mp4", appendIdx))
 			start := time.Now()
-			if err := MergeMP4Segments(
+			if _, err := MergeMP4Segments(
 				context.Background(),
 				[]*SegmentInfo{mergedInfo, newInfo},
 				outputPath,

--- a/internal/merge/mp4merge_test.go
+++ b/internal/merge/mp4merge_test.go
@@ -55,7 +55,7 @@ func TestMergeMP4Segments_SameSPS(t *testing.T) {
 
 	// Merge
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err)
 
 	// Verify output file exists and has content
@@ -94,7 +94,7 @@ func TestMergeMP4Segments_DifferentSPS(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "SPS/PPS mismatch")
 }
@@ -113,7 +113,7 @@ func TestMergeMP4Segments_SingleSegment(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
 	require.NoError(t, err)
 
 	// Verify merged file is parseable and has same samples
@@ -125,7 +125,7 @@ func TestMergeMP4Segments_SingleSegment(t *testing.T) {
 
 func TestMergeMP4Segments_EmptyList(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "merged.mp4")
-	err := MergeMP4Segments(context.Background(), nil, outputPath)
+	_, err := MergeMP4Segments(context.Background(), nil, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no segments")
 }
@@ -138,8 +138,11 @@ func TestMergeMP4Segments_ThreeSegments(t *testing.T) {
 	idrNAL := []byte{0x65, 0x88, 0x80, 0x40}
 	pNAL := []byte{0x41, 0x10, 0x00, 0x0c}
 
+	// seg2 starts mid-GOP: its two leading P-frames must be dropped by the
+	// keyframe alignment (the OLD behavior — stitching them in with dangling
+	// references — is exactly the #488 gray-screen corruption).
 	seg1 := createH264SegmentWithSamples(t, dir, "seg1.mp4", sps, pps, [][]byte{idrNAL})
-	seg2 := createH264SegmentWithSamples(t, dir, "seg2.mp4", sps, pps, [][]byte{pNAL, pNAL})
+	seg2 := createH264SegmentWithSamples(t, dir, "seg2.mp4", sps, pps, [][]byte{pNAL, pNAL, idrNAL, pNAL})
 	seg3 := createH264SegmentWithSamples(t, dir, "seg3.mp4", sps, pps, [][]byte{idrNAL, pNAL})
 
 	info1, err := ParseSegment(seg1)
@@ -150,18 +153,22 @@ func TestMergeMP4Segments_ThreeSegments(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2, info3}, outputPath)
+	stats, err := MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2, info3}, outputPath)
 	require.NoError(t, err)
+	require.Equal(t, []int{0, 1, 2}, stats.Included)
+	require.Equal(t, 2, stats.LeadingDropped[1])
 
 	merged, err := ParseSegment(outputPath)
 	require.NoError(t, err)
-	// 1 + 2 + 2 = 5 samples
+	// 1 + (4-2 aligned) + 2 = 5 samples
 	require.Equal(t, 5, merged.SampleCount)
 	require.Equal(t, 165*time.Millisecond, merged.TotalDuration)
 
-	// Keyframes at positions 0 and 3 (seg1 IDR + seg3 IDR)
+	// Keyframes at the start of every segment run: seg1 IDR (0), seg2's
+	// aligned IDR (1), seg3 IDR (3). Sample 1 must be the keyframe — a merged
+	// stream whose runs start on P-frames is the #488 corruption shape.
 	require.True(t, merged.Samples[0].IsKeyFrame)
-	require.False(t, merged.Samples[1].IsKeyFrame)
+	require.True(t, merged.Samples[1].IsKeyFrame)
 	require.False(t, merged.Samples[2].IsKeyFrame)
 	require.True(t, merged.Samples[3].IsKeyFrame)
 	require.False(t, merged.Samples[4].IsKeyFrame)
@@ -176,8 +183,10 @@ func TestMergeMP4Segments_H265(t *testing.T) {
 	idrNAL := []byte{0x27, 0x01, 0xaf, 0x15, 0x6a}
 	pNAL := []byte{0x03, 0x20, 0x10, 0x00}
 
+	// seg2 starts with a P-frame — the head is dropped by keyframe alignment
+	// (#488), so its IDR lands directly after seg1's IDR.
 	seg1 := createH265SegmentWithSamples(t, dir, "h265_seg1.mp4", vps, sps, pps, [][]byte{idrNAL})
-	seg2 := createH265SegmentWithSamples(t, dir, "h265_seg2.mp4", vps, sps, pps, [][]byte{pNAL, pNAL})
+	seg2 := createH265SegmentWithSamples(t, dir, "h265_seg2.mp4", vps, sps, pps, [][]byte{pNAL, idrNAL, pNAL})
 
 	info1, err := ParseSegment(seg1)
 	require.NoError(t, err)
@@ -185,14 +194,16 @@ func TestMergeMP4Segments_H265(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged_h265.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err)
 
 	merged, err := ParseSegment(outputPath)
 	require.NoError(t, err)
 	require.Equal(t, "h265", merged.Codec)
-	require.Equal(t, 3, merged.SampleCount)
+	require.Equal(t, 3, merged.SampleCount) // 1 + (3-1 aligned)
 	require.Equal(t, 99*time.Millisecond, merged.TotalDuration)
+	// The second run must start at the aligned IDR, not a dangling P-frame.
+	require.True(t, merged.Samples[1].IsKeyFrame)
 }
 
 // createH265SegmentWithSamples creates an H.265 MP4 with the given VPS/SPS/PPS and NALU samples.
@@ -340,7 +351,7 @@ func TestMergeMP4Segments_WithAudio(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err)
 
 	merged, err := ParseSegment(outputPath)
@@ -382,7 +393,7 @@ func TestMergeMP4Segments_AudioConfigMismatch(t *testing.T) {
 	// (video-only output). This handles camera reconnect scenarios where
 	// audio negotiation changes mid-session.
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err, "merge should succeed with audio dropped")
 
 	// Verify output is video-only (no audio).
@@ -414,7 +425,7 @@ func TestMergeMP4Segments_MixedAudioPresence(t *testing.T) {
 	// This is the real-world scenario: camera reconnected after audio_enabled
 	// was toggled, or G.711 negotiation succeeded/failed mid-session.
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err, "merge should succeed with audio dropped")
 
 	// Verify output is video-only.
@@ -433,10 +444,12 @@ func TestMergeMP4Segments_H265WithAudio(t *testing.T) {
 	idrNAL := []byte{0x27, 0x01, 0xaf, 0x15, 0x6a}
 	pNAL := []byte{0x03, 0x20, 0x10, 0x00}
 
+	// seg2 starts at an IDR so the audio counts stay exact; the mid-GOP head
+	// + audio-head trim path is covered by TestAlignToKeyframe_TrimsAudioHead.
 	seg1 := createH265SegmentWithAudio(t, dir, "h265_seg1.mp4", vps, sps, pps,
 		[][]byte{idrNAL}, testAudioConfig, [][]byte{testAACFrame, testAACFrame})
 	seg2 := createH265SegmentWithAudio(t, dir, "h265_seg2.mp4", vps, sps, pps,
-		[][]byte{pNAL, pNAL}, testAudioConfig, [][]byte{testAACFrame})
+		[][]byte{idrNAL, pNAL}, testAudioConfig, [][]byte{testAACFrame})
 
 	info1, err := ParseSegment(seg1)
 	require.NoError(t, err)
@@ -444,7 +457,7 @@ func TestMergeMP4Segments_H265WithAudio(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged_h265.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.NoError(t, err)
 
 	merged, err := ParseSegment(outputPath)
@@ -479,7 +492,7 @@ func TestMergeMP4Segments_CodecMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{h264Info, h265Info}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{h264Info, h265Info}, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "codec mismatch")
 }
@@ -502,7 +515,7 @@ func TestMergeMP4Segments_VPSMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info1, info2}, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "VPS mismatch")
 }
@@ -520,9 +533,11 @@ func TestMergeMP4Segments_EmptyFirstSegment(t *testing.T) {
 		PPS:   pps,
 	}
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err := MergeMP4Segments(context.Background(), []*SegmentInfo{emptyInfo}, outputPath)
+	_, err := MergeMP4Segments(context.Background(), []*SegmentInfo{emptyInfo}, outputPath)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "empty sample table")
+	// Since keyframe alignment (#488) an empty/segment sample-less segment is
+	// classified as keyframe-less rather than hitting the sample-table check.
+	require.ErrorIs(t, err, ErrNoKeyframe)
 }
 
 func TestMergeMP4Segments_ContextCancelled(t *testing.T) {
@@ -541,7 +556,7 @@ func TestMergeMP4Segments_ContextCancelled(t *testing.T) {
 	cancel()
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(ctx, []*SegmentInfo{info}, outputPath)
+	_, err = MergeMP4Segments(ctx, []*SegmentInfo{info}, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context canceled")
 }
@@ -560,7 +575,7 @@ func TestMergeMP4Segments_SpsParseWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
 	require.NoError(t, err)
 
 	merged, err := ParseSegment(outputPath)
@@ -582,7 +597,7 @@ func TestMergeMP4Segments_EmptyFilePath(t *testing.T) {
 	info.FilePath = ""
 
 	outputPath := filepath.Join(dir, "merged.mp4")
-	err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, outputPath)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty FilePath")
 }

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -808,6 +809,9 @@ func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID stri
 				rollingLogger.Warn("backfill MP4: batch merge failed",
 					"camera_id", cameraID, "error", err)
 			}
+			// Backfill batches also bypass the in-memory bucket state (see
+			// mergeSegments) — drop any stale bucket to avoid double coverage.
+			r.buckets.Delete(cameraID)
 			merged += n
 
 			rollingLogger.Info("backfill MP4 progress",
@@ -824,10 +828,11 @@ func (r *RollingMergeCoordinator) backfillMP4(ctx context.Context, cameraID stri
 
 // mergeBatchMP4 merges a batch of MP4 segments into output file(s).
 // Uses ParseSegment + MergeMP4Segments (the same as the periodic MergeManager).
-// The batch is first split into consecutive audio-homogeneous runs: a batch
-// that straddles an audio toggle boundary (audio_enabled flipped, codec
-// renegotiated) must not merge across it — MergeMP4Segments' mixed-audio
-// policy would silently drop the audio from the whole output.
+// The batch is first split into consecutive merge-compatible runs (codec +
+// SPS/PPS/VPS + audio): a batch that straddles a parameter-set or audio toggle
+// boundary must not merge across it — a codec/SPS change hard-fails the merge
+// and an audio change trips the mixed-audio policy that silently drops the
+// audio from the whole output.
 // Returns the number of segments successfully merged.
 func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID string, recs []*model.Recording) (int, error) {
 	// Parse all segments.
@@ -858,7 +863,7 @@ func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID st
 	}
 
 	merged := 0
-	for _, run := range splitRunsByAudioKey(parsedRecs, infos) {
+	for _, run := range splitRunsByCompatKey(parsedRecs, infos) {
 		if len(run.infos) < 2 {
 			// Lone segment in its audio run — no merge partner within the run.
 			// Mark it merged; the file stays as a standalone recording.
@@ -882,19 +887,34 @@ func (r *RollingMergeCoordinator) mergeBatchMP4(ctx context.Context, cameraID st
 	return merged, nil
 }
 
-// segmentRun is a consecutive, audio-homogeneous slice of a parsed batch.
+// segmentRun is a consecutive, merge-compatible slice of a parsed batch.
 type segmentRun struct {
 	recs   []*model.Recording
 	infos  []*SegmentInfo
 	keyStr string
 }
 
-// splitRunsByAudioKey splits a parsed batch into consecutive runs sharing the
-// same segmentAudioKey. recs and infos are parallel slices (same length).
-func splitRunsByAudioKey(recs []*model.Recording, infos []*SegmentInfo) []segmentRun {
+// segmentCompatKey is the merge-compatibility key for a parsed segment:
+// codec + parameter sets + audio state. Segments with different keys cannot
+// be merged into one MP4 — a codec/SPS change mid-run made the old
+// audio-only split hard-fail the WHOLE run inside MergeMP4Segments and
+// permanently mark it incompatible (#488 follow-up).
+func segmentCompatKey(info *SegmentInfo) string {
+	h := sha256.New()
+	h.Write([]byte(info.Codec))
+	h.Write(info.SPS)
+	h.Write(info.PPS)
+	h.Write(info.VPS)
+	return hex.EncodeToString(h.Sum(nil)) + "|" + segmentAudioKey(info)
+}
+
+// splitRunsByCompatKey splits a parsed batch into consecutive runs sharing the
+// same segmentCompatKey (codec + SPS/PPS/VPS + audio). recs and infos are
+// parallel slices (same length).
+func splitRunsByCompatKey(recs []*model.Recording, infos []*SegmentInfo) []segmentRun {
 	var runs []segmentRun
 	for i, info := range infos {
-		key := segmentAudioKey(info)
+		key := segmentCompatKey(info)
 		if len(runs) > 0 && runs[len(runs)-1].keyStr == key {
 			last := &runs[len(runs)-1]
 			last.recs = append(last.recs, recs[i])
@@ -925,7 +945,8 @@ func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID st
 	}
 
 	// Merge.
-	if err := MergeMP4Segments(ctx, infos, tempPath); err != nil {
+	stats, err := MergeMP4Segments(ctx, infos, tempPath)
+	if err != nil {
 		os.Remove(tempPath)
 		// Mark these as incompatible so we don't retry forever.
 		ids := make([]string, len(recs))
@@ -936,6 +957,34 @@ func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID st
 			return r.db.SetMergeStatus(ctx, ids, model.MergeStatusIncompatible)
 		})
 		return 0, fmt.Errorf("merge: %w", err)
+	}
+	// Keyframe-less segments are not in the output: mark them incompatible and
+	// exclude them from the DB replacement + source deletion below (#488).
+	if len(stats.SkippedNoKeyframe) > 0 {
+		skipIDs := make([]string, 0, len(stats.SkippedNoKeyframe))
+		for _, idx := range stats.SkippedNoKeyframe {
+			skipIDs = append(skipIDs, recs[idx].ID)
+		}
+		_ = storage.RetryOnBusy(ctx, func() error {
+			return r.db.SetMergeStatus(ctx, skipIDs, model.MergeStatusIncompatible)
+		})
+		rollingLogger.Warn("audio run merge skipped keyframe-less segments",
+			"camera_id", cameraID, "skipped", len(skipIDs))
+	}
+	if len(stats.Included) != len(recs) {
+		keepRecs := make([]*model.Recording, 0, len(stats.Included))
+		keepInfos := make([]*SegmentInfo, 0, len(stats.Included))
+		keepPaths := make([]string, 0, len(stats.Included))
+		for _, idx := range stats.Included {
+			keepRecs = append(keepRecs, recs[idx])
+			keepInfos = append(keepInfos, infos[idx])
+			keepPaths = append(keepPaths, recs[idx].FilePath)
+		}
+		recs, infos, sourcePaths = keepRecs, keepInfos, keepPaths
+	}
+	if len(recs) == 0 {
+		os.Remove(tempPath)
+		return 0, ErrNoKeyframe
 	}
 
 	fi, err := os.Stat(tempPath)
@@ -1361,6 +1410,11 @@ func (r *RollingMergeCoordinator) mergeSegments(ctx context.Context, cameraID st
 		} else {
 			rollingLogger.Info("rolling MP4 batch merged",
 				"camera_id", cameraID, "segments", n)
+			// The batch produced standalone output files that are NOT tracked
+			// by the in-memory bucket state. Drop the stale bucket so the next
+			// single-segment append builds a fresh bucket instead of appending
+			// over the batch's time range (double-covered timeline).
+			r.buckets.Delete(cameraID)
 		}
 	} else {
 		for _, seg := range mp4Segs {
@@ -1420,6 +1474,28 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	newInfo, err := ParseSegment(seg.filePath)
 	if err != nil {
 		return fmt.Errorf("parse new segment: %w", err)
+	}
+
+	// Keyframe alignment (#488): a segment that starts mid-GOP (adaptive TL-exit
+	// flush, reconnect micro-segment) references frames that get deleted with
+	// the previous source file — merging it verbatim produced the gray-screen
+	// merged recordings. Align its head to the first keyframe. A keyframe-less
+	// segment is undecodable in ANY merged context — mark it incompatible and
+	// leave it standalone instead of poisoning the bucket.
+	if dropped, ok := AlignToKeyframe(newInfo); !ok {
+		rollingLogger.Warn("segment has no keyframe sample, marking incompatible",
+			"camera_id", seg.cameraID, "recording_id", seg.recordingID,
+			"samples", newInfo.SampleCount)
+		if markErr := storage.RetryOnBusy(ctx, func() error {
+			return r.db.SetMergeStatus(ctx, []string{seg.recordingID}, model.MergeStatusIncompatible)
+		}); markErr != nil {
+			rollingLogger.Warn("failed to mark keyframe-less segment",
+				"recording_id", seg.recordingID, "error", markErr)
+		}
+		return nil
+	} else if dropped > 0 {
+		rollingLogger.Info("keyframe alignment dropped leading samples",
+			"camera_id", seg.cameraID, "recording_id", seg.recordingID, "dropped", dropped)
 	}
 
 	// Compute SPS/PPS compatibility key.
@@ -1517,6 +1593,20 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	} else {
 		// Append to existing bucket: merge [bucketFile + newSegment].
 		outputPath, mergedRecID, err = r.appendToBucket(ctx, seg, newInfo, bucket)
+		if err != nil && strings.Contains(err.Error(), "bucket keyframe-less") {
+			// Legacy corrupt bucket (written before keyframe alignment, no
+			// keyframe-bearing sample left): drop the in-memory state and
+			// rebuild the bucket from this segment alone.
+			rollingLogger.Warn("bucket has no keyframe-bearing samples, rebuilding bucket",
+				"camera_id", seg.cameraID, "old_bucket", bucket.mergedFilePath)
+			bucket.mergedFilePath = ""
+			bucket.mergedRecID = ""
+			bucket.spsKey = ""
+			bucket.audioKey = ""
+			bucket.segmentCount = 0
+			bucket.mergedFileSize = 0
+			outputPath, mergedRecID, err = r.createBucket(ctx, seg, newInfo)
+		}
 	}
 
 	if err != nil {
@@ -1571,8 +1661,8 @@ func (r *RollingMergeCoordinator) createBucket(
 		return "", "", fmt.Errorf("create bucket output: %w", derr)
 	}
 
-	// Merge single segment into the bucket file.
-	if err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath); err != nil {
+	// Merge single segment into the bucket file (pre-aligned by mergeOneSegment).
+	if _, err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath); err != nil {
 		os.Remove(tempPath)
 		return "", "", fmt.Errorf("merge initial segment: %w", err)
 	}
@@ -1652,10 +1742,19 @@ func (r *RollingMergeCoordinator) appendToBucket(
 		return "", "", fmt.Errorf("create append output: %w", derr)
 	}
 
-	// Merge [bucket + newSegment].
-	if err := MergeMP4Segments(ctx, []*SegmentInfo{bucketInfo, newInfo}, tempPath); err != nil {
+	// Merge [bucket + newSegment]. The new segment was pre-aligned by
+	// mergeOneSegment; the bucket head is re-aligned inside the merge
+	// (self-heals pre-fix buckets whose first sample was a P-frame). A bucket
+	// with NO keyframe-bearing sample at all (legacy corrupt data) aborts the
+	// append with a distinct error so mergeOneSegment can rebuild the bucket.
+	stats, mergeErr := MergeMP4Segments(ctx, []*SegmentInfo{bucketInfo, newInfo}, tempPath)
+	if mergeErr != nil {
 		os.Remove(tempPath)
-		return "", "", fmt.Errorf("merge append: %w", err)
+		return "", "", fmt.Errorf("merge append: %w", mergeErr)
+	}
+	if len(stats.Included) != 2 {
+		os.Remove(tempPath)
+		return "", "", fmt.Errorf("append dropped a segment (bucket keyframe-less): included=%d/2", len(stats.Included))
 	}
 
 	fi, err := os.Stat(tempPath)

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -396,10 +396,10 @@ func TestBackfillMP4_MixedAudioBatchSplitsRuns(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestSplitRunsByAudioKey — unit test for the run splitter.
+// TestSplitRunsByCompatKey — unit test for the run splitter.
 // ---------------------------------------------------------------------------
 
-func TestSplitRunsByAudioKey(t *testing.T) {
+func TestSplitRunsByCompatKey(t *testing.T) {
 	none := &SegmentInfo{HasAudio: false}
 	g711u := &SegmentInfo{HasAudio: true, AudioCodec: "g711", G711MULaw: true, AudioTimescale: 8000}
 	g711a := &SegmentInfo{HasAudio: true, AudioCodec: "g711", G711MULaw: false, AudioTimescale: 8000}
@@ -428,19 +428,19 @@ func TestSplitRunsByAudioKey(t *testing.T) {
 			return aac
 		}
 	})
-	runs := splitRunsByAudioKey(recs, infos)
+	runs := splitRunsByCompatKey(recs, infos)
 	require.Len(t, runs, 4)
 	require.Equal(t, []int{2, 2, 1, 1}, []int{len(runs[0].infos), len(runs[1].infos), len(runs[2].infos), len(runs[3].infos)})
-	require.Equal(t, "none", runs[0].keyStr)
-	require.Equal(t, segmentAudioKey(g711u), runs[1].keyStr)
-	require.Equal(t, "none", runs[2].keyStr)
-	require.Equal(t, segmentAudioKey(aac), runs[3].keyStr)
+	require.Equal(t, segmentCompatKey(none), runs[0].keyStr)
+	require.Equal(t, segmentCompatKey(g711u), runs[1].keyStr)
+	require.Equal(t, segmentCompatKey(none), runs[2].keyStr)
+	require.Equal(t, segmentCompatKey(aac), runs[3].keyStr)
 	// A-law vs μ-law must be different keys (config bytes differ).
 	require.NotEqual(t, segmentAudioKey(g711u), segmentAudioKey(g711a))
 
 	// All-homogeneous batch → single run.
 	recs, infos = mk(3, func(int) *SegmentInfo { return g711u })
-	runs = splitRunsByAudioKey(recs, infos)
+	runs = splitRunsByCompatKey(recs, infos)
 	require.Len(t, runs, 1)
 	require.Len(t, runs[0].infos, 3)
 }

--- a/internal/timelapse/periodic_merge.go
+++ b/internal/timelapse/periodic_merge.go
@@ -526,10 +526,17 @@ func (m *PeriodicMergeManager) goConcatMerge(ctx context.Context, segments []mod
 		"total_frames", totalFrames,
 	)
 
-	// merge.MergeMP4Segments validates codec/SPS/PPS/VPS/audio consistency.
-	if err := merge.MergeMP4Segments(ctx, segInfos, outputPath); err != nil {
+	// merge.MergeMP4Segments validates codec/SPS/PPS/VPS/audio consistency and
+	// keyframe-aligns every segment head (#488); keyframe-less segments are
+	// skipped and reported in stats.
+	stats, err := merge.MergeMP4Segments(ctx, segInfos, outputPath)
+	if err != nil {
 		_ = os.Remove(outputPath)
 		return fmt.Errorf("go concat merge: %w", err)
+	}
+	if len(stats.SkippedNoKeyframe) > 0 {
+		slog.Warn("periodic merge: skipped keyframe-less segments",
+			"skipped", len(stats.SkippedNoKeyframe), "total", len(segInfos))
 	}
 
 	// Report 100% progress — Go concat is fast (streaming copy), no granular progress.


### PR DESCRIPTION
Closes #488（视频灰屏部分；音频轨丢失同根于本 PR 的 key-compat 切分，进度回评到 issue）。

## 根因
`MergeMP4Segments` 逐样本原样拼接，**从不检查段是否以关键帧开头**。以 P 帧开头的段（adaptive TL 退出 flush 段、小米重连微段）其参考帧只存在于上一个源文件——而合并完成即删除源文件。播放器对缺参考帧做灰屏错误隐藏直到下一个 IDR；POC 编号跨段重叠产生 missing/duplicate POC。实机证据见 #488 评论（4/4 合并产物缺 POC、原始段全干净、两帧取证 100%/98% 灰屏）。

## 修复（三个耦合缺陷）
1. **关键帧对齐**：`AlignToKeyframe` 丢弃每段头部至首个关键帧的视频样本，音频头按同时长裁剪保持 A/V 对齐；完全无关键帧的段跳过并在 `MergeStats` 上报（调用方标 incompatible、保留独立段不毒化桶）。`mergeOneSegment` 对入桶段预检；发现无关键帧的存量腐坏桶时重建桶。
2. **批量合并绕过内存桶状态**：batch 合并后下一段仍 append 到旧桶文件 → 时间线双重覆盖。现在每次批量合并（实时+回填）后重置桶。
3. **批量 run 只按音频 key 切分**：SPS/编解码变化使整 run 硬失败并永久标 incompatible。`splitRunsByCompatKey` 现按 codec+SPS/PPS/VPS+音频复合 key 切分。

## 行为说明
- 输入 `SegmentInfo` 被对齐原地修改（Samples/时长/音频头），调用方元数据与产物一致——已在文档注释标明。
- 存量已损坏的合并产物不会被本 PR 自动修复（桶按小时滚动，部署后 ~1-2h 自然换代为新产物）；深检（#489）的 ok 计数应从部署后开始出现（配合 #492 修复后）。
- 少数头部 P 帧被丢弃的段，DB 的 started_at 不做微调（≤1 GOP 的偏差，量级 2-4s）。

## 测试
- 新增 5 个用例：对齐丢头/无关键帧跳过/全跳过报 ErrNoKeyframe/音频头同步裁剪/compat 复合切分。
- 存量 ThreeSegments/H265 夹具原本**固化了 #488 的错误行为**（seg2=[P,P] 以悬空参考缝合，断言 5 样本关键帧 0/3 = 生产灰屏结构）——已改为对齐语义断言。
- `internal/merge` + `internal/timelapse` 全部测试绿（Linux 跨编二进制实跑）。