### PR TITLE
fix(recorder): 原始段 POC 损伤 — TL 退出 flush 双写 + written 旗标跨段 (#498, #492, #487)

### DIFF
--- a/internal/health/audit.go
+++ b/internal/health/audit.go
@@ -25,7 +25,10 @@ package health
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -216,23 +219,82 @@ func (a *RecordingAuditor) maybeDeepCheck(seg event.SegmentCompleted) {
 	}
 	a.lastDeepCheck[seg.CameraID] = time.Now()
 
+	// The rolling merge consumes source files within ~35s of completion
+	// (issue #492 field data): by the time the hourly deep check fires, the
+	// file may already be gone. That is not a decode failure — classify it
+	// separately so ok/decode_error stay meaningful.
+	if _, err := os.Stat(seg.FilePath); err != nil {
+		a.metrics.IncRecordingDeepCheck(seg.CameraID, "vanished")
+		slog.Debug("recording deep check skipped: source file already consumed",
+			"camera_id", seg.CameraID, "file", seg.FilePath)
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(a.baseCtx, deepCheckTimeout)
 	defer cancel()
 	stderr, err := a.deepCheckNow(ctx, seg.FilePath)
 	switch {
+	case ctx.Err() != nil:
+		// Shutdown or hard timeout raced the verdict — do not score it.
+		return
+	case err != nil && isVanishedStderr(stderr):
+		// ffmpeg could not open the INPUT: the rolling merge consumed the
+		// source between the event and the probe (issue #492 field data).
+		a.metrics.IncRecordingDeepCheck(seg.CameraID, "vanished")
+		slog.Debug("recording deep check skipped: source file already consumed",
+			"camera_id", seg.CameraID, "file", seg.FilePath)
 	case err != nil:
 		a.metrics.IncRecordingDeepCheck(seg.CameraID, "decode_error")
 		slog.Warn("recording deep check failed",
 			"camera_id", seg.CameraID, "file", seg.FilePath, "error", err, "stderr", firstLine(stderr))
-	case stderr != "":
-		// ffmpeg exited 0 but printed error-level lines — still corruption
-		// (e.g. reference-chain issues that don't abort the decode).
-		a.metrics.IncRecordingDeepCheck(seg.CameraID, "decode_error")
-		slog.Warn("recording deep check found decode errors",
-			"camera_id", seg.CameraID, "file", seg.FilePath, "stderr", firstLine(stderr))
 	default:
-		a.metrics.IncRecordingDeepCheck(seg.CameraID, "ok")
+		if real := filterDeepCheckStderr(stderr); real != "" {
+			// ffmpeg exited 0 but printed real error-level lines — corruption
+			// (e.g. reference-chain issues that don't abort the decode).
+			a.metrics.IncRecordingDeepCheck(seg.CameraID, "decode_error")
+			slog.Warn("recording deep check found decode errors",
+				"camera_id", seg.CameraID, "file", seg.FilePath, "stderr", firstLine(real))
+		} else {
+			a.metrics.IncRecordingDeepCheck(seg.CameraID, "ok")
+		}
 	}
+}
+
+// isVanishedStderr reports whether ffmpeg's failure output says the INPUT
+// file could not be opened — the rolling merge consumed the source between
+// the segment event and the probe (issue #492), which is not a decode defect.
+func isVanishedStderr(stderr string) bool {
+	return strings.Contains(stderr, "Error opening input") ||
+		strings.Contains(stderr, "No such file or directory")
+}
+
+// filterDeepCheckStderr strips benign error-level lines from ffmpeg's stderr
+// so a healthy recording can still score ok:
+//
+//   - "non monotonically increasing dts" — the null muxer warns because the
+//     MP4 samples carry pts==dts by muxer design; virtually every real
+//     recording trips it, so without the filter `ok` was structurally
+//     unreachable (issue #492 field data: 28 steady-state checks, ok=0).
+//   - "Last message repeated N times" notices inherit the verdict of the
+//     line they repeat — dropped only when that line was dropped.
+func filterDeepCheckStderr(stderr string) string {
+	var kept []string
+	prevDropped := false
+	for _, line := range strings.Split(stderr, "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "non monotonically increasing dts") {
+			prevDropped = true
+			continue
+		}
+		if prevDropped && strings.Contains(line, "Last message repeated") {
+			continue
+		}
+		prevDropped = false
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
 }
 
 // runFFmpegDeepCheck decodes up to deepCheckSampleDur of the file, discarding
@@ -266,9 +328,26 @@ func firstLine(s string) string {
 
 // probe runs mediaprobe on one segment and records the outcome.
 func (a *RecordingAuditor) probe(seg event.SegmentCompleted) {
+	if _, err := os.Stat(seg.FilePath); err != nil {
+		// The rolling merge already consumed the source before the spaced
+		// probe reached it (issue #487 field data: probe_error grew on files
+		// deleted between event and probe) — expected on rolling-merge
+		// cameras, not a probe failure.
+		a.metrics.IncRecordingAudit(seg.CameraID, "vanished")
+		slog.Debug("recording audit: source file already consumed",
+			"camera_id", seg.CameraID, "file", seg.FilePath)
+		return
+	}
 	info, err := mediaprobe.ProbeMP4(seg.FilePath)
 	switch {
 	case err != nil:
+		if errors.Is(err, fs.ErrNotExist) {
+			// Vanished between the stat above and the open — same race.
+			a.metrics.IncRecordingAudit(seg.CameraID, "vanished")
+			slog.Debug("recording audit: source file vanished mid-probe",
+				"camera_id", seg.CameraID, "file", seg.FilePath)
+			return
+		}
 		a.metrics.IncRecordingAudit(seg.CameraID, "probe_error")
 		slog.Warn("recording audit: probe failed",
 			"camera_id", seg.CameraID, "file", seg.FilePath, "error", err)

--- a/internal/health/audit.go
+++ b/internal/health/audit.go
@@ -248,12 +248,12 @@ func (a *RecordingAuditor) maybeDeepCheck(seg event.SegmentCompleted) {
 		slog.Warn("recording deep check failed",
 			"camera_id", seg.CameraID, "file", seg.FilePath, "error", err, "stderr", firstLine(stderr))
 	default:
-		if real := filterDeepCheckStderr(stderr); real != "" {
+		if realErrs := filterDeepCheckStderr(stderr); realErrs != "" {
 			// ffmpeg exited 0 but printed real error-level lines — corruption
 			// (e.g. reference-chain issues that don't abort the decode).
 			a.metrics.IncRecordingDeepCheck(seg.CameraID, "decode_error")
 			slog.Warn("recording deep check found decode errors",
-				"camera_id", seg.CameraID, "file", seg.FilePath, "stderr", firstLine(real))
+				"camera_id", seg.CameraID, "file", seg.FilePath, "stderr", firstLine(realErrs))
 		} else {
 			a.metrics.IncRecordingDeepCheck(seg.CameraID, "ok")
 		}

--- a/internal/health/audit_test.go
+++ b/internal/health/audit_test.go
@@ -398,7 +398,7 @@ func TestRecordingAuditor_DeepCheckRealErrorsSurviveFilter(t *testing.T) {
 		FilePath: newValidMP4Path(t, "corrupt.mp4"),
 	})
 
-	require.Eventually(t, func() bool { return deepCheckResult(t, m, "decode_error") }, 3*time.Second, 20 * time.Millisecond,
+	require.Eventually(t, func() bool { return deepCheckResult(t, m, "decode_error") }, 3*time.Second, 20*time.Millisecond,
 		"real decode errors must survive the benign filter")
 }
 

--- a/internal/health/audit_test.go
+++ b/internal/health/audit_test.go
@@ -247,3 +247,178 @@ func TestRecordingAuditor_DeepCheckDisabledWithoutFFmpeg(t *testing.T) {
 			"deep check must not emit metrics when ffmpeg is not configured")
 	}
 }
+
+// ─── Vanished classification + benign stderr filter (#492/#487) ────────────
+
+// deepCheckResultValue waits for the given result label to appear (value 1)
+// on nvr_recording_deepcheck_total.
+func deepCheckResult(t *testing.T, m *metrics.Metrics, result string) bool {
+	t.Helper()
+	families, err := m.Registry.Gather()
+	if err != nil {
+		return false
+	}
+	for _, f := range families {
+		if f.GetName() != "nvr_recording_deepcheck_total" {
+			continue
+		}
+		for _, metric := range f.GetMetric() {
+			for _, l := range metric.GetLabel() {
+				if l.GetName() == "result" && l.GetValue() == result && metric.GetCounter().GetValue() >= 1 {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// auditResultValue reports whether nvr_recording_audit_total carries the
+// given result label with value >= 1.
+func auditResult(t *testing.T, m *metrics.Metrics, result string) bool {
+	t.Helper()
+	families, err := m.Registry.Gather()
+	if err != nil {
+		return false
+	}
+	for _, f := range families {
+		if f.GetName() != "nvr_recording_audit_total" {
+			continue
+		}
+		for _, metric := range f.GetMetric() {
+			for _, l := range metric.GetLabel() {
+				if l.GetName() == "result" && l.GetValue() == result && metric.GetCounter().GetValue() >= 1 {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// TestRecordingAuditor_DeepCheckVanishedBeforeDecode: the rolling merge
+// consumed the source before the hourly deep check ran — the file is gone,
+// the decoder must not even be spawned, and the verdict is `vanished`, not
+// decode_error (issue #492: ok was structurally 0 because vanish races and
+// benign dts lines were all scored as failures).
+func TestRecordingAuditor_DeepCheckVanishedBeforeDecode(t *testing.T) {
+	bus := event.NewEventBus(16)
+	m := metrics.NewMetrics()
+	a := NewRecordingAuditor(bus, m, WithFFmpegPath("/usr/bin/ffmpeg"))
+	require.NotNil(t, a)
+	ran := false
+	a.deepCheckNow = func(_ context.Context, _ string) (string, error) {
+		ran = true
+		return "", nil
+	}
+	a.lastDeepCheck["cam-van"] = time.Now().Add(-2 * deepCheckInterval)
+	require.NoError(t, a.Start(context.Background()))
+	t.Cleanup(func() { _ = a.Stop() })
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-van",
+		FilePath: filepath.Join(t.TempDir(), "consumed-by-merge.mp4"), // never created
+	})
+
+	require.Eventually(t, func() bool { return deepCheckResult(t, m, "vanished") }, 3*time.Second, 20*time.Millisecond,
+		"a vanished source must score result=vanished")
+	require.False(t, ran, "the decoder must not run for a vanished file")
+}
+
+// TestRecordingAuditor_DeepCheckVanishedStderr: the file vanished between the
+// stat pre-check and ffmpeg's open — the input-open failure must still
+// classify as vanished, not decode_error.
+func TestRecordingAuditor_DeepCheckVanishedStderr(t *testing.T) {
+	bus := event.NewEventBus(16)
+	m := metrics.NewMetrics()
+	a := NewRecordingAuditor(bus, m, WithFFmpegPath("/usr/bin/ffmpeg"))
+	require.NotNil(t, a)
+	a.deepCheckNow = func(_ context.Context, _ string) (string, error) {
+		return "/x/y.mp4: Error opening input: No such file or directory", errors.New("exit status 1")
+	}
+	a.lastDeepCheck["cam-van2"] = time.Now().Add(-2 * deepCheckInterval)
+	require.NoError(t, a.Start(context.Background()))
+	t.Cleanup(func() { _ = a.Stop() })
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-van2",
+		FilePath: newValidMP4Path(t, "gone.mp4"),
+	})
+
+	require.Eventually(t, func() bool { return deepCheckResult(t, m, "vanished") }, 3*time.Second, 20*time.Millisecond,
+		"input-open stderr must score result=vanished")
+	require.False(t, deepCheckResult(t, m, "decode_error"), "vanished must not be scored decode_error")
+}
+
+// TestRecordingAuditor_DeepCheckBenignDTSIsOK: the null muxer's
+// pts==dts design trips "non monotonically increasing dts" on healthy
+// recordings (plus its "Last message repeated" notices) — filtering those
+// lines is what makes ok reachable at all (issue #492).
+func TestRecordingAuditor_DeepCheckBenignDTSIsOK(t *testing.T) {
+	bus := event.NewEventBus(16)
+	m := metrics.NewMetrics()
+	a := NewRecordingAuditor(bus, m, WithFFmpegPath("/usr/bin/ffmpeg"))
+	require.NotNil(t, a)
+	a.deepCheckNow = func(_ context.Context, _ string) (string, error) {
+		return "[null @ 0x1] non monotonically increasing dts\n" +
+			"   Last message repeated 3 times\n", nil
+	}
+	a.lastDeepCheck["cam-ok"] = time.Now().Add(-2 * deepCheckInterval)
+	require.NoError(t, a.Start(context.Background()))
+	t.Cleanup(func() { _ = a.Stop() })
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-ok",
+		FilePath: newValidMP4Path(t, "healthy.mp4"),
+	})
+
+	require.Eventually(t, func() bool { return deepCheckResult(t, m, "ok") }, 3*time.Second, 20*time.Millisecond,
+		"benign dts-only stderr must score ok")
+	require.False(t, deepCheckResult(t, m, "decode_error"), "benign dts lines must not be decode errors")
+}
+
+// TestRecordingAuditor_DeepCheckRealErrorsSurviveFilter: a real
+// reference-chain error after benign lines must still score decode_error —
+// the filter must not swallow actual corruption.
+func TestRecordingAuditor_DeepCheckRealErrorsSurviveFilter(t *testing.T) {
+	bus := event.NewEventBus(16)
+	m := metrics.NewMetrics()
+	a := NewRecordingAuditor(bus, m, WithFFmpegPath("/usr/bin/ffmpeg"))
+	require.NotNil(t, a)
+	a.deepCheckNow = func(_ context.Context, _ string) (string, error) {
+		return "[null @ 0x1] non monotonically increasing dts\n" +
+			"[hevc @ 0x2] Could not find ref with POC 24\n", nil
+	}
+	a.lastDeepCheck["cam-real"] = time.Now().Add(-2 * deepCheckInterval)
+	require.NoError(t, a.Start(context.Background()))
+	t.Cleanup(func() { _ = a.Stop() })
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-real",
+		FilePath: newValidMP4Path(t, "corrupt.mp4"),
+	})
+
+	require.Eventually(t, func() bool { return deepCheckResult(t, m, "decode_error") }, 3*time.Second, 20 * time.Millisecond,
+		"real decode errors must survive the benign filter")
+}
+
+// TestRecordingAuditor_ProbeVanishedNotProbeError: a source deleted between
+// the segment event and the spaced structure probe (rolling merge, issue
+// #487) must score `vanished`, not grow probe_error.
+func TestRecordingAuditor_ProbeVanishedNotProbeError(t *testing.T) {
+	bus := event.NewEventBus(16)
+	m := metrics.NewMetrics()
+	a := NewRecordingAuditor(bus, m)
+	require.NotNil(t, a)
+	require.NoError(t, a.Start(context.Background()))
+	t.Cleanup(func() { _ = a.Stop() })
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-probe-van",
+		FilePath: filepath.Join(t.TempDir(), "merged-away.mp4"), // never created
+	})
+
+	require.Eventually(t, func() bool { return auditResult(t, m, "vanished") }, 3*time.Second, 20*time.Millisecond,
+		"a vanished source must score audit result=vanished")
+	require.False(t, auditResult(t, m, "probe_error"), "vanished must not grow probe_error")
+}

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -373,18 +373,34 @@ func (t *adaptiveTracker) appendGOP(nalu []byte, isIDR bool, now time.Time) {
 	t.gopBytes += size
 }
 
-// takeGOP detaches the retained GOP for flushing. Returns nil when the ring
-// is broken (overflowed) or does not start with an IDR (not independently
-// decodable). Callers skip already-written frames when flushing into an
-// existing segment (issue #473).
+// takeGOP detaches the retained GOP for flushing, EXCLUDING the current frame
+// — observe() just appended it (the trigger), and every caller writes that
+// frame itself via the normal write path right after the flush, so including
+// it here wrote it twice (one duplicate POC per timelapse exit, issue #498).
+// When the trigger is itself the IDR (ring == [IDR]) nothing remains that
+// needs flushing. Returns nil when the remainder is broken (overflowed ring)
+// or not independently decodable (does not start with an IDR). Callers skip
+// already-written frames when flushing into an existing segment (issue #473).
 func (t *adaptiveTracker) takeGOP() []gopFrame {
 	frames := t.gop
 	t.gop = nil
 	t.gopBytes = 0
-	if t.gopBroken || len(frames) == 0 || !frames[0].isIDR {
+	if t.gopBroken || len(frames) <= 1 || !frames[0].isIDR {
 		return nil
 	}
-	return frames
+	return frames[:len(frames)-1]
+}
+
+// clearWritten forgets every ring frame's on-disk marking. `written` means
+// "on disk in the CURRENT segment"; when that segment closes (rotation,
+// storage failure), the frames live in a closed file and a later
+// timelapse-exit flush that lands in a FRESH segment must write the whole
+// ring. Treating pre-rotation flags as current skipped mid-GOP frames that
+// were never in the new file ("Could not find ref with POC", issue #498).
+func (t *adaptiveTracker) clearWritten() {
+	for i := range t.gop {
+		t.gop[i].written = false
+	}
 }
 
 // classify updates the rolling baseline and reports whether the observed
@@ -543,6 +559,14 @@ func (g *AdaptiveGate) AudioLoud(at time.Time, hold time.Duration) {
 // or was detached by a flush.
 func (g *AdaptiveGate) MarkLastWritten() {
 	g.t.markTailWritten()
+}
+
+// ClearWritten forgets the per-segment written markings after the caller's
+// current segment closes (rotation, storage failure) — a later flush into a
+// FRESH segment must write the whole retained ring instead of skipping
+// frames that only exist in the closed file (issue #498).
+func (g *AdaptiveGate) ClearWritten() {
+	g.t.clearWritten()
 }
 
 // ResolveAdaptiveConfig builds a resolved AdaptiveConfig from optional

--- a/internal/recorder/adaptive_rotation_test.go
+++ b/internal/recorder/adaptive_rotation_test.go
@@ -1,0 +1,183 @@
+package recorder
+
+// Regression tests for issue #498 (original-segment POC damage), found during
+// the #435 adaptive-recording field test on real cameras:
+//
+//	Bug A — the timelapse-exit flush carried the TRIGGER frame (observe
+//	         appended it before takeGOP); the normal write path wrote it
+//	         again right after → "Duplicate POC" in every exit segment.
+//	Bug B — gopFrame.written is a per-SEGMENT marking but survived segment
+//	         rotation; a flush landing in a FRESH segment skipped mid-GOP
+//	         frames that existed only in the closed file → "Could not find
+//	         ref with POC".
+
+import (
+	"bytes"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdaptiveTracker_ClearWrittenResetsRingFlags(t *testing.T) {
+	cfg := DefaultAdaptiveConfig()
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	tr.observe(idr, true, time.Now())
+	for i := range 3 {
+		buf := make([]byte, 800)
+		buf[0] = 0x41
+		tr.observe(buf, false, time.Now().Add(time.Duration(i+1)*50*time.Millisecond))
+	}
+	// Simulate normal-path writes: everything retained is on disk.
+	for i := range tr.gop {
+		tr.gop[i].written = true
+	}
+
+	tr.clearWritten()
+
+	for i, f := range tr.gop {
+		if f.written {
+			t.Fatalf("frame %d still marked written after clearWritten", i)
+		}
+	}
+	if len(tr.gop) != 4 {
+		t.Fatalf("clearWritten must not drop ring frames, got %d", len(tr.gop))
+	}
+}
+
+func TestAdaptiveTracker_TakeGOPWithOnlyTriggerRingReturnsNil(t *testing.T) {
+	cfg := DefaultAdaptiveConfig()
+	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
+
+	// The trigger IS the IDR: observe() resets the ring to [IDR] and the exit
+	// path calls takeGOP — nothing remains that needs flushing (the caller
+	// writes the IDR itself via the normal path).
+	idr := bytes.Repeat([]byte{0x65}, 30000)
+	tr.mode = adaptiveTimelapse
+	_, flush := tr.observe(idr, true, time.Now())
+	if flush != nil {
+		t.Fatalf("ring of only the trigger frame must not flush, got %d frames", len(flush))
+	}
+}
+
+func TestAudioRing_ClearWrittenResetsFlags(t *testing.T) {
+	r := newAudioRing(3 * time.Second)
+	now := time.Now()
+	r.append(true, []byte{1, 2}, 250*time.Microsecond, now)
+	r.markWritten()
+	require.True(t, r.drain()[0].Written)
+
+	// Refill and clear — the rotation twin must forget the closed segment's
+	// markings just like the video ring.
+	r.append(true, []byte{3, 4}, 250*time.Microsecond, now.Add(time.Millisecond))
+	r.markWritten()
+	r.clearWritten()
+	for i, s := range r.drain() {
+		require.False(t, s.Written, "sample %d must be unwritten after clearWritten", i)
+	}
+}
+
+// TestH264Adaptive_TLExitFlushAfterRotation drives writeFrames end-to-end
+// through the exact field sequence that produced corrupted originals:
+// normal-rate writing → segment rotation (stale written flags) → timelapse
+// entry → spike exit whose flush must land in a FRESH segment containing the
+// complete retained GOP, with the trigger frame written exactly once.
+func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
+	mgr := newTestManager(t)
+	const cam = "h264-adaptive-poc"
+	rec := NewH264Recorder(H264Config{
+		CameraID:   cam,
+		RTSPURL:    "rtsp://ignored", // never connected — writeFrames driven directly
+		SegmentDur: 200 * time.Millisecond, // rotate mid-NORMAL, before TL entry
+		RingBufCap: 256,
+		Adaptive: &AdaptiveConfig{
+			CalmThreshold:     400 * time.Millisecond,
+			TimelapseInterval: time.Hour, // no sparse keyframes inside the window
+			SpikeFactor:       3.0,
+			MaxGOPBuffer:      8 << 20,
+		},
+	}, mgr)
+	b := rec.baseRecorder
+	b.frameCh = make(chan []byte, 256) // normally created in connectAndRecord
+	b.resetAdaptive()
+
+	done := make(chan struct{})
+	go b.writeFrames(done)
+	defer func() {
+		close(b.frameCh)
+		<-done
+	}()
+
+	send := func(nal []byte) {
+		b.frameCh <- append(append([]byte{}, 0, 0, 0, 1), nal...)
+	}
+
+	// Parameter sets + IDR anchor (padded to a realistic keyframe size).
+	send(testSPS)
+	send(testPPS)
+	idr := append(append([]byte{}, testIDR...), bytes.Repeat([]byte{0x11}, 20000)...)
+	send(idr)
+
+	// 35 calm P-frames at 20ms (700ms total): rotation fires at ~200ms
+	// (frames written to segment 1, flags marked), timelapse entry at ~400ms,
+	// the rest is sparse-skipped but retained.
+	const totalPs = 35
+	for i := range totalPs {
+		p := append([]byte{0x41}, bytes.Repeat([]byte{0x22}, 799)...)
+		p[len(p)-2] = byte(i >> 8) // unique per frame — adjacent-duplicate
+		p[len(p)-1] = byte(i)      // detection must not false-positive
+		send(p)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Major spike (300KB vs 800B baseline): single-frame timelapse exit.
+	spike := append([]byte{0x41}, bytes.Repeat([]byte{0x33}, 299999)...)
+	send(spike)
+
+	// Let the writer drain, then collect the finalized segments.
+	require.Eventually(t, func() bool { return len(b.frameCh) == 0 }, 3*time.Second, 10*time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+
+	files, err := mgr.ListFiles(cam)
+	require.NoError(t, err)
+	require.Len(t, files, 2, "rotation + exit flush must produce exactly 2 segments")
+	sort.Strings(files) // nano-suffixed names sort chronologically
+
+	seg1, err := merge.ParseSegment(files[0])
+	require.NoError(t, err)
+	// Bug B precondition: frames WERE written pre-rotation (their written
+	// flags went stale when segment 1 closed).
+	require.GreaterOrEqual(t, seg1.SampleCount, 3, "segment 1 must hold the IDR plus pre-rotation P-frames")
+
+	seg2, err := merge.ParseSegment(files[1])
+	require.NoError(t, err)
+	// The exit flush must carry the whole retained ring (IDR + every P since
+	// connect — rotation cleared the stale flags) plus the trigger written
+	// once by the normal path. Bug B skipped the pre-rotation frames here;
+	// Bug A wrote the trigger twice.
+	require.True(t, seg2.Samples[0].IsKeyFrame, "flush segment must start at the ring's IDR anchor")
+	require.Equal(t, 1+totalPs+1, seg2.SampleCount,
+		"fresh-segment flush must contain IDR + all %d retained P-frames + trigger", totalPs)
+
+	data, err := os.ReadFile(files[1])
+	require.NoError(t, err)
+	spikeTail := spike[len(spike)-16:]
+	spikeCount := 0
+	var prev []byte
+	for i, s := range seg2.Samples {
+		sample := data[s.Offset : s.Offset+int64(s.Size)]
+		if bytes.Contains(sample, spikeTail) {
+			spikeCount++
+		}
+		if i > 0 && bytes.Equal(prev, sample) {
+			t.Fatalf("segments %d/%d are identical — a frame was written twice (size=%d tail=%x)", i-1, i, len(sample), sample[len(sample)-4:])
+		}
+		prev = sample
+	}
+	require.Equal(t, 1, spikeCount, "trigger frame must be on disk exactly once")
+}

--- a/internal/recorder/adaptive_rotation_test.go
+++ b/internal/recorder/adaptive_rotation_test.go
@@ -92,7 +92,7 @@ func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
 	const cam = "h264-adaptive-poc"
 	rec := NewH264Recorder(H264Config{
 		CameraID:   cam,
-		RTSPURL:    "rtsp://ignored", // never connected — writeFrames driven directly
+		RTSPURL:    "rtsp://ignored",       // never connected — writeFrames driven directly
 		SegmentDur: 200 * time.Millisecond, // rotate mid-NORMAL, before TL entry
 		RingBufCap: 256,
 		Adaptive: &AdaptiveConfig{

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -77,8 +77,13 @@ func TestAdaptiveTracker_SpikeReturnsFlushAndResumesNormal(t *testing.T) {
 	if len(flush) == 0 || !flush[0].isIDR {
 		t.Fatal("flush must start with the retained IDR")
 	}
-	if len(flush) != 507 { // IDR + 500 calm + 5 sparse + the spike frame itself (appended before takeGOP)
-		t.Fatalf("flush = %d frames, want 507", len(flush))
+	if len(flush) != 506 { // IDR + 500 calm + 5 sparse; the spike (trigger) frame itself is
+		// NOT part of the flush — the caller writes it via the normal write path
+		// right after (including it double-wrote every exit frame, issue #498)
+		t.Fatalf("flush = %d frames, want 506", len(flush))
+	}
+	if last := flush[len(flush)-1]; bytes.Equal(last.nalu, spike) {
+		t.Fatal("flush must exclude the trigger frame — the caller writes it via the normal path (issue #498)")
 	}
 	if len(tr.gop) != 0 {
 		t.Fatalf("gop ring must be detached after flush, has %d", len(tr.gop))

--- a/internal/recorder/audio_trigger.go
+++ b/internal/recorder/audio_trigger.go
@@ -190,6 +190,18 @@ func (r *audioRing) markWritten() {
 	}
 }
 
+// clearWritten forgets the on-disk markings when the segment they were
+// written to closes — a later flush into a fresh segment must not skip
+// samples that only exist in the closed file (issue #498, the audio twin
+// of adaptiveTracker.clearWritten).
+func (r *audioRing) clearWritten() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := range r.s {
+		r.s[i].Written = false
+	}
+}
+
 // drain returns all retained packets (oldest first) and clears the ring.
 func (r *audioRing) drain() []AudioSample {
 	r.mu.Lock()
@@ -255,6 +267,12 @@ func (rt *AudioTriggerRuntime) Ingest(muLaw bool, payload []byte, dur time.Durat
 // MarkWritten flags the newest retained packet as written by the live path.
 func (rt *AudioTriggerRuntime) MarkWritten() {
 	rt.ring.markWritten()
+}
+
+// ClearWritten forgets the per-segment written markings after the caller's
+// current segment closes (issue #498 — see audioRing.clearWritten).
+func (rt *AudioTriggerRuntime) ClearWritten() {
+	rt.ring.clearWritten()
 }
 
 // Drain returns the retained pre-trigger packets (oldest first) and clears

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -897,6 +897,16 @@ func (b *baseRecorder) closeCurrentSegment() {
 	if b.muxer == nil {
 		return
 	}
+	// The retained GOP/audio rings' `written` markings refer to the segment
+	// being closed; a later timelapse-exit flush into a FRESH segment must
+	// write those frames instead of skipping them (issue #498: mid-GOP frames
+	// existed only in the closed file, so the skip produced missing refs).
+	if b.adaptive != nil {
+		b.adaptive.clearWritten()
+	}
+	if b.audioTrig != nil {
+		b.audioTrig.ClearWritten()
+	}
 	finishStart := time.Now()
 	if err := b.muxer.Close(); err != nil {
 		b.log.Error("failed to close muxer",
@@ -995,6 +1005,14 @@ func (b *baseRecorder) closeCurrentSegment() {
 // when storage recovers.
 func (b *baseRecorder) handleStorageFailure() {
 	if b.muxer != nil {
+		// The discarded segment's frames are on nowhere on disk — same
+		// written-flag reset as a clean rotation (issue #498).
+		if b.adaptive != nil {
+			b.adaptive.clearWritten()
+		}
+		if b.audioTrig != nil {
+			b.audioTrig.ClearWritten()
+		}
 		b.muxer.Close()
 		os.Remove(b.curTempPath)
 		b.mu.Lock()

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787526820896';
+const CACHE_VERSION = 'mibee-nvr-1787572912678';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -1103,6 +1103,15 @@ func (r *XiaomiRecorder) closeCurrentSegment() {
 	if r.muxer == nil {
 		return
 	}
+	// The retained rings' `written` markings refer to the segment being
+	// closed; a later flush into a fresh segment must write those frames
+	// instead of skipping them (issue #498 — mirrors baseRecorder).
+	if r.adaptive != nil {
+		r.adaptive.ClearWritten()
+	}
+	if r.audioTrig != nil {
+		r.audioTrig.ClearWritten()
+	}
 	if err := r.muxer.Close(); err != nil {
 		xiaomiLogger.Error("failed to close muxer", "camera_id", r.cfg.CameraID, "error", err)
 		if r.curTempPath != "" {


### PR DESCRIPTION
## 背景

#435 adaptive 长测中 #497 修复合并层后，原始段（recorder 落盘的 .mp4 本身）仍带 1-11 处 POC 损伤（#498）。现场捕获的原始段证据呈两种形态：

- `Duplicate POC in a sequence: N`（每个 TL 退出段一处）
- `Could not find ref with POC N`（多出现在轮转后的退出段）

## 根因（两个耦合缺陷，均在 adaptive 写密度门控）

**① 触发帧双写 → Duplicate POC。** `observe()` 在 `takeGOP()` 分离环之前就把当前帧（触发帧）追加进了 GOP 环，flush 列表因此**包含触发帧**；`writeFlushedGOP` 写完环后，正常写入路径（Step 9）又把同一帧再写一次——每次 TL→NORMAL 退出都产生一个重复 POC/同 pts 帧。`AdaptiveGate.Observe` 的契约注释本来就写着 flush 是 *"frames to write BEFORE the current frame"*——实现与契约相悖。

**② written 旗标跨段 → missing ref POC。** `gopFrame.written` 语义是"已在**当前段**落盘"，但 60s 分段轮转后旗标未清除。轮转后 muxer==nil，此时若 TL 退出 flush 落入**新段**：writeFlushedGOP 用环的 IDR 建新段后 muxer != nil，旧段的 written=true 帧全部被跳过——这些帧在新段里根本不存在 → 参考链断裂。

## 修复

- `takeGOP()` 返回**不含触发帧**的环（触发帧由调用方正常路径写一次；触发帧本身是 IDR 时环仅剩它 → 无需 flush 返回 nil）。base / Xiaomi / AdaptiveGate facade 三条路径同时治愈。
- `closeCurrentSegment()` / `handleStorageFailure()`（base + Xiaomi）轮转时清除视频环 written 旗标；音频 pre-trigger 环的 `Written` 孪生同样清除（`ClearWritten` 对）。
- 新段 flush 现在写入完整保留环，退出段完全可解。

## 顺带修复：深检/审计误报（#492/#487）——正是它们掩盖了损伤

- 消失源（滚动合并在 spaced probe 之前吃掉文件）单列 `result=vanished`，不再计入 `decode_error`/`probe_error`；
- 过滤 null-muxer 良性 `non monotonically increasing dts` 行（pts==dts 是 muxer 设计）及其 `Last message repeated` 通知行——修复前 `ok` 结构性不可达（现场 28 次深检 ok=0）；
- ctx 取消/超时不再记 verdict。

## 测试

- 新增 `TestH264Adaptive_TLExitFlushAfterRotation`：端到端驱动 writeFrames 走 轮转→TL→尖峰退出，断言新段含完整保留环（IDR+全部 P 帧）+ 触发帧**恰好一次**；不修 ① 或 ② 任一处即失败。
- 单测：takeGOP 排除尾帧 / 仅触发帧环返回 nil / clearWritten（视频+音频环）。
- #492/#487：vanished-by-stat、vanished-by-stderr、良性 dts→ok、真实 POC 错→decode_error、probe ENOENT→vanished（不再长 probe_error）。
- 既有断言旧语义的用例（flush 含触发帧）已翻转。

## 实测

M5 实机部署 `0.11.0-poc-fix-498` 验证后合入（原始段抽样 + 下载 + 浏览器播放 + 深检 ok>0）。修复前基线：视通原始段 1-4 错/段（missing+dup 双形态）。
