### PR TITLE
fix(tutk): clear stale handshake write deadline — ~10-20s disconnect loop on legacy cameras (#167)

### DIFF
--- a/internal/tutk/conn.go
+++ b/internal/tutk/conn.go
@@ -22,9 +22,11 @@ import (
 // ("tutk-transport" component) so testers' log-grep instructions stay stable.
 var tutkLogger = slog.Default().With("component", "tutk-transport")
 
-// Keepalive cadence for idle TUTK sessions (issue #167: Kalay devices/relays
-// drop the session after ~10-20s of client silence). We keep the read deadline
-// short so the worker wakes up regularly and can emit an alive signal.
+// Keepalive hardening for idle TUTK sessions. Root cause of the ~10-20s
+// disconnect loop (issue #167) was a stale handshake WRITE deadline that
+// silently killed all post-handshake writes (ACKs included) — fixed in Dial.
+// The periodic counters packet below is defense-in-depth so a silent camera
+// still hears from us, plus the tick/lost logs that exposed the bug.
 // Var (not const) so tests can shorten it.
 var (
 	keepaliveInterval = 2 * time.Second
@@ -66,7 +68,13 @@ func Dial(host, uid, username, password string) (*Conn, error) {
 
 	sid := GenSessionID()
 
-	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	// Handshake read timeout — READ side only. A write deadline here would
+	// silently kill every post-handshake outbound packet (per-frame counters
+	// ACKs, MISS commands, keepalives) once it expires ~5s in: the camera then
+	// starves for ACKs and stops streaming ~20s later — issue #167's disconnect
+	// loop. UDP writes never block, so a write deadline buys nothing.
+	// (Same pattern as cs2Handshake, which clears its deadline afterwards.)
+	_ = c.UDPConn.SetReadDeadline(time.Now().Add(5 * time.Second))
 
 	if addr.Port != 10001 {
 		err = c.connectDirect(uid, sid)
@@ -88,6 +96,10 @@ func Dial(host, uid, username, password string) (*Conn, error) {
 		_ = c.Close()
 		return nil, err
 	}
+
+	// Handshake done — clear any lingering deadline before the worker takes
+	// over (it manages its own read deadline). Mirrors cs2.go's handshake.
+	_ = c.UDPConn.SetDeadline(time.Time{})
 
 	tutkLogger.Info("tutk: session established", "uid", uid, "session_ver", c.ver[0], "keepalive", keepaliveEnabled())
 

--- a/internal/tutk/conn.go
+++ b/internal/tutk/conn.go
@@ -10,11 +10,34 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 )
+
+// tutkLogger matches the log vocabulary used during issue #167 field testing
+// ("tutk-transport" component) so testers' log-grep instructions stay stable.
+var tutkLogger = slog.Default().With("component", "tutk-transport")
+
+// Keepalive cadence for idle TUTK sessions (issue #167: Kalay devices/relays
+// drop the session after ~10-20s of client silence). We keep the read deadline
+// short so the worker wakes up regularly and can emit an alive signal.
+// Var (not const) so tests can shorten it.
+var (
+	keepaliveInterval = 2 * time.Second
+	tickInterval      = 30 * time.Second
+)
+
+// keepaliveEnabled gates the experimental active keepalive. TUTK has no
+// documented keepalive; Session25 counters (0x09) are the client's usual
+// "alive" signal and are reused here as a periodic unsolicited packet.
+// Disable with TUTK_KEEPALIVE=off if a camera misbehaves (issue #167).
+func keepaliveEnabled() bool {
+	return os.Getenv("TUTK_KEEPALIVE") != "off"
+}
 
 // Dial establishes a TUTK P2P connection to a device identified by UID.
 // host: IP address with optional port (default 32761).
@@ -36,6 +59,7 @@ func Dial(host, uid, username, password string) (*Conn, error) {
 	c := &Conn{
 		UDPConn:     udpConn,
 		addr:        addr,
+		uid:         uid,
 		idleTimeout: 30 * time.Second,
 		lastData:    time.Now(),
 	}
@@ -65,6 +89,8 @@ func Dial(host, uid, username, password string) (*Conn, error) {
 		return nil, err
 	}
 
+	tutkLogger.Info("tutk: session established", "uid", uid, "session_ver", c.ver[0], "keepalive", keepaliveEnabled())
+
 	go c.worker()
 
 	return c, nil
@@ -74,6 +100,7 @@ func Dial(host, uid, username, password string) (*Conn, error) {
 type Conn struct {
 	*net.UDPConn
 	addr    *net.UDPAddr
+	uid     string
 	session Session
 
 	ver    []byte
@@ -207,30 +234,67 @@ func (c *Conn) Error() error {
 }
 
 func (c *Conn) worker() {
-	defer c.workerExitGuard()
+	established := time.Now()
+	var keepalivesSent, pktsRecv uint64
+
+	// Declared before the exit guard so it runs after it (LIFO) and can log
+	// the final error the guard may have set.
+	defer func() {
+		tutkLogger.Info("tutk: connection lost",
+			"uid", c.uid, "reason", c.getErr().Error(),
+			"alive", time.Since(established).Round(time.Second).String(),
+			"keepalives_sent", keepalivesSent, "pkts", pktsRecv)
+	}()
 	defer c.session.Close()
+	defer c.workerExitGuard()
 
 	buf := make([]byte, 1200)
+	lastTick := time.Now()
+	// Periodic INFO heartbeat so field-test logs show liveness both while
+	// data flows (called from the read path) and during silence (timeout path).
+	tick := func(idle time.Duration) {
+		if time.Since(lastTick) >= tickInterval {
+			lastTick = time.Now()
+			tutkLogger.Info("tutk: keepalive tick",
+				"uid", c.uid, "sent", keepalivesSent, "pkts", pktsRecv,
+				"last_data_ago", idle.Round(time.Second).String())
+		}
+	}
 
 	for {
-		_ = c.UDPConn.SetReadDeadline(time.Now().Add(c.idleTimeout))
+		// Short deadline doubles as the keepalive timer: on active streams the
+		// read returns with data well before the deadline; on silence it wakes
+		// us up every keepaliveInterval to emit a client-alive signal.
+		wakeup := keepaliveInterval
+		if c.idleTimeout < wakeup {
+			wakeup = c.idleTimeout // short idleTimeout (tests): wake up sooner
+		}
+		_ = c.UDPConn.SetReadDeadline(time.Now().Add(wakeup))
 
 		n, err := c.Read(buf)
 		if err != nil {
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				c.mu.Lock()
-				idle := time.Since(c.lastData) > c.idleTimeout
+				idle := time.Since(c.lastData)
 				c.mu.Unlock()
-				if idle {
+
+				if idle > c.idleTimeout {
 					c.setErr(fmt.Errorf("tutk: no data for %v", c.idleTimeout))
 					return
 				}
+				if idle >= keepaliveInterval && c.sendKeepalive() {
+					keepalivesSent++
+				}
+				tick(idle)
 				continue
 			}
 			c.setErr(fmt.Errorf("tutk: %w", err))
 			return
 		}
+
+		pktsRecv++
+		tick(0)
 
 		switch c.handleMsg(buf[:n]) {
 		case msgUnknown:
@@ -243,6 +307,24 @@ func (c *Conn) worker() {
 			}
 		}
 	}
+}
+
+// sendKeepalive emits an unsolicited Session25 counters message (channel 0)
+// as a client-alive signal while the camera is silent. Session16 has no
+// counters builder, so those connections stay passive (as before).
+func (c *Conn) sendKeepalive() bool {
+	if !keepaliveEnabled() {
+		return false
+	}
+	s25, ok := c.session.(*Session25)
+	if !ok {
+		return false
+	}
+	if err := s25.SessionWrite(0, s25.msgAckCounters()); err != nil {
+		tutkLogger.Warn("tutk: keepalive write failed", "uid", c.uid, "error", err)
+		return false
+	}
+	return true
 }
 
 // workerExitGuard ensures c.err is set when worker() exits.

--- a/internal/tutk/conn_test.go
+++ b/internal/tutk/conn_test.go
@@ -256,3 +256,117 @@ func TestIdleTimeoutBehavior(t *testing.T) {
 		t.Errorf("unexpected error: %s", errStr)
 	}
 }
+
+// newKeepaliveTestConn builds a Conn wired to a fake camera UDP socket for
+// keepalive wire-format tests. Returns the client Conn and the fake camera.
+func newKeepaliveTestConn(t *testing.T) (*Conn, *net.UDPConn) {
+	t.Helper()
+
+	camera, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("camera ListenUDP: %v", err)
+	}
+	t.Cleanup(func() { _ = camera.Close() })
+
+	client, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		t.Fatalf("client ListenUDP: %v", err)
+	}
+
+	c := &Conn{
+		UDPConn:     client,
+		addr:        camera.LocalAddr().(*net.UDPAddr),
+		uid:         "TESTUID",
+		idleTimeout: 30 * time.Second,
+		lastData:    time.Now(),
+	}
+	c.session = NewSession25(c, GenSessionID())
+	return c, camera
+}
+
+// readDecoded reads one obfuscated packet from the fake camera and reverses
+// the wire obfuscation.
+func readDecoded(t *testing.T, camera *net.UDPConn) []byte {
+	t.Helper()
+
+	buf := make([]byte, 1200)
+	_ = camera.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := camera.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("camera ReadFromUDP: %v", err)
+	}
+	msg := buf[:n]
+	ReverseTransCodePartial(msg, msg)
+	return msg
+}
+
+func TestSendKeepaliveWireFormat(t *testing.T) {
+	c, camera := newKeepaliveTestConn(t)
+
+	if !c.sendKeepalive() {
+		t.Fatal("sendKeepalive should report success on Session25")
+	}
+
+	msg := readDecoded(t, camera)
+	if len(msg) < msgHhrSize+4 {
+		t.Fatalf("keepalive packet too short: %d bytes", len(msg))
+	}
+
+	// Header: client-request marker at [8:11] and channel-0 dispatch shape.
+	if string(msg[8:11]) != "\x07\x04\x21" {
+		t.Errorf("keepalive header [8:11] = %x, want 070421", msg[8:11])
+	}
+	// Payload starts at 28 with the counters command 09 00 0b 00.
+	if string(msg[msgHhrSize:msgHhrSize+4]) != "\x09\x00\x0b\x00" {
+		t.Errorf("keepalive cmd = %x, want 09000b00", msg[msgHhrSize:msgHhrSize+4])
+	}
+}
+
+func TestSendKeepaliveGating(t *testing.T) {
+	c, _ := newKeepaliveTestConn(t)
+
+	t.Run("session16 has no counters builder", func(t *testing.T) {
+		c16 := &Conn{UDPConn: c.UDPConn, addr: c.addr, uid: c.uid}
+		c16.session = NewSession16(&mockConn{}, GenSessionID())
+		if c16.sendKeepalive() {
+			t.Error("sendKeepalive should be a no-op on Session16")
+		}
+	})
+
+	t.Run("env off", func(t *testing.T) {
+		t.Setenv("TUTK_KEEPALIVE", "off")
+		if c.sendKeepalive() {
+			t.Error("sendKeepalive should be disabled via TUTK_KEEPALIVE=off")
+		}
+	})
+}
+
+func TestWorkerSendsKeepaliveWhenIdle(t *testing.T) {
+	orig := keepaliveInterval
+	keepaliveInterval = 100 * time.Millisecond
+	t.Cleanup(func() { keepaliveInterval = orig })
+
+	c, camera := newKeepaliveTestConn(t)
+
+	done := make(chan struct{})
+	go func() {
+		c.worker()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = c.UDPConn.Close() // unblocks worker read; it will exit via error
+		<-done
+	})
+
+	// With no inbound data the worker should emit several keepalives.
+	first := readDecoded(t, camera)
+	if string(first[msgHhrSize:msgHhrSize+4]) != "\x09\x00\x0b\x00" {
+		t.Errorf("expected counters keepalive, got cmd %x", first[msgHhrSize:msgHhrSize+4])
+	}
+
+	select {
+	case <-done:
+		t.Fatal("worker exited prematurely — idle timeout should be 30s")
+	default:
+	}
+}

--- a/internal/tutk/conn_test.go
+++ b/internal/tutk/conn_test.go
@@ -370,3 +370,33 @@ func TestWorkerSendsKeepaliveWhenIdle(t *testing.T) {
 	default:
 	}
 }
+
+// TestStaleWriteDeadlineKillsWrites is the regression test for issue #167's
+// root cause: Dial used to arm a combined SetDeadline(5s) for the handshake
+// and never cleared it, so every outbound packet after dial+5s (per-frame
+// counters ACKs, MISS commands, keepalives) failed with a silent
+// "write udp: i/o timeout". The camera, starved of ACKs, stopped streaming
+// ~20s later. This test pins the failure mechanism: a stale write deadline
+// breaks keepalive writes; clearing the deadline restores them.
+func TestStaleWriteDeadlineKillsWrites(t *testing.T) {
+	c, camera := newKeepaliveTestConn(t)
+
+	// Simulate the old Dial: deadline set 5s ago and forgotten.
+	_ = c.UDPConn.SetDeadline(time.Now().Add(-5 * time.Second))
+
+	if c.sendKeepalive() {
+		t.Fatal("sendKeepalive should fail under a stale write deadline")
+	}
+
+	// Fix under test: handshake clears the deadline before the worker runs.
+	_ = c.UDPConn.SetDeadline(time.Time{})
+
+	if !c.sendKeepalive() {
+		t.Fatal("sendKeepalive should succeed after deadline is cleared")
+	}
+
+	msg := readDecoded(t, camera)
+	if string(msg[msgHhrSize:msgHhrSize+4]) != "\x09\x00\x0b\x00" {
+		t.Errorf("expected counters keepalive, got cmd %x", msg[msgHhrSize:msgHhrSize+4])
+	}
+}

--- a/internal/xiaomi/miss.go
+++ b/internal/xiaomi/miss.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -226,6 +227,13 @@ func (c *MISSClient) StartMedia(channel, quality string, audioEnabled bool) erro
 	// enableaudio: "1" = on, "0" = off (default on for most cameras)
 	audioFlag := "0"
 	if audioEnabled {
+		audioFlag = "1"
+	}
+	// Issue #167 field-test knob: go2rtc always sends enableaudio=1; we send 0
+	// when per-camera audio is disabled. Some firmwares treat an audio-less
+	// session differently, so XIAOMI_MISS_ENABLEAUDIO=1 forces the flag on
+	// without changing how packets are consumed locally.
+	if os.Getenv("XIAOMI_MISS_ENABLEAUDIO") == "1" {
 		audioFlag = "1"
 	}
 


### PR DESCRIPTION
Fixes #167 (field-validated on real hardware by the reporter of #165)

## Root cause

`tutk.Dial()` armed a combined read+write `SetDeadline(5s)` for the handshake and never cleared it. The worker only refreshes the READ deadline, so the WRITE deadline sat in the past forever: **every outbound packet after dial+5s silently failed** — including the per-frame counters ACKs (`_ = SessionWrite(...)` in `handleChunk`, errors discarded) and MISS commands.

The camera, starved of ACKs for ~16s, stopped streaming ~21s into each session; our 30s idle timeout then killed the connection → the reconnect loop reported in #165/#167 (originally `read media: EOF` at ~10s, later measured as alive=52s cycles). CS2 never showed this because `cs2Handshake` correctly clears its deadline (`cs2.go:110→138`) — the TUTK port simply dropped that line.

## Changes

- `internal/tutk/conn.go`
  - handshake uses a **read-only** deadline; `SetDeadline(time.Time{})` clears everything before the worker starts (mirrors cs2Handshake)
  - defense-in-depth: when inbound data stalls ≥2s, the worker emits an unsolicited Session25 counters packet (`0x09`, channel 0) as a client-alive signal; `TUTK_KEEPALIVE=off` disables
  - diagnostics: `tutk: session established` (uid/session_ver), 30s `tutk: keepalive tick` (cumulative sent/pkts, last_data_ago — fires both while streaming and during silence), `tutk: connection lost` (reason/alive/counters) on every worker exit path
- `internal/xiaomi/miss.go`: `XIAOMI_MISS_ENABLEAUDIO=1` field-test knob (go2rtc always sends enableaudio=1; we send 0 when per-camera audio is off) — kept for future firmware-divergence diagnostics
- regression test `TestStaleWriteDeadlineKillsWrites` pins the failure mechanism (stale write deadline kills writes; clearing restores them); keepalive wire-format/worker/gating tests added

## Field validation (3 rounds on chuangmi.camera.ipc019, session_ver=25)

- v2 logs exposed the smoking gun: `keepalive write failed ... write udp: i/o timeout` every 2s from dial+5s
- v3 (this fix): single session, 5+ minutes continuous streaming, zero `connection lost` / zero WARN, `pkts` grows ~71/s, keepalive never needed to fire (`sent=0`, pure standby)

## Test plan

- [x] `go test -race ./...` — 449 pass in tutk+xiaomi, full suite green
- [x] coverage 59.1% (>55% gate)
- [x] golangci-lint v2 — 0 issues
- [x] amd64 test image validated on real hardware by community tester