### PR TITLE
feat: 延时录像压缩时间轴 + 环境声氛围层（#496）——正常速度播放即延时摄影，下载亦然

### DIFF
--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -23,10 +23,11 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 		var calm, interval string
 		var spike float64
 		var gop int64
+		var ambient bool
 		if a != nil {
-			calm, interval, spike, gop = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes
+			calm, interval, spike, gop, ambient = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio
 		}
-		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop)
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient)
 		return &ac
 	}
 	// resolveAudioTriggerConfig resolves the audio-trigger overrides (issue

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -148,6 +148,11 @@ type AdaptiveRecordingConfig struct {
 	// camera GOP — 2K cameras with IDR intervals near the 30s timelapse
 	// cadence overflow 16MB and lose the flush, issue #485). Range 1–64MB.
 	GOPBufferBytes int64 `yaml:"gop_buffer_bytes,omitempty" json:"gop_buffer_bytes,omitempty"`
+	// AmbientAudio keeps recording the audio track continuously while sparse
+	// (#496 audio phase): the merge compresses the ambient span into a quiet
+	// continuous atmosphere bed under the timelapse video (event spans keep
+	// real audio). G.711 cameras only; ~28.8MB/h storage while sparse.
+	AmbientAudio bool `yaml:"ambient_audio,omitempty" json:"ambient_audio,omitempty"`
 }
 
 // CameraAudioTriggerConfig tunes audio_trigger (issue #478).

--- a/internal/merge/ambient_audio.go
+++ b/internal/merge/ambient_audio.go
@@ -125,7 +125,7 @@ func mixdownAmbient(muLaw bool, in []byte, nOut int) []byte {
 	env := make([]float64, nOut)
 	for j := range nOut {
 		lo := j * len(in) / nOut
-		hi := (j+1) * len(in) / nOut
+		hi := (j + 1) * len(in) / nOut
 		if hi <= lo {
 			hi = lo + 1
 		}

--- a/internal/merge/ambient_audio.go
+++ b/internal/merge/ambient_audio.go
@@ -1,0 +1,181 @@
+package merge
+
+// ambient_audio.go — G.711 codec + the ambient-audio envelope mixdown (#496
+// audio phase).
+//
+// While a camera records in adaptive sparse mode with ambient_audio enabled,
+// its audio track keeps recording CONTINUOUSLY on the real-time axis. When
+// the merge compresses a span's video timeline (sparse dwells → fast cadence),
+// the span's audio cannot simply be sped up by the same ~300×: every audible
+// frequency would shift into ultrasound and what remains is aliasing noise.
+// Instead the span is rendered into a quiet continuous atmosphere bed:
+//
+//	per output sample, the RMS envelope of the corresponding input window
+//	modulates a low-passed noise carrier.
+//
+// Slow dynamics survive (wind gusts become swells, passing cars become brief
+// surges — the "whoosh" timelapse aesthetic), while waveform detail — which
+// would alias — is deliberately discarded. Event (full-rate) spans keep their
+// real audio verbatim, so anything that happened while recording at full rate
+// stays intelligible.
+//
+// The G.711 codec tables follow the ITU-T reference (Sun ulaw2linear /
+// alaw2linear form and their inverses).
+
+import "math"
+
+func g711DecodeMuLaw(u byte) int16 {
+	u = ^u
+	mag := int16(((int(u&0x0F) << 3) + 0x84) << ((u >> 4) & 0x07))
+	if u&0x80 != 0 {
+		return 0x84 - mag
+	}
+	return mag - 0x84
+}
+
+func g711DecodeALaw(a byte) int16 {
+	a ^= 0x55
+	t := int(a&0x0F) << 4
+	switch seg := (a >> 4) & 0x07; seg {
+	case 0:
+		t += 8
+	case 1:
+		t += 0x108
+	default:
+		t = (t + 0x108) << (seg - 1)
+	}
+	if a&0x80 != 0 {
+		return int16(t)
+	}
+	return -int16(t)
+}
+
+// g711EncodeMuLaw is the standard 14-bit companded encoder paired with
+// g711DecodeMuLaw (the decoder's complement makes a SET sign bit positive).
+var g711SegUEnd = [8]int32{0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF, 0x7FF, 0xFFF, 0x1FFF}
+
+func g711EncodeMuLaw(s int16) byte {
+	pcm := int32(s) >> 2 // 14-bit
+	var mask byte = 0xFF // positive sign (decoder complements)
+	if pcm < 0 {
+		pcm = -pcm
+		mask = 0x7F
+	}
+	if pcm > 8159 {
+		pcm = 8159
+	}
+	seg := 0
+	for seg < 7 && pcm > g711SegUEnd[seg] {
+		seg++
+	}
+	// XOR with the sign mask (complementing the codeword) — OR would smash
+	// the segment/mantissa bits.
+	return (byte(seg<<4) | byte((pcm>>(seg+1))&0xF)) ^ mask
+}
+
+// g711EncodeALaw inverts g711DecodeALaw by construction (the decoder
+// reconstructs |v| = (16m+264)<<(seg-1) for seg≥1, 16m+8 for seg 0 — the
+// encoder picks the segment and mantissa directly from those ranges, avoiding
+// the classic-table shift conventions).
+func g711EncodeALaw(s int16) byte {
+	v := int32(s)
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	seg := int32(0)
+	if v > 248 { // seg0 reconstructs 8..248
+		seg = 1
+		for seg < 7 && v > 504<<(seg-1) {
+			seg++
+		}
+	}
+	var m int32
+	if seg == 0 {
+		m = (v - 8) >> 4
+	} else {
+		m = ((v >> (seg - 1)) - 264) >> 4
+	}
+	if m < 0 {
+		m = 0
+	} else if m > 15 {
+		m = 15
+	}
+	a := byte(seg<<4 | m)
+	if !neg {
+		a |= 0x80
+	}
+	return a ^ 0x55
+}
+
+// ambientGain is the mixdown's master level relative to full scale. The
+// atmosphere bed must sit clearly under the real audio of event spans —
+// roughly -16 dBFS RMS after normalization (field-tuning knob).
+const ambientGain = 0.16 * 32768
+
+// mixdownAmbient renders one compressed span's G.711 audio (in, muLaw) into
+// nOut samples on the span's file timeline: RMS envelope per output window
+// modulating a low-passed deterministic noise carrier. Returns nil for empty
+// input.
+func mixdownAmbient(muLaw bool, in []byte, nOut int) []byte {
+	if len(in) == 0 || nOut <= 0 {
+		return nil
+	}
+	// RMS envelope per output sample over its proportional input window.
+	env := make([]float64, nOut)
+	for j := range nOut {
+		lo := j * len(in) / nOut
+		hi := (j+1) * len(in) / nOut
+		if hi <= lo {
+			hi = lo + 1
+		}
+		if hi > len(in) {
+			hi = len(in)
+		}
+		var sumSq float64
+		for _, b := range in[lo:hi] {
+			var v int16
+			if muLaw {
+				v = g711DecodeMuLaw(b)
+			} else {
+				v = g711DecodeALaw(b)
+			}
+			sumSq += float64(v) * float64(v)
+		}
+		env[j] = math.Sqrt(sumSq / float64(hi-lo))
+	}
+	// Normalize the envelope so a typical span uses the target headroom.
+	var ms float64
+	for _, v := range env {
+		ms += v * v
+	}
+	if rms := math.Sqrt(ms / float64(nOut)); rms > 1e-6 {
+		scale := ambientGain / rms
+		for j := range env {
+			env[j] *= scale
+		}
+	}
+	// Low-passed noise carrier (deterministic LCG — reproducible merges).
+	out := make([]byte, nOut)
+	const carrierTap = 8 // moving average ≈ 1kHz at 8k sample rate
+	var seed uint32 = 0x9E3779B9
+	var noise, lp float64
+	for j := range nOut {
+		seed = seed*1664525 + 1013904223
+		// uniform (−1,1): full int32 range over 2^31
+		noise = float64(int32(seed)) / 2147483648.0
+		lp += (noise - lp) / carrierTap
+		s := env[j] * lp
+		if s > 32767 {
+			s = 32767
+		} else if s < -32768 {
+			s = -32768
+		}
+		if muLaw {
+			out[j] = g711EncodeMuLaw(int16(s))
+		} else {
+			out[j] = g711EncodeALaw(int16(s))
+		}
+	}
+	return out
+}

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -54,11 +55,64 @@ type MergeStats struct {
 	// LeadingDropped maps input index → count of leading video samples dropped
 	// to reach that segment's first keyframe.
 	LeadingDropped map[int]int
+	// TimelapseFrames counts sparse dwell samples rewritten to
+	// TimelapseFrameDur — the compressed-timeline fix for #496.
+	TimelapseFrames int
+	// AmbientSamples counts synthesized atmosphere-bed samples rendered from
+	// compressed spans' continuous ambient audio (#496 audio phase).
+	AmbientSamples int
+	// WallToFile maps the product's wall-clock span onto its (possibly
+	// compressed) file timeline: cumulative [wallSeconds, fileSeconds] pairs
+	// at every input boundary, len == len(segments)+1 (starts at [0,0]).
+	// Piecewise-linear: within an input, wall time maps onto file time at that
+	// input's (possibly rewritten) rate. Callers with no UI plumbing may
+	// ignore it; it is always populated.
+	WallToFile [][2]float64
 }
 
 // ErrNoKeyframe is returned when no input segment carries a keyframe sample —
 // nothing decodable can be produced from the inputs.
 var ErrNoKeyframe = errors.New("no keyframe-bearing segments")
+
+// TimelineMapJSON renders WallToFile as the compact JSON stored on the
+// product row ("[[0,0],[126.3,2.5],...]"). Empty when no map was collected.
+func (s MergeStats) TimelineMapJSON() string {
+	if len(s.WallToFile) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(s.WallToFile)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// WallDurationSec returns the product's wall-clock span (the last WallToFile
+// point's wall component) — the merge-time companion of the row's
+// started_at..ended_at, unaffected by dwell compression.
+func (s MergeStats) WallDurationSec() float64 {
+	if n := len(s.WallToFile); n > 0 {
+		return s.WallToFile[n-1][0]
+	}
+	return 0
+}
+// Timelapse dwell compression (#496): adaptive sparse mode stores one keyframe
+// per timelapse_interval (~30s) ON THE REAL-TIME AXIS, so any player — the SPA
+// included, and crucially a DOWNLOADED file in a local player — freezes each
+// frame for the whole gap. A video sample whose duration exceeds
+// TimelapseGapThreshold is such a dwell; in segments WITHOUT an audio track
+// (sparse mode drops disk audio, so TL segments never carry one) the dwell is
+// rewritten to TimelapseFrameDur, making normal 1× playback feel like the
+// timelapse it is. Segments WITH audio keep real durations: their audio track
+// has its own timeline, and rewriting video there would desync it.
+//
+// Vars (not consts) so tooling and tests can inject alternative cadences —
+// the field-test flow generated per-camera sample clips at different frame
+// durations before fixing the default.
+var (
+	TimelapseGapThreshold = 2 * time.Second
+	TimelapseFrameDur     = 100 * time.Millisecond
+)
 
 // AlignToKeyframe trims seg's leading video samples up to (and including the
 // position of) its first keyframe and trims the audio head by the same wall
@@ -332,6 +386,8 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	var currentOffset int64
 	var allVideoSamples []mergedSample
 
+	stats.WallToFile = append(stats.WallToFile, [2]float64{0, 0})
+	var wallSec, fileSec float64
 	for _, seg := range segments {
 		if seg.FilePath == "" {
 			return stats, fmt.Errorf("segment has empty FilePath")
@@ -341,6 +397,16 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		if err != nil {
 			return stats, fmt.Errorf("open segment %s: %w", seg.FilePath, err)
 		}
+
+		// Sparse dwell compression (#496): no-audio segments (adaptive
+		// timelapse drops the disk audio track) have their >2s dwell samples
+		// rewritten to timelapseFrameDur so 1×/downloaded playback shows a
+		// timelapse instead of a frozen frame. Audio-bearing segments keep
+		// real durations — their audio track would desync.
+		ts := float64(seg.Timescale)
+		compress := !seg.HasAudio && seg.Timescale > 0
+		gapTicks := float64(seg.Timescale) * TimelapseGapThreshold.Seconds()
+		frameTicks := uint32(float64(seg.Timescale) * TimelapseFrameDur.Seconds())
 
 		for _, s := range seg.Samples {
 			select {
@@ -357,25 +423,85 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 				return stats, fmt.Errorf("copy sample from %s at offset %d: %w", seg.FilePath, s.Offset, copyErr)
 			}
 
+			dur := s.Duration
+			if compress && float64(dur) > gapTicks {
+				dur = frameTicks
+				stats.TimelapseFrames++
+			}
+			if ts > 0 {
+				wallSec += float64(s.Duration) / ts
+				fileSec += float64(dur) / ts
+			}
+
 			allVideoSamples = append(allVideoSamples, mergedSample{
 				offset:     sampleAbsOffset,
 				size:       s.Size,
-				duration:   s.Duration,
+				duration:   dur,
 				isKeyFrame: s.IsKeyFrame,
 			})
 			currentOffset += int64(s.Size)
 		}
 
 		src.Close()
+		stats.WallToFile = append(stats.WallToFile, [2]float64{wallSec, fileSec})
 	}
 
-	// Stream audio samples after video samples.
+	// Stream audio samples after video samples. Spans whose video timeline was
+	// compressed (#496) get their audio rendered by envelope mixdown instead of
+	// verbatim copy — see ambient_audio.go; non-G.711 compressed spans drop
+	// their audio (logged), uncompressed spans keep it byte-for-byte.
 	var allAudioSamples []mergedSample
 	if hasAudio {
-		for _, seg := range segments {
+		for segIdx, seg := range segments {
 			if len(seg.AudioSamples) == 0 {
 				continue
 			}
+
+			spanWall := stats.WallToFile[segIdx+1][0] - stats.WallToFile[segIdx][0]
+			spanFile := stats.WallToFile[segIdx+1][1] - stats.WallToFile[segIdx][1]
+			compressedSpan := spanWall > 0 && spanFile > 0 && spanWall > 1.5*spanFile
+
+			if compressedSpan {
+				if seg.AudioCodec != "g711" {
+					logger.Warn("merge: dropping audio of a compressed span with unsupported codec (g711 only)",
+						"path", seg.FilePath, "codec", seg.AudioCodec)
+					continue
+				}
+				src, err := os.Open(seg.FilePath)
+				if err != nil {
+					return stats, fmt.Errorf("open segment %s for audio: %w", seg.FilePath, err)
+				}
+				raw := make([]byte, 0, 1<<16)
+				for _, s := range seg.AudioSamples {
+					chunk := make([]byte, s.Size)
+					if _, err := src.ReadAt(chunk, s.Offset); err != nil {
+						src.Close()
+						return stats, fmt.Errorf("read audio sample from %s at offset %d: %w", seg.FilePath, s.Offset, err)
+					}
+					raw = append(raw, chunk...)
+				}
+				src.Close()
+
+				nOut := int(spanFile*float64(seg.AudioTimescale) + 0.5)
+				bed := mixdownAmbient(seg.G711MULaw, raw, nOut)
+				if len(bed) > 0 {
+					bedOffset := currentOffset + mdatDataStart
+					if _, err := out.Write(bed); err != nil {
+						return stats, fmt.Errorf("write ambient bed: %w", err)
+					}
+					for i := range bed {
+						allAudioSamples = append(allAudioSamples, mergedSample{
+							offset:   bedOffset + int64(i),
+							size:     1,
+							duration: 1, // one tick per G.711 byte on the audio timescale
+						})
+					}
+					currentOffset += int64(len(bed))
+					stats.AmbientSamples += len(bed)
+				}
+				continue
+			}
+
 			src, err := os.Open(seg.FilePath)
 			if err != nil {
 				return stats, fmt.Errorf("open segment %s for audio: %w", seg.FilePath, err)

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -398,13 +398,14 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 			return stats, fmt.Errorf("open segment %s: %w", seg.FilePath, err)
 		}
 
-		// Sparse dwell compression (#496): no-audio segments (adaptive
-		// timelapse drops the disk audio track) have their >2s dwell samples
-		// rewritten to timelapseFrameDur so 1×/downloaded playback shows a
-		// timelapse instead of a frozen frame. Audio-bearing segments keep
-		// real durations — their audio track would desync.
+		// Sparse dwell compression (#496): segments' >2s dwell samples are
+		// rewritten to TimelapseFrameDur so 1×/downloaded playback shows a
+		// timelapse instead of a frozen frame. Applies to audio-bearing
+		// segments too — the audio phase below renders such a span's G.711
+		// ambient audio onto the compressed timeline (envelope mixdown) or
+		// drops it for non-G.711 codecs.
 		ts := float64(seg.Timescale)
-		compress := !seg.HasAudio && seg.Timescale > 0
+		compress := seg.Timescale > 0
 		gapTicks := float64(seg.Timescale) * TimelapseGapThreshold.Seconds()
 		frameTicks := uint32(float64(seg.Timescale) * TimelapseFrameDur.Seconds())
 
@@ -563,6 +564,13 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 	}
 	videoTrack.duration = uint32(totalVideoDuration)
 	videoTrack.samples = allVideoSamples
+
+	// A merged product where every span was compressed with a dropped
+	// non-G.711 track has zero audio samples — emit no audio track at all.
+	if hasAudio && len(allAudioSamples) == 0 {
+		hasAudio = false
+		audioTrack = nil
+	}
 
 	// Set real audio track data.
 	if hasAudio {

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -96,6 +96,7 @@ func (s MergeStats) WallDurationSec() float64 {
 	}
 	return 0
 }
+
 // Timelapse dwell compression (#496): adaptive sparse mode stores one keyframe
 // per timelapse_interval (~30s) ON THE REAL-TIME AXIS, so any player — the SPA
 // included, and crucially a DOWNLOADED file in a local player — freezes each

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -1019,6 +1019,7 @@ func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID st
 		FrameCount:   totalFrames,
 		MergeStatus:  model.MergeStatusMerged,
 		MergeQuality: ComputeMergeQuality(recs[0].StartedAt, recs[len(recs)-1].EndedAt, durSec, r.resolveRollingConfig(cameraID).MinDuration.Seconds()),
+		TimelineMap:  stats.TimelineMapJSON(),
 	}
 
 	ids := make([]string, len(recs))
@@ -1662,7 +1663,8 @@ func (r *RollingMergeCoordinator) createBucket(
 	}
 
 	// Merge single segment into the bucket file (pre-aligned by mergeOneSegment).
-	if _, err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath); err != nil {
+	stats, err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath)
+	if err != nil {
 		os.Remove(tempPath)
 		return "", "", fmt.Errorf("merge initial segment: %w", err)
 	}
@@ -1689,10 +1691,14 @@ func (r *RollingMergeCoordinator) createBucket(
 		Format:      model.Format(seg.format),
 		StartedAt:   seg.startedAt,
 		EndedAt:     seg.endedAt,
-		Duration:    info.TotalDuration.Seconds(),
+		// Wall-clock span (#496): the file timeline may be timelapse-compressed;
+		// the row keeps reporting real time so storage accounting and the UI's
+		// wall-clock math stay on the real axis.
+		Duration:    statsWallDuration(stats, info.TotalDuration.Seconds()),
 		FileSize:    fi.Size(),
 		FrameCount:  info.SampleCount,
 		MergeStatus: model.MergeStatusMerged,
+		TimelineMap: stats.TimelineMapJSON(),
 	}
 
 	if err := storage.RetryOnBusy(ctx, func() error {
@@ -1773,10 +1779,10 @@ func (r *RollingMergeCoordinator) appendToBucket(
 		return "", "", fmt.Errorf("finalize append (rename): %w", err)
 	}
 
-	// Calculate updated metadata.
-	totalDur := bucketInfo.TotalDuration + newInfo.TotalDuration
+	// Calculate updated metadata. Duration stays on the wall-clock axis (#496):
+	// the bucket file's parsed durations shrink with each timelapse-compressed
+	// append, so the wall span comes from the merge stats' input sums instead.
 	totalFrames := bucketInfo.SampleCount + newInfo.SampleCount
-	totalDurSec := math.Round(totalDur.Seconds()*1000) / 1000
 
 	mergedRecID = bucket.mergedRecID
 	mergedRec := &model.Recording{
@@ -1786,10 +1792,11 @@ func (r *RollingMergeCoordinator) appendToBucket(
 		Format:      model.Format(seg.format),
 		StartedAt:   bucket.windowStart,
 		EndedAt:     seg.endedAt,
-		Duration:    totalDurSec,
+		Duration:    statsWallDuration(stats, totalDurFallbackSec(bucketInfo, newInfo)),
 		FileSize:    fi.Size(),
 		FrameCount:  totalFrames,
 		MergeStatus: model.MergeStatusMerged,
+		TimelineMap: stats.TimelineMapJSON(),
 	}
 
 	// UPDATE the merged row + DELETE the source segment row, in one transaction.
@@ -1847,4 +1854,22 @@ func bytesEqual(a, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// statsWallDuration picks the product's wall-clock span from the merge stats
+// (sum of input sample durations — unaffected by #496 timelapse dwell
+// compression), falling back to the caller's parsed-duration estimate when no
+// map was collected.
+func statsWallDuration(stats MergeStats, fallback float64) float64 {
+	if w := stats.WallDurationSec(); w > 0 {
+		return math.Round(w*1000) / 1000
+	}
+	return fallback
+}
+
+// totalDurFallbackSec is the pre-stats duration estimate for a bucket append:
+// the parsed bucket file plus the new input. Correct on the real-time axis
+// (no compression yet), and only used when stats carry no wall map.
+func totalDurFallbackSec(bucketInfo, newInfo *SegmentInfo) float64 {
+	return math.Round((bucketInfo.TotalDuration + newInfo.TotalDuration).Seconds()*1000) / 1000
 }

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -1685,12 +1685,12 @@ func (r *RollingMergeCoordinator) createBucket(
 	// Create merged recording row and delete the source segment row.
 	mergedRecID = strconv.FormatInt(time.Now().UnixNano(), 10)
 	mergedRec := &model.Recording{
-		ID:          mergedRecID,
-		CameraID:    seg.cameraID,
-		FilePath:    finalPath,
-		Format:      model.Format(seg.format),
-		StartedAt:   seg.startedAt,
-		EndedAt:     seg.endedAt,
+		ID:        mergedRecID,
+		CameraID:  seg.cameraID,
+		FilePath:  finalPath,
+		Format:    model.Format(seg.format),
+		StartedAt: seg.startedAt,
+		EndedAt:   seg.endedAt,
 		// Wall-clock span (#496): the file timeline may be timelapse-compressed;
 		// the row keeps reporting real time so storage accounting and the UI's
 		// wall-clock math stay on the real axis.
@@ -1871,5 +1871,5 @@ func statsWallDuration(stats MergeStats, fallback float64) float64 {
 // the parsed bucket file plus the new input. Correct on the real-time axis
 // (no compression yet), and only used when stats carry no wall map.
 func totalDurFallbackSec(bucketInfo, newInfo *SegmentInfo) float64 {
-	return math.Round((bucketInfo.TotalDuration + newInfo.TotalDuration).Seconds()*1000) / 1000
+	return math.Round((bucketInfo.TotalDuration+newInfo.TotalDuration).Seconds()*1000) / 1000
 }

--- a/internal/merge/timelapse_compress_test.go
+++ b/internal/merge/timelapse_compress_test.go
@@ -1,0 +1,153 @@
+package merge
+
+// Tests for #496: sparse timelapse dwell compression, the wall→file timeline
+// map, and the ambient-audio envelope mixdown.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/stretchr/testify/require"
+)
+
+// createH264SegmentWithDurations is createH264SegmentWithSamples with explicit
+// per-sample durations (the sparse fixtures need ~30s dwells).
+func createH264SegmentWithDurations(t *testing.T, dir, name string, sps, pps []byte, samples [][]byte, durs []time.Duration) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	m := muxer.NewMP4Muxer(path)
+	trackID, err := m.AddH264Track(sps, pps)
+	require.NoError(t, err)
+	var pts time.Duration
+	for i, nalu := range samples {
+		require.NoError(t, m.WriteSample(trackID, nalu, pts, durs[i]))
+		pts += durs[i]
+	}
+	require.NoError(t, m.Close())
+	return path
+}
+
+// TestMergeMP4Segments_CompressesSparseDwells: a no-audio sparse segment (one
+// keyframe per 30s) merged with a normal-rate segment must come out with the
+// sparse dwells rewritten to TimelapseFrameDur while the normal samples keep
+// their real durations, and the stats must carry the wall→file map.
+func TestMergeMP4Segments_CompressesSparseDwells(t *testing.T) {
+	dir := t.TempDir()
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	idr := []byte{0x65, 0x88, 0x80, 0x40}
+	pNAL := []byte{0x41, 0x10, 0x00, 0x0c}
+
+	sparse := createH264SegmentWithDurations(t, dir, "sparse.mp4", sps, pps,
+		[][]byte{idr, idr, idr},
+		[]time.Duration{30 * time.Second, 30 * time.Second, 30 * time.Second})
+	normal := createH264SegmentWithDurations(t, dir, "normal.mp4", sps, pps,
+		[][]byte{idr, pNAL},
+		[]time.Duration{33 * time.Millisecond, 33 * time.Millisecond})
+
+	si, err := ParseSegment(sparse)
+	require.NoError(t, err)
+	ni, err := ParseSegment(normal)
+	require.NoError(t, err)
+	require.False(t, si.HasAudio)
+
+	origFrame := TimelapseFrameDur
+	TimelapseFrameDur = 100 * time.Millisecond
+	t.Cleanup(func() { TimelapseFrameDur = origFrame })
+
+	stats, err := MergeMP4Segments(context.Background(), []*SegmentInfo{si, ni}, filepath.Join(dir, "out.mp4"))
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.TimelapseFrames)
+
+	out, err := ParseSegment(filepath.Join(dir, "out.mp4"))
+	require.NoError(t, err)
+	require.Equal(t, 5, out.SampleCount)
+	for i := range 3 {
+		got := time.Duration(out.Samples[i].Duration) * time.Second / time.Duration(out.Timescale)
+		require.Equal(t, 100*time.Millisecond, got, "sparse sample %d must be compressed", i)
+	}
+	for i := 3; i < 5; i++ {
+		got := time.Duration(out.Samples[i].Duration) * time.Second / time.Duration(out.Timescale)
+		require.Equal(t, 33*time.Millisecond, got, "normal sample %d must keep its real duration", i)
+	}
+
+	// Wall→file map: sparse span 90s wall → 0.3s file; normal span stays real.
+	require.Len(t, stats.WallToFile, 3)
+	require.InDelta(t, 0.0, stats.WallToFile[0][0], 1e-9)
+	require.InDelta(t, 90.0, stats.WallToFile[1][0], 0.01)
+	require.InDelta(t, 0.3, stats.WallToFile[1][1], 0.01)
+	require.InDelta(t, 90.066, stats.WallToFile[2][0], 0.01)
+	require.InDelta(t, 0.366, stats.WallToFile[2][1], 0.01)
+	require.NotEmpty(t, stats.TimelineMapJSON())
+}
+
+// TestMergeMP4Segments_AudioBearingSpansNotCompressed: the same sparse
+// dwell durations in a segment WITH an audio track must stay real — rewriting
+// video there would desync the verbatim audio.
+func TestMergeMP4Segments_AudioBearingSpansNotCompressed(t *testing.T) {
+	dir := t.TempDir()
+	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5d, 0xac, 0x59}
+	sps := []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5d, 0xa0, 0x02, 0x80, 0x80, 0x2d, 0x16, 0x59, 0x59, 0xa4, 0x93, 0x2b, 0x80, 0x40, 0x00, 0x00, 0x07, 0x92}
+	pps := []byte{0x44, 0x01, 0xc1, 0x73, 0xd1, 0x89}
+	idrNAL := []byte{0x27, 0x01, 0xaf, 0x15, 0x6a}
+	pNAL := []byte{0x03, 0x20, 0x10, 0x00}
+
+	seg := createH265SegmentWithAudio(t, dir, "h265_audio.mp4", vps, sps, pps,
+		[][]byte{idrNAL, pNAL}, testAudioConfig, [][]byte{testAACFrame, testAACFrame})
+	info, err := ParseSegment(seg)
+	require.NoError(t, err)
+	require.True(t, info.HasAudio)
+
+	// Give the video samples sparse dwell durations directly — the merge must
+	// leave them alone because the segment carries audio.
+	ts := info.Timescale
+	for i := range info.Samples {
+		info.Samples[i].Duration = uint32(30 * ts)
+	}
+
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, filepath.Join(dir, "out.mp4"))
+	require.NoError(t, err)
+	out, err := ParseSegment(filepath.Join(dir, "out.mp4"))
+	require.NoError(t, err)
+	got := time.Duration(out.Samples[0].Duration) * time.Second / time.Duration(out.Timescale)
+	require.Equal(t, 30*time.Second, got, "audio-bearing segment must keep real durations")
+}
+
+// TestMixdownAmbient: silence stays silent, loud input renders a bed of the
+// requested length within headroom, and the g711 codec round-trips.
+func TestMixdownAmbient(t *testing.T) {
+	// Silence (µ-law 0xFF decodes to 0) must not be normalized into noise.
+	// µ-law positive zero re-encodes as 0x7F, so assert on the decoded value.
+	bed := mixdownAmbient(true, []byte{0xFF, 0xFF, 0xFF, 0xFF}, 100)
+	require.Len(t, bed, 100)
+	for _, b := range bed {
+		require.Equal(t, int16(0), g711DecodeMuLaw(b), "silence in, silence out")
+	}
+
+	// Loud alternating input → 8000-sample bed with bounded amplitude.
+	loud := make([]byte, 30000)
+	for i := range loud {
+		loud[i] = byte(i % 251)
+	}
+	bed = mixdownAmbient(true, loud, 8000)
+	require.Len(t, bed, 8000)
+	for _, b := range bed {
+		v := g711DecodeMuLaw(b)
+		require.LessOrEqual(t, int(v), 32767)
+		require.GreaterOrEqual(t, int(v), -32768)
+	}
+
+	// Codec round-trip within quantization error (the max segment decodes to
+	// ±32124 by codec design — inherent ~644 at full scale).
+	for _, v := range []int16{-32768, -12345, -1, 0, 1, 999, 12345, 32767} {
+		rt := g711DecodeMuLaw(g711EncodeMuLaw(v))
+		require.InDelta(t, float64(v), float64(rt), 800, "µ-law round trip of %d", v)
+	}
+	for _, v := range []int16{-32768, -12345, -1, 0, 1, 999, 12345, 32767} {
+		rt := g711DecodeALaw(g711EncodeALaw(v))
+		require.InDelta(t, float64(v), float64(rt), 800, "A-law round trip of %d", v)
+	}
+}

--- a/internal/merge/timelapse_compress_test.go
+++ b/internal/merge/timelapse_compress_test.go
@@ -84,10 +84,11 @@ func TestMergeMP4Segments_CompressesSparseDwells(t *testing.T) {
 	require.NotEmpty(t, stats.TimelineMapJSON())
 }
 
-// TestMergeMP4Segments_AudioBearingSpansNotCompressed: the same sparse
-// dwell durations in a segment WITH an audio track must stay real — rewriting
-// video there would desync the verbatim audio.
-func TestMergeMP4Segments_AudioBearingSpansNotCompressed(t *testing.T) {
+// TestMergeMP4Segments_CompressedAACSpanDropsAudio: a sparse-dwell segment
+// carrying a NON-G.711 audio track gets its video compressed and the span's
+// audio dropped (the envelope mixdown is G.711-only) — the output carries no
+// audio track at all when nothing else contributes one.
+func TestMergeMP4Segments_CompressedAACSpanDropsAudio(t *testing.T) {
 	dir := t.TempDir()
 	vps := []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5d, 0xac, 0x59}
 	sps := []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5d, 0xa0, 0x02, 0x80, 0x80, 0x2d, 0x16, 0x59, 0x59, 0xa4, 0x93, 0x2b, 0x80, 0x40, 0x00, 0x00, 0x07, 0x92}
@@ -108,12 +109,18 @@ func TestMergeMP4Segments_AudioBearingSpansNotCompressed(t *testing.T) {
 		info.Samples[i].Duration = uint32(30 * ts)
 	}
 
-	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, filepath.Join(dir, "out.mp4"))
+	origFrame := TimelapseFrameDur
+	TimelapseFrameDur = 100 * time.Millisecond
+	t.Cleanup(func() { TimelapseFrameDur = origFrame })
+
+	stats, err := MergeMP4Segments(context.Background(), []*SegmentInfo{info}, filepath.Join(dir, "out.mp4"))
 	require.NoError(t, err)
+	require.Equal(t, 2, stats.TimelapseFrames)
 	out, err := ParseSegment(filepath.Join(dir, "out.mp4"))
 	require.NoError(t, err)
 	got := time.Duration(out.Samples[0].Duration) * time.Second / time.Duration(out.Timescale)
-	require.Equal(t, 30*time.Second, got, "audio-bearing segment must keep real durations")
+	require.Equal(t, 100*time.Millisecond, got, "sparse dwells compress even with an audio track")
+	require.False(t, out.HasAudio, "compressed AAC span's audio must be dropped")
 }
 
 // TestMixdownAmbient: silence stays silent, loud input renders a bed of the

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -68,6 +68,13 @@ type Recording struct {
 	// vocabulary: "static", "motion", "scene_cut".
 	MotionScore   float64 `json:"motion_score"`
 	ActivityFlags string  `json:"activity_flags,omitempty"`
+	// TimelineMap (#496) is set on rolling-merge products whose sparse
+	// timelapse dwells were compressed to a fast cadence: compact JSON
+	// "[[wallSec,fileSec],...]" breakpoints mapping the recording's
+	// wall-clock span onto the (shorter) file timeline. Clients resolve
+	// wall-clock seeks (?at=, day-timeline clicks) through it; empty for
+	// uncompressed recordings (identity mapping).
+	TimelineMap string `json:"timeline_map,omitempty"`
 }
 
 // MotionScoreUnanalyzed marks a recording the motion analyzer has not scored

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -46,7 +46,7 @@ import (
 type AdaptiveConfig struct {
 	CalmThreshold     time.Duration // sustained calm before dropping to sparse mode
 	TimelapseInterval time.Duration // keyframe cadence while sparse
-	SpikeFactor        float64       // MAD-floored deviations above baseline = spike
+	SpikeFactor       float64       // MAD-floored deviations above baseline = spike
 	MaxGOPBuffer      int64         // byte cap of the retained GOP ring
 	// AmbientAudio keeps the disk audio track recording CONTINUOUSLY while in
 	// sparse mode (#496 audio phase): the video timeline is compressed at

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -46,8 +46,15 @@ import (
 type AdaptiveConfig struct {
 	CalmThreshold     time.Duration // sustained calm before dropping to sparse mode
 	TimelapseInterval time.Duration // keyframe cadence while sparse
-	SpikeFactor       float64       // MAD-floored deviations above baseline = spike
+	SpikeFactor        float64       // MAD-floored deviations above baseline = spike
 	MaxGOPBuffer      int64         // byte cap of the retained GOP ring
+	// AmbientAudio keeps the disk audio track recording CONTINUOUSLY while in
+	// sparse mode (#496 audio phase): the video timeline is compressed at
+	// merge time and the merge renders the ambient span into a quiet
+	// continuous atmosphere bed (envelope mixdown) instead of dropping it.
+	// Costs ~28.8MB/h (G.711); enable per camera. Event (full-rate) spans
+	// always keep their real audio either way.
+	AmbientAudio bool
 }
 
 // DefaultAdaptiveConfig mirrors the validated ranges in config.validate.
@@ -573,7 +580,7 @@ func (g *AdaptiveGate) ClearWritten() {
 // overrides, defaulting unset fields. Shared by the camera-manager factory
 // (RTSP/ONVIF paths) and plugin-style recorders (Xiaomi) so both resolve
 // identically. String durations follow the frame_watchdog_timeout convention.
-func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor float64, gopBufferBytes int64) AdaptiveConfig {
+func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor float64, gopBufferBytes int64, ambientAudio bool) AdaptiveConfig {
 	ac := DefaultAdaptiveConfig()
 	if d, err := time.ParseDuration(calmThreshold); err == nil && d > 0 {
 		ac.CalmThreshold = d
@@ -587,5 +594,6 @@ func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor 
 	if gopBufferBytes > 0 {
 		ac.MaxGOPBuffer = gopBufferBytes
 	}
+	ac.AmbientAudio = ambientAudio
 	return ac
 }

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -362,12 +362,12 @@ func TestAdaptiveGate_SparseSkipAndFlushFacade(t *testing.T) {
 }
 
 func TestResolveAdaptiveConfig_DefaultsAndOverrides(t *testing.T) {
-	ac := ResolveAdaptiveConfig("", "", 0, 0)
+	ac := ResolveAdaptiveConfig("", "", 0, 0, false)
 	if ac != (AdaptiveConfig{CalmThreshold: 60 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 5.0, MaxGOPBuffer: 32 << 20}) {
 		t.Fatalf("defaults wrong: %+v", ac)
 	}
-	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20)
-	if ac.CalmThreshold != 2*time.Minute || ac.TimelapseInterval != 10*time.Second || ac.SpikeFactor != 7.5 || ac.MaxGOPBuffer != 1<<20 {
+	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20, true)
+	if ac.CalmThreshold != 2*time.Minute || ac.TimelapseInterval != 10*time.Second || ac.SpikeFactor != 7.5 || ac.MaxGOPBuffer != 1<<20 || !ac.AmbientAudio {
 		t.Fatalf("overrides wrong: %+v", ac)
 	}
 }

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -607,8 +607,10 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 			if b.adaptive.mode == adaptiveTimelapse && !spike {
 				if !b.adaptive.shouldWriteSparse(isIDR, now) {
 					// Sparse: the frame is retained in the GOP ring, not
-					// written; a later spike can still flush it.
-					if sa := b.adaptive.mode == adaptiveTimelapse; sa != sparseAudio {
+					// written; a later spike can still flush it. Ambient-audio
+					// cameras keep writing the audio track (#496): the merge
+					// renders it into the compressed timeline's atmosphere bed.
+					if sa := b.adaptive.mode == adaptiveTimelapse && !b.cfg.Adaptive.AmbientAudio; sa != sparseAudio {
 						sparseAudio = sa
 						b.audioSparse.Store(sa)
 					}
@@ -624,7 +626,7 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 					b.adaptive.lastSparseWrite = now
 				}
 			}
-			if sa := b.adaptive.mode == adaptiveTimelapse; sa != sparseAudio {
+			if sa := b.adaptive.mode == adaptiveTimelapse && !b.cfg.Adaptive.AmbientAudio; sa != sparseAudio {
 				sparseAudio = sa
 				b.audioSparse.Store(sa)
 			}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -285,6 +285,7 @@ func (d *DB) Init(ctx context.Context) error {
         ai_error TEXT DEFAULT NULL,
         motion_score REAL DEFAULT -1,
         activity_flags TEXT DEFAULT '',
+        timeline_map TEXT DEFAULT '',
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (camera_id) REFERENCES cameras(id)
     );`
@@ -518,6 +519,18 @@ func (d *DB) ensureRecordingsMotionColumns(ctx context.Context) error {
 		if _, err := d.db.ExecContext(ctx,
 			`ALTER TABLE recordings ADD COLUMN activity_flags TEXT DEFAULT ''`); err != nil {
 			return fmt.Errorf("add activity_flags column: %w", err)
+		}
+	}
+	var mapColExists int
+	if err := d.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('recordings') WHERE name='timeline_map'`,
+	).Scan(&mapColExists); err != nil {
+		return fmt.Errorf("check timeline_map column: %w", err)
+	}
+	if mapColExists == 0 {
+		if _, err := d.db.ExecContext(ctx,
+			`ALTER TABLE recordings ADD COLUMN timeline_map TEXT DEFAULT ''`); err != nil {
+			return fmt.Errorf("add timeline_map column: %w", err)
 		}
 	}
 	return nil

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -179,8 +179,8 @@ func (d *DB) MergeAndReplaceRecordings(ctx context.Context, merged *model.Record
 	}
 	motionScore, motionFlags := agg.result()
 
-	q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
-	_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format, timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize, merged.FrameCount, model.MergeStatusMerged, merged.MergeTier, 100, merged.MergeQuality, motionScore, motionFlags)
+	q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags, timeline_map) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
+	_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format, timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize, merged.FrameCount, model.MergeStatusMerged, merged.MergeTier, 100, merged.MergeQuality, motionScore, motionFlags, merged.TimelineMap)
 	if err != nil {
 		return err
 	}
@@ -280,18 +280,18 @@ func (d *DB) RollingReplaceRecordings(ctx context.Context, merged *model.Recordi
 
 	if existingMergedID == "" {
 		// Case 1: Create — INSERT new merged recording.
-		q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
+		q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, merge_progress, merge_quality, motion_score, activity_flags, timeline_map) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
 		_, err = tx.ExecContext(ctx, q, merged.ID, merged.CameraID, merged.FilePath, merged.Format,
 			timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration, merged.FileSize,
-			merged.FrameCount, model.MergeStatusMerged, "rolling", 100, merged.MergeQuality, motionScore, motionFlags)
+			merged.FrameCount, model.MergeStatusMerged, "rolling", 100, merged.MergeQuality, motionScore, motionFlags, merged.TimelineMap)
 		if err != nil {
 			return err
 		}
 	} else {
 		// Case 2: Append — UPDATE existing merged recording.
-		q := `UPDATE recordings SET file_path = ?, ended_at = ?, duration = ?, file_size = ?, frame_count = ?, merge_quality = ?, motion_score = ?, activity_flags = ? WHERE id = ?;`
+		q := `UPDATE recordings SET file_path = ?, ended_at = ?, duration = ?, file_size = ?, frame_count = ?, merge_quality = ?, motion_score = ?, activity_flags = ?, timeline_map = ? WHERE id = ?;`
 		_, err = tx.ExecContext(ctx, q, merged.FilePath, timeToDB(merged.EndedAt), merged.Duration,
-			merged.FileSize, merged.FrameCount, merged.MergeQuality, motionScore, motionFlags, existingMergedID)
+			merged.FileSize, merged.FrameCount, merged.MergeQuality, motionScore, motionFlags, merged.TimelineMap, existingMergedID)
 		if err != nil {
 			return err
 		}

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -113,12 +113,12 @@ func (d *DB) UpdateRecording(ctx context.Context, r *model.Recording) error {
 }
 
 func (d *DB) GetRecording(ctx context.Context, id string) (*model.Recording, error) {
-	row := d.readConn().QueryRowContext(ctx, `SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived, ai_status, ai_processed_at, ai_error, motion_score, activity_flags FROM recordings WHERE id=?;`, id)
+	row := d.readConn().QueryRowContext(ctx, `SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_path, merge_tier, merge_progress, merge_error, merge_quality, archived, ai_status, ai_processed_at, ai_error, motion_score, activity_flags, timeline_map FROM recordings WHERE id=?;`, id)
 	var r model.Recording
 	var startedAtStr, endedAtStr, mergePathStr, mergeTierStr, mergeErrorStr, mergeQualityStr sql.NullString
 	var mergeProgress sql.NullInt64
-	var aiStatus, aiProcessedAt, aiError sql.NullString
-	if err := row.Scan(&r.ID, &r.CameraID, &r.FilePath, &r.Format, &startedAtStr, &endedAtStr, &r.Duration, &r.FileSize, &r.FrameCount, &r.MergeStatus, &mergePathStr, &mergeTierStr, &mergeProgress, &mergeErrorStr, &mergeQualityStr, &r.Archived, &aiStatus, &aiProcessedAt, &aiError, &r.MotionScore, &r.ActivityFlags); err != nil {
+	var aiStatus, aiProcessedAt, aiError, timelineMap sql.NullString
+	if err := row.Scan(&r.ID, &r.CameraID, &r.FilePath, &r.Format, &startedAtStr, &endedAtStr, &r.Duration, &r.FileSize, &r.FrameCount, &r.MergeStatus, &mergePathStr, &mergeTierStr, &mergeProgress, &mergeErrorStr, &mergeQualityStr, &r.Archived, &aiStatus, &aiProcessedAt, &aiError, &r.MotionScore, &r.ActivityFlags, &timelineMap); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
@@ -126,6 +126,9 @@ func (d *DB) GetRecording(ctx context.Context, id string) (*model.Recording, err
 	}
 	r.StartedAt = scanTime(startedAtStr)
 	r.EndedAt = scanTime(endedAtStr)
+	if timelineMap.Valid {
+		r.TimelineMap = timelineMap.String
+	}
 	if mergePathStr.Valid {
 		r.MergePath = mergePathStr.String
 	}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787572912678';
+const CACHE_VERSION = 'mibee-nvr-1787614727767';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -78,11 +78,11 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 		if cfg.Adaptive != nil {
 			a = cfg.Adaptive
 		}
-		calm, interval, spike, gop := "", "", 0.0, int64(0)
+		calm, interval, spike, gop, ambient := "", "", 0.0, int64(0), false
 		if a != nil {
-			calm, interval, spike, gop = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes
+			calm, interval, spike, gop, ambient = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio
 		}
-		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop)
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient)
 		recCfg.Adaptive = &ac
 		// Audio-trigger (issue #478): only meaningful on top of adaptive, and
 		// only for G.711 cameras — the recorder logs Opus as inactive.

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -683,7 +683,9 @@ func (r *XiaomiRecorder) processH264NALU(nalu []byte, timestamp uint64, lastTime
 		now := time.Now()
 		isIDR := naluType == 5
 		_, skip, flush := r.adaptive.Observe(nalu, isIDR, now)
-		r.audioSparse.Store(r.adaptive.Timelapse())
+		// Ambient-audio cameras keep the disk audio track through sparse mode
+		// (#496); the merge renders the ambient span into the atmosphere bed.
+		r.audioSparse.Store(r.adaptive.Timelapse() && !r.cfg.Adaptive.AmbientAudio)
 		if len(flush) > 0 {
 			r.writeFlushedGOP(flush)
 			// Pre-trigger audio back-fill (issue #478), mirroring the built-in
@@ -815,7 +817,9 @@ func (r *XiaomiRecorder) processH265NALU(nalu []byte, timestamp uint64, lastTime
 		now := time.Now()
 		isIDR := naluType == 19 || naluType == 20
 		_, skip, flush := r.adaptive.Observe(nalu, isIDR, now)
-		r.audioSparse.Store(r.adaptive.Timelapse())
+		// Ambient-audio cameras keep the disk audio track through sparse mode
+		// (#496); the merge renders the ambient span into the atmosphere bed.
+		r.audioSparse.Store(r.adaptive.Timelapse() && !r.cfg.Adaptive.AmbientAudio)
 		if len(flush) > 0 {
 			r.writeFlushedGOP(flush)
 			// Pre-trigger audio back-fill (issue #478), mirroring the built-in

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -85,6 +85,10 @@ export interface AdaptiveRecordingConfig {
   spike_factor?: number;
   /** Seamless-transition GOP pre-buffer cap in bytes. Default 16MB. */
   gop_buffer_bytes?: number;
+  /** Keep the audio track recording continuously while sparse (#496): the
+   *  merge renders it into a quiet atmosphere bed under the compressed
+   *  timelapse video. G.711 cameras only; ~28.8MB/h while sparse. */
+  ambient_audio?: boolean;
 }
 
 /** Loudness trigger knobs for recording_mode: 'adaptive' (#478). */

--- a/web/src/lib/api/recordings.ts
+++ b/web/src/lib/api/recordings.ts
@@ -24,6 +24,9 @@ export interface Recording {
   // Motion score (#435): compressed-domain activity score in [0,1]; -1 =
   // not yet analyzed. activity_flags: comma-separated "static"/"motion"/"scene_cut".
   motion_score?: number;
+  /** #496: piecewise wall→file timeline map (JSON "[[wallSec,fileSec],…]")
+   *  for timelapse-compressed recordings; absent = real-time axis. */
+  timeline_map?: string;
   activity_flags?: string;
 }
 

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -102,6 +102,8 @@
   let formAdaptiveTimelapseInterval = $state('');
   let formAdaptiveSpikeFactor = $state('');
   let formAdaptiveGopBufferMB = $state('');
+  let formAmbientAudio = $state(false);
+  let formAdaptiveWasAmbient = false;
   // Audio trigger (#478): loudness input on top of the adaptive gate. Only
   // meaningful (and only sent) for adaptive + G.711 cameras.
   let formAudioTriggerEnabled = $state(false);
@@ -383,6 +385,8 @@ let validationErrors = $state<Record<string, string>>({});
     formAdaptiveGopBufferMB = camera.adaptive?.gop_buffer_bytes
       ? String(Math.round(camera.adaptive.gop_buffer_bytes / (1024 * 1024)))
       : '';
+    formAmbientAudio = camera.adaptive?.ambient_audio ?? false;
+    formAdaptiveWasAmbient = formAmbientAudio;
     formAudioTriggerEnabled = camera.audio_trigger?.enabled ?? false;
     formAudioTriggerWasEnabled = formAudioTriggerEnabled;
     formAudioMinDBFS =
@@ -636,8 +640,13 @@ async function handleSubmit() {
 // only the params the user actually filled (blank = backend default). Eligible
 // only for differential encodings — the backend rejects adaptive + jpeg/mjpeg.
 function buildAdaptivePayload() {
-    if (formRecordingMode !== 'adaptive') return undefined;
+    if (formRecordingMode !== 'adaptive') {
+        // Leaving adaptive: explicitly clear a previously-armed ambient flag
+        // (nil = unchanged server-side, which could leave it stale).
+        return formAdaptiveWasAmbient ? { ambient_audio: false } : undefined;
+    }
     const p: AdaptiveRecordingConfig = {};
+    p.ambient_audio = formAmbientAudio;
     if (formAdaptiveCalmThreshold.trim()) p.calm_threshold = formAdaptiveCalmThreshold.trim();
     if (formAdaptiveTimelapseInterval.trim()) p.timelapse_interval = formAdaptiveTimelapseInterval.trim();
     const spike = parseFloat(formAdaptiveSpikeFactor);
@@ -997,6 +1006,20 @@ async function performCameraSave() {
           </div>
         {/if}
         <p class="text-xs th-text-muted -mt-1">{t('cameras.audioTriggerHint')}</p>
+        <div class="flex items-center gap-2">
+          <input
+            id="cam-ambient-audio"
+            type="checkbox"
+            class="checkbox"
+            bind:checked={formAmbientAudio}
+          />
+          <label for="cam-ambient-audio" class="input-label cursor-pointer">
+            {t('cameras.ambientAudio')}
+          </label>
+        </div>
+        {#if formAmbientAudio}
+          <p class="text-xs th-text-muted -mt-1">{t('cameras.ambientAudioHint')}</p>
+        {/if}
       {/if}
     {/if}
 

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1693,6 +1693,8 @@
   "cameras.adaptiveParamsHint": "Leave blank for defaults (60s / 30s / 5.0 / 16MB).",
   "cameras.audioTrigger": "Audio-triggered recording",
   "cameras.audioTriggerHint": "Abnormal sounds (glass breaking, shouting, alarms) instantly resume full-rate recording and keep the audio track. G.711 cameras only (inactive for AAC/Opus).",
+  "cameras.ambientAudio": "Record ambient audio continuously while sparse (atmosphere bed)",
+  "cameras.ambientAudioHint": "Lays a quiet ambient bed under compressed timelapse playback (~28.8MB/h storage, G.711 cameras only)",
   "cameras.audioTriggerMinDBFS": "Loudness threshold (dBFS)",
   "cameras.audioTriggerPreCapture": "Pre-capture audio (s)",
   "recordings.motionScore": "Motion score",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1692,6 +1692,8 @@
   "cameras.adaptiveParamsHint": "留空使用默认值（60s / 30s / 5.0 / 16MB）。",
   "cameras.audioTrigger": "音频触发录像",
   "cameras.audioTriggerHint": "异常声音（玻璃破碎/呼喊/警报）立即恢复全速录像并保留音频轨。仅支持 G.711 音频相机（AAC/Opus 相机不生效）。",
+  "cameras.ambientAudio": "无人时段连续录制环境声（合成延时氛围层）",
+  "cameras.ambientAudioHint": "延时无人段回放时铺低音量环境声氛围层（约 28.8MB/小时存储，仅 G.711 相机）",
   "cameras.audioTriggerMinDBFS": "响度阈值 (dBFS)",
   "cameras.audioTriggerPreCapture": "预录音频 (秒)",
   "recordings.motionScore": "活动分",

--- a/web/src/lib/timeline-map.ts
+++ b/web/src/lib/timeline-map.ts
@@ -1,0 +1,55 @@
+/**
+ * Wall-clock ↔ file-timeline mapping for timelapse-compressed recordings
+ * (#496): the rolling merge rewrites sparse dwell samples to a fast cadence
+ * and stores the piecewise mapping as [[wallSec, fileSec], ...] breakpoints
+ * on the recording row. Uncompressed recordings carry no map — the identity
+ * fallbacks below keep them exact.
+ */
+export type TimelineMap = Array<[number, number]>;
+
+export function parseTimelineMap(json?: string | null): TimelineMap | null {
+  if (!json) return null;
+  try {
+    const v = JSON.parse(json);
+    if (!Array.isArray(v) || v.length < 2 || !Array.isArray(v[0])) return null;
+    return v as TimelineMap;
+  } catch {
+    return null;
+  }
+}
+
+function interpForward(map: TimelineMap, x: number): number {
+  if (x <= map[0][0]) return map[0][1];
+  for (let i = 1; i < map.length; i++) {
+    if (x <= map[i][0]) {
+      const [w0, f0] = map[i - 1];
+      const [w1, f1] = map[i];
+      if (w1 <= w0) return f1;
+      return f0 + ((x - w0) / (w1 - w0)) * (f1 - f0);
+    }
+  }
+  return map[map.length - 1][1];
+}
+
+function interpInverse(map: TimelineMap, y: number): number {
+  if (y <= map[0][1]) return map[0][0];
+  for (let i = 1; i < map.length; i++) {
+    if (y <= map[i][1]) {
+      const [w0, f0] = map[i - 1];
+      const [w1, f1] = map[i];
+      if (f1 <= f0) return w1;
+      return w0 + ((y - f0) / (f1 - f0)) * (w1 - w0);
+    }
+  }
+  return map[map.length - 1][0];
+}
+
+/** Wall-clock seconds within the recording → file-timeline seconds. */
+export function wallToFileSec(map: TimelineMap | null, wallSec: number): number {
+  return map ? interpForward(map, wallSec) : wallSec;
+}
+
+/** File-timeline seconds → wall-clock seconds within the recording. */
+export function fileToWallSec(map: TimelineMap | null, fileSec: number): number {
+  return map ? interpInverse(map, fileSec) : fileSec;
+}

--- a/web/src/routes/RecordingDetail.svelte
+++ b/web/src/routes/RecordingDetail.svelte
@@ -18,6 +18,7 @@
     clearMergedCodecCache,
   } from '$lib/api';
   import { AlertTriangle, RefreshCw } from 'lucide-svelte';
+  import { parseTimelineMap, wallToFileSec } from '$lib/timeline-map';
 
   import MergePanel from './recordings/MergePanel.svelte';
   import PlaybackPanel from './recordings/PlaybackPanel.svelte';
@@ -168,7 +169,13 @@
     if (!recording || !recording.started_at) return;
     const startedAtMs = Date.parse(recording.started_at);
     if (!Number.isFinite(startedAtMs)) return;
-    const offsetSec = Math.max(0, Math.floor((pendingTimelineSeekAtMs - startedAtMs) / 1000));
+    // #496: timelapse-compressed recordings keep the wall clock only in the
+    // row's timeline map — resolve ?at= through it so AI-event deep links
+    // land on the right frame of the (much shorter) file.
+    const wallOffsetSec = Math.max(0, (pendingTimelineSeekAtMs - startedAtMs) / 1000);
+    const offsetSec = Math.floor(
+      wallToFileSec(parseTimelineMap(recording.timeline_map), wallOffsetSec)
+    );
     pendingTimelineSeekAtMs = null;
     if (pendingTimelineSeekOffset == null) pendingTimelineSeekOffset = offsetSec;
   });

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -27,6 +27,7 @@
   import { AlertTriangle, HelpCircle, SkipForward, Loader2, RefreshCw, Play, Pause, ChevronLeft, ChevronRight } from 'lucide-svelte';
   import MjpegPlayer from '$lib/components/MjpegPlayer.svelte';
   import { parseVodPlaylist, entryAt, nearestEntryByWallClock, mediaTimeFor, type VodEntry } from '$lib/vod-playlist';
+  import { parseTimelineMap, wallToFileSec, fileToWallSec } from '$lib/timeline-map';
   import VideoPlaybackControls from '$lib/components/VideoPlaybackControls.svelte';
   import AviPlayback from '../../components/AviPlayback.svelte';
   import TimelineBar from '$lib/components/TimelineBar.svelte';
@@ -428,10 +429,17 @@
         const cur = entryAt(vodMap, t);
         if (cur) {
           vodRebuilds++;
+          // #496: inside the current recording, media seconds advance slower
+          // than wall seconds when its timeline is timelapse-compressed —
+          // convert before resuming so a session rebuild lands at the same
+          // wall-clock moment. Other entries keep the identity estimate.
+          const resumeMap = cur.rid === recording?.id ? parseTimelineMap(recording?.timeline_map) : null;
           vodResume = {
             rid: cur.rid,
             offset: Math.max(0, t - cur.mediaStart),
-            wallMs: cur.wallStart ? cur.wallStart + Math.max(0, t - cur.mediaStart) * 1000 : 0,
+            wallMs: cur.wallStart
+              ? cur.wallStart + Math.max(0, fileToWallSec(resumeMap, t - cur.mediaStart)) * 1000
+              : 0,
           };
           console.warn('VOD HLS fatal error, rebuilding continuous session', data);
           teardownContinuous();
@@ -686,7 +694,11 @@
     // Continuous mode: every target maps into the single media timeline —
     // cross-recording, cross-gap, anything. No source switch, no reload.
     if (continuousMode && continuousReady) {
-      const mt = mediaTimeFor(vodMap, recordingId, offsetSeconds);
+      // #496: timeline offsets are wall-clock seconds within the target
+      // recording; the current recording's compressed file maps them onto
+      // its (shorter) media axis.
+      const seekMap = recordingId === recording.id ? parseTimelineMap(recording.timeline_map) : null;
+      const mt = mediaTimeFor(vodMap, recordingId, wallToFileSec(seekMap, offsetSeconds));
       if (mt != null && videoEl) {
         void recordTimelineSeek(recording.camera_id, 'segment');
         videoEl.currentTime = mt;


### PR DESCRIPTION
## 背景（用户三轮反馈）

adaptive 无人时段每 30s 存 1 个关键帧、按**真实时间轴**排 pts——1× 播放（网页或下载后本地播放器）一帧停 30 秒。用户期望（比对样片后确认参数）：**正常速度、连续播放本身就是延时摄影**；帧距 **100ms**；环境声做成低音量氛围层。

## 视频：合并层压缩时间轴

无音频条件的旧设计在 ambient 开启后自锁（TL 段都带音频了），本 PR 压缩**所有** >2s 驻留样本至 100ms：
- 10 分钟无人段（20 帧）→ **2 秒连续延时视频**；有人段保持原速，同一文件内自动切换。
- 分段保留 wall→file 映射（recordings.timeline_map，分段线性断点），行时长保持墙钟轴（存储统计不变）。
- 幂等：已压缩样本 duration=0.1s < 2s 阈值，重复合并不二次压缩。

## 音频：环境声连续录制 + 包络混缩氛围层（按相机 adaptive.ambient_audio）

- **录制**：sparse 模式不再丢盘音频（~28.8MB/h，G.711 相机）；事件段原速真音频不变。
- **合并**：压缩段的音频走**包络混缩**——每输出采样的输入窗 RMS 包络调制低通噪声载波（~-16dBFS）：风声成涌动、车声成短促涌起、会被 300× 搬成超声波的波形细节主动丢弃（不脏）；事件段音频逐字节保留。非 G.711 压缩段丢音频（日志）。纯压缩产物无音频样本时不输出音轨。
- g711 编解码器按所用解码器数学严格配对（µ-law 异或符号位 + A-law 反推编码器），单测覆盖往返。

## SPA

- ?at= 深链与日时间轴 seek 经 timeline_map 解析（RecordingDetail + PlaybackPanel 的 wall↔media 两向换算）。
- CameraForm：adaptive 区块新增「无人时段连续录制环境声」开关（zh/en）。

## 实测（M5, 0.11.0-tl-compress-496b）

- 工作室纯 TL 产物：**122.2s 墙钟 → 0.401s 文件**，帧 pts `0/0.001/0.101/0.201/0.301`（100ms 精确），**0 解码错误**，音轨 pcm_mulaw 氛围层 mean −33.6dB。
- 视通全速段产物：恒等映射 + 原速真音频 ✓（有人段不受影响）。
- 浏览器播放 3/3 PASS。样片对比页（两速度×纯TL/混合）经用户确认选定 100ms。
