### PR TITLE
feat: 延时帧距可配(100/300/500ms) + 录像音频轨保留开关(默认关) + 原始环境声留档(默认关)

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2638,6 +2638,7 @@ func TestHandleMergeStatus_WithManager(t *testing.T) {
 		db, store,
 		func() config.MergeConfig { return cfg.Merge },
 		func(cameraID string) *config.MergeConfig { return nil },
+		func(cameraID string) *config.AdaptiveRecordingConfig { return nil },
 		func() []config.CameraConfig { return cfg.Cameras },
 		nil,
 	)
@@ -2666,6 +2667,7 @@ func TestHandleMergePending_WithManager(t *testing.T) {
 		db, store,
 		func() config.MergeConfig { return cfg.Merge },
 		func(cameraID string) *config.MergeConfig { return nil },
+		func(cameraID string) *config.AdaptiveRecordingConfig { return nil },
 		func() []config.CameraConfig { return cfg.Cameras },
 		nil,
 	)

--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -293,6 +293,8 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		Timelapse      *config.CameraTimelapseConfig `json:"timelapse"`
 		Channel        string                        `json:"channel"`
 		AudioEnabled   *bool                         `json:"audio_enabled"`
+		// Keep the camera's real audio track in recorded segments (default off).
+		AudioInRecordings *bool                      `json:"audio_in_recordings"`
 		// Recording gate: false = live-only (no segments written). nil = record.
 		RecordingEnabled *bool `json:"recording_enabled"`
 		// Cascade gate: false = hidden from the GB28181 cascade catalog and
@@ -498,6 +500,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		Timelapse:         body.Timelapse,
 		Channel:           body.Channel,
 		AudioEnabled:      body.AudioEnabled != nil && *body.AudioEnabled,
+		AudioInRecordings: body.AudioInRecordings != nil && *body.AudioInRecordings,
 		RecordingEnabled:  body.RecordingEnabled,
 		CascadeEnabled:    body.CascadeEnabled,
 		RecordingMode:     body.RecordingMode,

--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -294,7 +294,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		Channel        string                        `json:"channel"`
 		AudioEnabled   *bool                         `json:"audio_enabled"`
 		// Keep the camera's real audio track in recorded segments (default off).
-		AudioInRecordings *bool                      `json:"audio_in_recordings"`
+		AudioInRecordings *bool `json:"audio_in_recordings"`
 		// Recording gate: false = live-only (no segments written). nil = record.
 		RecordingEnabled *bool `json:"recording_enabled"`
 		// Cascade gate: false = hidden from the GB28181 cascade catalog and

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -54,16 +54,16 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 		switch cam.Encoding {
 		case string(model.FormatH264):
 			h264Cfg := recorder.H264Config{
-				CameraID:      cam.ID,
-				RTSPURL:       cam.URL,
-				Username:      cam.Username,
-				Password:      cam.Password,
-				SegmentDur:    segDur,
-				DB:            cm.db,
-				AudioEnabled:  cam.AudioEnabled,
-				AudioInRecordings:  cam.AudioInRecordings,
-				EventBus:      cm.eventBus,
-				RecordEnabled: cam.RecordingEnabled,
+				CameraID:          cam.ID,
+				RTSPURL:           cam.URL,
+				Username:          cam.Username,
+				Password:          cam.Password,
+				SegmentDur:        segDur,
+				DB:                cm.db,
+				AudioEnabled:      cam.AudioEnabled,
+				AudioInRecordings: cam.AudioInRecordings,
+				EventBus:          cm.eventBus,
+				RecordEnabled:     cam.RecordingEnabled,
 			}
 			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
 				h264Cfg.FrameWatchdogTimeout = d
@@ -75,16 +75,16 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 			rec = recorder.NewH264Recorder(h264Cfg, cm.store, cm.metrics)
 		case string(model.FormatH265):
 			h265Cfg := recorder.H265Config{
-				CameraID:      cam.ID,
-				RTSPURL:       cam.URL,
-				Username:      cam.Username,
-				Password:      cam.Password,
-				SegmentDur:    segDur,
-				DB:            cm.db,
-				AudioEnabled:  cam.AudioEnabled,
-				AudioInRecordings:  cam.AudioInRecordings,
-				EventBus:      cm.eventBus,
-				RecordEnabled: cam.RecordingEnabled,
+				CameraID:          cam.ID,
+				RTSPURL:           cam.URL,
+				Username:          cam.Username,
+				Password:          cam.Password,
+				SegmentDur:        segDur,
+				DB:                cm.db,
+				AudioEnabled:      cam.AudioEnabled,
+				AudioInRecordings: cam.AudioInRecordings,
+				EventBus:          cm.eventBus,
+				RecordEnabled:     cam.RecordingEnabled,
 			}
 			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
 				h265Cfg.FrameWatchdogTimeout = d
@@ -136,19 +136,19 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 		}
 		onvifClient := cm.reuseOrCreateONVIFClient(cam.ID, onvifEndpoint, cam.Username, cam.Password)
 		onvifCfg := recorder.ONVIFConfig{
-			CameraID:       cam.ID,
-			ProfileToken:   cam.ProfileToken,
-			StreamEncoding: cam.StreamEncoding,
-			Username:       cam.Username,
-			Password:       cam.Password,
-			SegmentDur:     segDur,
-			DB:             cm.db,
-			AudioEnabled:   cam.AudioEnabled,
-				AudioInRecordings: cam.AudioInRecordings,
-			ONVIFEndpoint:  onvifEndpoint,
-			AVI:            cam.HTTPJPEGAVI,
-			EventBus:       cm.eventBus,
-			RecordEnabled:  cam.RecordingEnabled,
+			CameraID:          cam.ID,
+			ProfileToken:      cam.ProfileToken,
+			StreamEncoding:    cam.StreamEncoding,
+			Username:          cam.Username,
+			Password:          cam.Password,
+			SegmentDur:        segDur,
+			DB:                cm.db,
+			AudioEnabled:      cam.AudioEnabled,
+			AudioInRecordings: cam.AudioInRecordings,
+			ONVIFEndpoint:     onvifEndpoint,
+			AVI:               cam.HTTPJPEGAVI,
+			EventBus:          cm.eventBus,
+			RecordEnabled:     cam.RecordingEnabled,
 		}
 		if cam.RecordingMode == "adaptive" {
 			// Validated by config.ValidateCameraRecordingMode (h264/h265 only);

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -23,11 +23,11 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 		var calm, interval string
 		var spike float64
 		var gop int64
-		var ambient bool
+		var ambient, archive bool
 		if a != nil {
-			calm, interval, spike, gop, ambient = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio
+			calm, interval, spike, gop, ambient, archive = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio, a.AmbientArchive
 		}
-		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient)
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient, archive)
 		return &ac
 	}
 	// resolveAudioTriggerConfig resolves the audio-trigger overrides (issue
@@ -61,6 +61,7 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 				SegmentDur:    segDur,
 				DB:            cm.db,
 				AudioEnabled:  cam.AudioEnabled,
+				AudioInRecordings:  cam.AudioInRecordings,
 				EventBus:      cm.eventBus,
 				RecordEnabled: cam.RecordingEnabled,
 			}
@@ -81,6 +82,7 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 				SegmentDur:    segDur,
 				DB:            cm.db,
 				AudioEnabled:  cam.AudioEnabled,
+				AudioInRecordings:  cam.AudioInRecordings,
 				EventBus:      cm.eventBus,
 				RecordEnabled: cam.RecordingEnabled,
 			}
@@ -142,6 +144,7 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 			SegmentDur:     segDur,
 			DB:             cm.db,
 			AudioEnabled:   cam.AudioEnabled,
+				AudioInRecordings: cam.AudioInRecordings,
 			ONVIFEndpoint:  onvifEndpoint,
 			AVI:            cam.HTTPJPEGAVI,
 			EventBus:       cm.eventBus,

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -364,6 +364,10 @@ func (cm *CleanupManager) BatchDeleteRecordingsWithFiles(ctx context.Context, re
 		if err := cm.store.DeleteFile(rec.FilePath); err != nil {
 			logger.Warn("failed to delete file", "file_path", rec.FilePath, "error", err)
 		}
+		// Ambient archive sidecar shares the recording's lifetime (#496).
+		if err := os.Remove(rec.FilePath + ".g711"); err != nil && !os.IsNotExist(err) {
+			logger.Warn("failed to delete ambient sidecar", "file_path", rec.FilePath+".g711", "error", err)
+		}
 	}
 
 	// 6. Publish segment.deleted events for successfully deleted recordings

--- a/internal/config/config_adaptive_test.go
+++ b/internal/config/config_adaptive_test.go
@@ -107,7 +107,6 @@ func TestValidateAudioTrigger(t *testing.T) {
 	}
 }
 
-
 func TestValidateTimelapseFrameMs(t *testing.T) {
 	ok := func(ms int) *Config {
 		c := adaptiveTestConfig("adaptive", "h264", nil)

--- a/internal/config/config_adaptive_test.go
+++ b/internal/config/config_adaptive_test.go
@@ -106,3 +106,32 @@ func TestValidateAudioTrigger(t *testing.T) {
 		})
 	}
 }
+
+
+func TestValidateTimelapseFrameMs(t *testing.T) {
+	ok := func(ms int) *Config {
+		c := adaptiveTestConfig("adaptive", "h264", nil)
+		c.Cameras[0].Adaptive = &AdaptiveRecordingConfig{TimelapseFrameMs: ms}
+		return c
+	}
+	for _, ms := range []int{0, 100, 300, 500} {
+		if err := Validate(ok(ms)); err != nil {
+			t.Fatalf("timelapse_frame_ms=%d must validate: %v", ms, err)
+		}
+	}
+	for _, ms := range []int{50, 200, 1000} {
+		if err := Validate(ok(ms)); err == nil {
+			t.Fatalf("timelapse_frame_ms=%d must be rejected", ms)
+		}
+	}
+	// ambient_archive requires ambient_audio
+	c := ok(100)
+	c.Cameras[0].Adaptive.AmbientArchive = true
+	if err := Validate(c); err == nil {
+		t.Fatal("ambient_archive without ambient_audio must be rejected")
+	}
+	c.Cameras[0].Adaptive.AmbientAudio = true
+	if err := Validate(c); err != nil {
+		t.Fatalf("ambient_archive with ambient_audio must validate: %v", err)
+	}
+}

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -22,6 +22,11 @@ type CameraConfig struct {
 	Transcoding          *CameraTranscodingConfig `yaml:"transcoding,omitempty"`
 	Timelapse            *CameraTimelapseConfig   `yaml:"timelapse,omitempty" json:"timelapse,omitempty"`
 	AudioEnabled         bool                     `yaml:"audio_enabled"`
+	// AudioInRecordings keeps the camera's real audio track in recorded
+	// segments (event spans in merged products; live preview and the audio
+	// trigger are unaffected). Default false — recordings are video-only
+	// unless explicitly enabled per camera.
+	AudioInRecordings    bool                     `yaml:"audio_in_recordings,omitempty" json:"audio_in_recordings,omitempty"`
 	HealthOverrides      HealthOverrides          `yaml:"health_overrides,omitempty"`
 	FrameWatchdogTimeout string                   `yaml:"frame_watchdog_timeout,omitempty"` // default "30s" (per-camera frame watchdog)
 	HTTPJPEGAVI          bool                     `yaml:"http_jpeg_avi"`                    // write AVI single-file instead of MJPEG directory
@@ -153,6 +158,14 @@ type AdaptiveRecordingConfig struct {
 	// continuous atmosphere bed under the timelapse video (event spans keep
 	// real audio). G.711 cameras only; ~28.8MB/h storage while sparse.
 	AmbientAudio bool `yaml:"ambient_audio,omitempty" json:"ambient_audio,omitempty"`
+	// TimelapseFrameMs is the compressed-timeline cadence the merge writes
+	// sparse dwell samples at: preset 100 / 300 / 500 ms, 0/unset = 100.
+	TimelapseFrameMs int `yaml:"timelapse_frame_ms,omitempty" json:"timelapse_frame_ms,omitempty"`
+	// AmbientArchive additionally keeps the raw continuous ambient audio as a
+	// sidecar file (<segment>.g711) beside the recording for post-production
+	// (the merged product still only carries the atmosphere bed). Only
+	// meaningful with ambient_audio; default false.
+	AmbientArchive bool `yaml:"ambient_archive,omitempty" json:"ambient_archive,omitempty"`
 }
 
 // CameraAudioTriggerConfig tunes audio_trigger (issue #478).

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -4,32 +4,32 @@ package config
 // top-level Config aggregate and Validate/ApplyDefaults entry points.
 
 type CameraConfig struct {
-	ID                   string                   `yaml:"id"`
-	Name                 string                   `yaml:"name"`
-	Protocol             string                   `yaml:"protocol"` // rtsp_h264, rtsp_mjpeg, http_jpeg
-	Encoding             string                   `yaml:"encoding"` // h264, h265, mjpeg, jpeg (independent of protocol)
-	URL                  string                   `yaml:"url"`
-	Username             string                   `yaml:"username"`
-	Password             string                   `yaml:"password"`
-	ONVIFEndpoint        string                   `yaml:"onvif_endpoint"`
-	ProfileToken         string                   `yaml:"profile_token"`
-	StreamEncoding       string                   `yaml:"stream_encoding"` // H264 or H265, for ONVIF cameras. Empty = auto-detect.
-	SubStreamURL         string                   `yaml:"sub_stream_url"`
-	SnapshotURL          string                   `yaml:"snapshot_url"`
-	SampleInterval       int                      `yaml:"sample_interval"`
-	HLSMaxFPS            int                      `yaml:"hls_max_fps"`
-	Merge                *MergeConfig             `yaml:"merge"`
-	Transcoding          *CameraTranscodingConfig `yaml:"transcoding,omitempty"`
-	Timelapse            *CameraTimelapseConfig   `yaml:"timelapse,omitempty" json:"timelapse,omitempty"`
-	AudioEnabled         bool                     `yaml:"audio_enabled"`
+	ID             string                   `yaml:"id"`
+	Name           string                   `yaml:"name"`
+	Protocol       string                   `yaml:"protocol"` // rtsp_h264, rtsp_mjpeg, http_jpeg
+	Encoding       string                   `yaml:"encoding"` // h264, h265, mjpeg, jpeg (independent of protocol)
+	URL            string                   `yaml:"url"`
+	Username       string                   `yaml:"username"`
+	Password       string                   `yaml:"password"`
+	ONVIFEndpoint  string                   `yaml:"onvif_endpoint"`
+	ProfileToken   string                   `yaml:"profile_token"`
+	StreamEncoding string                   `yaml:"stream_encoding"` // H264 or H265, for ONVIF cameras. Empty = auto-detect.
+	SubStreamURL   string                   `yaml:"sub_stream_url"`
+	SnapshotURL    string                   `yaml:"snapshot_url"`
+	SampleInterval int                      `yaml:"sample_interval"`
+	HLSMaxFPS      int                      `yaml:"hls_max_fps"`
+	Merge          *MergeConfig             `yaml:"merge"`
+	Transcoding    *CameraTranscodingConfig `yaml:"transcoding,omitempty"`
+	Timelapse      *CameraTimelapseConfig   `yaml:"timelapse,omitempty" json:"timelapse,omitempty"`
+	AudioEnabled   bool                     `yaml:"audio_enabled"`
 	// AudioInRecordings keeps the camera's real audio track in recorded
 	// segments (event spans in merged products; live preview and the audio
 	// trigger are unaffected). Default false — recordings are video-only
 	// unless explicitly enabled per camera.
-	AudioInRecordings    bool                     `yaml:"audio_in_recordings,omitempty" json:"audio_in_recordings,omitempty"`
-	HealthOverrides      HealthOverrides          `yaml:"health_overrides,omitempty"`
-	FrameWatchdogTimeout string                   `yaml:"frame_watchdog_timeout,omitempty"` // default "30s" (per-camera frame watchdog)
-	HTTPJPEGAVI          bool                     `yaml:"http_jpeg_avi"`                    // write AVI single-file instead of MJPEG directory
+	AudioInRecordings    bool            `yaml:"audio_in_recordings,omitempty" json:"audio_in_recordings,omitempty"`
+	HealthOverrides      HealthOverrides `yaml:"health_overrides,omitempty"`
+	FrameWatchdogTimeout string          `yaml:"frame_watchdog_timeout,omitempty"` // default "30s" (per-camera frame watchdog)
+	HTTPJPEGAVI          bool            `yaml:"http_jpeg_avi"`                    // write AVI single-file instead of MJPEG directory
 
 	// StableID is a hardware-level stable identifier (ONVIF serial number) used to
 	// re-acquire the SAME camera after its IP changes (e.g. after an AP reboot when

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -773,5 +773,13 @@ func ValidateCameraRecordingMode(cam CameraConfig) error {
 	if a.GOPBufferBytes != 0 && (a.GOPBufferBytes < 1<<20 || a.GOPBufferBytes > 64<<20) {
 		return fmt.Errorf("cameras.%s.adaptive.gop_buffer_bytes must be 1MB–64MB, got %d", cam.ID, a.GOPBufferBytes)
 	}
+	switch a.TimelapseFrameMs {
+	case 0, 100, 300, 500:
+	default:
+		return fmt.Errorf("cameras.%s.adaptive.timelapse_frame_ms must be one of 100/300/500, got %d", cam.ID, a.TimelapseFrameMs)
+	}
+	if a.AmbientArchive && !a.AmbientAudio {
+		return fmt.Errorf("cameras.%s.adaptive.ambient_archive requires ambient_audio", cam.ID)
+	}
 	return nil
 }

--- a/internal/merge/manager.go
+++ b/internal/merge/manager.go
@@ -41,6 +41,7 @@ type MergeManager struct {
 	store        *storage.Manager
 	getGlobalCfg func() config.MergeConfig
 	getCameraCfg func(cameraID string) *config.MergeConfig
+	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig
 	cameras      func() []config.CameraConfig
 	mergeLocks   sync.Map // map[string]*mergeLock — per-camera merge mutex
 	metrics      *metrics.Metrics
@@ -54,6 +55,7 @@ func NewMergeManager(
 	store *storage.Manager,
 	getGlobalCfg func() config.MergeConfig,
 	getCameraCfg func(cameraID string) *config.MergeConfig,
+	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig,
 	cameras func() []config.CameraConfig,
 	m *metrics.Metrics,
 ) *MergeManager {
@@ -70,6 +72,19 @@ func NewMergeManager(
 // acquireMergeLock attempts to acquire a non-blocking per-camera merge lock.
 // Returns a release function and true if the lock was acquired.
 // Returns nil, false if another merge is already in progress for this camera.
+// resolveTimelapseCadence mirrors RollingMergeCoordinator's per-camera
+// compressed-timeline cadence (adaptive.timelapse_frame_ms).
+func (m *MergeManager) resolveTimelapseCadence(cameraID string) time.Duration {
+	if m.getAdaptiveCfg == nil {
+		return 0
+	}
+	a := m.getAdaptiveCfg(cameraID)
+	if a == nil || a.TimelapseFrameMs == 0 {
+		return 0
+	}
+	return time.Duration(a.TimelapseFrameMs) * time.Millisecond
+}
+
 func (m *MergeManager) acquireMergeLock(cameraID string) (release func(), ok bool) {
 	lock := &mergeLock{}
 	actual, _ := m.mergeLocks.LoadOrStore(cameraID, lock)
@@ -439,7 +454,7 @@ func (m *MergeManager) mergeFormatGroup(ctx context.Context, cameraID, format st
 			continue
 		}
 
-		stats, err := MergeMP4Segments(ctx, segmentInfos, tempPath)
+		stats, err := MergeMP4Segments(ctx, segmentInfos, tempPath, m.resolveTimelapseCadence(cameraID))
 		if err != nil {
 			logger.Error("failed to merge MP4 segments", "camera_id", cameraID, "error", err)
 			os.Remove(tempPath)

--- a/internal/merge/manager.go
+++ b/internal/merge/manager.go
@@ -35,16 +35,16 @@ type mergeLock struct {
 
 // MergeManager handles periodic merging of consecutive MP4 segments.
 type MergeManager struct {
-	mu           sync.RWMutex
-	status       MergeStatus
-	db           *storage.DB
-	store        *storage.Manager
-	getGlobalCfg func() config.MergeConfig
-	getCameraCfg func(cameraID string) *config.MergeConfig
+	mu             sync.RWMutex
+	status         MergeStatus
+	db             *storage.DB
+	store          *storage.Manager
+	getGlobalCfg   func() config.MergeConfig
+	getCameraCfg   func(cameraID string) *config.MergeConfig
 	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig
-	cameras      func() []config.CameraConfig
-	mergeLocks   sync.Map // map[string]*mergeLock — per-camera merge mutex
-	metrics      *metrics.Metrics
+	cameras        func() []config.CameraConfig
+	mergeLocks     sync.Map // map[string]*mergeLock — per-camera merge mutex
+	metrics        *metrics.Metrics
 }
 
 // NewMergeManager creates a new MergeManager with the given dependencies.

--- a/internal/merge/manager_test.go
+++ b/internal/merge/manager_test.go
@@ -101,7 +101,7 @@ func (e *mergeTestEnv) insertMergeableRecording(t *testing.T, id string, cameraI
 
 // newTestMergeManager creates a MergeManager with the given config for testing.
 func newTestMergeManager(db *storage.DB, store *storage.Manager, cfg config.MergeConfig, cameras []config.CameraConfig) *MergeManager {
-	return NewMergeManager(db, store, func() config.MergeConfig { return cfg }, func(string) *config.MergeConfig { return nil }, func() []config.CameraConfig { return cameras }, nil)
+	return NewMergeManager(db, store, func() config.MergeConfig { return cfg }, func(string) *config.MergeConfig { return nil }, func(string) *config.AdaptiveRecordingConfig { return nil }, func() []config.CameraConfig { return cameras }, nil)
 }
 
 func TestRunOnce_NoCameras(t *testing.T) {
@@ -398,6 +398,7 @@ func TestHotReload_PerCameraConfig(t *testing.T) {
 			}
 			return nil
 		},
+		nil, // no per-camera adaptive config
 		func() []config.CameraConfig { return []config.CameraConfig{{ID: cameraID}} },
 		nil,
 	)
@@ -1109,6 +1110,7 @@ func TestIntegration_FullMergeWorkflow(t *testing.T) {
 			env.db, env.store,
 			func() config.MergeConfig { return cfg },
 			func(string) *config.MergeConfig { return nil },
+			nil, // no per-camera adaptive config in test
 			func() []config.CameraConfig { return cameras },
 			m,
 		)
@@ -1168,6 +1170,7 @@ func TestIntegration_FullMergeWorkflow(t *testing.T) {
 			env.db, env.store,
 			func() config.MergeConfig { return cfg },
 			func(string) *config.MergeConfig { return nil },
+			nil, // no per-camera adaptive config in test
 			func() []config.CameraConfig { return cameras },
 			m,
 		)
@@ -1227,6 +1230,7 @@ func TestIntegration_FullMergeWorkflow(t *testing.T) {
 			env.db, env.store,
 			func() config.MergeConfig { return cfg },
 			func(string) *config.MergeConfig { return nil },
+			nil, // no per-camera adaptive config in test
 			func() []config.CameraConfig { return cameras },
 			m,
 		)
@@ -1293,6 +1297,7 @@ func TestIntegration_FullMergeWorkflow(t *testing.T) {
 			concEnv.db, concEnv.store,
 			func() config.MergeConfig { return cfg },
 			func(string) *config.MergeConfig { return nil },
+			nil, // no per-camera adaptive config in test
 			func() []config.CameraConfig { return cameras },
 			concM,
 		)

--- a/internal/merge/mp4merge.go
+++ b/internal/merge/mp4merge.go
@@ -194,7 +194,10 @@ func trimAudioHead(seg *SegmentInfo, droppedSec float64) {
 // players conceal them with gray until the next IDR. Input SegmentInfos are
 // mutated to their aligned state so callers' duration/frame metadata matches
 // what actually landed in the output.
-func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath string) (MergeStats, error) {
+// MergeMP4Segments merges aligned segments into outputPath. The optional
+// frameDur overrides the package default TimelapseFrameDur — callers with a
+// per-camera cadence (adaptive.timelapse_frame_ms) pass it through.
+func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath string, frameDur ...time.Duration) (MergeStats, error) {
 	stats := MergeStats{LeadingDropped: map[int]int{}}
 	if len(segments) == 0 {
 		return stats, fmt.Errorf("no segments to merge")
@@ -407,8 +410,12 @@ func MergeMP4Segments(ctx context.Context, segments []*SegmentInfo, outputPath s
 		// drops it for non-G.711 codecs.
 		ts := float64(seg.Timescale)
 		compress := seg.Timescale > 0
+		cadence := TimelapseFrameDur
+		if len(frameDur) > 0 && frameDur[0] > 0 {
+			cadence = frameDur[0]
+		}
 		gapTicks := float64(seg.Timescale) * TimelapseGapThreshold.Seconds()
-		frameTicks := uint32(float64(seg.Timescale) * TimelapseFrameDur.Seconds())
+		frameTicks := uint32(float64(seg.Timescale) * cadence.Seconds())
 
 		for _, s := range seg.Samples {
 			select {

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -134,6 +134,9 @@ type RollingMergeCoordinator struct {
 	store        *storage.Manager
 	getGlobalCfg func() config.MergeConfig
 	getCameraCfg func(cameraID string) *config.MergeConfig
+	// getAdaptiveCfg resolves the per-camera adaptive config (the compressed
+	// timeline cadence lives there); nil = package default.
+	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig
 	cameras      func() []config.CameraConfig
 	metrics      *metrics.Metrics
 
@@ -202,6 +205,7 @@ func NewRollingMergeCoordinator(
 	store *storage.Manager,
 	getGlobalCfg func() config.MergeConfig,
 	getCameraCfg func(cameraID string) *config.MergeConfig,
+	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig,
 	cameras func() []config.CameraConfig,
 	m *metrics.Metrics,
 	eventBus *event.EventBus,
@@ -211,7 +215,8 @@ func NewRollingMergeCoordinator(
 		store:        store,
 		getGlobalCfg: getGlobalCfg,
 		getCameraCfg: getCameraCfg,
-		cameras:      cameras,
+		getAdaptiveCfg: getAdaptiveCfg,
+		cameras:       cameras,
 		metrics:      m,
 		eventBus:     eventBus,
 		eventCh:      make(chan event.Event, 128), // buffered: bursts of segment closes
@@ -219,6 +224,20 @@ func NewRollingMergeCoordinator(
 }
 
 // resolveRollingConfig returns the effective rolling config for a camera.
+// resolveTimelapseCadence returns the per-camera compressed-timeline frame
+// duration (adaptive.timelapse_frame_ms presets 100/300/500ms); zero = the
+// merge package default.
+func (r *RollingMergeCoordinator) resolveTimelapseCadence(cameraID string) time.Duration {
+	if r.getAdaptiveCfg == nil {
+		return 0
+	}
+	a := r.getAdaptiveCfg(cameraID)
+	if a == nil || a.TimelapseFrameMs == 0 {
+		return 0
+	}
+	return time.Duration(a.TimelapseFrameMs) * time.Millisecond
+}
+
 func (r *RollingMergeCoordinator) resolveRollingConfig(cameraID string) RollingMergeConfig {
 	global := r.getGlobalCfg()
 	perCamera := r.getCameraCfg(cameraID)
@@ -945,7 +964,7 @@ func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID st
 	}
 
 	// Merge.
-	stats, err := MergeMP4Segments(ctx, infos, tempPath)
+	stats, err := MergeMP4Segments(ctx, infos, tempPath, r.resolveTimelapseCadence(cameraID))
 	if err != nil {
 		os.Remove(tempPath)
 		// Mark these as incompatible so we don't retry forever.
@@ -1663,7 +1682,7 @@ func (r *RollingMergeCoordinator) createBucket(
 	}
 
 	// Merge single segment into the bucket file (pre-aligned by mergeOneSegment).
-	stats, err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath)
+	stats, err := MergeMP4Segments(ctx, []*SegmentInfo{info}, tempPath, r.resolveTimelapseCadence(seg.cameraID))
 	if err != nil {
 		os.Remove(tempPath)
 		return "", "", fmt.Errorf("merge initial segment: %w", err)
@@ -1710,6 +1729,7 @@ func (r *RollingMergeCoordinator) createBucket(
 
 	// Delete the source segment file (DB already committed).
 	r.store.DeleteFile(seg.filePath)
+	os.Remove(seg.filePath + ".g711") // ambient archive sidecar (#496)
 
 	return finalPath, mergedRecID, nil
 }
@@ -1753,7 +1773,7 @@ func (r *RollingMergeCoordinator) appendToBucket(
 	// (self-heals pre-fix buckets whose first sample was a P-frame). A bucket
 	// with NO keyframe-bearing sample at all (legacy corrupt data) aborts the
 	// append with a distinct error so mergeOneSegment can rebuild the bucket.
-	stats, mergeErr := MergeMP4Segments(ctx, []*SegmentInfo{bucketInfo, newInfo}, tempPath)
+	stats, mergeErr := MergeMP4Segments(ctx, []*SegmentInfo{bucketInfo, newInfo}, tempPath, r.resolveTimelapseCadence(seg.cameraID))
 	if mergeErr != nil {
 		os.Remove(tempPath)
 		return "", "", fmt.Errorf("merge append: %w", mergeErr)
@@ -1814,6 +1834,7 @@ func (r *RollingMergeCoordinator) appendToBucket(
 
 	// Delete the source segment file.
 	r.store.DeleteFile(seg.filePath)
+	os.Remove(seg.filePath + ".g711") // ambient archive sidecar (#496)
 
 	// Delete the PREVIOUS bucket file (each append creates a new file via
 	// store.CreateSegment, so the old bucket path is now orphaned). Only
@@ -1821,6 +1842,7 @@ func (r *RollingMergeCoordinator) appendToBucket(
 	// CreateSegment generates unique timestamps).
 	if bucket.mergedFilePath != "" && bucket.mergedFilePath != finalPath {
 		r.store.DeleteFile(bucket.mergedFilePath)
+		os.Remove(bucket.mergedFilePath + ".g711")
 	}
 
 	return finalPath, mergedRecID, nil

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -137,8 +137,8 @@ type RollingMergeCoordinator struct {
 	// getAdaptiveCfg resolves the per-camera adaptive config (the compressed
 	// timeline cadence lives there); nil = package default.
 	getAdaptiveCfg func(cameraID string) *config.AdaptiveRecordingConfig
-	cameras      func() []config.CameraConfig
-	metrics      *metrics.Metrics
+	cameras        func() []config.CameraConfig
+	metrics        *metrics.Metrics
 
 	mergeLocks sync.Map // map[string]*mergeLock — per-camera non-blocking mutex
 
@@ -211,15 +211,15 @@ func NewRollingMergeCoordinator(
 	eventBus *event.EventBus,
 ) *RollingMergeCoordinator {
 	return &RollingMergeCoordinator{
-		db:           db,
-		store:        store,
-		getGlobalCfg: getGlobalCfg,
-		getCameraCfg: getCameraCfg,
+		db:             db,
+		store:          store,
+		getGlobalCfg:   getGlobalCfg,
+		getCameraCfg:   getCameraCfg,
 		getAdaptiveCfg: getAdaptiveCfg,
-		cameras:       cameras,
-		metrics:      m,
-		eventBus:     eventBus,
-		eventCh:      make(chan event.Event, 128), // buffered: bursts of segment closes
+		cameras:        cameras,
+		metrics:        m,
+		eventBus:       eventBus,
+		eventCh:        make(chan event.Event, 128), // buffered: bursts of segment closes
 	}
 }
 

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -22,6 +22,7 @@ func newTestRollingCoordinator(env *mergeTestEnv, cfg config.MergeConfig, bus *e
 		env.db, env.store,
 		func() config.MergeConfig { return cfg },
 		func(string) *config.MergeConfig { return nil },
+		nil, // no per-camera adaptive config in test
 		func() []config.CameraConfig { return nil },
 		nil,
 		bus,
@@ -38,6 +39,7 @@ func newTestRollingCoordinatorWithCameras(env *mergeTestEnv, cfg config.MergeCon
 		env.db, env.store,
 		func() config.MergeConfig { return cfg },
 		func(string) *config.MergeConfig { return nil },
+		nil, // no per-camera adaptive config in test
 		func() []config.CameraConfig { return cameras },
 		nil,
 		bus,

--- a/internal/merge/timelapse_compress_test.go
+++ b/internal/merge/timelapse_compress_test.go
@@ -84,6 +84,26 @@ func TestMergeMP4Segments_CompressesSparseDwells(t *testing.T) {
 	require.NotEmpty(t, stats.TimelineMapJSON())
 }
 
+// TestMergeMP4Segments_CadenceOverride: the per-camera preset (300ms) wins
+// over the package default.
+func TestMergeMP4Segments_CadenceOverride(t *testing.T) {
+	dir := t.TempDir()
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	idr := []byte{0x65, 0x88, 0x80, 0x40}
+	sparse := createH264SegmentWithDurations(t, dir, "s.mp4", sps, pps,
+		[][]byte{idr, idr}, []time.Duration{30 * time.Second, 30 * time.Second})
+	info, err := ParseSegment(sparse)
+	require.NoError(t, err)
+
+	_, err = MergeMP4Segments(context.Background(), []*SegmentInfo{info}, filepath.Join(dir, "o.mp4"), 300*time.Millisecond)
+	require.NoError(t, err)
+	out, err := ParseSegment(filepath.Join(dir, "o.mp4"))
+	require.NoError(t, err)
+	got := time.Duration(out.Samples[0].Duration) * time.Second / time.Duration(out.Timescale)
+	require.Equal(t, 300*time.Millisecond, got, "explicit cadence must override the default")
+}
+
 // TestMergeMP4Segments_CompressedAACSpanDropsAudio: a sparse-dwell segment
 // carrying a NON-G.711 audio track gets its video compressed and the span's
 // audio dropped (the envelope mixdown is G.711-only) — the output carries no

--- a/internal/recorder/adaptive.go
+++ b/internal/recorder/adaptive.go
@@ -48,6 +48,10 @@ type AdaptiveConfig struct {
 	TimelapseInterval time.Duration // keyframe cadence while sparse
 	SpikeFactor       float64       // MAD-floored deviations above baseline = spike
 	MaxGOPBuffer      int64         // byte cap of the retained GOP ring
+	// AmbientArchive additionally keeps the raw G.711 stream as a sidecar file
+	// beside each segment for post-production (only meaningful with
+	// AmbientAudio; default off).
+	AmbientArchive bool
 	// AmbientAudio keeps the disk audio track recording CONTINUOUSLY while in
 	// sparse mode (#496 audio phase): the video timeline is compressed at
 	// merge time and the merge renders the ambient span into a quiet
@@ -580,7 +584,7 @@ func (g *AdaptiveGate) ClearWritten() {
 // overrides, defaulting unset fields. Shared by the camera-manager factory
 // (RTSP/ONVIF paths) and plugin-style recorders (Xiaomi) so both resolve
 // identically. String durations follow the frame_watchdog_timeout convention.
-func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor float64, gopBufferBytes int64, ambientAudio bool) AdaptiveConfig {
+func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor float64, gopBufferBytes int64, ambientAudio, ambientArchive bool) AdaptiveConfig {
 	ac := DefaultAdaptiveConfig()
 	if d, err := time.ParseDuration(calmThreshold); err == nil && d > 0 {
 		ac.CalmThreshold = d
@@ -595,5 +599,6 @@ func ResolveAdaptiveConfig(calmThreshold, timelapseInterval string, spikeFactor 
 		ac.MaxGOPBuffer = gopBufferBytes
 	}
 	ac.AmbientAudio = ambientAudio
+	ac.AmbientArchive = ambientArchive
 	return ac
 }

--- a/internal/recorder/adaptive_test.go
+++ b/internal/recorder/adaptive_test.go
@@ -362,11 +362,11 @@ func TestAdaptiveGate_SparseSkipAndFlushFacade(t *testing.T) {
 }
 
 func TestResolveAdaptiveConfig_DefaultsAndOverrides(t *testing.T) {
-	ac := ResolveAdaptiveConfig("", "", 0, 0, false)
+	ac := ResolveAdaptiveConfig("", "", 0, 0, false, false)
 	if ac != (AdaptiveConfig{CalmThreshold: 60 * time.Second, TimelapseInterval: 30 * time.Second, SpikeFactor: 5.0, MaxGOPBuffer: 32 << 20}) {
 		t.Fatalf("defaults wrong: %+v", ac)
 	}
-	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20, true)
+	ac = ResolveAdaptiveConfig("2m", "10s", 7.5, 1<<20, true, false)
 	if ac.CalmThreshold != 2*time.Minute || ac.TimelapseInterval != 10*time.Second || ac.SpikeFactor != 7.5 || ac.MaxGOPBuffer != 1<<20 || !ac.AmbientAudio {
 		t.Fatalf("overrides wrong: %+v", ac)
 	}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -64,6 +64,11 @@ type BaseConfig struct {
 	RingBufCap             int
 	DB                     RecordingDB
 	AudioEnabled           bool
+	// AudioInRecordings keeps the camera's real audio track in recorded
+	// segments (event spans in merged products). Default false — recordings
+	// are video-only unless enabled per camera; live preview and the audio
+	// trigger run off the pre-disk path and are unaffected.
+	AudioInRecordings    bool
 	FrameWatchdogTimeout   time.Duration // default 30s (0 = use defaultFrameWatchdogTimeout)
 	EventBus               *event.EventBus
 	DarkFrameFilterEnabled bool // skip dark/night segments (MJPEG/AVI only)
@@ -269,6 +274,9 @@ type baseRecorder struct {
 	muxer         *muxer.MP4Muxer
 	trackID       int
 	audioTrackID  int
+	// ambientFile is the raw G.711 sidecar handle (nil unless
+	// adaptive.ambient_audio+ambient_archive; guarded by mu like muxer).
+	ambientFile *os.File
 	curFinalPath  string
 	curTempPath   string
 	segStart      time.Time
@@ -859,11 +867,11 @@ func (b *baseRecorder) createNewSegment() bool {
 	}
 	b.trackID = trackID
 
-	// Add audio track if audio config is available (read the immutable snapshot
-	// once — the audio config is set during connectAndRecord and read here from
-	// writeFrames; the snapshot makes this race-free, #226).
+	// Add audio track if audio config is available AND the camera keeps audio
+	// in recordings (default off — #496 follow-up). Live preview and the audio
+	// trigger read the pre-disk path and do not need the track.
 	var audioTrackID int
-	if a := b.audioSnapshot(); a != nil && len(a.muxerConfig) > 0 && a.codec != "" {
+	if a := b.audioSnapshot(); a != nil && len(a.muxerConfig) > 0 && a.codec != "" && b.cfg.AudioInRecordings {
 		aID, err := m.AddAudioTrack(a.codec, a.muxerConfig)
 		if err != nil {
 			b.log.Error("failed to add audio track",
@@ -881,12 +889,57 @@ func (b *baseRecorder) createNewSegment() bool {
 	b.muxer = m
 	b.segStart = time.Now()
 	b.audioTrackID = audioTrackID
+	b.ambientFile = b.openAmbientSidecar(finalPath)
 	b.mu.Unlock()
 	b.curTempPath = tempPath
 	b.curFinalPath = finalPath
 	b.lastFrameTime = b.segStart
 	b.frameCount = 0
 	return true
+}
+
+// openAmbientSidecar opens the raw ambient-audio archive file
+// (<final>.g711) when adaptive.ambient_audio + ambient_archive are both on
+// (#496 playability option): the merge only carries the atmosphere bed, the
+// sidecar keeps the untouched recording for post-production. Called under mu
+// from createNewSegment; nil when disabled.
+func (b *baseRecorder) openAmbientSidecar(finalPath string) *os.File {
+	if b.cfg.Adaptive == nil || !b.cfg.Adaptive.AmbientAudio || !b.cfg.Adaptive.AmbientArchive {
+		return nil
+	}
+	f, err := os.OpenFile(finalPath+".g711", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		b.log.Warn("ambient archive sidecar unavailable", "camera_id", b.cfg.CameraID, "error", err)
+		return nil
+	}
+	return f
+}
+
+// writeAmbientArchive appends raw G.711 bytes to the sidecar (audio RTP
+// callback goroutine; snapshots the handle under mu like the muxer).
+func (b *baseRecorder) writeAmbientArchive(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	b.mu.Lock()
+	f := b.ambientFile
+	b.mu.Unlock()
+	if f == nil {
+		return
+	}
+	if _, err := f.Write(data); err != nil {
+		b.log.Warn("ambient archive write failed", "camera_id", b.cfg.CameraID, "error", err)
+	}
+}
+
+// closeAmbientSidecar closes the sidecar (segment lifecycle paths, under mu).
+func (b *baseRecorder) closeAmbientSidecar() {
+	if b.ambientFile != nil {
+		if err := b.ambientFile.Close(); err != nil {
+			b.log.Warn("ambient archive close failed", "camera_id", b.cfg.CameraID, "error", err)
+		}
+		b.ambientFile = nil
+	}
 }
 
 // closeCurrentSegment finalizes the current segment: closes the muxer,
@@ -910,6 +963,9 @@ func (b *baseRecorder) closeCurrentSegment() {
 		b.audioTrig.ClearWritten()
 	}
 	finishStart := time.Now()
+	b.mu.Lock()
+	b.closeAmbientSidecar()
+	b.mu.Unlock()
 	if err := b.muxer.Close(); err != nil {
 		b.log.Error("failed to close muxer",
 			"camera_id", b.cfg.CameraID, "error", err)
@@ -996,6 +1052,7 @@ func (b *baseRecorder) closeCurrentSegment() {
 	b.mu.Lock()
 	b.muxer = nil
 	b.audioTrackID = 0
+	b.closeAmbientSidecar()
 	b.mu.Unlock()
 	b.curTempPath = ""
 	b.curFinalPath = ""
@@ -1015,8 +1072,10 @@ func (b *baseRecorder) handleStorageFailure() {
 		if b.audioTrig != nil {
 			b.audioTrig.ClearWritten()
 		}
+		b.closeAmbientSidecar()
 		b.muxer.Close()
 		os.Remove(b.curTempPath)
+		os.Remove(b.curFinalPath + ".g711")
 		b.mu.Lock()
 		b.muxer = nil
 		b.curTempPath = ""

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -56,19 +56,19 @@ import (
 // recorders. H264Config and H265Config embed BaseConfig to eliminate the
 // duplication of these fields across the H.264 and H.265 recorder configs.
 type BaseConfig struct {
-	CameraID               string
-	RTSPURL                string
-	Username               string
-	Password               string
-	SegmentDur             time.Duration
-	RingBufCap             int
-	DB                     RecordingDB
-	AudioEnabled           bool
+	CameraID     string
+	RTSPURL      string
+	Username     string
+	Password     string
+	SegmentDur   time.Duration
+	RingBufCap   int
+	DB           RecordingDB
+	AudioEnabled bool
 	// AudioInRecordings keeps the camera's real audio track in recorded
 	// segments (event spans in merged products). Default false — recordings
 	// are video-only unless enabled per camera; live preview and the audio
 	// trigger run off the pre-disk path and are unaffected.
-	AudioInRecordings    bool
+	AudioInRecordings      bool
 	FrameWatchdogTimeout   time.Duration // default 30s (0 = use defaultFrameWatchdogTimeout)
 	EventBus               *event.EventBus
 	DarkFrameFilterEnabled bool // skip dark/night segments (MJPEG/AVI only)
@@ -271,12 +271,12 @@ type baseRecorder struct {
 	// RTP callbacks under mu). muxer is published together with segStart and
 	// audioTrackID in createNewSegment so the audio callback observes an
 	// aligned (muxer, trackID, segStart) triplet.
-	muxer         *muxer.MP4Muxer
-	trackID       int
-	audioTrackID  int
+	muxer        *muxer.MP4Muxer
+	trackID      int
+	audioTrackID int
 	// ambientFile is the raw G.711 sidecar handle (nil unless
 	// adaptive.ambient_audio+ambient_archive; guarded by mu like muxer).
-	ambientFile *os.File
+	ambientFile   *os.File
 	curFinalPath  string
 	curTempPath   string
 	segStart      time.Time

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -430,7 +430,7 @@ func (r *H264Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 				aid := r.audioTrackID
 				start := r.segStart
 				r.mu.Unlock()
-				if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse (adaptive-timelapse) mode drops disk audio, live audio continues
+				if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse drops disk audio; the track exists only when AudioInRecordings is on
 					pts := time.Since(start)
 					dur := 1024 * time.Second / time.Duration(audioForma.ClockRate())
 					if err := m.WriteAudioSample(aid, aacData, pts, dur); err != nil {
@@ -458,12 +458,13 @@ func (r *H264Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 				g711Rate = a.g711SampleRate
 			}
 			r.audioTriggerIngest(g711Forma.MULaw, data, g711Rate, time.Now())
+			r.writeAmbientArchive(data) // raw sidecar when adaptive.ambient_archive is on
 			r.mu.Lock()
 			m := r.muxer
 			aid := r.audioTrackID
 			start := r.segStart
 			r.mu.Unlock()
-			if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse (adaptive-timelapse) mode drops disk audio, live audio continues
+			if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse drops disk audio; the track exists only when AudioInRecordings is on
 				pts := time.Since(start)
 				// g711SampleRate is read from the immutable audio snapshot
 				// (this callback runs on the RTP reader goroutine, concurrently

--- a/internal/recorder/h264_h265_characterization_test.go
+++ b/internal/recorder/h264_h265_characterization_test.go
@@ -240,11 +240,11 @@ func TestH264Characterization_AudioCapturedInSegment(t *testing.T) {
 	mgr := newTestManager(t)
 
 	rec := NewH264Recorder(H264Config{
-		CameraID:     "h264-char-audio",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "h264-char-audio",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 
@@ -658,11 +658,11 @@ func TestH265Characterization_AudioCapturedInSegment(t *testing.T) {
 	mgr := newTestManager(t)
 
 	rec := NewH265Recorder(H265Config{
-		CameraID:     "h265-char-audio",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "h265-char-audio",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 

--- a/internal/recorder/h264_h265_characterization_test.go
+++ b/internal/recorder/h264_h265_characterization_test.go
@@ -245,6 +245,7 @@ func TestH264Characterization_AudioCapturedInSegment(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -662,6 +663,7 @@ func TestH265Characterization_AudioCapturedInSegment(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/internal/recorder/h264_test.go
+++ b/internal/recorder/h264_test.go
@@ -643,11 +643,11 @@ func TestH264Recorder_AudioBroadcast(t *testing.T) {
 	hub := model.NewStreamHub()
 
 	rec := NewH264Recorder(H264Config{
-		CameraID:     "cam-audio",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "cam-audio",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 	rec.Hub = hub
@@ -743,11 +743,11 @@ func TestH264Recorder_AudioEnabled_NoAudioInStream(t *testing.T) {
 	mgr := newTestManager(t)
 
 	rec := NewH264Recorder(H264Config{
-		CameraID:     "cam-videoonly",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "cam-videoonly",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 

--- a/internal/recorder/h264_test.go
+++ b/internal/recorder/h264_test.go
@@ -648,6 +648,7 @@ func TestH264Recorder_AudioBroadcast(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 	rec.Hub = hub
 
@@ -747,6 +748,7 @@ func TestH264Recorder_AudioEnabled_NoAudioInStream(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -418,7 +418,7 @@ func (r *H265Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 				aid := r.audioTrackID
 				start := r.segStart
 				r.mu.Unlock()
-				if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse (adaptive-timelapse) mode drops disk audio, live audio continues
+				if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse drops disk audio; the track exists only when AudioInRecordings is on
 					pts := time.Since(start)
 					dur := 1024 * time.Second / time.Duration(audioForma.ClockRate())
 					if err := m.WriteAudioSample(aid, aacData, pts, dur); err != nil {
@@ -446,12 +446,13 @@ func (r *H265Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 				g711Rate = a.g711SampleRate
 			}
 			r.audioTriggerIngest(g711Forma.MULaw, data, g711Rate, time.Now())
+			r.writeAmbientArchive(data) // raw sidecar when adaptive.ambient_archive is on
 			r.mu.Lock()
 			m := r.muxer
 			aid := r.audioTrackID
 			start := r.segStart
 			r.mu.Unlock()
-			if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse (adaptive-timelapse) mode drops disk audio, live audio continues
+			if m != nil && aid > 0 && !r.audioSparse.Load() { // sparse drops disk audio; the track exists only when AudioInRecordings is on
 				pts := time.Since(start)
 				// g711SampleRate from the immutable snapshot (race-free read
 				// from this RTP-callback goroutine, #226).

--- a/internal/recorder/h265_test.go
+++ b/internal/recorder/h265_test.go
@@ -222,11 +222,11 @@ func TestH265Recorder_AudioBroadcast(t *testing.T) {
 	hub := model.NewStreamHub()
 
 	rec := NewH265Recorder(H265Config{
-		CameraID:     "cam-audio-h265",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "cam-audio-h265",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 	rec.Hub = hub
@@ -322,11 +322,11 @@ func TestH265Recorder_AudioEnabled_NoAudioInStream(t *testing.T) {
 	mgr := newTestManager(t)
 
 	rec := NewH265Recorder(H265Config{
-		CameraID:     "cam-videoonly-h265",
-		RTSPURL:      srv.rtspURL,
-		SegmentDur:   5 * time.Minute,
-		RingBufCap:   100,
-		AudioEnabled: true,
+		CameraID:          "cam-videoonly-h265",
+		RTSPURL:           srv.rtspURL,
+		SegmentDur:        5 * time.Minute,
+		RingBufCap:        100,
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, mgr)
 

--- a/internal/recorder/h265_test.go
+++ b/internal/recorder/h265_test.go
@@ -227,6 +227,7 @@ func TestH265Recorder_AudioBroadcast(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 	rec.Hub = hub
 
@@ -326,6 +327,7 @@ func TestH265Recorder_AudioEnabled_NoAudioInStream(t *testing.T) {
 		SegmentDur:   5 * time.Minute,
 		RingBufCap:   100,
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, mgr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -32,6 +32,7 @@ type ONVIFConfig struct {
 	SegmentDur           time.Duration
 	DB                   RecordingDB
 	AudioEnabled         bool
+	AudioInRecordings    bool
 	FrameWatchdogTimeout time.Duration // default 30s (0 = use constant default)
 	ONVIFEndpoint        string        // ONVIF device endpoint URL (for HTTP MJPEG probe base)
 	EventBus             *event.EventBus
@@ -678,6 +679,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 			RingBufCap:           DefaultRingBufCap,
 			DB:                   r.cfg.DB,
 			AudioEnabled:         r.cfg.AudioEnabled,
+			AudioInRecordings:    r.cfg.AudioInRecordings,
 			FrameWatchdogTimeout: r.cfg.FrameWatchdogTimeout,
 			EventBus:             r.cfg.EventBus,
 			RecordEnabled:        r.cfg.RecordEnabled,
@@ -768,6 +770,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 			RingBufCap:           DefaultRingBufCap,
 			DB:                   r.cfg.DB,
 			AudioEnabled:         r.cfg.AudioEnabled,
+			AudioInRecordings:    r.cfg.AudioInRecordings,
 			FrameWatchdogTimeout: r.cfg.FrameWatchdogTimeout,
 			EventBus:             r.cfg.EventBus,
 			RecordEnabled:        r.cfg.RecordEnabled,

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787614727767';
+const CACHE_VERSION = 'mibee-nvr-1787624354055';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -58,17 +58,17 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 	}
 
 	recCfg := XiaomiRecorderConfig{
-		CameraID:      cfg.ID,
-		DID:           did,
-		CloudCfg:      cloudCfg,
-		SegmentDur:    30 * time.Second,
-		DB:            db,
-		AudioEnabled:  cfg.AudioEnabled,
+		CameraID:          cfg.ID,
+		DID:               did,
+		CloudCfg:          cloudCfg,
+		SegmentDur:        30 * time.Second,
+		DB:                db,
+		AudioEnabled:      cfg.AudioEnabled,
 		AudioInRecordings: cfg.AudioInRecordings,
-		Channel:       cfg.Channel,
-		Quality:       cfg.Quality,
-		EventBus:      p.eventBus,
-		RecordEnabled: cfg.RecordingEnabled,
+		Channel:           cfg.Channel,
+		Quality:           cfg.Quality,
+		EventBus:          p.eventBus,
+		RecordEnabled:     cfg.RecordingEnabled,
 	}
 	// Adaptive write-density (issue #435/#468): recording_mode: adaptive was
 	// silently ignored by the Xiaomi recorder until the gate was ported.

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -64,6 +64,7 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 		SegmentDur:    30 * time.Second,
 		DB:            db,
 		AudioEnabled:  cfg.AudioEnabled,
+		AudioInRecordings: cfg.AudioInRecordings,
 		Channel:       cfg.Channel,
 		Quality:       cfg.Quality,
 		EventBus:      p.eventBus,
@@ -78,11 +79,11 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 		if cfg.Adaptive != nil {
 			a = cfg.Adaptive
 		}
-		calm, interval, spike, gop, ambient := "", "", 0.0, int64(0), false
+		calm, interval, spike, gop, ambient, archive := "", "", 0.0, int64(0), false, false
 		if a != nil {
-			calm, interval, spike, gop, ambient = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio
+			calm, interval, spike, gop, ambient, archive = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio, a.AmbientArchive
 		}
-		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient)
+		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient, archive)
 		recCfg.Adaptive = &ac
 		// Audio-trigger (issue #478): only meaningful on top of adaptive, and
 		// only for G.711 cameras — the recorder logs Opus as inactive.

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -60,19 +60,19 @@ type XiaomiCloudConfig struct {
 
 // XiaomiRecorderConfig holds configuration for the Xiaomi recorder.
 type XiaomiRecorderConfig struct {
-	CameraID     string
-	DID          string            // Device ID extracted from xiaomi:// URL (e.g. "655448418")
-	Model        string            // Camera model (e.g. ModelC200, ModelC300)
-	CloudCfg     XiaomiCloudConfig // Cloud API credentials for MISS URL resolution
-	SegmentDur   time.Duration
-	DB           RecordingDB
-	ErrReporter  ErrorReporter // Optional: reports detailed errors (e.g. TUTK incompatibility)
-	AudioEnabled bool          // Capture and broadcast audio via StreamHub when true
-	AudioInRecordings bool     // Keep the audio track in recorded segments (default off)
-	IdleTimeout  time.Duration
-	Channel      string // Xiaomi dual-lens channel ("" or "0" = main, "1" = secondary)
-	Quality      string // Stream quality: "" or "auto" (HD→SD fallback), "hd", "sd"
-	EventBus     *event.EventBus
+	CameraID          string
+	DID               string            // Device ID extracted from xiaomi:// URL (e.g. "655448418")
+	Model             string            // Camera model (e.g. ModelC200, ModelC300)
+	CloudCfg          XiaomiCloudConfig // Cloud API credentials for MISS URL resolution
+	SegmentDur        time.Duration
+	DB                RecordingDB
+	ErrReporter       ErrorReporter // Optional: reports detailed errors (e.g. TUTK incompatibility)
+	AudioEnabled      bool          // Capture and broadcast audio via StreamHub when true
+	AudioInRecordings bool          // Keep the audio track in recorded segments (default off)
+	IdleTimeout       time.Duration
+	Channel           string // Xiaomi dual-lens channel ("" or "0" = main, "1" = secondary)
+	Quality           string // Stream quality: "" or "auto" (HD→SD fallback), "hd", "sd"
+	EventBus          *event.EventBus
 	// RecordEnabled gates disk writes. nil or true = record normally;
 	// false = "live-only" mode — the stream stays connected (for live preview /
 	// HLS) but no segments are written to disk. Matches baseRecorder.RecordEnabled

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -68,6 +68,7 @@ type XiaomiRecorderConfig struct {
 	DB           RecordingDB
 	ErrReporter  ErrorReporter // Optional: reports detailed errors (e.g. TUTK incompatibility)
 	AudioEnabled bool          // Capture and broadcast audio via StreamHub when true
+	AudioInRecordings bool     // Keep the audio track in recorded segments (default off)
 	IdleTimeout  time.Duration
 	Channel      string // Xiaomi dual-lens channel ("" or "0" = main, "1" = secondary)
 	Quality      string // Stream quality: "" or "auto" (HD→SD fallback), "hd", "sd"

--- a/internal/xiaomi/recorder_test.go
+++ b/internal/xiaomi/recorder_test.go
@@ -713,6 +713,7 @@ func TestXiaomiRecorderAudioForwardWhenEnabled(t *testing.T) {
 		CameraID:     "test-cam",
 		DID:          "test-device",
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
 	r.Hub = model.NewStreamHub()
@@ -789,6 +790,7 @@ func TestXiaomiRecorderAudioUnknownCodecSkipped(t *testing.T) {
 		CameraID:     "test-cam",
 		DID:          "test-device",
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
 	r.Hub = model.NewStreamHub()
@@ -822,6 +824,7 @@ func TestXiaomiRecorderAudioNilHub(t *testing.T) {
 		CameraID:     "test-cam",
 		DID:          "test-device",
 		AudioEnabled: true,
+		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
 	r.codec = model.FormatH264

--- a/internal/xiaomi/recorder_test.go
+++ b/internal/xiaomi/recorder_test.go
@@ -710,9 +710,9 @@ func TestMissCodecToAudio(t *testing.T) {
 func TestXiaomiRecorderAudioForwardWhenEnabled(t *testing.T) {
 	t.Helper()
 	r := NewXiaomiRecorder(XiaomiRecorderConfig{
-		CameraID:     "test-cam",
-		DID:          "test-device",
-		AudioEnabled: true,
+		CameraID:          "test-cam",
+		DID:               "test-device",
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
@@ -787,9 +787,9 @@ func TestXiaomiRecorderAudioSkippedWhenDisabled(t *testing.T) {
 func TestXiaomiRecorderAudioUnknownCodecSkipped(t *testing.T) {
 	t.Helper()
 	r := NewXiaomiRecorder(XiaomiRecorderConfig{
-		CameraID:     "test-cam",
-		DID:          "test-device",
-		AudioEnabled: true,
+		CameraID:          "test-cam",
+		DID:               "test-device",
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
@@ -821,9 +821,9 @@ func TestXiaomiRecorderAudioUnknownCodecSkipped(t *testing.T) {
 func TestXiaomiRecorderAudioNilHub(t *testing.T) {
 	t.Helper()
 	r := NewXiaomiRecorder(XiaomiRecorderConfig{
-		CameraID:     "test-cam",
-		DID:          "test-device",
-		AudioEnabled: true,
+		CameraID:          "test-cam",
+		DID:               "test-device",
+		AudioEnabled:      true,
 		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -245,6 +245,14 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			}
 			return nil
 		},
+		func(cameraID string) *config.AdaptiveRecordingConfig {
+			for _, c := range cfg.Cameras {
+				if c.ID == cameraID {
+					return c.Adaptive
+				}
+			}
+			return nil
+		},
 		func() []config.CameraConfig { return cfg.Cameras },
 		m,
 	)
@@ -259,6 +267,14 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			for _, c := range cfg.Cameras {
 				if c.ID == cameraID {
 					return c.Merge
+				}
+			}
+			return nil
+		},
+		func(cameraID string) *config.AdaptiveRecordingConfig {
+			for _, c := range cfg.Cameras {
+				if c.ID == cameraID {
+					return c.Adaptive
 				}
 			}
 			return nil

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -36,6 +36,8 @@ export interface Camera {
   transcoding?: CameraTranscodingConfig;
   channel?: string;
   audio_enabled?: boolean;
+  /** Keep the real audio track in recorded segments (default off). */
+  audio_in_recordings?: boolean;
   // Recording gate: false = live-only (no segments written to disk; the recorder
   // stays connected for live preview + relay + health). undefined = record.
   recording_enabled?: boolean | null;
@@ -89,6 +91,10 @@ export interface AdaptiveRecordingConfig {
    *  merge renders it into a quiet atmosphere bed under the compressed
    *  timelapse video. G.711 cameras only; ~28.8MB/h while sparse. */
   ambient_audio?: boolean;
+  /** Compressed-timeline frame cadence preset (ms): 100/300/500, 0 = default 100. */
+  timelapse_frame_ms?: number;
+  /** Keep the raw ambient G.711 as a sidecar file for post-production. */
+  ambient_archive?: boolean;
 }
 
 /** Loudness trigger knobs for recording_mode: 'adaptive' (#478). */

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -90,6 +90,7 @@
   let formStreamEncoding = $state('');
   let formChannel = $state('');
   let formAudioEnabled = $state(false);
+  let formAudioInRecordings = $state(false);
   // Recording gate — when off, the recorder stays connected for live preview
   // and relay but writes NO segments to disk (live-only / stream-forward mode).
   let formRecordingEnabled = $state(true);
@@ -103,6 +104,8 @@
   let formAdaptiveSpikeFactor = $state('');
   let formAdaptiveGopBufferMB = $state('');
   let formAmbientAudio = $state(false);
+  let formAmbientArchive = $state(false);
+  let formTimelapseFrameMs = $state('');
   let formAdaptiveWasAmbient = false;
   // Audio trigger (#478): loudness input on top of the adaptive gate. Only
   // meaningful (and only sent) for adaptive + G.711 cameras.
@@ -271,6 +274,7 @@ let validationErrors = $state<Record<string, string>>({});
     validationErrors = {};
     formChannel = '';
     formAudioEnabled = false;
+    formAudioInRecordings = false;
     formTwoWayAudioEnabled = false;
     formSubnetHints = '';
     formDarkFrameFilterEnabled = false;
@@ -376,6 +380,7 @@ let validationErrors = $state<Record<string, string>>({});
     }
     formChannel = camera.channel || '';
     formAudioEnabled = camera.audio_enabled ?? false;
+    formAudioInRecordings = camera.audio_in_recordings ?? false;
     formRecordingEnabled = camera.recording_enabled ?? true;
     formCascadeEnabled = camera.cascade_enabled ?? true;
     formRecordingMode = camera.recording_mode === 'adaptive' ? 'adaptive' : 'continuous';
@@ -386,6 +391,8 @@ let validationErrors = $state<Record<string, string>>({});
       ? String(Math.round(camera.adaptive.gop_buffer_bytes / (1024 * 1024)))
       : '';
     formAmbientAudio = camera.adaptive?.ambient_audio ?? false;
+    formAmbientArchive = camera.adaptive?.ambient_archive ?? false;
+    formTimelapseFrameMs = camera.adaptive?.timelapse_frame_ms ? String(camera.adaptive.timelapse_frame_ms) : '';
     formAdaptiveWasAmbient = formAmbientAudio;
     formAudioTriggerEnabled = camera.audio_trigger?.enabled ?? false;
     formAudioTriggerWasEnabled = formAudioTriggerEnabled;
@@ -653,6 +660,10 @@ function buildAdaptivePayload() {
     if (!Number.isNaN(spike) && spike > 0) p.spike_factor = spike;
     const mb = parseInt(formAdaptiveGopBufferMB, 10);
     if (!Number.isNaN(mb) && mb > 0) p.gop_buffer_bytes = mb * 1024 * 1024;
+    p.ambient_audio = formAmbientAudio;
+    p.ambient_archive = formAmbientAudio && formAmbientArchive;
+    const fms = parseInt(formTimelapseFrameMs, 10);
+    if (!Number.isNaN(fms) && fms > 0) p.timelapse_frame_ms = fms;
     return p;
 }
 
@@ -699,6 +710,7 @@ async function performCameraSave() {
             },
             channel: formProtocol === 'xiaomi' ? (formChannel || undefined) : undefined,
             audio_enabled: formAudioEnabled,
+            audio_in_recordings: formAudioInRecordings,
             recording_enabled: formRecordingEnabled,
             cascade_enabled: formCascadeEnabled,
             recording_mode: formRecordingMode,
@@ -765,6 +777,7 @@ async function performCameraSave() {
             },
             channel: formProtocol === 'xiaomi' ? (formChannel || undefined) : undefined,
             audio_enabled: formAudioEnabled,
+            audio_in_recordings: formAudioInRecordings,
             recording_enabled: formRecordingEnabled,
             cascade_enabled: formCascadeEnabled,
             recording_mode: formRecordingMode,
@@ -981,6 +994,15 @@ async function performCameraSave() {
             <input id="cam-adaptive-gop" class="input" type="number" step="1" min="1" max="64" placeholder="16" bind:value={formAdaptiveGopBufferMB} />
           </div>
         </div>
+        <div>
+          <label for="cam-adaptive-framems" class="input-label">{t('cameras.timelapseFrameMs')}</label>
+          <select id="cam-adaptive-framems" class="input" bind:value={formTimelapseFrameMs}>
+            <option value="">{t('cameras.timelapseFrameMsDefault')}</option>
+            <option value="100">0.1s</option>
+            <option value="300">0.3s</option>
+            <option value="500">0.5s</option>
+          </select>
+        </div>
         <p class="text-xs th-text-muted -mt-1">{t('cameras.adaptiveParamsHint')}</p>
         <div class="flex items-center gap-2">
           <input
@@ -1019,6 +1041,18 @@ async function performCameraSave() {
         </div>
         {#if formAmbientAudio}
           <p class="text-xs th-text-muted -mt-1">{t('cameras.ambientAudioHint')}</p>
+          <div class="flex items-center gap-2">
+            <input
+              id="cam-ambient-archive"
+              type="checkbox"
+              class="checkbox"
+              bind:checked={formAmbientArchive}
+            />
+            <label for="cam-ambient-archive" class="input-label cursor-pointer">
+              {t('cameras.ambientArchive')}
+            </label>
+          </div>
+          <p class="text-xs th-text-muted -mt-1">{t('cameras.ambientArchiveHint')}</p>
         {/if}
       {/if}
     {/if}
@@ -1103,6 +1137,20 @@ async function performCameraSave() {
           {t('cameras.audioEnabled')}
         </label>
       </div>
+      {#if formAudioEnabled}
+        <div class="flex items-center gap-2 -mt-1">
+          <input
+            id="cam-audio-in-recordings"
+            type="checkbox"
+            class="checkbox"
+            bind:checked={formAudioInRecordings}
+          />
+          <label for="cam-audio-in-recordings" class="input-label cursor-pointer">
+            {t('cameras.audioInRecordings')}
+          </label>
+        </div>
+        <p class="text-xs th-text-muted -mt-1">{t('cameras.audioInRecordingsHint')}</p>
+      {/if}
     {/if}
 
     <!-- Xiaomi two-way audio toggle -->

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1742,5 +1742,11 @@
   "detail.activity.score": "activity score",
   "detail.activity.noScore": "not analyzed",
   "detail.activity.current": "current",
-  "detail.activity.hint": "green=calm → red=busy; click to jump to that recording"
+  "detail.activity.hint": "green=calm → red=busy; click to jump to that recording",
+  "cameras.audioInRecordings": "Keep audio in recordings",
+  "cameras.audioInRecordingsHint": "Default off: recordings are video-only (live preview and the audio trigger are unaffected)",
+  "cameras.ambientArchive": "Archive raw ambient audio",
+  "cameras.ambientArchiveHint": "Saves the raw G.711 ambience as a sidecar file for post-production",
+  "cameras.timelapseFrameMs": "Timelapse frame gap",
+  "cameras.timelapseFrameMsDefault": "Default (0.1s)"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1741,5 +1741,11 @@
   "detail.activity.score": "活动分",
   "detail.activity.noScore": "未分析",
   "detail.activity.current": "本段",
-  "detail.activity.hint": "绿=平静 → 红=活跃;点击跳转该录像"
+  "detail.activity.hint": "绿=平静 → 红=活跃;点击跳转该录像",
+  "cameras.audioInRecordings": "录像保留音频轨",
+  "cameras.audioInRecordingsHint": "默认不保留：录像文件为纯视频（直播与音频触发不受影响）",
+  "cameras.ambientArchive": "原始环境声留档",
+  "cameras.ambientArchiveHint": "无人时段的原始 G.711 声音另存为附属文件供后期处理",
+  "cameras.timelapseFrameMs": "延时帧距",
+  "cameras.timelapseFrameMsDefault": "默认（0.1s）"
 }


### PR DESCRIPTION
## 三个可玩性开关（用户确认的参数）

1. **adaptive.timelapse_frame_ms**（枚举 100/300/500ms，默认 100=0.1s）：压缩时间轴帧距按相机配置，贯穿 rolling 与周期合并（MergeMP4Segments 变参 + 按相机 adaptive 配置解析器）。
2. **audio_in_recordings**（相机级，**默认 false**）：录像段默认纯视频（直播预览与音频触发走盘前路径不受影响）；RTSP/ONVIF/小米三条录制路径接线 + API/UI。测试断言音频的用例显式开启该开关。
3. **adaptive.ambient_archive**（**默认 false**，要求 ambient_audio）：无人时段原始 G.711 环境声另存 `<segment>.g711` 附属文件供后期；合并产物仍只用混缩氛围层。附属文件生命周期随录像（滚动合并消费 + 保留清理同步删除）。

## 实测（M5）

- 新段（adaptive+对照组）默认无音轨 ✓；API 设 timelapse_frame_ms=300 后按 0.3s 帧距产出（见评论）。
- 构造器签名变更的测试调用点已全部适配；config/merge/recorder/camera/xiaomi 套件 + SPA 574 用例全绿。
