### PR TITLE
fix(recorder): 录制时间戳跟随帧到达时间，消除突发塌缩类 POC 损伤 (#506)

### DIFF
--- a/internal/recorder/adaptive_rotation_test.go
+++ b/internal/recorder/adaptive_rotation_test.go
@@ -85,7 +85,7 @@ func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
 		Adaptive: &AdaptiveConfig{
 			CalmThreshold:     400 * time.Millisecond,
 			TimelapseInterval: time.Hour,
-			SpikeFactor:        3.0,
+			SpikeFactor:       3.0,
 			MaxGOPBuffer:      8 << 20,
 		},
 	}, mgr)

--- a/internal/recorder/adaptive_rotation_test.go
+++ b/internal/recorder/adaptive_rotation_test.go
@@ -1,15 +1,9 @@
 package recorder
 
-// Regression tests for issue #498 (original-segment POC damage), found during
-// the #435 adaptive-recording field test on real cameras:
-//
-//	Bug A — the timelapse-exit flush carried the TRIGGER frame (observe
-//	         appended it before takeGOP); the normal write path wrote it
-//	         again right after → "Duplicate POC" in every exit segment.
-//	Bug B — gopFrame.written is a per-SEGMENT marking but survived segment
-//	         rotation; a flush landing in a FRESH segment skipped mid-GOP
-//	         frames that existed only in the closed file → "Could not find
-//	         ref with POC".
+// Regression tests for issue #498 (original-segment POC damage) and #506
+// (timestamp collapse): writeFrames driven end-to-end with SYNTHETIC arrival
+// timestamps — no real-time pacing needed since the #506 arrival-time
+// refactor, which also makes burst drains keep real spacing.
 
 import (
 	"bytes"
@@ -33,7 +27,6 @@ func TestAdaptiveTracker_ClearWrittenResetsRingFlags(t *testing.T) {
 		buf[0] = 0x41
 		tr.observe(buf, false, time.Now().Add(time.Duration(i+1)*50*time.Millisecond))
 	}
-	// Simulate normal-path writes: everything retained is on disk.
 	for i := range tr.gop {
 		tr.gop[i].written = true
 	}
@@ -54,9 +47,6 @@ func TestAdaptiveTracker_TakeGOPWithOnlyTriggerRingReturnsNil(t *testing.T) {
 	cfg := DefaultAdaptiveConfig()
 	tr := newAdaptiveTracker(cfg, "cam", testAdaptiveLogger())
 
-	// The trigger IS the IDR: observe() resets the ring to [IDR] and the exit
-	// path calls takeGOP — nothing remains that needs flushing (the caller
-	// writes the IDR itself via the normal path).
 	idr := bytes.Repeat([]byte{0x65}, 30000)
 	tr.mode = adaptiveTimelapse
 	_, flush := tr.observe(idr, true, time.Now())
@@ -72,8 +62,6 @@ func TestAudioRing_ClearWrittenResetsFlags(t *testing.T) {
 	r.markWritten()
 	require.True(t, r.drain()[0].Written)
 
-	// Refill and clear — the rotation twin must forget the closed segment's
-	// markings just like the video ring.
 	r.append(true, []byte{3, 4}, 250*time.Microsecond, now.Add(time.Millisecond))
 	r.markWritten()
 	r.clearWritten()
@@ -82,28 +70,27 @@ func TestAudioRing_ClearWrittenResetsFlags(t *testing.T) {
 	}
 }
 
-// TestH264Adaptive_TLExitFlushAfterRotation drives writeFrames end-to-end
-// through the exact field sequence that produced corrupted originals:
-// normal-rate writing → segment rotation (stale written flags) → timelapse
-// entry → spike exit whose flush must land in a FRESH segment containing the
-// complete retained GOP, with the trigger frame written exactly once.
+// feedStudio drives writeFrames through the exact field sequence that
+// produced corrupted originals: normal-rate writing → segment rotation
+// (stale written flags) → timelapse entry → spike exit whose flush lands in
+// a FRESH segment containing the complete retained GOP, trigger written once.
 func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
 	mgr := newTestManager(t)
 	const cam = "h264-adaptive-poc"
 	rec := NewH264Recorder(H264Config{
 		CameraID:   cam,
-		RTSPURL:    "rtsp://ignored",       // never connected — writeFrames driven directly
-		SegmentDur: 200 * time.Millisecond, // rotate mid-NORMAL, before TL entry
+		RTSPURL:    "rtsp://ignored",
+		SegmentDur: 200 * time.Millisecond,
 		RingBufCap: 256,
 		Adaptive: &AdaptiveConfig{
 			CalmThreshold:     400 * time.Millisecond,
-			TimelapseInterval: time.Hour, // no sparse keyframes inside the window
-			SpikeFactor:       3.0,
+			TimelapseInterval: time.Hour,
+			SpikeFactor:        3.0,
 			MaxGOPBuffer:      8 << 20,
 		},
 	}, mgr)
 	b := rec.baseRecorder
-	b.frameCh = make(chan []byte, 256) // normally created in connectAndRecord
+	b.frameCh = make(chan framePacket, 256)
 	b.resetAdaptive()
 
 	done := make(chan struct{})
@@ -113,53 +100,42 @@ func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
 		<-done
 	}()
 
-	send := func(nal []byte) {
-		b.frameCh <- append(append([]byte{}, 0, 0, 0, 1), nal...)
+	send := func(nal []byte, at time.Time) {
+		b.frameCh <- framePacket{data: append(append([]byte{}, 0, 0, 0, 1), nal...), at: at}
 	}
 
-	// Parameter sets + IDR anchor (padded to a realistic keyframe size).
-	send(testSPS)
-	send(testPPS)
+	// Synthetic arrival axis: 20ms per frame.
+	t0 := time.Now()
+	send(testSPS, t0)
+	send(testPPS, t0)
 	idr := append(append([]byte{}, testIDR...), bytes.Repeat([]byte{0x11}, 20000)...)
-	send(idr)
+	send(idr, t0)
 
-	// 35 calm P-frames at 20ms (700ms total): rotation fires at ~200ms
-	// (frames written to segment 1, flags marked), timelapse entry at ~400ms,
-	// the rest is sparse-skipped but retained.
 	const totalPs = 35
 	for i := range totalPs {
 		p := append([]byte{0x41}, bytes.Repeat([]byte{0x22}, 799)...)
-		p[len(p)-2] = byte(i >> 8) // unique per frame — adjacent-duplicate
-		p[len(p)-1] = byte(i)      // detection must not false-positive
-		send(p)
-		time.Sleep(20 * time.Millisecond)
+		p[len(p)-2] = byte(i >> 8)
+		p[len(p)-1] = byte(i)
+		send(p, t0.Add(time.Duration(i+1)*20*time.Millisecond))
 	}
 
-	// Major spike (300KB vs 800B baseline): single-frame timelapse exit.
 	spike := append([]byte{0x41}, bytes.Repeat([]byte{0x33}, 299999)...)
-	send(spike)
+	send(spike, t0.Add(time.Duration(totalPs+1)*20*time.Millisecond))
 
-	// Let the writer drain, then collect the finalized segments.
-	require.Eventually(t, func() bool { return len(b.frameCh) == 0 }, 3*time.Second, 10*time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
+	require.Eventually(t, func() bool { return len(b.frameCh) == 0 }, 5*time.Second, 5*time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	files, err := mgr.ListFiles(cam)
 	require.NoError(t, err)
 	require.Len(t, files, 2, "rotation + exit flush must produce exactly 2 segments")
-	sort.Strings(files) // nano-suffixed names sort chronologically
+	sort.Strings(files)
 
 	seg1, err := merge.ParseSegment(files[0])
 	require.NoError(t, err)
-	// Bug B precondition: frames WERE written pre-rotation (their written
-	// flags went stale when segment 1 closed).
 	require.GreaterOrEqual(t, seg1.SampleCount, 3, "segment 1 must hold the IDR plus pre-rotation P-frames")
 
 	seg2, err := merge.ParseSegment(files[1])
 	require.NoError(t, err)
-	// The exit flush must carry the whole retained ring (IDR + every P since
-	// connect — rotation cleared the stale flags) plus the trigger written
-	// once by the normal path. Bug B skipped the pre-rotation frames here;
-	// Bug A wrote the trigger twice.
 	require.True(t, seg2.Samples[0].IsKeyFrame, "flush segment must start at the ring's IDR anchor")
 	require.Equal(t, 1+totalPs+1, seg2.SampleCount,
 		"fresh-segment flush must contain IDR + all %d retained P-frames + trigger", totalPs)
@@ -175,9 +151,65 @@ func TestH264Adaptive_TLExitFlushAfterRotation(t *testing.T) {
 			spikeCount++
 		}
 		if i > 0 && bytes.Equal(prev, sample) {
-			t.Fatalf("segments %d/%d are identical — a frame was written twice (size=%d tail=%x)", i-1, i, len(sample), sample[len(sample)-4:])
+			t.Fatalf("segments %d/%d are identical — a frame was written twice", i-1, i)
 		}
 		prev = sample
 	}
 	require.Equal(t, 1, spikeCount, "trigger frame must be on disk exactly once")
+}
+
+// TestH264Adaptive_BurstDrainKeepsArrivalSpacing (#506): a writer stall
+// back-pressures the channel; the drained burst must keep its ARRIVAL spacing
+// in the output timeline instead of collapsing onto the drain millisecond.
+func TestH264Adaptive_BurstDrainKeepsArrivalSpacing(t *testing.T) {
+	mgr := newTestManager(t)
+	const cam = "h264-adaptive-burst"
+	rec := NewH264Recorder(H264Config{
+		CameraID:   cam,
+		RTSPURL:    "rtsp://ignored",
+		SegmentDur: time.Hour,
+		RingBufCap: 512,
+	}, mgr)
+	b := rec.baseRecorder
+	b.frameCh = make(chan framePacket, 512)
+
+	// The writer is NOT running: enqueue 60 IDR-anchored frames whose arrival
+	// times span 1.2s (20ms apart) — the stalled-writer backlog.
+	t0 := time.Now()
+	b.frameCh <- framePacket{data: append(append([]byte{}, 0, 0, 0, 1), testSPS...), at: t0}
+	b.frameCh <- framePacket{data: append(append([]byte{}, 0, 0, 0, 1), testPPS...), at: t0}
+	for i := range 60 {
+		p := append([]byte{0x41}, bytes.Repeat([]byte{0x44}, 799)...)
+		p[len(p)-1] = byte(i)
+		at := t0.Add(time.Duration(i+1) * 20 * time.Millisecond)
+		if i == 0 {
+			p = append(append([]byte{}, testIDR...), bytes.Repeat([]byte{0x11}, 4000)...)
+		}
+		b.frameCh <- framePacket{data: append(append([]byte{}, 0, 0, 0, 1), p...), at: at}
+	}
+
+	done := make(chan struct{})
+	go b.writeFrames(done)
+	// All packets carry pre-computed arrival times spanning 1.2s while the
+	// writer consumes them in microseconds — the stalled-writer burst drain.
+	for len(b.frameCh) > 0 {
+		time.Sleep(time.Millisecond)
+	}
+	close(b.frameCh)
+	<-done
+	b.closeCurrentSegment() // finalize the still-open segment for listing
+
+	files, err := mgr.ListFiles(cam)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	seg, err := merge.ParseSegment(files[0])
+	require.NoError(t, err)
+	require.Equal(t, 60, seg.SampleCount)
+
+	// The pre-#506 bug: the whole backlog drained within microseconds wrote
+	// 1ms-clamped durations, collapsing the timeline to ~60ms. Arrival-based
+	// durations must span ≈ the 1.2s of real arrivals.
+	got := seg.TotalDuration.Truncate(10 * time.Millisecond)
+	require.GreaterOrEqual(t, got, 1100*time.Millisecond,
+		"drained backlog must keep its arrival spacing (got %s)", seg.TotalDuration)
 }

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -246,6 +246,19 @@ type codecDriver interface {
 // each take the muxer's own mutex), so concurrent video (writeFrames) and
 // audio (RTP callback) writes are safe by construction — the concern in #226
 // was the audio *config* fields, now migrated to the Tier-2 snapshot.
+// framePacket pairs one channel-delivered unit with its ARRIVAL time
+// (#506). Recording timestamps, rotation checks and the adaptive cadence
+// must follow arrival time, never the consumption-time wall clock: when the
+// writer goroutine blocks (big-segment finalize, SD stall, reconnect
+// backpressure) and then drains a backlog in a burst, consumption-time
+// timestamps collapse onto the same millisecond — collapsed dts breaks the
+// decode reference chain (field-found: duplicate-dts runs immediately before
+// missing-ref POC errors on cameras with TCP-timeout flaps).
+type framePacket struct {
+	data []byte
+	at   time.Time
+}
+
 type baseRecorder struct {
 	// driver provides codec-specific behavior (NAL parsing, track creation).
 	driver codecDriver
@@ -297,7 +310,7 @@ type baseRecorder struct {
 	audio atomic.Pointer[audioConfig]
 
 	// Frame pipeline (written from RTP callback goroutine, read from writeFrames).
-	frameCh chan []byte
+	frameCh chan framePacket
 	dropped atomic.Int64
 	lastPTS atomic.Int64 // for PTS monotonicity check
 
@@ -548,7 +561,12 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 	// nil check per frame.
 	sparseAudio := false
 
-	for data := range b.frameCh {
+	for pkt := range b.frameCh {
+		// pkt.at is the unit's ARRIVAL time (#506) — every timestamp decision
+		// below (adaptive cadence, sample pts/duration, rotation) uses it so a
+		// backlog burst drained after a writer stall keeps real spacing instead
+		// of collapsing onto one wall-clock millisecond.
+		data := pkt.data
 		// Always parse NALUs to capture codec parameter sets (VPS/SPS/PPS), even
 		// in live-only mode (RecordEnabled=false). Live preview (HLS/WebRTC/WS)
 		// needs these via getCodecParams(); if we skip parsing here, the codec
@@ -591,7 +609,7 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 		// reach the disk; on a spike the retained GOP ring is flushed and
 		// full-rate writing resumes through the normal path below.
 		if b.adaptive != nil {
-			now := time.Now()
+			now := pkt.at
 			isIDR := b.driver.isIDR(typ)
 			spike, flush := b.adaptive.observe(nalu, isIDR, now)
 			if len(flush) > 0 {
@@ -658,21 +676,23 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 			continue
 		}
 
-		// Step 8: Create new segment if needed.
+		// Step 8: Create new segment if needed (anchored to this frame's
+		// arrival so pts start at zero for the first sample).
 		if b.muxer == nil {
-			if !b.createNewSegment() {
+			if !b.createNewSegment(pkt.at) {
 				continue
 			}
 		}
 
-		// Step 9: Write the NALU sample to the muxer.
-		now := time.Now()
-		pts := now.Sub(b.segStart)
-		duration := now.Sub(b.lastFrameTime)
+		// Step 9: Write the NALU sample to the muxer. pts/duration follow the
+		// frame's ARRIVAL time (#506) — a drained backlog keeps its real
+		// spacing instead of collapsing onto the drain moment.
+		pts := pkt.at.Sub(b.segStart)
+		duration := pkt.at.Sub(b.lastFrameTime)
 		if duration < time.Millisecond {
 			duration = time.Millisecond
 		}
-		b.lastFrameTime = now
+		b.lastFrameTime = pkt.at
 
 		if err := b.muxer.WriteSample(b.trackID, nalu, pts, duration); err != nil {
 			b.log.Error("failed to write sample",
@@ -686,8 +706,8 @@ func (b *baseRecorder) writeFrames(done chan struct{}) {
 			b.adaptive.markTailWritten()
 		}
 
-		// Step 10: Check segment duration rollover.
-		if time.Since(b.segStart) >= b.cfg.SegmentDur {
+		// Step 10: Check segment duration rollover (on the arrival axis).
+		if pkt.at.Sub(b.segStart) >= b.cfg.SegmentDur {
 			b.closeCurrentSegment()
 		}
 	}
@@ -720,15 +740,11 @@ func (b *baseRecorder) writeFlushedGOP(frames []gopFrame) {
 			if !f.isIDR {
 				continue // never start a segment on a P frame
 			}
-			if !b.createNewSegment() {
+			// The segment anchors to the flushed IDR's own capture time so
+			// pts = at - segStart >= 0 for the whole flushed chain (#473/#506).
+			if !b.createNewSegment(f.at) {
 				return
 			}
-			// createNewSegment stamps segStart with "now"; back-date it to
-			// the first flushed frame so pts = at - segStart >= 0. Published
-			// under mu like every segStart write (the audio callback reads it).
-			b.mu.Lock()
-			b.segStart = f.at
-			b.mu.Unlock()
 			b.lastFrameTime = f.at
 		}
 		pts := f.at.Sub(b.segStart)
@@ -850,7 +866,7 @@ func (b *baseRecorder) AudioTriggerEvent(at time.Time, hold time.Duration) error
 // createNewSegment creates a new MP4 segment via the store, adds the
 // codec-specific video track (and audio track if configured), and stores
 // the muxer + segment metadata. Returns false on failure.
-func (b *baseRecorder) createNewSegment() bool {
+func (b *baseRecorder) createNewSegment(at time.Time) bool {
 	tempPath, finalPath, err := b.store.CreateSegment(b.cfg.CameraID, string(b.driver.segmentFormat()))
 	if err != nil {
 		b.log.Error("failed to create segment",
@@ -885,15 +901,16 @@ func (b *baseRecorder) createNewSegment() bool {
 	// RTP callback (a different goroutine) observes an aligned triplet. Earlier
 	// audioTrackID was assigned outside this lock, so a callback could see a
 	// non-zero trackID before muxer was published (torn view) — fixed (#226).
+	// segStart anchors to the creating frame's ARRIVAL time (#506).
 	b.mu.Lock()
 	b.muxer = m
-	b.segStart = time.Now()
+	b.segStart = at
 	b.audioTrackID = audioTrackID
 	b.ambientFile = b.openAmbientSidecar(finalPath)
 	b.mu.Unlock()
 	b.curTempPath = tempPath
 	b.curFinalPath = finalPath
-	b.lastFrameTime = b.segStart
+	b.lastFrameTime = at
 	b.frameCount = 0
 	return true
 }

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -360,7 +360,7 @@ func (r *H264Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 	}
 
 	frameAlive := make(chan struct{}, 1)
-	r.frameCh = make(chan []byte, r.cfg.RingBufCap)
+	r.frameCh = make(chan framePacket, r.cfg.RingBufCap)
 	r.dropped.Store(0)
 	// Arm the adaptive tracker + audio-trigger runtime BEFORE the writer
 	// goroutine and the audio callbacks start (issue #478: the audio
@@ -393,12 +393,13 @@ func (r *H264Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 		if r.Hub != nil {
 			r.Hub.Broadcast(int64(pkt.Timestamp), au, nalutil.IsIDR(au, false))
 		}
+		at := time.Now() // one arrival stamp for the whole AU (#506)
 		for _, nalu := range au {
 			data := make([]byte, 4+len(nalu))
 			copy(data, []byte{0x00, 0x00, 0x00, 0x01})
 			copy(data[4:], nalu)
 			select {
-			case r.frameCh <- data:
+			case r.frameCh <- framePacket{data: data, at: at}:
 			default:
 				d := r.dropped.Add(1)
 				if r.mtrics != nil {

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -348,7 +348,7 @@ func (r *H265Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 	}
 
 	frameAlive := make(chan struct{}, 1)
-	r.frameCh = make(chan []byte, r.cfg.RingBufCap)
+	r.frameCh = make(chan framePacket, r.cfg.RingBufCap)
 	r.dropped.Store(0)
 	// Arm the adaptive tracker + audio-trigger runtime BEFORE the writer
 	// goroutine and the audio callbacks start (issue #478: the audio
@@ -381,12 +381,13 @@ func (r *H265Recorder) connectAndRecord(ctx context.Context) (error, bool) {
 		if r.Hub != nil {
 			r.Hub.Broadcast(int64(pkt.Timestamp), au, nalutil.IsIDR(au, true))
 		}
+		at := time.Now() // one arrival stamp for the whole AU (#506)
 		for _, nalu := range au {
 			data := make([]byte, 4+len(nalu))
 			copy(data, []byte{0x00, 0x00, 0x00, 0x01})
 			copy(data[4:], nalu)
 			select {
-			case r.frameCh <- data:
+			case r.frameCh <- framePacket{data: data, at: at}:
 			default:
 				d := r.dropped.Add(1)
 				if r.mtrics != nil {

--- a/internal/recorder/live_only_test.go
+++ b/internal/recorder/live_only_test.go
@@ -43,7 +43,7 @@ func newLiveOnlyBaseRecorder(t *testing.T, recordDisabled bool) (*baseRecorder, 
 		store:   store,
 		driver:  H264NALDriver{},
 		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-		frameCh: make(chan []byte, 32),
+		frameCh: make(chan framePacket, 32),
 	}
 	return b, store
 }
@@ -65,9 +65,9 @@ func TestWriteFrames_LiveOnlyDrainsWithoutRecording(t *testing.T) {
 	done := make(chan struct{})
 	go b.writeFrames(done)
 
-	b.frameCh <- sps
-	b.frameCh <- pps
-	b.frameCh <- idr
+	b.frameCh <- framePacket{data: sps, at: time.Now()}
+	b.frameCh <- framePacket{data: pps, at: time.Now()}
+	b.frameCh <- framePacket{data: idr, at: time.Now()}
 	// Give the goroutine a moment to process.
 	time.Sleep(50 * time.Millisecond)
 	close(b.frameCh)
@@ -92,9 +92,9 @@ func TestWriteFrames_RecordingEnabledCreatesSegment(t *testing.T) {
 	done := make(chan struct{})
 	go b.writeFrames(done)
 
-	b.frameCh <- sps
-	b.frameCh <- pps
-	b.frameCh <- idr
+	b.frameCh <- framePacket{data: sps, at: time.Now()}
+	b.frameCh <- framePacket{data: pps, at: time.Now()}
+	b.frameCh <- framePacket{data: idr, at: time.Now()}
 	time.Sleep(50 * time.Millisecond)
 	close(b.frameCh)
 	<-done


### PR DESCRIPTION
## 根因（#506 取证链）

chainmerge 桶增长重放 + showinfo 帧图定位：每处损伤前都有**同 dts 连跑**——写线程停顿（大段收尾/SD 写停/TCP timeout 背压）→ frameCh 积压 → 突泄时每帧以"消费时刻"取 now，时间戳全部塌到同一毫秒 → 解码参考链断裂（missing/duplicate POC）。相机侧网络抖动（TCP timeout + RTP PTS 前跳）使停顿频发；弱点本身早于 #505 存在。

## 修复

frameCh 携带 `framePacket{data, at}`（RTP 回调每 AU 盖一次到达戳）。writeFrames 的 adaptive 节奏/样本 pts/duration/轮转判定、createNewSegment 的 segStart 锚点（flush 路径锚到 flushed IDR 自身捕获时刻）全部改用到达时间。MJPEG 路径同步。

## 回归测试（合成时间轴，无真实等待）

- `BurstDrainKeepsArrivalSpacing`：60 帧积压在微秒内突泄，产物保留 1.2s 真实间距（修复前塌缩到 ~60ms）——#506 直接回归。
- #498 的 `TLExitFlushAfterRotation` 改合成时间（0.06s）。

实机部署验证后合入。
