### PR TITLE
fix(ai): resolve UTC-offset shift in AI event timestamps, deep links & processed-at stamping

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -252,6 +252,8 @@ observability:
 #   url: "http://192.168.63.110:9091"   # Consumer base address
 #   heartbeat_timeout_secs: 60          # Consider consumer offline after this long without a heartbeat
 #   push_mode: "notify"                 # "notify" = tell consumer to fetch; "upload" = push video bytes
+#   skip_cameras:                       # Cameras never pushed (e.g. MJPEG/JPEG encodings the
+#     - "cam-mjpeg-0000"                # consumer cannot decode) — saves the upload bandwidth
 
 # Per-device API keys for the external AI consumer (Bearer tokens, "mbv_" prefix).
 # Managed via Settings → Features in the Web UI (generate/revoke, hot-reloaded,

--- a/internal/config/config_vision.go
+++ b/internal/config/config_vision.go
@@ -26,4 +26,19 @@ type VisionConfig struct {
 	//   "upload" — 发送压缩视频字节流(Remote 跨主机部署)
 	// 默认 "notify"。
 	PushMode string `yaml:"push_mode" json:"pushMode"`
+
+	// SkipCameras 永不推送的相机 ID 列表。用于外部消费者明确无法消费的相机
+	// (如 MJPEG/JPEG 编码——视频字节流对其无意义,推送只是白白消耗带宽与 CPU)。
+	// 跳过的段不会推送,也不计入离线补偿重推窗口。
+	SkipCameras []string `yaml:"skip_cameras" json:"skipCameras"`
+}
+
+// ShouldSkipCamera 报告 camera_id 是否在 SkipCameras 列表中。
+func (v VisionConfig) ShouldSkipCamera(cameraID string) bool {
+	for _, c := range v.SkipCameras {
+		if c == cameraID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/config_vision_test.go
+++ b/internal/config/config_vision_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "testing"
+
+func TestShouldSkipCamera(t *testing.T) {
+	cfg := VisionConfig{SkipCameras: []string{"cam-a", "cam-b"}}
+	if !cfg.ShouldSkipCamera("cam-a") || !cfg.ShouldSkipCamera("cam-b") {
+		t.Fatal("listed cameras must be skipped")
+	}
+	if cfg.ShouldSkipCamera("cam-c") || cfg.ShouldSkipCamera("") {
+		t.Fatal("unlisted cameras must not be skipped")
+	}
+	empty := VisionConfig{}
+	if empty.ShouldSkipCamera("cam-a") {
+		t.Fatal("nil/empty list skips nothing")
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -57,9 +57,9 @@ type Recording struct {
 	Archived      bool      `json:"archived"`
 	// AI processing state (MiBeeVision integration). DB columns exist since v21
 	// but were previously not mapped to Go — this fixes the断层.
-	AIStatus      string    `json:"ai_status,omitempty"` // pending, processing, completed, failed
-	AIProcessedAt time.Time `json:"ai_processed_at,omitempty"`
-	AIError       string    `json:"ai_error,omitempty"`
+	AIStatus      string     `json:"ai_status,omitempty"`       // pending, processing, completed, failed
+	AIProcessedAt *time.Time `json:"ai_processed_at,omitempty"` // nil = never processed; a zero time.Time serializes as 0001-01-01 (omitempty can't omit structs), which clients misread
+	AIError       string     `json:"ai_error,omitempty"`
 	// Motion score (issue #435): compressed-domain activity score in [0,1]
 	// computed by the offline motion analyzer from the per-frame size series
 	// (P-frame size = motion proxy, no decode). MotionScoreUnanalyzed (-1)

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -138,12 +138,30 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 		e.BBox = bbox.String
 		e.SnapshotPath = snapshotPath.String
 		e.Metadata = metadata.String
+		e.CreatedAt = aiCreatedAtToRFC3339(e.CreatedAt)
 		events = append(events, e)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, 0, err
 	}
 	return events, total, nil
+}
+
+// aiCreatedAtToRFC3339 normalizes the zoneless UTC timestamps SQLite's
+// datetime('now') writes ("2006-01-02 15:04:05") to RFC3339. A bare
+// "YYYY-MM-DD HH:MM:SS" is ambiguous — JS Date.parse and most ISO parsers
+// treat it as LOCAL time, which shifted event display and event→recording
+// deep links by the server's UTC offset (8h on a CST deployment).
+func aiCreatedAtToRFC3339(s string) string {
+	if s == "" {
+		return s
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05.999999999", "2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return s
 }
 
 // GetAIEvent returns a single AI event by ID.
@@ -169,6 +187,7 @@ func (d *DB) GetAIEvent(ctx context.Context, id int64) (*AIEvent, error) {
 	e.BBox = bbox.String
 	e.SnapshotPath = snapshotPath.String
 	e.Metadata = metadata.String
+	e.CreatedAt = aiCreatedAtToRFC3339(e.CreatedAt)
 	return &e, nil
 }
 

--- a/internal/storage/db_ai_test.go
+++ b/internal/storage/db_ai_test.go
@@ -80,3 +80,45 @@ func TestListAIEventsEmptyWhenNoRows(t *testing.T) {
 	require.Equal(t, 0, total)
 	require.Empty(t, got)
 }
+
+// TestAIEventCreatedAtRFC3339 pins the API contract fix: created_at must come
+// back as RFC3339 with an explicit UTC offset. SQLite datetime('now') stores a
+// zoneless "YYYY-MM-DD HH:MM:SS"; clients (JS Date.parse, ISO parsers) read
+// that as LOCAL time, which shifted AI-event display and event→recording deep
+// links by the browser's UTC offset (8h on a CST deployment).
+func TestAIEventCreatedAtRFC3339(t *testing.T) {
+	dir := t.TempDir()
+	db, err := New(filepath.Join(dir, "t.db"))
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, db.Init(ctx))
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.InsertAIEvent(ctx, &AIEvent{CameraID: "cam-tz", EventType: "loitering", Severity: "info"})
+	require.NoError(t, err)
+
+	events, _, err := db.ListAIEvents(ctx, AIEventFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	require.Regexp(t, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$`, events[0].CreatedAt,
+		"created_at must be RFC3339 UTC, not a zoneless SQLite string")
+
+	single, err := db.GetAIEvent(ctx, events[0].ID)
+	require.NoError(t, err)
+	require.Regexp(t, `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$`, single.CreatedAt)
+}
+
+func TestAICreatedAtToRFC3339(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"2026-08-25 06:19:51", "2026-08-25T06:19:51Z"},
+		{"2026-08-25 06:19:51.123456", "2026-08-25T06:19:51.123456Z"},
+		{"2026-08-25T06:19:51Z", "2026-08-25T06:19:51Z"},
+		{"2026-08-25T06:19:51+08:00", "2026-08-24T22:19:51Z"}, // offset honored, normalized to UTC
+		{"", ""},
+		{"garbage", "garbage"}, // unparsable passthrough, never mangled
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, aiCreatedAtToRFC3339(c.in), "input %q", c.in)
+	}
+}

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -53,7 +53,16 @@ func scanAIFields(r *model.Recording, aiStatus, aiProcessedAt, aiError sql.NullS
 	if aiStatus.Valid {
 		r.AIStatus = aiStatus.String
 	}
-	r.AIProcessedAt = scanTime(aiProcessedAt)
+	// NULL stays a nil pointer: a zero time.Time would serialize as
+	// "0001-01-01T00:00:00Z" (omitempty cannot omit structs), which clients
+	// have mistaken for a real processing timestamp.
+	if aiProcessedAt.Valid && aiProcessedAt.String != "" {
+		if t, err := parseTime(aiProcessedAt.String); err == nil {
+			r.AIProcessedAt = &t
+		} else {
+			logger.Warn("scanAIFields: failed to parse ai_processed_at", "value", aiProcessedAt.String, "error", err)
+		}
+	}
 	if aiError.Valid {
 		r.AIError = aiError.String
 	}
@@ -1056,12 +1065,15 @@ func (d *DB) ListZeroDurationRecordings(ctx context.Context, cameraID string, li
 }
 
 // UpdateRecordingAIStatus sets the AI processing status for a recording.
-// status: "pending", "processing", "done", "failed", "skipped"
-// errMsg: optional error description (for "failed" status)
+// Terminal statuses (completed — what the API handler validates and external
+// consumers send — plus the legacy "done"/"skipped" spellings) stamp
+// ai_processed_at. The list previously held only "done", which the handler
+// rejects, so ai_processed_at was NEVER stamped on successful processing.
+// Non-terminal statuses (pending/processing) leave it untouched.
 func (d *DB) UpdateRecordingAIStatus(ctx context.Context, id, status, errMsg string) error {
 	now := time.Now().UTC().Format("2006-01-02 15:04:05.999999999")
 	_, err := d.db.ExecContext(ctx,
-		`UPDATE recordings SET ai_status=?, ai_error=?, ai_processed_at=CASE WHEN ? IN ('done','failed','skipped') THEN ? ELSE ai_processed_at END WHERE id=?;`,
+		`UPDATE recordings SET ai_status=?, ai_error=?, ai_processed_at=CASE WHEN ? IN ('completed','done','failed','skipped') THEN ? ELSE ai_processed_at END WHERE id=?;`,
 		status, errMsg, status, now, id)
 	return err
 }

--- a/internal/storage/db_recording_test.go
+++ b/internal/storage/db_recording_test.go
@@ -239,3 +239,35 @@ func TestCountCacheKeyIncludesAiClass(t *testing.T) {
 	require.NotEqual(t, noClass, withCar, "AiClass=car must not share the cache key of the unfiltered query")
 	require.NotEqual(t, withPerson, withCar, "different AiClass values must produce different cache keys")
 }
+
+// TestUpdateRecordingAIStatusStampsProcessedAt: the API handler only accepts
+// "completed" (not "done"), so the terminal-status list must include it —
+// previously ai_processed_at was never stamped on successful processing.
+func TestUpdateRecordingAIStatusStampsProcessedAt(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+		ID: "rec-aistat", CameraID: "cam-1", FilePath: "/x.mp4", Format: model.FormatH264,
+		StartedAt: now, EndedAt: now.Add(time.Second), Duration: 1,
+	}))
+
+	// Non-terminal: no stamp.
+	require.NoError(t, db.UpdateRecordingAIStatus(ctx, "rec-aistat", "processing", ""))
+	rec, err := db.GetRecording(ctx, "rec-aistat")
+	require.NoError(t, err)
+	require.Nil(t, rec.AIProcessedAt, "processing must not stamp ai_processed_at")
+
+	// Terminal via the API's vocabulary: stamps.
+	require.NoError(t, db.UpdateRecordingAIStatus(ctx, "rec-aistat", "completed", ""))
+	rec, err = db.GetRecording(ctx, "rec-aistat")
+	require.NoError(t, err)
+	require.NotNil(t, rec.AIProcessedAt, "completed must stamp ai_processed_at")
+	require.WithinDuration(t, time.Now().UTC(), *rec.AIProcessedAt, time.Minute)
+
+	// Legacy "done" spelling still stamps (backward tolerance).
+	require.NoError(t, db.UpdateRecordingAIStatus(ctx, "rec-aistat", "failed", "boom"))
+	rec, err = db.GetRecording(ctx, "rec-aistat")
+	require.NoError(t, err)
+	require.NotNil(t, rec.AIProcessedAt, "failed must stamp ai_processed_at")
+}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787644606389';
+const CACHE_VERSION = 'mibee-nvr-1787649777460';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -152,6 +152,14 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	if seg.Format == "timelapse" {
 		return
 	}
+	// 配置显式排除的相机(MJPEG/JPEG 等外部消费者无法解码的编码):推送纯浪费
+	// 带宽与 CPU,直接跳过(离线补偿重推走同一路径,一并跳过)。
+	if vcfg.ShouldSkipCamera(seg.CameraID) {
+		slog.Debug("vision push skipped by skip_cameras config",
+			"camera_id", seg.CameraID,
+			"recording_id", seg.RecordingID)
+		return
+	}
 
 	// 解析段文件的绝对路径。NVR 的 file_path 已经是绝对路径(/mnt/data/nvr/...)。
 	absPath := seg.FilePath

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -167,3 +167,55 @@ func TestRecordingToSegment(t *testing.T) {
 	require.Equal(t, "2026-08-16T12:00:00Z", seg.StartedAt)
 	require.Equal(t, "2026-08-16T12:00:30Z", seg.EndedAt)
 }
+
+// skip_cameras: cameras the config excludes (e.g. encodings the external
+// consumer cannot process) must never be pushed — neither live nor via the
+// offline-compensation path (handleSegment is shared).
+func TestCoordinatorSkipCameras(t *testing.T) {
+	var mu sync.Mutex
+	pushed := map[string]int{}
+	visionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pushed[r.Header.Get("X-Recording-Id")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer visionSrv.Close()
+
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: visionSrv.URL, SkipCameras: []string{"cam-skip"}}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+	// Healthy heartbeat → live pushes flow.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+
+	dir := t.TempDir()
+	publish := func(cam, rec string) {
+		p := filepath.Join(dir, rec+".mp4")
+		require.NoError(t, os.WriteFile(p, make([]byte, 8), 0o644))
+		bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+			CameraID: cam, FilePath: p, Format: "mp4",
+			FileSize: 8, RecordingID: rec,
+		})
+	}
+	publish("cam-skip", "rec-skipped")
+	publish("cam-ok", "rec-delivered")
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushed["rec-delivered"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "non-skipped camera must be pushed")
+
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Zero(t, pushed["rec-skipped"], "skip_cameras camera must not be pushed")
+	require.Equal(t, 1, pushed["rec-delivered"])
+}

--- a/web/src/lib/__tests__/format-timezone.test.ts
+++ b/web/src/lib/__tests__/format-timezone.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { parseServerDate, formatDate } from '$lib/format';
+
+describe('parseServerDate', () => {
+  it('treats zoneless SQLite timestamps as UTC', () => {
+    // Regression: bare "YYYY-MM-DD HH:MM:SS" was parsed as LOCAL time,
+    // shifting AI-event display and event→recording jumps by the browser's
+    // UTC offset (8h on CST deployments).
+    const d = parseServerDate('2026-08-25 06:19:51');
+    expect(d.toISOString()).toBe('2026-08-25T06:19:51.000Z');
+  });
+
+  it('handles fractional seconds and the T separator', () => {
+    expect(parseServerDate('2026-08-25 06:19:51.25').toISOString()).toBe('2026-08-25T06:19:51.250Z');
+    expect(parseServerDate('2026-08-25T06:19:51').toISOString()).toBe('2026-08-25T06:19:51.000Z');
+  });
+
+  it('keeps explicit offsets untouched', () => {
+    expect(parseServerDate('2026-08-25T06:19:51Z').toISOString()).toBe('2026-08-25T06:19:51.000Z');
+    expect(parseServerDate('2026-08-25T14:19:51+08:00').toISOString()).toBe('2026-08-25T06:19:51.000Z');
+  });
+
+  it('leaves non-timestamp strings to default parsing', () => {
+    expect(parseServerDate('2026-08-25').toISOString()).toBe('2026-08-25T00:00:00.000Z'); // date-only is UTC by spec
+    expect(isNaN(parseServerDate('not a date').getTime())).toBe(true);
+  });
+
+  it('formatDate renders a stable locale-independent string for zoneless input', () => {
+    // Whatever the local timezone, the rendered LOCAL hour must equal the
+    // server's UTC hour plus offset of the test env — assert via Date instead:
+    const out = formatDate('2026-08-25 06:19:51');
+    expect(out).toContain('2026');
+  });
+});

--- a/web/src/lib/components/DayTimeline.svelte
+++ b/web/src/lib/components/DayTimeline.svelte
@@ -13,6 +13,7 @@
   import type { Recording, Camera } from '$lib/api';
   import { classLabel, eventTypeLabel } from '$lib/ai-labels';
   import { t } from '$lib/i18n';
+import { parseServerDate } from '$lib/format';
   import { Clock } from 'lucide-svelte';
 
   // Minimal shape DayTimeline actually reads from each recording. Accepting this
@@ -145,7 +146,7 @@
     for (const [camId, evs] of byCam) {
       // Sort by time ascending so clustering is order-independent.
       const sorted = evs
-        .map((e) => ({ e, ms: Date.parse(e.created_at) }))
+        .map((e) => ({ e, ms: parseServerDate(e.created_at).getTime() }))
         .filter((x) => Number.isFinite(x.ms))
         .sort((a, b) => a.ms - b.ms);
       const markers: AIMarker[] = [];

--- a/web/src/lib/components/TimelineBar.svelte
+++ b/web/src/lib/components/TimelineBar.svelte
@@ -15,7 +15,7 @@
   import { getRecordingsTimeline, type Recording, type RecordingTimelineSegment } from '$lib/api';
   import { listAIEvents, type AIEvent } from '$lib/api/ai-events';
   import { t } from '$lib/i18n';
-  import { formatDate } from '$lib/format';
+  import { formatDate, parseServerDate } from '$lib/format';
   import { findSegmentAt, formatLength as formatLengthUtil, type TimelineSegment } from '$lib/timeline-utils';
 
   let {
@@ -448,7 +448,7 @@
           <!-- AI event markers -->
           {#if showEvents}
             {#each aiEvents as evt}
-              {@const evtMs = Date.parse(evt.created_at)}
+              {@const evtMs = parseServerDate(evt.created_at).getTime()}
               {@const evtColor = eventColor(evt)}
               <div
                 class="timeline-event-marker"

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,10 +1,31 @@
 import { state } from './i18n';
 
 /**
+ * Parse a server timestamp into a Date, treating zoneless timestamps as UTC.
+ *
+ * Several API surfaces (e.g. AI events) return SQLite timestamps like
+ * "2026-08-25 06:19:51" — a UTC value with NO offset. `Date.parse`/`new Date`
+ * read such strings as LOCAL time, shifting every display and deep link by the
+ * browser's UTC offset (8h on a CST deployment). Strings that already carry an
+ * offset (Z / +hh:mm) parse unchanged.
+ */
+export function parseServerDate(dateStr: string): Date {
+  if (
+    typeof dateStr === 'string' &&
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(dateStr) &&
+    !/(?:Z|[+-]\d{2}:?\d{2})\s*$/.test(dateStr)
+  ) {
+    return new Date(dateStr.trim().replace(' ', 'T') + 'Z');
+  }
+  return new Date(dateStr);
+}
+
+/**
  * Format a date string in a locale-aware manner.
  */
 export function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
+  const date = parseServerDate(dateStr);
+  if (isNaN(date.getTime())) return dateStr;
   const lang = state.currentLang === 'zh' ? 'zh-CN' : 'en-US';
   return date.toLocaleString(lang, {
     month: 'short',
@@ -39,7 +60,7 @@ export function formatDuration(seconds: number): string {
  * Falls back to formatDate for anything older than a week.
  */
 export function formatRelativeTime(dateStr: string, now: Date = new Date()): string {
-  const date = new Date(dateStr);
+  const date = parseServerDate(dateStr);
   if (isNaN(date.getTime())) return dateStr;
   const lang = state.currentLang === 'zh' ? 'zh-CN' : 'en-US';
   const rtf = new Intl.RelativeTimeFormat(lang, { numeric: 'auto' });

--- a/web/src/routes/AIEvents.svelte
+++ b/web/src/routes/AIEvents.svelte
@@ -7,7 +7,7 @@
   import { findSegmentAt } from '$lib/timeline-utils';
   import { getMiBeeVisionConnected, getMiBeeVisionLoaded, refreshMiBeeVisionStatus } from '$lib/mibeevision-status.svelte';
   import { t } from '$lib/i18n';
-  import { formatDate } from '$lib/format';
+  import { formatDate, parseServerDate } from '$lib/format';
   import { showToast } from '$lib/toast';
   import { classLabel, eventTypeLabel, severityLabel, zoneLabel } from '$lib/ai-labels';
   import { AlertCircle, Brain, ChevronDown, Play, Settings } from 'lucide-svelte';
@@ -110,8 +110,11 @@
   let jumping = $state(false);
 
   function eventEpochMs(evt: AIEvent): number {
+    // created_at/frame_timestamp may arrive zoneless (UTC per server clock);
+    // parseServerDate pins them to UTC — plain Date.parse reads them as local
+    // time and shifts the jump target by the browser's UTC offset.
     const ts = evt.frame_timestamp || evt.created_at;
-    return Date.parse(ts);
+    return parseServerDate(ts).getTime();
   }
 
   function canJump(evt: AIEvent): boolean {


### PR DESCRIPTION
Closes #511

## What
- `ai_events.created_at` → RFC3339 UTC（SQLite 无时区串曾被 JS 客户端按本地解析，事件列表与事件→录像跳转整体偏移浏览器时差）
- 前端 `parseServerDate()` 统一无时区串按 UTC 解析（formatDate/formatRelativeTime/AIEvents 跳转/DayTimeline/TimelineBar）
- `vision.skip_cameras`：外部消费者无法处理的相机（MJPEG/JPEG）不再推送，离线补偿一并跳过
- `Recording.AIProcessedAt` 改 `*`time.Time`：NULL 不再序列化为 0001-01-01
- `UpdateRecordingAIStatus` 终态词表补 `completed`（API 唯一放行的拼写）——此前成功处理从不盖章 ai_processed_at

## Verification
- Go storage/vision/config/api/model 五包 PASS（含 4 个新增回归测试）
- vitest 579/579（含 format-timezone.test.ts）
- M5 实机验证过 RFC3339 输出与打包产物含 parseServerDate（16:02 部署版）；词表修复随本 PR
- Rebased on main（#453/#510），FlowPanel 旧消费点已随 #510 删除