### PR TITLE
feat(vision): consumer-reported camera skip list in heartbeat

### DIFF
--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -35,6 +35,9 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		Device         string `json:"device"`
 		QueueDepth     int    `json:"queue_depth"`
 		ProcessedCount int    `json:"processed_count"`
+		// SkipCameras(#515): 消费者声明不处理的相机,NVR 停推(含离线补偿)。
+		// 缺省/为空 = 全推(向后兼容)。
+		SkipCameras []string `json:"skip_cameras"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
@@ -46,6 +49,7 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		Device:         body.Device,
 		QueueDepth:     body.QueueDepth,
 		ProcessedCount: body.ProcessedCount,
+		SkipCameras:    body.SkipCameras,
 	})
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -66,11 +70,12 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 
 	healthy, lastSeen, status := h.visionCoordinator.Health().Snapshot()
 	resp := map[string]interface{}{
-		"enabled":     true,
-		"healthy":     healthy,
-		"device":      status.Device,
-		"queue_depth": status.QueueDepth,
-		"processed":   status.ProcessedCount,
+		"enabled":      true,
+		"healthy":      healthy,
+		"device":       status.Device,
+		"queue_depth":  status.QueueDepth,
+		"processed":    status.ProcessedCount,
+		"skip_cameras": status.SkipCameras, // #515: 消费者声明的跳单(空=nil=全推)
 	}
 	// Omit the zero time — no heartbeat has ever been received. Rendering it
 	// would surface "0001-01-01" in the UI (#328).

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -160,6 +160,13 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"recording_id", seg.RecordingID)
 		return
 	}
+	// 消费者心跳声明的跳单(#515):与静态配置取并集生效。
+	if c.health.SkipCamera(seg.CameraID) {
+		slog.Debug("vision push skipped by consumer-reported skip list",
+			"camera_id", seg.CameraID,
+			"recording_id", seg.RecordingID)
+		return
+	}
 
 	// 解析段文件的绝对路径。NVR 的 file_path 已经是绝对路径(/mnt/data/nvr/...)。
 	absPath := seg.FilePath

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -219,3 +219,67 @@ func TestCoordinatorSkipCameras(t *testing.T) {
 	require.Zero(t, pushed["rec-skipped"], "skip_cameras camera must not be pushed")
 	require.Equal(t, 1, pushed["rec-delivered"])
 }
+
+// #515: a consumer-reported skip list (heartbeat field) must stop pushes for
+// those cameras without any NVR-side config; clearing the list (or an old
+// consumer never sending it) restores full push.
+func TestCoordinatorHeartbeatSkipCameras(t *testing.T) {
+	var mu sync.Mutex
+	pushed := map[string]int{}
+	visionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		pushed[r.Header.Get("X-Recording-Id")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer visionSrv.Close()
+
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{Enabled: true, URL: visionSrv.URL}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	// Heartbeat declares a skip list BEFORE any segment flows.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy", SkipCameras: []string{"cam-hbskip"}})
+
+	dir := t.TempDir()
+	publish := func(cam, rec string) {
+		p := filepath.Join(dir, rec+".mp4")
+		require.NoError(t, os.WriteFile(p, make([]byte, 8), 0o644))
+		bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+			CameraID: cam, FilePath: p, Format: "mp4",
+			FileSize: 8, RecordingID: rec,
+		})
+	}
+	publish("cam-hbskip", "rec-hb-skipped")
+	publish("cam-ok", "rec-hb-delivered")
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushed["rec-hb-delivered"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "non-skipped camera must be pushed")
+
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	require.Zero(t, pushed["rec-hb-skipped"], "heartbeat-reported skip camera must not be pushed")
+	mu.Unlock()
+
+	// Consumer clears the list → pushes resume for the same camera.
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	publish("cam-hbskip", "rec-hb-resumed")
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushed["rec-hb-resumed"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "cleared skip list must resume pushes")
+
+	// SkipCamera semantics without a heartbeat ever received: no skips.
+	require.False(t, NewHealthTracker(60).SkipCamera("any"))
+}

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -11,6 +11,10 @@ type HeartbeatStatus struct {
 	Device         string `json:"device"`          // "cuda" / "cpu"
 	QueueDepth     int    `json:"queue_depth"`     // 待处理段数
 	ProcessedCount int    `json:"processed_count"` // 累计已处理段数
+	// SkipCameras 是消费者声明不处理的相机 ID(#515):编码不支持(如 MJPEG/JPEG)
+	// 或处理容量取舍。NVR 对这些相机停推(含离线补偿),省下纯浪费的上传带宽。
+	// 字段缺省/为空 = 不跳过任何相机(向后兼容旧版本消费者)。
+	SkipCameras []string `json:"skip_cameras,omitempty"`
 }
 
 // HealthTracker 追踪 Vision 的心跳健康状态。
@@ -67,6 +71,19 @@ func (h *HealthTracker) IsHealthy() bool {
 		return false
 	}
 	return time.Since(h.lastSeen) < h.timeout
+}
+
+// SkipCamera 报告相机是否在消费者最近一次心跳声明的跳单里(#515)。
+// 以最后一次心跳为准:字段缺省(旧消费者)或清空即恢复全推。
+func (h *HealthTracker) SkipCamera(cameraID string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, c := range h.status.SkipCameras {
+		if c == cameraID {
+			return true
+		}
+	}
+	return false
 }
 
 // Snapshot 返回当前健康状态、最后心跳时间和状态详情。


### PR DESCRIPTION
Closes #515

## What
- 心跳 payload 新增可选 `skip_cameras: [camera_id]`——消费者声明不处理的相机(编码不支持/容量取舍),NVR 停推(实时 + 离线补偿路径)
- 语义:最后一次心跳生效;字段缺省或清空 = 恢复全推(旧版本消费者零影响)
- 与 NVR 侧静态 `vision.skip_cameras` 配置取**并集**生效
- `/api/vision/status` 暴露当前生效跳单——盲区可观测(静默 202 的教训)

## Verification
- Go vision/api 包 PASS(含新增 TestCoordinatorHeartbeatSkipCameras: 声明→停推→清空→恢复 全链路)
- 待消费者侧对接后实测端到端(MiBeeVision 侧跟进在其私有仓库)