### PR TITLE
fix(xiaomi): gate recording audio track on audio_in_recordings

### DIFF
--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -716,8 +716,11 @@ func (r *XiaomiRecorder) processH264NALU(nalu []byte, timestamp uint64, lastTime
 		}
 		r.trackID = trackID
 
-		// Add audio track if audio codec detected (G.711 or Opus).
-		if r.cfg.AudioEnabled && r.audioCodecID > 0 {
+		// Add audio track only when audio is enabled AND the camera keeps
+		// audio in recordings (default off — #496 follow-up, issue #520).
+		// Live audio and the audio trigger read the pre-disk path and do not
+		// need the track.
+		if r.cfg.AudioEnabled && r.cfg.AudioInRecordings && r.audioCodecID > 0 {
 			codec, cfg, ok := buildAudioMuxerConfig(r.audioCodecID)
 			if ok {
 				aID, err := r.muxer.AddAudioTrack(codec, cfg)
@@ -850,8 +853,9 @@ func (r *XiaomiRecorder) processH265NALU(nalu []byte, timestamp uint64, lastTime
 		}
 		r.trackID = trackID
 
-		// Add audio track if audio codec detected (same as H264 path).
-		if r.cfg.AudioEnabled && r.audioCodecID > 0 {
+		// Add audio track if audio codec detected (same gating as H264 path:
+		// enabled AND kept in recordings — issue #520).
+		if r.cfg.AudioEnabled && r.cfg.AudioInRecordings && r.audioCodecID > 0 {
 			codec, cfg, ok := buildAudioMuxerConfig(r.audioCodecID)
 			if ok {
 				aID, err := r.muxer.AddAudioTrack(codec, cfg)

--- a/internal/xiaomi/recorder_audio_gating_test.go
+++ b/internal/xiaomi/recorder_audio_gating_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+//
+// Regression tests for issue #520: the xiaomi recorder must honor the
+// per-camera AudioInRecordings gate when adding the MP4 audio track, matching
+// the direct-RTSP and ONVIF recorder paths (#496 follow-up). Live preview and
+// the audio trigger are NOT gated and have separate tests.
+
+package xiaomi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// feedH264IDR drives the H264 segment-creation path far enough to run the
+// audio-track decision, with a detected audio codec armed.
+func feedH264IDR(t *testing.T, r *XiaomiRecorder) {
+	t.Helper()
+	r.codec = model.FormatH264
+	r.codecOK = true
+	r.cfg.AudioEnabled = true
+	r.audioCodecID = missCodecPCMU
+	r.store = newRecordingSegmentStore(t)
+
+	var lastTS uint64
+	r.processH264NALU([]byte{0x67, 0x42, 0xc0, 0x1e}, 0, &lastTS)
+	r.processH264NALU([]byte{0x68, 0xce, 0x38, 0x80}, 0, &lastTS)
+	r.processH264NALU([]byte{0x65, 0x01, 0x02, 0x03}, 0, &lastTS)
+	require.NotNil(t, r.muxer)
+}
+
+// feedH265IDR drives the H265 segment-creation path far enough to run the
+// audio-track decision, with a detected audio codec armed.
+func feedH265IDR(t *testing.T, r *XiaomiRecorder) {
+	t.Helper()
+	r.codec = model.FormatH265
+	r.codecOK = true
+	r.cfg.AudioEnabled = true
+	r.audioCodecID = missCodecPCMU
+	r.store = newRecordingSegmentStore(t)
+
+	var lastTS uint64
+	r.processH265NALU([]byte{0x26, 0x01, 0x02, 0x03}, 0, &lastTS)
+	require.NotNil(t, r.muxer)
+}
+
+func TestXiaomiAudioTrackGatedByAudioInRecordings_H264(t *testing.T) {
+	t.Helper()
+	r := makeTestRecorder(t)
+	r.cfg.AudioInRecordings = false
+	feedH264IDR(t, r)
+	require.NotNil(t, r.muxer)
+	require.Zero(t, r.audioTrackID, "audio track must NOT be added when audio_in_recordings is false")
+}
+
+func TestXiaomiAudioTrackKeptWhenAudioInRecordings_H264(t *testing.T) {
+	t.Helper()
+	r := makeTestRecorder(t)
+	r.cfg.AudioInRecordings = true
+	feedH264IDR(t, r)
+	require.NotZero(t, r.audioTrackID, "audio track must be added when audio_in_recordings is true")
+}
+
+func TestXiaomiAudioTrackGatedByAudioInRecordings_H265(t *testing.T) {
+	t.Helper()
+	r := makeTestRecorder(t)
+	r.vps = []byte{0x40, 0x01, 0x0c}
+	r.sps = []byte{0x42, 0x01, 0x01}
+	r.pps = []byte{0x44, 0x01, 0xc1}
+	r.cfg.AudioInRecordings = false
+	feedH265IDR(t, r)
+	require.Zero(t, r.audioTrackID, "audio track must NOT be added when audio_in_recordings is false")
+}
+
+func TestXiaomiAudioTrackKeptWhenAudioInRecordings_H265(t *testing.T) {
+	t.Helper()
+	r := makeTestRecorder(t)
+	r.vps = []byte{0x40, 0x01, 0x0c}
+	r.sps = []byte{0x42, 0x01, 0x01}
+	r.pps = []byte{0x44, 0x01, 0xc1}
+	r.cfg.AudioInRecordings = true
+	feedH265IDR(t, r)
+	require.NotZero(t, r.audioTrackID, "audio track must be added when audio_in_recordings is true")
+}


### PR DESCRIPTION
Closes #520.

## 问题

`audio_in_recordings`（#507 引入，默认 false = 录像纯视频）在 direct-RTSP 与 ONVIF 路径已生效，但 xiaomi 路径的两处 `muxer.AddAudioTrack`（H264/H265 建段各一处）只判断了 `AudioEnabled`，导致小米相机录像产物始终带音轨（M5 多轮 download_verify 确认）。

## 修复

两处条件加 `AudioInRecordings` 门控，与 `internal/recorder/base.go` 的既有模式对齐。音轨不存在时音频帧写入（`aid > 0` 判断）自然跳过。直播预览与音频触发走盘前路径，不受影响。

## 测试

- [x] 新增 4 个回归测试：H264/H265 × 开关两态（`recorder_audio_gating_test.go`），WSL 全量 xiaomi 包测试通过
- [ ] M5 实机复核：小米相机开关两态各录一段，download_verify 验证音轨有/无（部署下个构建后顺带）