### PR TITLE
feat(rtsp): built-in RTSP output server — per-camera pull URLs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -21,6 +21,17 @@ server:
   #   udp:
   #     enabled: true   # answer "MIBEE-NVR-DISCv1?" probes on UDP 49090
   #     port: 49090
+  # Built-in RTSP output server: every camera gets a pull URL
+  # rtsp://<NVR-IP>:8554/<camera_id> that third-party platforms (e.g. Synology
+  # Surveillance Station) can fill in as a camera source. H.264/H.265 are
+  # served natively (no transcoding). Docker deployments must publish the port
+  # (e.g. -p 8554:8554). A bind failure (port already in use) only logs an
+  # error; the rest of the NVR keeps working.
+  # rtsp:
+  #   enabled: true
+  #   port: 8554
+  #   # username: ""   # optional credentials; empty = open on the LAN
+  #   # password: ""
 
 # HTTP security response headers.
 # frame_ancestors controls who may embed the Web UI in an <iframe> via the CSP

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       # If port 9090 is taken on your host (e.g. Synology DSM), change ONLY
       # the left side, e.g. "8080:9090" → access via http://HOST_IP:8080.
       - "9090:9090"   # Web UI / API
+      - "8554:8554"   # RTSP pull (rtsp://HOST:8554/<camera_id>)
       - "2121:2121"   # FTP
       - "2122-2140:2122-2140"  # FTP passive ports
     volumes:

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
@@ -542,6 +543,17 @@ type cameraProtocolsResponse struct {
 	Protocols []ProtocolDetail `json:"protocols"`
 	Encoding  string           `json:"encoding"`
 	Default   string           `json:"default"`
+	// RTSP exposes the built-in RTSP output server pull URL (#522) — the
+	// address third-party platforms (Synology etc.) fill in as a camera
+	// source. Nil when the server is disabled.
+	RTSP *rtspEndpointDetail `json:"rtsp,omitempty"`
+}
+
+// rtspEndpointDetail describes the RTSP pull endpoint for one camera.
+type rtspEndpointDetail struct {
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+	URL       string `json:"url,omitempty"`
 }
 
 // handleCameraProtocols handles GET /api/cameras/{id}/protocols.
@@ -618,7 +630,29 @@ func (h *Handler) handleCameraProtocols(w http.ResponseWriter, r *http.Request) 
 		Protocols: protocols,
 		Encoding:  encoding,
 		Default:   defaultProto,
+		RTSP:      h.rtspEndpointFor(r, id, model.Format(encoding)),
 	})
+}
+
+// rtspEndpointFor builds the RTSP output-server entry for the protocols
+// response (#522): available when the server is enabled, the camera's codec
+// is servable (H.264/H.265), and its parameter sets have been detected. The
+// URL targets the requesting host so it is directly copy-pasteable.
+func (h *Handler) rtspEndpointFor(r *http.Request, cameraID string, codec model.Format) *rtspEndpointDetail {
+	if h.config == nil || h.config.Server.RTSP.Enabled == nil || !*h.config.Server.RTSP.Enabled {
+		return nil
+	}
+	detail := &rtspEndpointDetail{}
+	switch codec {
+	case model.FormatH264, model.FormatH265:
+		// Parameter readiness mirrors the RTSP server's own gate — an idle or
+		// warming-up camera still gets the URL (clients retry DESCRIBE).
+		detail.Available = true
+		detail.URL = rtsp.URLFor(r.Host, h.config.Server.RTSP.Port, cameraID)
+	default:
+		detail.Reason = "codec not servable over RTSP (H.264/H.265 only)"
+	}
+	return detail
 }
 
 // handleCapabilities handles GET /api/capabilities.

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -113,6 +113,17 @@ func applyConfigDefaults(cfg *Config) {
 		enabled := true
 		cfg.Server.Discovery.MDNS.Enabled = &enabled
 	}
+	// RTSP output server (#522): on by default — same LAN exposure posture as
+	// the public HTTP-FLV live endpoint, and the #499 promise is
+	// works-out-of-the-box pull URLs. A bind failure (e.g. MediaMTX already on
+	// 8554) logs an error without affecting the rest of the app.
+	if cfg.Server.RTSP.Enabled == nil {
+		enabled := true
+		cfg.Server.RTSP.Enabled = &enabled
+	}
+	if cfg.Server.RTSP.Port == 0 {
+		cfg.Server.RTSP.Port = 8554
+	}
 	// Storage
 	if strings.TrimSpace(cfg.Storage.RootDir) == "" {
 		cfg.Storage.RootDir = "/var/lib/mibee-nvr"

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -47,6 +47,23 @@ type ServerConfig struct {
 	// Discovery controls how the NVR announces itself on the LAN for clients
 	// that cannot rely on subnet scanning or multicast (mDNS).
 	Discovery DiscoveryConfig `yaml:"discovery"`
+	// RTSP is the built-in RTSP output server (#522): serves
+	// rtsp://<host>:<port>/<camera_id> pull URLs that third-party platforms
+	// (Synology Surveillance Station etc.) fill in as camera sources (#499).
+	RTSP RTSPOutputConfig `yaml:"rtsp"`
+}
+
+// RTSPOutputConfig configures the RTSP output server (PLAY direction only,
+// video-only H.264/H.265 native — no transcoding). Frames come from the same
+// live hubs the FLV/HLS/WS endpoints consume.
+type RTSPOutputConfig struct {
+	Enabled *bool `yaml:"enabled"` // default true
+	Port    int   `yaml:"port"`    // default 8554
+	// Username/Password enable basic/digest auth when set; clients then use
+	// rtsp://user:pass@host/<camera>. Both empty = open access, matching the
+	// HTTP-FLV live endpoint's LAN posture.
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
 }
 
 // DiscoveryConfig groups LAN self-announcement mechanisms.

--- a/internal/rtsp/server.go
+++ b/internal/rtsp/server.go
@@ -165,19 +165,29 @@ func NewServer(cfg Config, provider StreamProvider) *Server {
 	return s
 }
 
-// Start binds the RTSP listener and blocks serving until Stop/Close or a
-// fatal listener error. Run in a goroutine (mirrors the RTMP server shape).
+// Start binds the RTSP listener (blocking) and spawns the serve loop. The
+// whole gortsplib Start runs under s.mu so a concurrent Stop either sees the
+// server fully initialized (Close is safe) or not started at all — gortsplib
+// panics on Close-during-Start, and App.Stop can race the service's start
+// goroutine on fast shutdowns (CI TestRunFree_StopJoinsBackgroundGoroutines).
 func (s *Server) Start(_ context.Context) error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.stopped {
-		s.mu.Unlock()
 		return nil
 	}
+	if err := s.gs.Start(); err != nil {
+		return err
+	}
 	s.started = true
-	s.mu.Unlock()
+	go func() {
+		if err := s.gs.Wait(); err != nil {
+			rtspLogger.Error("rtsp output server terminated", "error", err)
+		}
+	}()
 	rtspLogger.Info("rtsp output server listening", "addr", s.cfg.Addr,
 		"auth", s.cfg.Username != "" || s.cfg.Password != "")
-	return s.gs.StartAndWait()
+	return nil
 }
 
 // Stop tears the server down: closes all camera streams (disconnecting their

--- a/internal/rtsp/server.go
+++ b/internal/rtsp/server.go
@@ -1,0 +1,442 @@
+// Package rtsp implements the built-in RTSP output server (#522): the NVR
+// serves rtsp://<host>:<port>/<camera_id> pull URLs so third-party platforms
+// (Synology Surveillance Station etc.) can ingest cameras directly, without a
+// MediaMTX intermediary (#499). PLAY direction only, video-only H.264/H.265
+// natively (no transcoding), frames tapped from the recorders' StreamHub —
+// the same source the FLV/HLS/WS live endpoints consume.
+package rtsp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pion/rtp"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/gortsplib/v5/pkg/liberrors"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+var rtspLogger = slog.Default().With("component", "rtsp-server")
+
+// StreamInfo is the current live-stream state of one camera, as resolved by
+// the StreamProvider on demand.
+type StreamInfo struct {
+	Codec model.Format
+	SPS   []byte
+	PPS   []byte
+	VPS   []byte // H.265 only
+	Hub   *model.StreamHub
+}
+
+// Ready reports whether the stream has everything needed to build an SDP.
+func (i StreamInfo) Ready() bool {
+	if i.Hub == nil {
+		return false
+	}
+	switch i.Codec {
+	case model.FormatH264:
+		return len(i.SPS) > 0 && len(i.PPS) > 0
+	case model.FormatH265:
+		return len(i.VPS) > 0 && len(i.SPS) > 0 && len(i.PPS) > 0
+	default:
+		return false // mjpeg/jpeg cameras are not served over RTSP yet
+	}
+}
+
+// StreamProvider resolves a camera ID to its current live stream. Called on
+// every DESCRIBE/SETUP so recorder restarts (a new hub) and parameter-set
+// changes are picked up without restarting the server.
+type StreamProvider func(cameraID string) (StreamInfo, bool)
+
+// Config configures the RTSP output server.
+type Config struct {
+	// Addr is the RTSP listen address (e.g. ":8554").
+	Addr string
+	// Username/Password enable HTTP basic/digest auth when both semantics are
+	// desired. Both empty = open access, matching the HTTP-FLV live endpoint's
+	// LAN posture. Clients then use rtsp://user:pass@host/<camera>.
+	Username string
+	Password string
+	// ListenFn overrides the TCP listener factory (tests bind a deterministic
+	// port). Nil = net.Listen.
+	ListenFn func(network, addr string) (net.Listener, error)
+}
+
+// rtpEncoder abstracts rtph264.Encoder / rtph265.Encoder.
+type rtpEncoder interface {
+	Encode(au [][]byte) ([]*rtp.Packet, error)
+}
+
+// cameraStream is the per-camera serving state: one gortsplib ServerStream
+// fanned out to all its readers, fed by a StreamHub subscription.
+type cameraStream struct {
+	cameraID string
+	codec    model.Format
+	sps      []byte
+	pps      []byte
+	vps      []byte
+	hub      *model.StreamHub
+	subID    string
+
+	stream *gortsplib.ServerStream
+	media  *description.Media
+	enc    rtpEncoder
+
+	// tsOrigin is the IngestAt (unix ns) of the first delivered frame; RTP
+	// timestamps derive from it at 90 kHz. Recorder hubs carry heterogeneous
+	// pts units, so the hub-entry wallclock is the only consistent clock.
+	tsOrigin int64
+	// readers counts PLAYing sessions. Encoding is skipped at zero readers —
+	// keeps an idle subscribed camera at one atomic load per frame.
+	readers atomic.Int64
+	closed  atomic.Bool
+}
+
+func (cs *cameraStream) deliver(m model.FrameMsg) {
+	if cs.closed.Load() || cs.readers.Load() == 0 {
+		return
+	}
+	at := m.IngestAt
+	if at <= 0 {
+		at = time.Now().UnixNano()
+	}
+	if cs.tsOrigin == 0 {
+		cs.tsOrigin = at
+	}
+	ts := uint32(((at - cs.tsOrigin) / 1000) * 9 / 1000) // ns → 90 kHz
+	pkts, err := cs.enc.Encode(m.AU)
+	if err != nil {
+		rtspLogger.Warn("rtsp encode failed", "camera_id", cs.cameraID, "error", err)
+		return
+	}
+	for _, p := range pkts {
+		p.Timestamp = ts
+		if err := cs.stream.WritePacketRTP(cs.media, p); err != nil {
+			rtspLogger.Warn("rtsp write failed", "camera_id", cs.cameraID, "error", err)
+			return
+		}
+	}
+}
+
+// Server is the RTSP output server.
+type Server struct {
+	cfg      Config
+	provider StreamProvider
+	gs       *gortsplib.Server
+
+	mu      sync.Mutex
+	streams map[string]*cameraStream
+	// sessions maps RTSP sessions to their camera stream for reader counting.
+	sessions map[*gortsplib.ServerSession]*cameraStream
+	// started/stopped (under mu) make Stop safe against a Stop that races a
+	// Start still inside gortsplib's startup (fast shutdown after service
+	// registration).
+	started bool
+	stopped bool
+}
+
+// NewServer creates an RTSP output server. Call Start to bind.
+func NewServer(cfg Config, provider StreamProvider) *Server {
+	s := &Server{
+		cfg:      cfg,
+		provider: provider,
+		streams:  make(map[string]*cameraStream),
+		sessions: make(map[*gortsplib.ServerSession]*cameraStream),
+	}
+	s.gs = &gortsplib.Server{
+		Handler:     s,
+		RTSPAddress: cfg.Addr,
+	}
+	if cfg.ListenFn != nil {
+		s.gs.Listen = cfg.ListenFn
+	}
+	return s
+}
+
+// Start binds the RTSP listener and blocks serving until Stop/Close or a
+// fatal listener error. Run in a goroutine (mirrors the RTMP server shape).
+func (s *Server) Start(_ context.Context) error {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return nil
+	}
+	s.started = true
+	s.mu.Unlock()
+	rtspLogger.Info("rtsp output server listening", "addr", s.cfg.Addr,
+		"auth", s.cfg.Username != "" || s.cfg.Password != "")
+	return s.gs.StartAndWait()
+}
+
+// Stop tears the server down: closes all camera streams (disconnecting their
+// readers), unsubscribes from the hubs, and closes the listener. Safe to call
+// even when Start was never reached (gortsplib panics on Close-before-Start).
+func (s *Server) Stop() error {
+	s.mu.Lock()
+	streams := make([]*cameraStream, 0, len(s.streams))
+	for _, cs := range s.streams {
+		streams = append(streams, cs)
+	}
+	s.streams = make(map[string]*cameraStream)
+	s.sessions = make(map[*gortsplib.ServerSession]*cameraStream)
+	wasStarted := s.started
+	s.stopped = true
+	s.mu.Unlock()
+
+	for _, cs := range streams {
+		s.teardownStream(cs)
+	}
+	// gortsplib panics on Close-before-Start; a Stop that lost the race with
+	// Start's goroutine just prevents the listener from ever coming up.
+	if wasStarted {
+		s.gs.Close()
+	}
+	return nil
+}
+
+func (s *Server) teardownStream(cs *cameraStream) {
+	cs.closed.Store(true)
+	cs.hub.Unsubscribe(cs.subID)
+	cs.stream.Close()
+}
+
+// reloadParams hot-swaps the SDP parameter sets on a live stream (same hub):
+// connected readers keep streaming; new DESCRIBEs see the updated SDP.
+func (cs *cameraStream) reloadParams(info StreamInfo) {
+	cs.sps = bytes.Clone(info.SPS)
+	cs.pps = bytes.Clone(info.PPS)
+	cs.vps = bytes.Clone(info.VPS)
+	switch f := cs.media.Formats[0].(type) {
+	case *format.H264:
+		f.SPS = cs.sps
+		f.PPS = cs.pps
+	case *format.H265:
+		f.VPS = cs.vps
+		f.SPS = cs.sps
+		f.PPS = cs.pps
+	}
+	cs.stream.ReloadDesc()
+	rtspLogger.Info("rtsp stream parameters reloaded", "camera_id", cs.cameraID)
+}
+
+// streamFor returns the serving stream for the camera. Parameter-set changes
+// on the same hub hot-reload the SDP (gortsplib ReloadDesc — readers keep
+// streaming, they also receive the new sets in-band); a recorder restart (new
+// hub) rebuilds the stream. Returns nil when the camera is unknown, not an
+// H.264/H.265 live stream, or still warming up (readers naturally retry).
+func (s *Server) streamFor(cameraID string) *cameraStream {
+	if cameraID == "" || s.provider == nil {
+		return nil
+	}
+	info, ok := s.provider(cameraID)
+	if !ok || !info.Ready() {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cs, ok := s.streams[cameraID]; ok {
+		switch {
+		case cs.hub != info.Hub:
+			// Recorder restart: the old hub is dead — tear the stream down
+			// (readers disconnect and re-DESCRIBE) and fall through to rebuild.
+			s.teardownStream(cs)
+			delete(s.streams, cameraID)
+			rtspLogger.Info("rtsp stream rebuilt (recorder restart)",
+				"camera_id", cameraID, "codec", string(info.Codec))
+		case !bytes.Equal(cs.sps, info.SPS) || !bytes.Equal(cs.pps, info.PPS) || !bytes.Equal(cs.vps, info.VPS):
+			// Parameter-set change (e.g. camera resolution switch): reload the
+			// description without disconnecting readers.
+			cs.reloadParams(info)
+			return cs
+		default:
+			return cs
+		}
+	}
+
+	cs := &cameraStream{
+		cameraID: cameraID,
+		codec:    info.Codec,
+		sps:      bytes.Clone(info.SPS),
+		pps:      bytes.Clone(info.PPS),
+		vps:      bytes.Clone(info.VPS),
+		hub:      info.Hub,
+		subID:    "rtsp-" + cameraID,
+	}
+
+	var forma format.Format
+	switch info.Codec {
+	case model.FormatH264:
+		f := &format.H264{
+			PayloadTyp:        96,
+			SPS:               cs.sps,
+			PPS:               cs.pps,
+			PacketizationMode: 1,
+		}
+		enc, err := f.CreateEncoder()
+		if err != nil {
+			rtspLogger.Error("rtsp h264 encoder init failed", "camera_id", cameraID, "error", err)
+			return nil
+		}
+		forma = f
+		cs.enc = enc
+	case model.FormatH265:
+		f := &format.H265{
+			PayloadTyp: 96,
+			VPS:        cs.vps,
+			SPS:        cs.sps,
+			PPS:        cs.pps,
+		}
+		enc, err := f.CreateEncoder()
+		if err != nil {
+			rtspLogger.Error("rtsp h265 encoder init failed", "camera_id", cameraID, "error", err)
+			return nil
+		}
+		forma = f
+		cs.enc = enc
+	default:
+		return nil
+	}
+
+	media := &description.Media{
+		Type:    description.MediaTypeVideo,
+		Control: "trackID=0",
+		Formats: []format.Format{forma},
+	}
+	desc := &description.Session{
+		Medias: []*description.Media{media},
+	}
+	stream := &gortsplib.ServerStream{Server: s.gs, Desc: desc}
+	if err := stream.Initialize(); err != nil {
+		rtspLogger.Error("rtsp stream init failed", "camera_id", cameraID, "error", err)
+		return nil
+	}
+	cs.stream = stream
+	cs.media = media
+
+	if err := info.Hub.SubscribeMsg(cs.subID, func(m model.FrameMsg) { cs.deliver(m) }); err != nil {
+		stream.Close()
+		rtspLogger.Error("rtsp hub subscribe failed", "camera_id", cameraID, "error", err)
+		return nil
+	}
+
+	s.streams[cameraID] = cs
+	rtspLogger.Info("rtsp stream serving", "camera_id", cameraID, "codec", string(info.Codec))
+	return cs
+}
+
+func (s *Server) authorized(conn *gortsplib.ServerConn, req *base.Request) bool {
+	if s.cfg.Username == "" && s.cfg.Password == "" {
+		return true
+	}
+	return conn.VerifyCredentials(req, s.cfg.Username, s.cfg.Password)
+}
+
+// --- gortsplib.ServerHandler ---
+
+// OnConnOpen implements gortsplib.ServerHandler.
+func (s *Server) OnConnOpen(*gortsplib.ServerHandlerOnConnOpenCtx) {}
+
+// OnConnClose implements gortsplib.ServerHandlerOnConnClose.
+func (s *Server) OnConnClose(ctx *gortsplib.ServerHandlerOnConnCloseCtx) {}
+
+// OnSessionOpen implements gortsplib.ServerHandler.
+func (s *Server) OnSessionOpen(*gortsplib.ServerHandlerOnSessionOpenCtx) {}
+
+// OnSessionClose implements gortsplib.ServerHandlerOnSessionClose.
+func (s *Server) OnSessionClose(ctx *gortsplib.ServerHandlerOnSessionCloseCtx) {
+	s.mu.Lock()
+	cs := s.sessions[ctx.Session]
+	delete(s.sessions, ctx.Session)
+	s.mu.Unlock()
+	if cs != nil {
+		cs.readers.Add(-1)
+	}
+}
+
+// OnDescribe implements gortsplib.ServerHandlerOnDescribe.
+func (s *Server) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	if !s.authorized(ctx.Conn, ctx.Request) {
+		return &base.Response{StatusCode: base.StatusUnauthorized}, nil, liberrors.ErrServerAuth{}
+	}
+	cs := s.streamFor(cameraIDFromPath(ctx.Request.URL.Path))
+	if cs == nil {
+		return &base.Response{StatusCode: base.StatusNotFound}, nil, nil
+	}
+	return &base.Response{StatusCode: base.StatusOK}, cs.stream, nil
+}
+
+// OnSetup implements gortsplib.ServerHandlerOnSetup.
+func (s *Server) OnSetup(ctx *gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	if !s.authorized(ctx.Conn, ctx.Request) {
+		return &base.Response{StatusCode: base.StatusUnauthorized}, nil, liberrors.ErrServerAuth{}
+	}
+	cs := s.streamFor(cameraIDFromPath(ctx.Request.URL.Path))
+	if cs == nil {
+		return &base.Response{StatusCode: base.StatusNotFound}, nil, nil
+	}
+	// Count the session as a reader at SETUP (symmetric with the decrement in
+	// OnSessionClose): gortsplib only delivers frames after PLAY, but a
+	// SETUP→TEARDOWN without PLAY must not skew the count negative.
+	s.mu.Lock()
+	if _, ok := s.sessions[ctx.Session]; !ok {
+		s.sessions[ctx.Session] = cs
+		cs.readers.Add(1)
+	}
+	s.mu.Unlock()
+	return &base.Response{StatusCode: base.StatusOK}, cs.stream, nil
+}
+
+// OnPlay implements gortsplib.ServerHandlerOnPlay.
+func (s *Server) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	return &base.Response{StatusCode: base.StatusOK}, nil
+}
+
+// cameraIDFromPath extracts the camera ID from an RTSP request path. DESCRIBE
+// targets /<camera_id>; SETUP targets the media control path /<camera_id>/trackID=0.
+func cameraIDFromPath(p string) string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return ""
+	}
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		last := p[i+1:]
+		if strings.HasPrefix(last, "trackID=") || strings.HasPrefix(last, "streamid=") {
+			p = p[:i]
+		}
+	}
+	return p
+}
+
+// URLFor builds the pull URL advertised to clients (API/UI copy buttons).
+// host is a host or host:port (the port is dropped — the RTSP server has its
+// own); bare IPv6 hosts are bracketed.
+func URLFor(host string, port int, cameraID string) string {
+	if h, _, err := splitHostPort(host); err == nil {
+		host = h
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		host = "[" + host + "]"
+	}
+	return fmt.Sprintf("rtsp://%s:%d/%s", host, port, cameraID)
+}
+
+func splitHostPort(hostport string) (string, string, error) {
+	i := strings.LastIndex(hostport, ":")
+	if i < 0 {
+		return hostport, "", fmt.Errorf("missing port")
+	}
+	return strings.Trim(hostport[:i], "[]"), hostport[i+1:], nil
+}

--- a/internal/rtsp/server_test.go
+++ b/internal/rtsp/server_test.go
@@ -100,8 +100,10 @@ func (ts *testServer) waitReady() {
 	tcp := gortsplib.ProtocolTCP
 	deadline := time.Now().Add(3 * time.Second)
 	for {
-		c := &gortsplib.Client{Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
-			ReadTimeout: time.Second, WriteTimeout: time.Second}
+		c := &gortsplib.Client{
+			Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
+			ReadTimeout: time.Second, WriteTimeout: time.Second,
+		}
 		if err := c.Start(); err == nil {
 			_, err := c.Options(u)
 			c.Close()
@@ -121,8 +123,10 @@ func dialClient(t *testing.T, rawURL string) *gortsplib.Client {
 	u, err := base.ParseURL(rawURL)
 	require.NoError(t, err)
 	tcp := gortsplib.ProtocolTCP
-	c := &gortsplib.Client{Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
-		ReadTimeout: 3 * time.Second, WriteTimeout: 3 * time.Second}
+	c := &gortsplib.Client{
+		Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
+		ReadTimeout: 3 * time.Second, WriteTimeout: 3 * time.Second,
+	}
 	require.NoError(t, c.Start())
 	t.Cleanup(c.Close)
 	return c

--- a/internal/rtsp/server_test.go
+++ b/internal/rtsp/server_test.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the RTSP output server (#522): DESCRIBE/SETUP/PLAY round-trips
+// against a real gortsplib client, auth, stream (re)build semantics on
+// recorder restart / parameter change, and request-path parsing.
+
+package rtsp
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// Minimal-but-plausible parameter sets (contents are opaque to the server;
+// SDP only base64-carries them).
+var (
+	tSPS = []byte{0x67, 0x64, 0x00, 0x0c, 0xac, 0x3b, 0x50, 0xb0, 0x4b, 0x42, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x3d, 0x08}
+	tPPS = []byte{0x68, 0xee, 0x3c, 0x80}
+	// H.265 parameter sets (NAL types 32/33/34) — the client's SDP parser
+	// fully parses SPS/PPS, so these must be structurally valid (borrowed from
+	// the hls manager tests' real camera capture).
+	tVPS    = []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0x95, 0x98, 0x09}
+	tSPS265 = []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0xa0, 0x03, 0xc0, 0x80, 0x10, 0xe5, 0x96, 0x66, 0x69, 0x24, 0xca, 0xe0, 0x10, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x03, 0x01, 0xe0, 0x80}
+	tPPS265 = []byte{0x44, 0x01, 0xc1, 0x72, 0xb4, 0x62, 0x40}
+)
+
+type testServer struct {
+	*Server
+	t       *testing.T
+	url     string
+	hub     *model.StreamHub
+	codec   model.Format
+	sps     []byte
+	pps     []byte
+	known   atomic.Bool
+	stopped chan struct{}
+}
+
+// startTestServer boots an RTSP server on an ephemeral port with an injectable
+// provider whose responses the test can mutate.
+func startTestServer(t *testing.T, cfg Config) *testServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	ts := &testServer{
+		t:       t,
+		hub:     model.NewStreamHub(),
+		codec:   model.FormatH264,
+		sps:     tSPS,
+		pps:     tPPS,
+		stopped: make(chan struct{}),
+	}
+	ts.known.Store(true)
+	cfg.Addr = addr
+	// Hand the PRE-BOUND listener to gortsplib so the socket is accepting
+	// before Start runs — clients may dial immediately.
+	cfg.ListenFn = func(_, _ string) (net.Listener, error) { return ln, nil }
+	ts.Server = NewServer(cfg, func(cameraID string) (StreamInfo, bool) {
+		if cameraID != "cam-1" || !ts.known.Load() {
+			return StreamInfo{}, false
+		}
+		return StreamInfo{Codec: ts.codec, SPS: ts.sps, PPS: ts.pps, VPS: tVPS, Hub: ts.hub}, true
+	})
+	go func() {
+		_ = ts.Server.Start(context.Background())
+		close(ts.stopped)
+	}()
+	t.Cleanup(func() {
+		_ = ts.Server.Stop()
+		select {
+		case <-ts.stopped:
+		case <-time.After(3 * time.Second):
+			t.Error("rtsp server did not stop")
+		}
+	})
+	ts.url = "rtsp://" + addr + "/cam-1"
+	ts.waitReady()
+	return ts
+}
+
+// waitReady blocks until gortsplib's Start fully completed — a successful RTSP
+// OPTIONS round-trip proves the accept loop is live and the internal state
+// (sessions map) exists, so direct streamFor calls in tests don't race startup.
+func (ts *testServer) waitReady() {
+	u := mustURL(ts.t, "rtsp://"+ts.hostPart()+"/")
+	tcp := gortsplib.ProtocolTCP
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		c := &gortsplib.Client{Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
+			ReadTimeout: time.Second, WriteTimeout: time.Second}
+		if err := c.Start(); err == nil {
+			_, err := c.Options(u)
+			c.Close()
+			if err == nil {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			ts.t.Fatalf("rtsp server never became ready")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func dialClient(t *testing.T, rawURL string) *gortsplib.Client {
+	t.Helper()
+	u, err := base.ParseURL(rawURL)
+	require.NoError(t, err)
+	tcp := gortsplib.ProtocolTCP
+	c := &gortsplib.Client{Scheme: u.Scheme, Host: u.Host, Protocol: &tcp,
+		ReadTimeout: 3 * time.Second, WriteTimeout: 3 * time.Second}
+	require.NoError(t, c.Start())
+	t.Cleanup(c.Close)
+	return c
+}
+
+// feedIDR pushes one synthetic IDR AU through the hub.
+func (ts *testServer) feedIDR() {
+	ts.hub.Broadcast(0, [][]byte{tSPS, tPPS, {0x65, 0x01, 0x02, 0x03}}, true)
+}
+
+func TestRTSPServeAndPullH264(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	c := dialClient(t, ts.url)
+
+	desc, _, err := c.Describe(mustURL(t, ts.url))
+	require.NoError(t, err)
+	require.Len(t, desc.Medias, 1)
+	require.Len(t, desc.Medias[0].Formats, 1)
+	require.Equal(t, tSPS, desc.Medias[0].Formats[0].(*format.H264).SPS,
+		"SDP must carry the camera's current SPS")
+
+	_, err = c.Setup(desc.BaseURL, desc.Medias[0], 0, 0)
+	require.NoError(t, err)
+
+	pkts := make(chan *rtp.Packet, 16)
+	c.OnPacketRTP(desc.Medias[0], desc.Medias[0].Formats[0], func(pkt *rtp.Packet) {
+		select {
+		case pkts <- pkt:
+		default:
+		}
+	})
+	_, err = c.Play(nil)
+	require.NoError(t, err)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		ts.feedIDR()
+		select {
+		case p := <-pkts:
+			// First AU's RTP timestamp is legitimately 0 (it anchors the
+			// clock); SSRC proves real packets from our encoder.
+			require.NotZero(t, p.SSRC)
+			return
+		case <-time.After(200 * time.Millisecond):
+			select {
+			case <-deadline:
+				t.Fatal("no RTP packet received within 5s")
+			default:
+			}
+		}
+	}
+}
+
+func TestRTSPServeH265(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	ts.codec = model.FormatH265
+	ts.sps = tSPS265
+	ts.pps = tPPS265
+	c := dialClient(t, ts.url)
+
+	desc, _, err := c.Describe(mustURL(t, ts.url))
+	require.NoError(t, err)
+	require.Len(t, desc.Medias, 1)
+	require.Equal(t, tSPS265, desc.Medias[0].Formats[0].(*format.H265).SPS)
+
+	_, err = c.Setup(desc.BaseURL, desc.Medias[0], 0, 0)
+	require.NoError(t, err)
+	pkts := make(chan *rtp.Packet, 16)
+	c.OnPacketRTP(desc.Medias[0], desc.Medias[0].Formats[0], func(pkt *rtp.Packet) {
+		select {
+		case pkts <- pkt:
+		default:
+		}
+	})
+	_, err = c.Play(nil)
+	require.NoError(t, err)
+
+	ts.hub.Broadcast(0, [][]byte{tVPS, tSPS265, tPPS265, {0x26, 0x01, 0x02}}, true)
+	select {
+	case <-pkts:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no H265 RTP packet received")
+	}
+}
+
+func TestRTSPUnknownCamera(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	ts.known.Store(false)
+	c := dialClient(t, ts.url)
+	_, _, err := c.Describe(mustURL(t, ts.url))
+	require.Error(t, err, "DESCRIBE for unknown camera must fail")
+}
+
+func TestRTSPAuth(t *testing.T) {
+	ts := startTestServer(t, Config{Username: "user", Password: "pass"})
+
+	// No credentials → rejected.
+	c := dialClient(t, ts.url)
+	_, _, err := c.Describe(mustURL(t, ts.url))
+	require.Error(t, err, "DESCRIBE without credentials must be rejected")
+
+	// Correct credentials in the URL → accepted.
+	c2 := dialClient(t, "rtsp://user:pass@"+ts.hostPart()+"/cam-1")
+	_, _, err = c2.Describe(mustURL(t, "rtsp://user:pass@"+ts.hostPart()+"/cam-1"))
+	require.NoError(t, err)
+}
+
+func (ts *testServer) hostPart() string {
+	return mustURL(ts.t, ts.url).Host
+}
+
+func mustURL(t *testing.T, raw string) *base.URL {
+	t.Helper()
+	u, err := base.ParseURL(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestRTSPStreamRebuildOnParamAndHubChange(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	s := ts.Server
+
+	cs1 := s.streamFor("cam-1")
+	require.NotNil(t, cs1)
+	require.Same(t, cs1, s.streamFor("cam-1"), "unchanged state must reuse the stream")
+
+	// Parameter-set change (e.g. camera resolution switch) → same stream, hot
+	// SDP reload — readers are NOT disconnected.
+	newSPS := []byte{0x67, 0x64, 0x00, 0x0c, 0xff}
+	ts.sps = newSPS
+	cs2 := s.streamFor("cam-1")
+	require.Same(t, cs1, cs2)
+	require.False(t, cs2.closed.Load())
+	require.Equal(t, newSPS, cs2.sps)
+	require.Equal(t, newSPS, cs2.media.Formats[0].(*format.H264).SPS, "SDP format must carry the new SPS")
+
+	// Recorder restart → new hub → full rebuild even with identical params.
+	ts.hub = model.NewStreamHub()
+	cs3 := s.streamFor("cam-1")
+	require.NotNil(t, cs3)
+	require.NotSame(t, cs2, cs3)
+	require.True(t, cs2.closed.Load(), "old stream must be torn down")
+}
+
+func TestRTSPNotReady(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	ts.sps = nil // camera warming up
+	require.Nil(t, ts.Server.streamFor("cam-1"))
+
+	// MJPEG cameras are not servable.
+	ts.sps = tSPS
+	ts.codec = model.FormatMJPEG
+	require.Nil(t, ts.Server.streamFor("cam-1"))
+}
+
+func TestCameraIDFromPath(t *testing.T) {
+	require.Equal(t, "cam-1", cameraIDFromPath("/cam-1"))
+	require.Equal(t, "cam-1", cameraIDFromPath("cam-1/"))
+	require.Equal(t, "cam-1", cameraIDFromPath("/cam-1/trackID=0"))
+	require.Equal(t, "cam-1", cameraIDFromPath("/cam-1/streamid=0"))
+	require.Equal(t, "cam/a", cameraIDFromPath("/cam/a"))
+	require.Equal(t, "", cameraIDFromPath("/"))
+}
+
+func TestURLFor(t *testing.T) {
+	require.Equal(t, "rtsp://192.168.1.5:8554/cam-9", URLFor("192.168.1.5:9090", 8554, "cam-9"))
+	require.Equal(t, "rtsp://nas.local:8554/cam-9", URLFor("nas.local", 8554, "cam-9"))
+	require.Equal(t, "rtsp://[::1]:8554/cam-9", URLFor("[::1]:9090", 8554, "cam-9"))
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mqtt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtmp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/srt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
@@ -622,6 +623,22 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			}
 		}
 		slog.Info("WHIP ingest endpoint enabled", "path", "/whip/{streamKey}")
+	}
+
+	// Step 7.7c: RTSP output server (#522/#499) — serves
+	// rtsp://<host>:<port>/<camera_id> pull URLs for third-party platforms.
+	// Enabled by default; a bind failure only logs (see register.go).
+	if cfg.Server.RTSP.Enabled != nil && *cfg.Server.RTSP.Enabled {
+		deps.rtspServer = rtsp.NewServer(
+			rtsp.Config{
+				Addr:     fmt.Sprintf(":%d", cfg.Server.RTSP.Port),
+				Username: cfg.Server.RTSP.Username,
+				Password: cfg.Server.RTSP.Password,
+			},
+			rtspStreamProvider(camMgr),
+		)
+		slog.Info("RTSP output server configured", "port", cfg.Server.RTSP.Port,
+			"auth", cfg.Server.RTSP.Username != "" || cfg.Server.RTSP.Password != "")
 	}
 
 	// Step 7.8: SRT listener (optional)

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mqtt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtmp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/srt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
@@ -85,6 +86,7 @@ type appDeps struct {
 	rtmpServer        *rtmp.Server
 	srtListener       *srt.Listener
 	whipServer        *whip.Server
+	rtspServer        *rtsp.Server
 	gb28181Server     *sip.Server
 	gb28181Cascade    *cascade.Service
 	gb28181DevMgr     *gb28181.DeviceManager

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -397,6 +397,29 @@ func registerServices(a *App, deps *appDeps) error {
 		}
 	}
 
+	// 10c. rtsp output server (#522, optional — default on). Start runs in a
+	// goroutine: a bind failure (port taken by e.g. MediaMTX) must log, not
+	// take the app down.
+	if deps.rtspServer != nil {
+		if err := a.Register(&serviceFunc{
+			name: "rtsp",
+			startFunc: func(ctx context.Context) error {
+				go func() {
+					if err := deps.rtspServer.Start(ctx); err != nil {
+						slog.Error("rtsp", "error", err)
+					}
+				}()
+				return nil
+			},
+			stopFunc: func() error {
+				_ = deps.rtspServer.Stop()
+				return nil
+			},
+		}); err != nil {
+			return fmt.Errorf("register rtsp: %w", err)
+		}
+	}
+
 	// 11. srt (optional)
 	if deps.srtListener != nil {
 		if err := a.Register(&serviceFunc{

--- a/pkg/app/rtsp_provider.go
+++ b/pkg/app/rtsp_provider.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
+)
+
+// rtspStreamProvider adapts the camera manager to the RTSP output server's
+// StreamProvider (#522): resolves the camera's CURRENT recorder — restarted
+// recorders own a fresh hub, and the RTSP server re-resolves on every
+// DESCRIBE/SETUP — and reads its codec parameters. Mirrors the api package's
+// getCodecParams/getStreamHub (ONVIF delegates unwrap to the concrete recorder
+// that owns the params; the outer recorder still carries the live hub).
+func rtspStreamProvider(camMgr *camera.CameraManager) rtsp.StreamProvider {
+	return func(cameraID string) (rtsp.StreamInfo, bool) {
+		rec := camMgr.GetRecorder(cameraID)
+		if rec == nil {
+			return rtsp.StreamInfo{}, false
+		}
+		var info rtsp.StreamInfo
+		if provider, ok := unwrapRTSPDelegate(rec).(model.HLSProvider); ok {
+			info.Codec, info.SPS, info.PPS, info.VPS = provider.CodecParams()
+		}
+		if h, ok := rec.(interface{ GetHub() *model.StreamHub }); ok {
+			info.Hub = h.GetHub()
+		}
+		if info.Codec == "" || info.Hub == nil {
+			return rtsp.StreamInfo{}, false
+		}
+		return info, true
+	}
+}
+
+// unwrapRTSPDelegate unwraps delegate layers (e.g. ONVIF → H264/H265) to the
+// recorder that implements model.HLSProvider. Same shape as the api package's
+// unwrapDelegate, kept local to avoid an app→api dependency.
+func unwrapRTSPDelegate(rec model.Recorder) model.Recorder {
+	for {
+		u, ok := rec.(interface{ Delegate() model.Recorder })
+		if !ok {
+			return rec
+		}
+		if d := u.Delegate(); d != nil {
+			rec = d
+			continue
+		}
+		return rec
+	}
+}

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -171,7 +171,7 @@ func TestRunFree_ServiceOrder(t *testing.T) {
 	// (storage-migrator runs the background per-camera recording migration worker)
 	// (startup-bg joins the two RunFree background goroutines; api-handler closes
 	// tracked timelapse-merge goroutines — both added for #143 TempDir flake fix)
-	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "ws", "hls", "api-handler", "pprof-loopback"}
+	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "rtsp", "ws", "hls", "api-handler", "pprof-loopback"}
 	if len(svcs) != len(expected) {
 		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
 	}
@@ -203,7 +203,7 @@ func TestRunFree_ServiceOrder_GB28181Enabled(t *testing.T) {
 	svcs := a.Services()
 	t.Logf("observed Services() = %v", svcs)
 
-	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "srt", "gb28181", "ws", "hls", "api-handler", "pprof-loopback"}
+	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "rtsp", "srt", "gb28181", "ws", "hls", "api-handler", "pprof-loopback"}
 	if len(svcs) != len(expected) {
 		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
 	}
@@ -259,7 +259,7 @@ func TestRunFree_ServiceOrder_DiscoveryEnabled(t *testing.T) {
 	svcs := a.Services()
 	t.Logf("observed Services() = %v", svcs)
 
-	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "discovery", "mdns", "ws", "hls", "api-handler", "pprof-loopback"}
+	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "rtsp", "discovery", "mdns", "ws", "hls", "api-handler", "pprof-loopback"}
 	if len(svcs) != len(expected) {
 		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
 	}


### PR DESCRIPTION
Closes #522 (落地 #499 的承诺).

## 能力

NVR 内置 RTSP 输出服务端（PLAY 只读方向）：每路摄像头一个稳定拉流地址 `rtsp://<NVR-IP>:8554/<camera_id>`，第三方平台（群晖 Surveillance Station 等）自定义摄像头处直接填入，不再需要 MediaMTX 中转。

- **H.264 / H.265 原生直出**，零转码——帧来自 recorder 的 StreamHub，与 FLV/HLS/WS 直播端点同源
- **多客户端并发**同看一路（gortsplib ServerStream 原生扇出）
- **可选凭据** `server.rtsp.username/password`（basic/digest；缺省开放，对齐 HTTP-FLV 的局域网姿态）
- **配置**：
  ```yaml
  server:
    rtsp:
      enabled: true   # 默认开启
      port: 8554
  ```
- **健壮性**：DESCRIBE 时惰性建流（相机未就绪 404，播放端自然重试）；SPS/PPS 变化热更新 SDP（`ReloadDesc`，不断开读者）；recorder 重启（新 hub）整体重建；端口被占只记 ERROR 不影响主服务；零读者时跳过 RTP 编码
- **发现**：`/api/cameras/{id}/protocols` 新增 `rtsp` 条目（含可直接复制的完整 URL；服务关闭时省略）
- **部署**：bridge compose 增加 `8554:8554` 发布；host 网络（fnOS/host compose）无需映射

## 实现

- `internal/rtsp`：gortsplib 服务端模式（该库已是 RTSP 拉流客户端依赖，服务端能力同库）；RTP 时间戳取 hub IngestAt（各 recorder 的 pts 单位不一致，到达墙钟是唯一一致时钟）
- `pkg/app/rtsp_provider.go`：camera manager → StreamProvider 适配（ONVIF 委托解包，镜像 api 包 getCodecParams）
- 时序细节见 #522 的 issue 描述与代码注释

## 测试

- [x] 真实 gortsplib 客户端全流程往返：DESCRIBE→SETUP→PLAY→收 RTP 包（H.264 + H.265 各一）
- [x] 无凭据 401 / 带凭据通过
- [x] 未知相机、参数未就绪 404；MJPEG 相机不可服务
- [x] 参数热更新（同 stream + 新 SPS 进 SDP）vs hub 变化（重建 + 旧流关闭）语义
- [x] 路径解析（trackID 后缀剥离）、URL 构建（IPv6 括号）
- [x] `-race` 干净（WSL）
- [ ] 群晖 Surveillance Station 真机接入（发布前，验收项）
- [ ] M5 实机验证（部署后：ffplay 拉一路 H.265 + 一路 H.264）