### PR TITLE
fix(camera): expose sub-stream fields in camera API responses

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -69,6 +69,8 @@ func injectYAMLConfigFields(row *storage.CameraRow, cfg *config.Config) {
 		row.PushRetentionDays = cam.PushRetentionDays
 		row.StableID = cam.StableID
 		row.SubnetHints = cam.SubnetHints
+		row.SubProfileToken = cam.SubProfileToken
+		row.SubStreamURL = cam.SubStreamURL
 		row.DarkFrameFilterEnabled = cam.DarkFrameFilterEnabled
 		row.DarkFrameThreshold = cam.DarkFrameThreshold
 		row.RecordingEnabled = cam.RecordingEnabled

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -64,6 +64,11 @@ type CameraRow struct {
 	// Persisted in DB via UpsertCamera / UpdateCameraStableID.
 	StableID    string   `json:"stable_id,omitempty"`
 	SubnetHints []string `json:"subnet_hints,omitempty"`
+	// Sub-stream fields (#512), injected from YAML at API response time —
+	// the edit form round-trips them so a save can't silently clear an
+	// auto-discovered sub_profile_token.
+	SubProfileToken string `json:"sub_profile_token,omitempty"`
+	SubStreamURL    string `json:"sub_stream_url,omitempty"`
 	// Dark frame filtering (injected from YAML at API response time)
 	DarkFrameFilterEnabled bool `json:"dark_frame_filter_enabled"`
 	DarkFrameThreshold     int  `json:"dark_frame_threshold"`


### PR DESCRIPTION
Follow-up to #525（M5 实机验证数分钟后发现的连带 bug）：编辑表单从 list/get API 加载相机（storage.CameraRow），响应不含 sub 字段时表单保存永远提交空串——**任何一次相机编辑都会清掉自动发现的 sub_profile_token**。按 StableID/SubnetHints 的既有模式从 YAML 配置注入这两个字段，list/get 共用注入路径。M5 实测复现于 #525 部署后的首次编辑。