### PR TITLE
chore(ui): rebuild SPA — sub-stream section in CameraForm

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787649777460';
+const CACHE_VERSION = 'mibee-nvr-1787666478972';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives


### PR DESCRIPTION
sw.js hash 更新随 #525 的 SPA 改动（仓库惯例：internal/ui/static 下仅 sw.js 被跟踪，作为本地构建的 SPA 新鲜度锚点）。