### PR TITLE
feat(stream): on-demand sub-stream ingest + quality negotiation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,17 @@ server:
   #   # username: ""   # optional credentials; empty = open on the LAN
   #   # password: ""
 
+  # Sub-stream on-demand ingest (#513): a camera's secondary (lower-
+  # resolution) stream is pulled over RTSP only while live consumers watch it
+  # (stream/ws / stream.flv with ?quality=sub, or the HLS path
+  # /api/cameras/{id}/stream/sub/index.m3u8) and torn down after
+  # idle_timeout_s with no consumers. Requires the camera to expose a sub
+  # stream — an ONVIF secondary profile (auto-discovered) or a manual
+  # sub_stream_url in the camera config.
+  # substream:
+  #   idle_timeout_s: 30    # keep an idle pull warm this long before recycling
+  #   ready_timeout_s: 8    # how long a quality=sub request waits for first video
+
 # HTTP security response headers.
 # frame_ancestors controls who may embed the Web UI in an <iframe> via the CSP
 # frame-ancestors directive. A space-separated list of sources, e.g.

--- a/internal/api/handlers_flv.go
+++ b/internal/api/handlers_flv.go
@@ -5,15 +5,26 @@ import (
 	"net/http"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/flv"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/go-chi/chi/v5"
 )
 
 // --- HTTP-FLV streaming endpoint ---
 
-// handleFLVStream handles GET /api/cameras/{id}/stream.flv
+// handleFLVStream handles GET /api/cameras/{id}/stream.flv[?quality=main|sub]
 // It streams FLV data via HTTP chunked transfer encoding.
+// quality=sub (#513) registers the entry under the camera's "/sub" key and
+// streams the on-demand sub-stream; it falls back to main when the camera has
+// no usable sub-stream (X-Stream-Quality response header reports the outcome).
 func (h *Handler) handleFLVStream(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	quality, qerr := parseQuality(r)
+	if qerr != nil {
+		WriteError(w, http.StatusBadRequest, qerr.Error())
+		return
+	}
 
 	if h.flvMgr == nil {
 		WriteError(w, http.StatusServiceUnavailable, "FLV streaming not available")
@@ -31,36 +42,64 @@ func (h *Handler) handleFLVStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// quality=sub: acquire the on-demand pull and hold the reference for the
+	// whole ServeFLV lifetime (the handler blocks until the viewer leaves).
+	key := id
+	var subSrc *substream.Source
+	if quality == qualitySub && h.camMgr != nil {
+		subSrc = h.acquireSub(w, r, id)
+		if subSrc != nil {
+			key = subKey(id)
+			defer h.camMgr.ReleaseSubStream(id)
+		}
+	}
+
 	// On-demand registration: if FLV stream not registered, register it
-	if !h.flvMgr.IsActive(id) {
+	if !h.flvMgr.IsActive(key) {
 		if h.camMgr == nil {
 			WriteError(w, http.StatusNotFound, "FLV stream not active")
 			return
 		}
-		rec := h.camMgr.GetRecorder(id)
-		if rec == nil {
-			WriteError(w, http.StatusBadRequest, "camera recorder not running")
-			return
+
+		var codec model.Format
+		var sps, pps, vps []byte
+		var hub *model.StreamHub
+		if subSrc != nil {
+			codec, sps, pps, vps = subSrc.CodecParams()
+			hub = subSrc.Hub()
+			if (codec != model.FormatH264 && codec != model.FormatH265) || sps == nil || pps == nil {
+				WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
+				return
+			}
+		} else {
+			rec := h.camMgr.GetRecorder(id)
+			if rec == nil {
+				WriteError(w, http.StatusBadRequest, "camera recorder not running")
+				return
+			}
+
+			codec, sps, pps, vps = getCodecParams(rec)
+			if sps == nil || pps == nil {
+				WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
+				return
+			}
+			hub = getStreamHub(rec)
 		}
 
-		codec, sps, pps, vps := getCodecParams(rec)
-		if sps == nil || pps == nil {
-			WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
-			return
-		}
-
-		hub := getStreamHub(rec)
-		if err := h.flvMgr.RegisterStream(id, codec, sps, pps, vps, hub); err != nil {
+		if err := h.flvMgr.RegisterStream(key, codec, sps, pps, vps, hub); err != nil {
 			if !errors.Is(err, flv.ErrStreamExists) {
-				logger.Error("failed to register FLV stream", "camera_id", id, "error", err)
+				logger.Error("failed to register FLV stream", "camera_id", id, "key", key, "error", err)
 				WriteError(w, http.StatusInternalServerError, "failed to register FLV stream")
 				return
 			}
 		}
+	} else if subSrc != nil && h.flvMgr.ActiveHub(key) != subSrc.Hub() {
+		// Active entry subscribed to a recycled puller's dead hub — rebind.
+		h.flvMgr.RebindHub(key, subSrc.Hub())
 	}
 
 	// Serve FLV stream (blocks until client disconnects)
-	if err := h.flvMgr.ServeFLV(id, w, r); err != nil {
+	if err := h.flvMgr.ServeFLV(key, w, r); err != nil {
 		if errors.Is(err, flv.ErrStreamNotActive) {
 			WriteError(w, http.StatusNotFound, "FLV stream not active")
 			return

--- a/internal/api/handlers_hls.go
+++ b/internal/api/handlers_hls.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 	"github.com/go-chi/chi/v5"
 )
@@ -31,8 +32,31 @@ func subscribeHLS(hub *model.StreamHub, cameraID string, hlsMgr *hls.Manager, is
 	return hlsMgr.SubscribeToHub(cameraID, hub, isH265)
 }
 
+// hlsSubPathPrefix is the URL path marker selecting the sub-stream for HLS.
+// HLS is served under a path wildcard (/stream/*) and playlists reference
+// segments with RELATIVE URLs — the segment requests must resolve to the same
+// entry the playlist came from, so quality rides in the PATH
+// (/api/cameras/{id}/stream/sub/index.m3u8), not a query parameter that
+// segment fetches would drop.
+const hlsSubPathPrefix = "/stream/sub/"
+
 func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	// Validate request parameters before service availability. quality
+	// negotiation (#513): the path form (/stream/sub/…) selects the
+	// sub-stream; an explicit ?quality= on HLS is rejected because segments
+	// cannot carry it (they would fall back to the main entry and desync the
+	// playlist).
+	if q := r.URL.Query().Get("quality"); q != "" {
+		if _, err := parseQuality(r); err != nil {
+			WriteError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		WriteError(w, http.StatusBadRequest,
+			"HLS quality selection uses the path form /stream/sub/index.m3u8 (segments cannot carry a query parameter)")
+		return
+	}
 
 	if h.hlsMgr == nil || h.camMgr == nil {
 		WriteError(w, http.StatusInternalServerError, "HLS not available")
@@ -50,14 +74,28 @@ func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If stream not active, start it
-	if !h.hlsMgr.IsActive(id) {
-		rec := h.camMgr.GetRecorder(id)
-		if rec == nil {
-			WriteError(w, http.StatusBadRequest, "camera recorder not running")
-			return
+	key := id
+	var subSrc *substream.Source
+	if strings.Contains(r.URL.Path, hlsSubPathPrefix) {
+		// Hold the reference for this request only. Playlist polling re-
+		// acquires well inside the idle timeout, so an active player keeps
+		// the puller warm; once polling stops, the idle timeout recycles it.
+		if src := h.acquireSub(w, r, id); src != nil {
+			subSrc = src
+			key = subKey(id)
+			defer h.camMgr.ReleaseSubStream(id)
 		}
+		if strings.HasSuffix(r.URL.Path, ".m3u8") {
+			// (acquireSub already set the header; re-affirm for playlists
+			// because hls.js inspects only these responses.)
+			if subSrc == nil {
+				w.Header().Set("X-Stream-Quality", qualityMain)
+			}
+		}
+	}
 
+	// If stream not active, start it
+	if !h.hlsMgr.IsActive(key) {
 		// Get camera config for HLS options
 		camCfg := h.camMgr.GetCameraConfig(id)
 		hlsMaxFPS := 0
@@ -65,160 +103,66 @@ func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 			hlsMaxFPS = camCfg.HLSMaxFPS
 		}
 
-		// Try H264 recorder first
-		if h264Rec, ok := rec.(*recorder.H264Recorder); ok {
-			sps := h264Rec.SPS()
-			pps := h264Rec.PPS()
+		var codec model.Format
+		var sps, pps, vps []byte
+		var hub *model.StreamHub
+		if subSrc != nil {
+			// Sub-stream: parameters from the pull's SDP/in-band snapshot;
+			// the main recorder need not be running at all.
+			codec, sps, pps, vps = subSrc.CodecParams()
+			hub = subSrc.Hub()
+		} else {
+			rec := h.camMgr.GetRecorder(id)
+			if rec == nil {
+				WriteError(w, http.StatusBadRequest, "camera recorder not running")
+				return
+			}
+			codec, sps, pps, vps = getCodecParams(rec)
+			hub = getStreamHub(rec)
+		}
+
+		switch codec {
+		case model.FormatH264:
 			if sps == nil || pps == nil {
 				WriteError(w, http.StatusServiceUnavailable, "SPS/PPS not available yet, waiting for video stream")
 				return
 			}
-
-			err := h.hlsMgr.StartStream(id, sps, pps, hlsMaxFPS)
-			if err != nil {
+			if err := h.hlsMgr.StartStream(key, sps, pps, hlsMaxFPS); err != nil {
 				if errors.Is(err, hls.ErrMaxStreamsReached) {
 					writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
 				} else {
-					logger.Error("failed to start HLS stream", "camera_id", id, "error", err)
+					logger.Error("failed to start HLS stream", "camera_id", id, "key", key, "error", err)
 					WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
 				}
 				return
 			}
-
-			// Check if sub-stream URL is configured
-			if camCfg != nil && camCfg.SubStreamURL != "" {
-				fallback := func() {
-					_ = subscribeHLS(h264Rec.Hub, id, h.hlsMgr, false)
-				}
-				if subErr := h.hlsMgr.StartSubStreamReader(id, camCfg.SubStreamURL, false, fallback); subErr != nil {
-					logger.Warn("failed to start HLS sub-stream reader, falling back to main stream", "camera_id", id, "error", subErr)
-					fallback()
-				}
-				// Sub-stream reader is running — do NOT subscribe hub on recorder
-			} else {
-				_ = subscribeHLS(h264Rec.Hub, id, h.hlsMgr, false)
-			}
-		} else if h265Rec, ok := rec.(*recorder.H265Recorder); ok {
-			vps := h265Rec.VPS()
-			sps := h265Rec.SPS()
-			pps := h265Rec.PPS()
-			if vps == nil || sps == nil || pps == nil {
+			_ = subscribeHLS(hub, key, h.hlsMgr, false)
+		case model.FormatH265:
+			if sps == nil || pps == nil || vps == nil {
 				WriteError(w, http.StatusServiceUnavailable, "VPS/SPS/PPS not available yet, waiting for video stream")
 				return
 			}
-
-			err := h.hlsMgr.StartStreamH265(id, vps, sps, pps, hlsMaxFPS)
-			if err != nil {
+			if err := h.hlsMgr.StartStreamH265(key, vps, sps, pps, hlsMaxFPS); err != nil {
 				if errors.Is(err, hls.ErrMaxStreamsReached) {
 					writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
 				} else {
-					logger.Error("failed to start HLS H265 stream", "camera_id", id, "error", err)
+					logger.Error("failed to start HLS H265 stream", "camera_id", id, "key", key, "error", err)
 					WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
 				}
 				return
 			}
-
-			// Check if sub-stream URL is configured
-			if camCfg != nil && camCfg.SubStreamURL != "" {
-				fallback := func() {
-					_ = subscribeHLS(h265Rec.Hub, id, h.hlsMgr, true)
-				}
-				if subErr := h.hlsMgr.StartSubStreamReader(id, camCfg.SubStreamURL, true, fallback); subErr != nil {
-					logger.Warn("failed to start HLS sub-stream reader, falling back to main stream", "camera_id", id, "error", subErr)
-					fallback()
-				}
-			} else {
-				_ = subscribeHLS(h265Rec.Hub, id, h.hlsMgr, true)
-			}
-		} else if onvifRec, ok := rec.(*recorder.ONVIFRecorder); ok {
-			// ONVIF recorder delegates to H264/H265 internally
-			delegate := onvifRec.Delegate()
-			if delegate == nil {
-				WriteError(w, http.StatusServiceUnavailable, "ONVIF recorder delegate not available yet")
-				return
-			}
-			// Unwrap the delegate and handle as H264/H265
-			if h264Rec, ok := delegate.(*recorder.H264Recorder); ok {
-				sps := h264Rec.SPS()
-				pps := h264Rec.PPS()
-				if sps == nil || pps == nil {
-					WriteError(w, http.StatusServiceUnavailable, "SPS/PPS not available yet, waiting for video stream")
-					return
-				}
-				err := h.hlsMgr.StartStream(id, sps, pps, hlsMaxFPS)
-				if err != nil {
-					if errors.Is(err, hls.ErrMaxStreamsReached) {
-						writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
-					} else {
-						WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
-					}
-					return
-				}
-				_ = subscribeHLS(h264Rec.Hub, id, h.hlsMgr, false)
-			} else if h265Rec, ok := delegate.(*recorder.H265Recorder); ok {
-				vps := h265Rec.VPS()
-				sps := h265Rec.SPS()
-				pps := h265Rec.PPS()
-				if vps == nil || sps == nil || pps == nil {
-					WriteError(w, http.StatusServiceUnavailable, "VPS/SPS/PPS not available yet, waiting for video stream")
-					return
-				}
-				err := h.hlsMgr.StartStreamH265(id, vps, sps, pps, hlsMaxFPS)
-				if err != nil {
-					if errors.Is(err, hls.ErrMaxStreamsReached) {
-						writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
-					} else {
-						WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
-					}
-					return
-				}
-				_ = subscribeHLS(h265Rec.Hub, id, h.hlsMgr, true)
-			} else {
-				writeAPIError(w, http.StatusBadRequest, &model.HLSSupportedCodecError{CameraID: id})
-				return
-			}
-		} else if provider, ok := rec.(model.HLSProvider); ok {
-			codec, sps, pps, vps := provider.CodecParams()
-			if sps == nil || pps == nil {
-				WriteError(w, http.StatusServiceUnavailable, "codec params not ready yet, waiting for video stream")
-				return
-			}
-			switch codec {
-			case model.FormatH264:
-				err := h.hlsMgr.StartStream(id, sps, pps, hlsMaxFPS)
-				if err != nil {
-					if errors.Is(err, hls.ErrMaxStreamsReached) {
-						writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
-					} else {
-						logger.Error("failed to start HLS stream", "camera_id", id, "error", err)
-						WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
-					}
-					return
-				}
-				_ = subscribeHLS(getRecorderHub(rec), id, h.hlsMgr, false)
-			case model.FormatH265:
-				if vps == nil {
-					WriteError(w, http.StatusServiceUnavailable, "VPS not ready yet, waiting for video stream")
-					return
-				}
-				err := h.hlsMgr.StartStreamH265(id, vps, sps, pps, hlsMaxFPS)
-				if err != nil {
-					if errors.Is(err, hls.ErrMaxStreamsReached) {
-						writeAPIError(w, http.StatusServiceUnavailable, &model.HLSMaxStreamsError{})
-					} else {
-						logger.Error("failed to start HLS H265 stream", "camera_id", id, "error", err)
-						WriteError(w, http.StatusInternalServerError, "failed to start HLS stream")
-					}
-					return
-				}
-				_ = subscribeHLS(getRecorderHub(rec), id, h.hlsMgr, true)
-			default:
-				writeAPIError(w, http.StatusBadRequest, &model.HLSSupportedCodecError{CameraID: id})
-				return
-			}
-		} else {
+			_ = subscribeHLS(hub, key, h.hlsMgr, true)
+		default:
 			writeAPIError(w, http.StatusBadRequest, &model.HLSSupportedCodecError{CameraID: id})
 			return
+		}
+	} else if subSrc != nil {
+		// Active entry, but it may be subscribed to a hub from a previous
+		// puller generation (recycled + restarted since) — rebind, mirroring
+		// the WS endpoint's recovery.
+		codec, _, _, _ := subSrc.CodecParams()
+		if h.hlsMgr.ActiveHub(key) != subSrc.Hub() {
+			h.hlsMgr.RebindHub(key, subSrc.Hub(), codec == model.FormatH265)
 		}
 	}
 	// Issue the stream cookie on playlist fetches (#331): media players that
@@ -230,7 +174,7 @@ func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 	// every playlist fetch, so players polling the playlist stay fresh.
 	setStreamCookieOnPlaylist(w, r, id)
 	// Proxy to muxer handler
-	if !h.hlsMgr.Handle(id, w, r) {
+	if !h.hlsMgr.Handle(key, w, r) {
 		WriteError(w, http.StatusServiceUnavailable, "HLS stream not available")
 		return
 	}
@@ -270,7 +214,7 @@ func (h *Handler) handleStopHLSStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.hlsMgr.IsActive(id) {
+	if !h.hlsMgr.IsActive(id) && !h.hlsMgr.IsActive(subKey(id)) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "not active"})
 		return
 	}
@@ -286,6 +230,14 @@ func (h *Handler) handleStopHLSStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.hlsMgr.StopStream(id)
+	// Stop the sub-stream entry too and release its pull reference (#513) —
+	// the on-demand puller otherwise idles out up to idle_timeout_s later.
+	if h.hlsMgr.IsActive(subKey(id)) {
+		if hub := h.hlsMgr.ActiveHub(subKey(id)); hub != nil {
+			hub.Unsubscribe("hls")
+		}
+		h.hlsMgr.StopStream(subKey(id))
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
 

--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -2,11 +2,14 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 )
 
@@ -337,6 +340,55 @@ func getStreamHub(rec model.Recorder) *model.StreamHub {
 // SetStreamRegistry sets the stream registry on the handler for protocol queries.
 func (h *Handler) SetStreamRegistry(reg *StreamRegistry) {
 	h.streamRegistry = reg
+}
+
+// --- Stream quality negotiation (#513) ---
+
+// Quality values for the live egress endpoints. "main" is the default;
+// "sub" selects the camera's on-demand sub-stream (falls back to main when
+// the camera has none — callers detect the fallback via X-Stream-Quality).
+const (
+	qualityMain = "main"
+	qualitySub  = "sub"
+)
+
+// parseQuality parses the ?quality= parameter ("" and "main" → main).
+func parseQuality(r *http.Request) (string, error) {
+	switch q := r.URL.Query().Get("quality"); q {
+	case "", qualityMain:
+		return qualityMain, nil
+	case qualitySub:
+		return qualitySub, nil
+	default:
+		return "", fmt.Errorf("invalid quality %q (supported: main, sub)", q)
+	}
+}
+
+// subKey is the protocol-manager stream key under which a camera's sub-stream
+// egress is registered. Managers key entries by an opaque string, so the
+// suffixed key reuses all of their machinery (viewer caps, GOP cache, idle
+// watchdogs) without any per-quality plumbing inside them.
+func subKey(cameraID string) string { return cameraID + "/" + qualitySub }
+
+// acquireSub attempts the on-demand sub-stream acquisition and reports
+// whether egress should serve the sub entry. On any failure (no sub config,
+// pull not ready) it falls back to main — quality negotiation degrades, never
+// hard-fails — and logs the reason. The header tells the client which quality
+// it actually got.
+func (h *Handler) acquireSub(w http.ResponseWriter, r *http.Request, cameraID string) *substream.Source {
+	if h.camMgr == nil {
+		w.Header().Set("X-Stream-Quality", qualityMain)
+		return nil
+	}
+	src, err := h.camMgr.AcquireSubStream(r.Context(), cameraID)
+	if err != nil {
+		streamLogger.Info("quality=sub unavailable, serving main stream",
+			"camera_id", cameraID, "reason", err.Error())
+		w.Header().Set("X-Stream-Quality", qualityMain)
+		return nil
+	}
+	w.Header().Set("X-Stream-Quality", qualitySub)
+	return src
 }
 
 // --- WebRTCStreamHandler ---

--- a/internal/api/handlers_substream_test.go
+++ b/internal/api/handlers_substream_test.go
@@ -1,0 +1,85 @@
+package api
+
+// Tests for the quality negotiation surface (#513): parseQuality / subKey /
+// WHEP rejection of ?quality=sub. The full sub-stream egress path (acquire →
+// register under "/sub" key → serve) needs a live RTSP sub source and is
+// exercised by the internal/substream round-trip tests plus on-device M5
+// verification.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQuality(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw   string
+		want  string
+		valid bool
+	}{
+		{"", qualityMain, true},
+		{"main", qualityMain, true},
+		{"sub", qualitySub, true},
+		{"MAIN", "", false},
+		{"hd", "", false},
+		{"", qualityMain, true},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/api/cameras/cam-1/stream.flv?quality="+tc.raw, nil)
+		got, err := parseQuality(r)
+		if !tc.valid {
+			require.Error(t, err, "quality=%q", tc.raw)
+			continue
+		}
+		require.NoError(t, err, "quality=%q", tc.raw)
+		require.Equal(t, tc.want, got, "quality=%q", tc.raw)
+	}
+}
+
+func TestSubKey(t *testing.T) {
+	require.Equal(t, "cam-1/sub", subKey("cam-1"))
+}
+
+// WHEP must reject quality=sub with an explicit message pointing at the
+// endpoints that support it (#513 v1).
+func TestWHEP_RejectsSubQuality(t *testing.T) {
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), "POST",
+		"/api/cameras/cam-1/stream/webrtc?quality=sub",
+		nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "not supported for WebRTC")
+}
+
+// WS endpoint validates the quality parameter before anything else.
+func TestWS_RejectsBadQuality(t *testing.T) {
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), "GET",
+		"/api/cameras/cam-1/stream/ws?quality=hd",
+		nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// HLS rejects the query form (segments cannot carry it — the path form
+// /stream/sub/index.m3u8 is the supported selector).
+func TestHLS_RejectsQualityQuery(t *testing.T) {
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), "GET",
+		"/api/cameras/cam-1/stream/index.m3u8?quality=sub",
+		nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "path form")
+}

--- a/internal/api/handlers_webrtc.go
+++ b/internal/api/handlers_webrtc.go
@@ -18,6 +18,18 @@ import (
 func (h *Handler) handleCreateWHEPSession(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
+	// quality=sub is not wired for WHEP yet (#513 v1): WHEP sessions outlive
+	// the creating HTTP request, so the sub-stream puller's reference count
+	// has no anchor to decrement on session close — the manager needs a
+	// session-scoped release hook first. Clients get an explicit error and
+	// can use ws/flv/hls sub endpoints meanwhile. Validated before service
+	// availability so the contract is observable even with WebRTC disabled.
+	if q := r.URL.Query().Get("quality"); q != "" && q != qualityMain {
+		WriteError(w, http.StatusBadRequest,
+			"quality=sub is not supported for WebRTC yet; use stream/ws, stream.flv (?quality=sub) or stream/sub/index.m3u8")
+		return
+	}
+
 	if h.webrtcMgr == nil {
 		WriteError(w, http.StatusServiceUnavailable, "WebRTC not available")
 		return

--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -8,17 +8,29 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 	"github.com/go-chi/chi/v5"
 )
 
 // --- WebSocket streaming endpoint ---
 
-// handleStreamWS handles GET /api/cameras/{id}/stream/ws
+// handleStreamWS handles GET /api/cameras/{id}/stream/ws[?quality=main|sub]
 // It upgrades the HTTP connection to a WebSocket and streams binary-encoded
 // video frames (CodecInfo first, then VideoFrame messages).
+// quality=sub (#513) registers the entry under the camera's "/sub" key and
+// streams the on-demand sub-stream; it falls back to main when the camera has
+// no usable sub-stream (X-Stream-Quality response header reports the outcome).
 func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	// Validate request parameters before service availability (a bad
+	// quality= must not masquerade as "streaming unavailable").
+	quality, qerr := parseQuality(r)
+	if qerr != nil {
+		WriteError(w, http.StatusBadRequest, qerr.Error())
+		return
+	}
 
 	if h.wsMgr == nil {
 		WriteError(w, http.StatusServiceUnavailable, "WebSocket streaming not available")
@@ -37,75 +49,124 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// quality=sub: acquire the on-demand pull and hold the reference for the
+	// whole ServeWS lifetime (the handler blocks until the viewer leaves).
+	key := id
+	var subSrc *substream.Source
+	if quality == qualitySub && h.camMgr != nil {
+		subSrc = h.acquireSub(w, r, id)
+		if subSrc != nil {
+			key = subKey(id)
+			defer h.camMgr.ReleaseSubStream(id)
+		}
+	}
+
 	// On-demand registration: if WebSocket stream not registered, register it.
 	// An already-active entry may be subscribed to a STALE StreamHub (the
-	// recorder reconnected and got a fresh hub) — rebind before serving, or
-	// the viewer would sit on a dead hub with zero frames forever.
-	if h.wsMgr.IsActive(id) && h.camMgr != nil {
-		if rec := h.camMgr.GetRecorder(id); rec != nil {
+	// recorder reconnected and got a fresh hub — or the sub-stream puller was
+	// recycled and restarted) — rebind before serving, or the viewer would
+	// sit on a dead hub with zero frames forever.
+	if h.wsMgr.IsActive(key) && h.camMgr != nil {
+		if subSrc != nil {
+			if h.wsMgr.ActiveHub(key) != subSrc.Hub() {
+				h.wsMgr.RebindHub(key, subSrc.Hub())
+			}
+		} else if rec := h.camMgr.GetRecorder(id); rec != nil {
 			if hub := getStreamHub(rec); hub != nil && hub != h.wsMgr.ActiveHub(id) {
 				h.wsMgr.RebindHub(id, hub)
 			}
 		}
 	}
-	if !h.wsMgr.IsActive(id) {
+	if !h.wsMgr.IsActive(key) {
 		if h.camMgr == nil {
 			WriteError(w, http.StatusNotFound, "WebSocket stream not active")
 			return
 		}
-		rec := h.camMgr.GetRecorder(id)
-		if rec == nil {
-			slog.Warn("WS: recorder not running", "camera_id", id)
-			WriteError(w, http.StatusBadRequest, "camera recorder not running")
-			return
-		}
 
-		codec, sps, pps, vps := getCodecParams(rec)
-		// Normalize JPEG/MJPEG codec names for wsstream: both "jpeg" and "mjpeg"
-		// map to wsstream.CodecMJPEG ("mjpeg") since the wire protocol treats
-		// them identically (complete JPEG frames in VideoFrame.NALUs[0]).
-		if codec == model.EncJPEG {
-			codec = model.FormatMJPEG
-		}
-		slog.Info("WS: on-demand register", "camera_id", id, "codec", codec, "has_sps", sps != nil, "has_pps", pps != nil)
-		// MJPEG cameras don't have SPS/PPS — skip the keyframe wait.
-		if codec != model.FormatMJPEG {
-			if sps == nil || pps == nil {
-				// Recorder is active but hasn't received a keyframe yet.
-				// Poll for up to 5 seconds (typical keyframe interval is 1-4s).
+		var codec model.Format
+		var sps, pps, vps []byte
+		var hub *model.StreamHub
+		if subSrc != nil {
+			// Sub-stream: parameters come from the pull's SDP/in-band
+			// snapshot; the main recorder need not be running at all.
+			codec, sps, pps, vps = subSrc.CodecParams()
+			hub = subSrc.Hub()
+			if codec != model.FormatH264 && codec != model.FormatH265 {
+				// Pull came up without usable video parameters (still
+				// warming up) — poll briefly like the main path below.
 				const wsCodecWait = 5 * time.Second
 				const wsCodecPoll = 200 * time.Millisecond
 				deadline := time.Now().Add(wsCodecWait)
-				for sps == nil || pps == nil {
+				for (codec != model.FormatH264 && codec != model.FormatH265) ||
+					sps == nil || pps == nil {
 					if time.Now().After(deadline) {
-						slog.Warn("WS: timed out waiting for codec params", "camera_id", id)
+						slog.Warn("WS: timed out waiting for sub-stream codec params", "camera_id", id)
 						WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
 						return
 					}
 					time.Sleep(wsCodecPoll)
-					codec, sps, pps, vps = getCodecParams(rec)
+					codec, sps, pps, vps = subSrc.CodecParams()
 				}
-				slog.Info("WS: codec params available after poll", "camera_id", id, "codec", codec)
 			}
+		} else {
+			rec := h.camMgr.GetRecorder(id)
+			if rec == nil {
+				slog.Warn("WS: recorder not running", "camera_id", id)
+				WriteError(w, http.StatusBadRequest, "camera recorder not running")
+				return
+			}
+
+			codec, sps, pps, vps = getCodecParams(rec)
+			// Normalize JPEG/MJPEG codec names for wsstream: both "jpeg" and "mjpeg"
+			// map to wsstream.CodecMJPEG ("mjpeg") since the wire protocol treats
+			// them identically (complete JPEG frames in VideoFrame.NALUs[0]).
+			if codec == model.EncJPEG {
+				codec = model.FormatMJPEG
+			}
+			slog.Info("WS: on-demand register", "camera_id", id, "codec", codec, "has_sps", sps != nil, "has_pps", pps != nil)
+			// MJPEG cameras don't have SPS/PPS — skip the keyframe wait.
+			if codec != model.FormatMJPEG {
+				if sps == nil || pps == nil {
+					// Recorder is active but hasn't received a keyframe yet.
+					// Poll for up to 5 seconds (typical keyframe interval is 1-4s).
+					const wsCodecWait = 5 * time.Second
+					const wsCodecPoll = 200 * time.Millisecond
+					deadline := time.Now().Add(wsCodecWait)
+					for sps == nil || pps == nil {
+						if time.Now().After(deadline) {
+							slog.Warn("WS: timed out waiting for codec params", "camera_id", id)
+							WriteError(w, http.StatusServiceUnavailable, "waiting for video stream")
+							return
+						}
+						time.Sleep(wsCodecPoll)
+						codec, sps, pps, vps = getCodecParams(rec)
+					}
+					slog.Info("WS: codec params available after poll", "camera_id", id, "codec", codec)
+				}
+			}
+			hub = getStreamHub(rec)
 		}
 
-		hub := getStreamHub(rec)
-		if err := h.wsMgr.RegisterStream(id, codec, sps, pps, vps, hub); err != nil {
+		if err := h.wsMgr.RegisterStream(key, codec, sps, pps, vps, hub); err != nil {
 			if !errors.Is(err, wsstream.ErrStreamExists) {
-				slog.Error("WS: failed to register", "camera_id", id, "error", err)
+				slog.Error("WS: failed to register", "camera_id", id, "key", key, "error", err)
 				WriteError(w, http.StatusInternalServerError, "failed to register WebSocket stream")
 				return
 			}
 		}
 		// Configure audio streaming if the recorder provides audio
-		setupAudioForWS(h, id, rec)
-
+		// (main-stream entries only — the sub-stream pull is video-only).
+		if subSrc == nil {
+			if rec := h.camMgr.GetRecorder(id); rec != nil {
+				setupAudioForWS(h, id, rec)
+			}
+		}
 	}
 
-	slog.Info("WS: serving", "camera_id", id)
+	slog.Info("WS: serving", "camera_id", id, "key", key)
 
 	// Serve WebSocket stream (blocks until client disconnects)
-	if err := h.wsMgr.ServeWS(id, w, r); err != nil {
+	if err := h.wsMgr.ServeWS(key, w, r); err != nil {
 		if errors.Is(err, wsstream.ErrStreamNotActive) {
 			WriteError(w, http.StatusNotFound, "WebSocket stream not active")
 			return

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -318,6 +318,10 @@ func (cm *CameraManager) RemoveCamera(ctx context.Context, cameraID string) erro
 	cm.stopTimelapseFramePoller(cameraID)
 	// Stop dual-mode timelapse schedule monitor
 	cm.stopDualModeTimelapseScheduleMonitor(cameraID)
+	// Tear the on-demand sub-stream pull down with the camera (#513).
+	if cm.subStreams != nil {
+		cm.subStreams.StopCamera(cameraID)
+	}
 
 	return nil
 }
@@ -729,6 +733,18 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 				logger.Error("failed to start recorder", "error", err)
 			}
 		}
+	}
+
+	// Sub-stream target inputs changed (protocol/credentials/endpoint/sub
+	// fields) → recycle the on-demand pull so the next Acquire re-resolves
+	// from the new config (#513). Runs for sub-only changes too, which need
+	// no recorder restart. Compared against savedCam outside configMu
+	// instead of scattering change flags through the apply block above.
+	if cm.subStreams != nil &&
+		(savedCam.Protocol != camCopy.Protocol || savedCam.Username != camCopy.Username ||
+			savedCam.Password != camCopy.Password || savedCam.ONVIFEndpoint != camCopy.ONVIFEndpoint ||
+			savedCam.SubStreamURL != camCopy.SubStreamURL || savedCam.SubProfileToken != camCopy.SubProfileToken) {
+		cm.subStreams.StopCamera(cameraID)
 	}
 
 	// Auto-populate SnapshotURL for ONVIF cameras (non-blocking)

--- a/internal/camera/lifecycle.go
+++ b/internal/camera/lifecycle.go
@@ -239,6 +239,13 @@ func (cm *CameraManager) Stop() error {
 	// Stop / the caller above (#163). Bounded by the ensure* 15s timeout.
 	cm.onvifEnsureWg.Wait()
 
+	// Stop every on-demand sub-stream pull (#513) — runs AFTER recorders so
+	// recycle callbacks can still touch protocol managers safely (they are
+	// idempotent against already-stopped entries anyway).
+	if cm.subStreams != nil {
+		cm.subStreams.Stop()
+	}
+
 	// Stop the hub stats flusher (#469).
 	cm.stopHubStatsFlusher()
 
@@ -359,6 +366,11 @@ func (cm *CameraManager) StopCamera(_ context.Context, cameraID string) error {
 
 		// Stop dual-mode timelapse schedule monitor if running
 		cm.stopDualModeTimelapseScheduleMonitor(cameraID)
+
+		// Tear the on-demand sub-stream pull down with the camera (#513).
+		if cm.subStreams != nil {
+			cm.subStreams.StopCamera(cameraID)
+		}
 
 		return nil
 	})

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
@@ -101,11 +102,15 @@ type CameraUpdate struct {
 }
 
 type CameraManager struct {
-	cfg                *config.Config
-	store              *storage.Manager
-	db                 *storage.DB
-	configPath         string
-	metrics            *metrics.Metrics
+	cfg        *config.Config
+	store      *storage.Manager
+	db         *storage.DB
+	configPath string
+	metrics    *metrics.Metrics
+	// subStreams pulls camera sub-streams on demand (#513). Constructed here,
+	// torn down with the manager; per-camera teardown rides the camera
+	// lifecycle (StopCamera/RemoveCamera/UpdateCamera).
+	subStreams         *substream.Manager
 	mergeMgr           *merge.MergeManager                     // segment merge manager (nil = no merge)
 	timelapseMergeMgr  *timelapse.RollingMergeManager          // timelapse rolling merge (nil = no merge)
 	transcodeMgr       *transcoding.TranscodeManager           // transcoding manager (nil = no transcoding)
@@ -238,6 +243,16 @@ func NewCameraManager(cfg *config.Config, store *storage.Manager, db *storage.DB
 		hubBytesLast:       make(map[string]int64),
 		eventBus:           eb,
 	}
+	cm.subStreams = newSubStreamManager(
+		substream.Config{
+			Resolver: cm.resolveSubTarget,
+			WireHub: func(hub *model.StreamHub, cameraID string) {
+				wireHubMetrics(hub, cameraID, m)
+			},
+		},
+		subIdleTimeoutS(cfg),
+		subReadyTimeoutS(cfg),
+	)
 	// Publish the initial immutable snapshot. Config pointers seed the configs
 	// map from cfg.Cameras so GetCameraConfig works before Start() runs. The
 	// recorders/hubs maps start empty (populated as recorders start). Guard

--- a/internal/camera/substream.go
+++ b/internal/camera/substream.go
@@ -1,0 +1,118 @@
+package camera
+
+// On-demand sub-stream ingest wiring (#513): the camera manager owns the
+// substream.Manager, resolves pull targets from camera configs (manual
+// sub_stream_url, or ONVIF GetStreamUri on the discovered secondary profile),
+// and ties its lifecycle to camera start/stop/remove/update. Egress endpoints
+// (WS/FLV/HLS quality=sub) reach it through AcquireSubStream/ReleaseSubStream.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
+)
+
+// resolveSubTarget implements the substream.Resolver contract against camera
+// configs:
+//
+//   - rtsp protocol: sub_stream_url must be set manually.
+//   - onvif protocol: sub_stream_url wins when present; otherwise the
+//     auto-discovered sub_profile_token (#512) is resolved via GetStreamUri,
+//     with the same DHCP-stale host rewriting the main stream path applies.
+//
+// Everything else (gb28131 sub-channels, push ingest, xiaomi) is not
+// supported yet — ok=false → ErrNoSubStream → the caller falls back to main.
+func (cm *CameraManager) resolveSubTarget(ctx context.Context, cameraID string) (substream.Target, bool, error) {
+	cam := cm.snapshotConfig(cameraID)
+	if cam == nil {
+		return substream.Target{}, false, nil
+	}
+	switch cam.Protocol {
+	case string(model.ProtoRTSP):
+		if strings.TrimSpace(cam.SubStreamURL) == "" {
+			return substream.Target{}, false, nil
+		}
+		return substream.Target{URL: cam.SubStreamURL, Username: cam.Username, Password: cam.Password}, true, nil
+
+	case string(model.ProtoONVIF):
+		if strings.TrimSpace(cam.SubStreamURL) != "" {
+			return substream.Target{URL: cam.SubStreamURL, Username: cam.Username, Password: cam.Password}, true, nil
+		}
+		token := strings.TrimSpace(cam.SubProfileToken)
+		if token == "" {
+			return substream.Target{}, false, nil
+		}
+		endpoint := cam.ONVIFEndpoint
+		if endpoint == "" {
+			endpoint = cam.URL
+		}
+		client := cm.reuseOrCreateONVIFClient(cameraID, endpoint, cam.Username, cam.Password)
+		uriCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		info, err := client.GetStreamURI(uriCtx, token)
+		if err != nil {
+			return substream.Target{}, false, fmt.Errorf("onvif GetStreamUri(sub profile): %w", err)
+		}
+		if info == nil || strings.TrimSpace(info.URI) == "" {
+			return substream.Target{}, false, nil
+		}
+		uri := recorder.RewriteStaleStreamHost(info.URI, endpoint)
+		return substream.Target{URL: uri, Username: cam.Username, Password: cam.Password}, true, nil
+	}
+	return substream.Target{}, false, nil
+}
+
+// AcquireSubStream starts (or joins) the camera's on-demand sub-stream pull
+// and returns its source. Each success must be balanced with
+// ReleaseSubStream. Returns substream.ErrNoSubStream when the camera has no
+// usable sub-stream configuration — callers treat that as "negotiate down to
+// main".
+func (cm *CameraManager) AcquireSubStream(ctx context.Context, cameraID string) (*substream.Source, error) {
+	if cm.subStreams == nil {
+		return nil, substream.ErrNoSubStream
+	}
+	return cm.subStreams.Acquire(ctx, cameraID)
+}
+
+// ReleaseSubStream drops one reference; the pull stops after the idle timeout.
+func (cm *CameraManager) ReleaseSubStream(cameraID string) {
+	if cm.subStreams != nil {
+		cm.subStreams.Release(cameraID)
+	}
+}
+
+// SubStreams exposes the manager for app-level wiring (recycle callback,
+// observability). May be nil in reduced test constructors.
+func (cm *CameraManager) SubStreams() *substream.Manager { return cm.subStreams }
+
+// newSubStreamManager builds the manager from server config. Nil-safe against
+// reduced configs (tests construct managers with a nil cfg).
+func newSubStreamManager(cfg substream.Config, idleTimeoutS, readyTimeoutS int) *substream.Manager {
+	if idleTimeoutS > 0 {
+		cfg.IdleTimeout = time.Duration(idleTimeoutS) * time.Second
+	}
+	if readyTimeoutS > 0 {
+		cfg.ReadyTimeout = time.Duration(readyTimeoutS) * time.Second
+	}
+	return substream.NewManager(cfg)
+}
+
+func subIdleTimeoutS(cfg *config.Config) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Server.SubStream.IdleTimeoutS
+}
+
+func subReadyTimeoutS(cfg *config.Config) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Server.SubStream.ReadyTimeoutS
+}

--- a/internal/camera/substream_test.go
+++ b/internal/camera/substream_test.go
@@ -1,0 +1,98 @@
+package camera
+
+// Tests for the sub-stream target resolver (#513): config → pull target for
+// the on-demand substream manager. The ONVIF GetStreamUri branch needs a live
+// device and is exercised on real hardware (M5); here we cover the config
+// matrix that gates it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
+)
+
+func TestResolveSubTarget(t *testing.T) {
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{
+			ID:           "cam-rtsp-sub",
+			Protocol:     "rtsp",
+			URL:          "rtsp://192.168.1.10:554/main",
+			SubStreamURL: "rtsp://192.168.1.10:554/sub",
+			Username:     "admin",
+			Password:     "secret",
+		},
+		{ID: "cam-rtsp-nosub", Protocol: "rtsp", URL: "rtsp://192.168.1.11:554/main"},
+		{
+			ID:              "cam-onvif-token",
+			Protocol:        "onvif",
+			URL:             "http://192.168.1.12/onvif/device_service",
+			SubProfileToken: "profile_2",
+		},
+		{ID: "cam-onvif-manual", Protocol: "onvif", URL: "http://192.168.1.13/onvif/device_service", SubStreamURL: "rtsp://192.168.1.13:554/sub2"},
+		{ID: "cam-onvif-nothing", Protocol: "onvif", URL: "http://192.168.1.14/onvif/device_service"},
+		{ID: "cam-xiaomi", Protocol: "xiaomi"},
+	}}
+	cm := NewCameraManager(cfg, nil, nil, "")
+
+	// rtsp: manual sub URL + credentials pass through.
+	tgt, ok, err := cm.resolveSubTarget(context.Background(), "cam-rtsp-sub")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "rtsp://192.168.1.10:554/sub", tgt.URL)
+	require.Equal(t, "admin", tgt.Username)
+	require.Equal(t, "secret", tgt.Password)
+
+	// rtsp without sub_stream_url: not available.
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-rtsp-nosub")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// onvif with a discovered token but no live device: resolution errors
+	// (surfaced to Acquire as "resolve sub-stream: …", which egress treats as
+	// fallback-to-main — never a hard failure).
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-onvif-token")
+	require.Error(t, err)
+	require.False(t, ok)
+
+	// onvif with manual sub_stream_url wins without touching the device.
+	tgt, ok, err = cm.resolveSubTarget(context.Background(), "cam-onvif-manual")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "rtsp://192.168.1.13:554/sub2", tgt.URL)
+
+	// onvif with neither: not available.
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-onvif-nothing")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// unsupported protocol: not available.
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-xiaomi")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// unknown camera: not available.
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-missing")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// TestSubStreamsAccessors verifies the manager-level surface egress endpoints
+// use: nil-safe when the constructor ran with a nil config (reduced test
+// constructors), ErrNoSubStream for cameras without sub configuration.
+func TestSubStreamsAccessors(t *testing.T) {
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{ID: "cam-1", Protocol: "rtsp", URL: "rtsp://192.168.1.10:554/main"},
+	}}
+	cm := NewCameraManager(cfg, nil, nil, "")
+	require.NotNil(t, cm.SubStreams())
+
+	_, err := cm.AcquireSubStream(context.Background(), "cam-1")
+	require.ErrorIs(t, err, substream.ErrNoSubStream)
+	// Release on a never-acquired camera must not panic.
+	cm.ReleaseSubStream("cam-1")
+	cm.ReleaseSubStream("cam-unknown")
+}

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -124,6 +124,15 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.Server.RTSP.Port == 0 {
 		cfg.Server.RTSP.Port = 8554
 	}
+	// Sub-stream ingest (#513): zero-cost until a quality=sub consumer
+	// arrives; defaults keep an idle session warm briefly so UI grid
+	// close/reopen doesn't churn the camera.
+	if cfg.Server.SubStream.IdleTimeoutS == 0 {
+		cfg.Server.SubStream.IdleTimeoutS = 30
+	}
+	if cfg.Server.SubStream.ReadyTimeoutS == 0 {
+		cfg.Server.SubStream.ReadyTimeoutS = 8
+	}
 	// Storage
 	if strings.TrimSpace(cfg.Storage.RootDir) == "" {
 		cfg.Storage.RootDir = "/var/lib/mibee-nvr"

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -51,6 +51,21 @@ type ServerConfig struct {
 	// rtsp://<host>:<port>/<camera_id> pull URLs that third-party platforms
 	// (Synology Surveillance Station etc.) fill in as camera sources (#499).
 	RTSP RTSPOutputConfig `yaml:"rtsp"`
+	// SubStream tunes the on-demand sub-stream ingest (#513): secondary
+	// profiles are pulled over RTSP only while egress consumers (WS/FLV/HLS
+	// quality=sub) hold references, then torn down after the idle timeout.
+	SubStream SubStreamServerConfig `yaml:"substream"`
+}
+
+// SubStreamServerConfig tunes the on-demand sub-stream puller. All fields
+// optional; zero values fall back to the defaults below.
+type SubStreamServerConfig struct {
+	// IdleTimeoutS: how long a sub-stream with zero consumers keeps its RTSP
+	// session before recycling (default 30).
+	IdleTimeoutS int `yaml:"idle_timeout_s,omitempty"`
+	// ReadyTimeoutS: how long a quality=sub request waits for the pull's
+	// first keyframe before erroring (default 8).
+	ReadyTimeoutS int `yaml:"ready_timeout_s,omitempty"`
 }
 
 // RTSPOutputConfig configures the RTSP output server (PLAY direction only,

--- a/internal/flv/manager.go
+++ b/internal/flv/manager.go
@@ -186,6 +186,54 @@ func (m *Manager) unregisterStream(camID string) {
 	}
 }
 
+// UnregisterStream is the exported teardown for a single stream — used by the
+// sub-stream recycler (#513) to drop a camera's "/sub" entry when the on-demand
+// puller is torn down. Mirrors wsstream.UnregisterStream.
+func (m *Manager) UnregisterStream(camID string) { m.unregisterStream(camID) }
+
+// ActiveHub returns the StreamHub the registered entry is currently
+// subscribed to (nil when the stream is not active).
+func (m *Manager) ActiveHub(camID string) *model.StreamHub {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, ok := m.streams[camID]
+	if !ok {
+		return nil
+	}
+	return entry.hub
+}
+
+// RebindHub re-subscribes an active stream to a new StreamHub. The sub-stream
+// puller (#513) restarts with a FRESH hub after each idle recycle; without a
+// rebind the entry keeps listening to the dead hub and every viewer goes
+// black forever. Mirrors wsstream.Manager.RebindHub.
+func (m *Manager) RebindHub(camID string, hub *model.StreamHub) {
+	if hub == nil {
+		return
+	}
+	m.mu.Lock()
+	entry, ok := m.streams[camID]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	oldHub := entry.hub
+	entry.hub = hub
+	subID := entry.hubSubID
+	m.mu.Unlock()
+
+	if oldHub != nil && subID != "" {
+		oldHub.Unsubscribe(subID)
+	}
+	if hub.Subscribe(subID, func(pts int64, au [][]byte) {
+		m.writeFrame(camID, pts, au)
+	}) != nil {
+		flvLogger.Warn("FLV rebind: hub subscribe failed", "camera_id", camID)
+		return
+	}
+	flvLogger.Info("FLV stream rebound to new StreamHub", "camera_id", camID)
+}
+
 // IsActive returns whether a stream is registered.
 func (m *Manager) IsActive(camID string) bool {
 	m.mu.RLock()

--- a/internal/hls/manager.go
+++ b/internal/hls/manager.go
@@ -65,6 +65,10 @@ type streamEntry struct {
 	lastErrorTime     time.Time
 	backoff           time.Duration
 	observedSegments  map[string]bool
+	// hub is the StreamHub the entry's "hls" consumer is subscribed to.
+	// Set by SubscribeToHub; compared by the sub-stream recycler (#513) to
+	// decide whether this entry still belongs to a recycled pull generation.
+	hub *model.StreamHub
 	// wg tracks the writeLoop + idleWatchdog goroutines so stopStreamLocked
 	// can join them before returning. Without this, the goroutines briefly
 	// outlive the entry (they touch entry.mux / entry.dirPath), leaking
@@ -1092,6 +1096,11 @@ func (m *Manager) StopAll() {
 // destroyed the camera manager's hub-level Prometheus wiring as soon as any
 // HLS subscriber attached.
 func (m *Manager) SubscribeToHub(cameraID string, hub *model.StreamHub, isH265 bool) error {
+	m.mu.Lock()
+	if entry, ok := m.streams[cameraID]; ok {
+		entry.hub = hub
+	}
+	m.mu.Unlock()
 	if m.metrics != nil {
 		hub.AddOnDrop(func(id string, isIDR bool) {
 			if id == "hls" {
@@ -1107,6 +1116,46 @@ func (m *Manager) SubscribeToHub(cameraID string, hub *model.StreamHub, isH265 b
 	return hub.Subscribe("hls", func(pts int64, au [][]byte) {
 		_ = m.WriteH264(cameraID, pts, au)
 	})
+}
+
+// ActiveHub returns the StreamHub the entry's "hls" consumer is currently
+// subscribed to (nil when the stream is not active). The sub-stream recycler
+// (#513) compares this against the recycled hub to avoid stopping an entry
+// that already rebound to a fresh pull generation.
+func (m *Manager) ActiveHub(cameraID string) *model.StreamHub {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	entry, ok := m.streams[cameraID]
+	if !ok {
+		return nil
+	}
+	return entry.hub
+}
+
+// RebindHub re-subscribes an active HLS entry to a new StreamHub — used when
+// the sub-stream puller restarted with a fresh hub (#513). The muxer's track
+// parameters stay from registration; puller restarts preserve the camera's
+// parameter sets in practice, and the recycle path stops the entry anyway, so
+// the rebind is only a short-window safety net.
+func (m *Manager) RebindHub(cameraID string, hub *model.StreamHub, isH265 bool) {
+	if hub == nil {
+		return
+	}
+	m.mu.RLock()
+	entry, ok := m.streams[cameraID]
+	oldHub := (*model.StreamHub)(nil)
+	if ok {
+		oldHub = entry.hub
+	}
+	m.mu.RUnlock()
+	if !ok || oldHub == hub {
+		return
+	}
+	if oldHub != nil {
+		oldHub.Unsubscribe("hls")
+	}
+	_ = m.SubscribeToHub(cameraID, hub, isH265)
+	hlsLogger.Info("HLS stream rebound to new StreamHub", "camera_id", cameraID)
 }
 
 func (m *Manager) idleWatchdog(ctx context.Context, cameraID string) {

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -174,7 +174,7 @@ func (r *ONVIFRecorder) Start(ctx context.Context) error {
 	// The stream URI's host may lag behind the ONVIF endpoint after a DHCP
 	// reassignment (device still advertises its old IP). Rewrite it to the
 	// known-good endpoint host so the RTSP dial reaches the right address.
-	if fixed := rewriteStaleStreamHost(rtspURL, r.cfg.ONVIFEndpoint); fixed != rtspURL {
+	if fixed := RewriteStaleStreamHost(rtspURL, r.cfg.ONVIFEndpoint); fixed != rtspURL {
 		onvifRecLogger.Info("rewrote stale stream URI host to match ONVIF endpoint",
 			"camera_id", r.cfg.CameraID, "old", rtspURL, "new", fixed)
 		rtspURL = fixed
@@ -453,7 +453,7 @@ func deriveRTSPURL(httpURL string) string {
 	return u.String()
 }
 
-// rewriteStaleStreamHost fixes a GetStreamUri response whose host lags behind
+// RewriteStaleStreamHost fixes a GetStreamUri response whose host lags behind
 // the ONVIF endpoint we are actually connected to. After a DHCP reassignment the
 // camera's GetStreamUri often still returns the OLD IP (e.g. rtsp://192.168.63.200
 // while the ONVIF service is reachable at .199). The library's fixLocalhostURL
@@ -462,7 +462,9 @@ func deriveRTSPURL(httpURL string) string {
 // Port is preserved from the stream URI (RTSP commonly lives on 554, distinct
 // from the ONVIF port). Returns rtspURL unchanged if either URL fails to parse
 // or the hosts already agree.
-func rewriteStaleStreamHost(rtspURL, onvifEndpoint string) string {
+// Exported for the camera manager's sub-stream resolver (#513) — same
+// GetStreamUri staleness applies to secondary-profile URIs.
+func RewriteStaleStreamHost(rtspURL, onvifEndpoint string) string {
 	if rtspURL == "" || onvifEndpoint == "" {
 		return rtspURL
 	}

--- a/internal/recorder/onvif_test.go
+++ b/internal/recorder/onvif_test.go
@@ -802,7 +802,7 @@ func TestRewriteStaleStreamHost(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, rewriteStaleStreamHost(tc.rtspURL, tc.onvifEndpoint))
+			require.Equal(t, tc.want, RewriteStaleStreamHost(tc.rtspURL, tc.onvifEndpoint))
 		})
 	}
 }

--- a/internal/substream/pull.go
+++ b/internal/substream/pull.go
@@ -1,0 +1,313 @@
+package substream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/gortsplib/v5/pkg/format/rtph264"
+	"github.com/bluenviron/gortsplib/v5/pkg/format/rtph265"
+	"github.com/pion/rtp"
+)
+
+// errNoVideo marks an SDP that carries neither H.264 nor H.265 — permanent
+// for this target, the pull gives up instead of retrying.
+var errNoVideo = errors.New("no H.264/H.265 video track in sub-stream SDP")
+
+// sessionGapPTS is the timeline gap (90 kHz units, 1s) inserted between RTP
+// sessions when rebasing timestamps, so a reconnect never emits a backwards
+// or collapsing timestamp (see pullOnce).
+const sessionGapPTS = 90000
+
+// pull runs the reconnect loop for one source until the entry is cancelled.
+// Exits when ctx is done, or after a permanent failure (leaving the source in
+// StateFailed and scheduling a self-recycle so a later Acquire re-resolves
+// the target from scratch instead of erroring forever).
+func (m *Manager) pull(ctx context.Context, e *entry) {
+	defer close(e.done)
+
+	cameraID := e.src.cameraID
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := m.pullOnce(ctx, e, &backoff)
+		if ctx.Err() != nil {
+			return
+		}
+		if errors.Is(err, errNoVideo) {
+			e.src.state.Store(StateFailed)
+			subLogger.Error("sub-stream pull failed permanently", "camera_id", cameraID, "error", err)
+			go func() {
+				select {
+				case <-ctx.Done():
+				case <-time.After(m.cfg.IdleTimeout):
+				}
+				m.recycle(cameraID, "failed")
+			}()
+			return
+		}
+		e.src.state.Store(StateReconnecting)
+		subLogger.Warn("sub-stream pull error, reconnecting", "camera_id", cameraID,
+			"error", err, "backoff", backoff.String())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > 5*time.Second {
+			backoff = 5 * time.Second
+		}
+	}
+}
+
+// pullOnce dials the target, plays the video track, and blocks until the
+// session fails, stalls, or ctx is done. backoff is reset once the session
+// reaches PLAY.
+//
+// RTP timestamps are per-session random bases; downstream muxers
+// (FLV/HLS/WS) require a monotonic timeline, so each session is REBASED to
+// continue 1s after the previous session's high-water mark (entry.lastPTS —
+// same failure class as #506's dts collapse otherwise).
+func (m *Manager) pullOnce(ctx context.Context, e *entry, backoff *time.Duration) error {
+	rawURL := e.target.URL
+	if e.target.Username != "" {
+		rawURL = injectCredentials(rawURL, e.target.Username, e.target.Password)
+	}
+	u, err := base.ParseURL(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid sub-stream URL: %w", err)
+	}
+
+	tcp := gortsplib.ProtocolTCP
+	client := &gortsplib.Client{
+		Scheme:      u.Scheme,
+		Host:        u.Host,
+		Protocol:    &tcp,
+		ReadTimeout: m.cfg.DialTimeout,
+		// Keep writes lenient: slow cameras with large IDRs can exceed the
+		// dial budget on the RTCP feedback path.
+		WriteTimeout: m.cfg.DialTimeout * 2,
+	}
+	// gortsplib's Client.Close() dereferences a nil ctxCancel when Start was
+	// never reached (same class as the server-side Close panic fixed in
+	// #524) — every Close goes through this guard. Start's dial is bounded
+	// by ReadTimeout (= DialTimeout) via connOpen's context, so the window
+	// where the guard suppresses a Close cannot hang the session.
+	started := &atomic.Bool{}
+	closeClient := func() {
+		if started.Load() {
+			client.Close()
+		}
+	}
+	defer closeClient()
+
+	// Bound the whole setup sequence regardless of gortsplib's internal
+	// handshake behavior (e.g. a camera that accepts TCP then never answers
+	// DESCRIBE). Closing the client unblocks any in-flight handshake call.
+	setupTimer := time.AfterFunc(m.cfg.DialTimeout*2, closeClient)
+
+	if err = client.Start(); err != nil {
+		setupTimer.Stop()
+		return fmt.Errorf("sub-stream connect: %w", err)
+	}
+	started.Store(true)
+
+	desc, _, err := client.Describe(u)
+	if err != nil {
+		setupTimer.Stop()
+		return fmt.Errorf("sub-stream DESCRIBE: %w", err)
+	}
+
+	var (
+		medi   *description.Media
+		isH265 bool
+		codec  model.Format
+		h264f  *format.H264
+		h265f  *format.H265
+	)
+	if m264 := desc.FindFormat(&h264f); m264 != nil && len(h264f.SPS) > 0 && len(h264f.PPS) > 0 {
+		medi, isH265, codec = m264, false, model.FormatH264
+	} else if m265 := desc.FindFormat(&h265f); m265 != nil && len(h265f.SPS) > 0 && len(h265f.PPS) > 0 {
+		medi, isH265, codec = m265, true, model.FormatH265
+	}
+	if medi == nil {
+		setupTimer.Stop()
+		return errNoVideo
+	}
+
+	// SDP parameter sets make the source READY immediately — egress endpoints
+	// can register players without waiting for an in-band keyframe. In-band
+	// sets refresh the snapshot during the session.
+	if isH265 {
+		e.src.publishParams(codec, h265f.SPS, h265f.PPS, h265f.VPS)
+	} else {
+		e.src.publishParams(codec, h264f.SPS, h264f.PPS, nil)
+	}
+
+	if _, err = client.Setup(desc.BaseURL, medi, 0, 0); err != nil {
+		setupTimer.Stop()
+		return fmt.Errorf("sub-stream SETUP: %w", err)
+	}
+
+	src := e.src
+	src.lastFrameAt.Store(time.Now().UnixNano())
+
+	// Session-local rebase state: the first frame of this session continues
+	// the cross-session timeline (entry.lastPTS, updated atomically below).
+	var tsOffset int64
+	haveOffset := false
+	handleAU := func(au [][]byte, pktTS uint32) {
+		ts := int64(pktTS)
+		if !haveOffset {
+			haveOffset = true
+			if prev := e.lastPTS.Load(); prev > 0 {
+				tsOffset = prev + sessionGapPTS - ts
+			}
+		}
+		pts := ts + tsOffset
+		if minGap := e.lastPTS.Load() + 3600; pts < minGap { // ~40ms floor
+			pts = minGap
+		}
+		e.lastPTS.Store(pts)
+		refreshParamSets(src, codec, au)
+		src.lastFrameAt.Store(time.Now().UnixNano())
+		src.hub.Broadcast(pts, au, nalutil.IsIDR(au, isH265))
+	}
+
+	if isH265 {
+		rtpDec, derr := h265f.CreateDecoder()
+		if derr != nil {
+			setupTimer.Stop()
+			return fmt.Errorf("sub-stream RTP decoder: %w", derr)
+		}
+		client.OnPacketRTP(medi, h265f, func(pkt *rtp.Packet) {
+			if ctx.Err() != nil {
+				return
+			}
+			au, decErr := rtpDec.Decode(pkt)
+			if decErr != nil {
+				if !errors.Is(decErr, rtph265.ErrNonStartingPacketAndNoPrevious) &&
+					!errors.Is(decErr, rtph265.ErrMorePacketsNeeded) {
+					subLogger.Warn("sub-stream RTP decode error", "camera_id", src.cameraID, "error", decErr)
+				}
+				return
+			}
+			handleAU(au, pkt.Timestamp)
+		})
+	} else {
+		rtpDec, derr := h264f.CreateDecoder()
+		if derr != nil {
+			setupTimer.Stop()
+			return fmt.Errorf("sub-stream RTP decoder: %w", derr)
+		}
+		client.OnPacketRTP(medi, h264f, func(pkt *rtp.Packet) {
+			if ctx.Err() != nil {
+				return
+			}
+			au, decErr := rtpDec.Decode(pkt)
+			if decErr != nil {
+				if !errors.Is(decErr, rtph264.ErrNonStartingPacketAndNoPrevious) &&
+					!errors.Is(decErr, rtph264.ErrMorePacketsNeeded) {
+					subLogger.Warn("sub-stream RTP decode error", "camera_id", src.cameraID, "error", decErr)
+				}
+				return
+			}
+			handleAU(au, pkt.Timestamp)
+		})
+	}
+
+	if _, err = client.Play(nil); err != nil {
+		setupTimer.Stop()
+		return fmt.Errorf("sub-stream PLAY: %w", err)
+	}
+	setupTimer.Stop()
+	*backoff = time.Second
+	src.state.Store(StateLive)
+	subLogger.Info("sub-stream live", "camera_id", src.cameraID, "codec", string(codec), "url", redactURL(rawURL))
+
+	// Stall watchdog: closing the client forces Wait() to return, which the
+	// reconnect loop turns into a fresh session.
+	watchStop := make(chan struct{})
+	defer close(watchStop)
+	go func() {
+		t := time.NewTicker(m.cfg.FrameStallTimeout / 3)
+		defer t.Stop()
+		for {
+			select {
+			case <-watchStop:
+				return
+			case <-ctx.Done():
+				closeClient()
+				return
+			case <-t.C:
+				if since := time.Since(time.Unix(0, src.lastFrameAt.Load())); since > m.cfg.FrameStallTimeout {
+					subLogger.Warn("sub-stream stalled, reconnecting", "camera_id", src.cameraID,
+						"silent_for", since.Round(time.Second).String())
+					closeClient()
+					return
+				}
+			}
+		}
+	}()
+
+	waitErr := client.Wait()
+	if ctx.Err() != nil {
+		return nil
+	}
+	return waitErr
+}
+
+// refreshParamSets publishes in-band SPS/PPS(/VPS) when they differ from the
+// current snapshot (encoder reconfigured mid-session — resolution change,
+// profile change). AUs are passed through unfiltered, matching main
+// recorders: in-band parameter sets inside IDR AUs reach consumers as-is.
+func refreshParamSets(src *Source, codec model.Format, au [][]byte) {
+	var sps, pps, vps []byte
+	if codec == model.FormatH265 {
+		vps, sps, pps = nalutil.ExtractParamSetsH265(au)
+	} else {
+		sps, pps = nalutil.ExtractParamSetsH264(au)
+	}
+	if len(sps) == 0 || len(pps) == 0 || (codec == model.FormatH265 && len(vps) == 0) {
+		return
+	}
+	cur := src.params.Load()
+	if cur == nil ||
+		!nalutil.EqualParamSets(cur.sps, sps) || !nalutil.EqualParamSets(cur.pps, pps) ||
+		(codec == model.FormatH265 && !nalutil.EqualParamSets(cur.vps, vps)) {
+		src.publishParams(codec, sps, pps, vps)
+	}
+}
+
+// injectCredentials embeds user:pass userinfo into an rtsp:// URL that lacks
+// it. gortsplib answers WWW-Authenticate challenges from the URL userinfo;
+// ONVIF GetStreamUri frequently returns credential-less URIs.
+func injectCredentials(rawURL, user, pass string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User != nil {
+		return rawURL
+	}
+	u.User = url.UserPassword(user, pass)
+	return u.String()
+}
+
+// redactURL strips userinfo for logging.
+func redactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.User == nil {
+		return rawURL
+	}
+	u.User = nil
+	return u.String()
+}

--- a/internal/substream/substream.go
+++ b/internal/substream/substream.go
@@ -1,0 +1,415 @@
+// Package substream implements on-demand secondary-stream (子码流) ingest.
+//
+// A camera's sub stream (lower-resolution H.264/H.265, typically 480p-720p)
+// is pulled over RTSP ONLY while consumers hold references — the pull stops
+// after an idle timeout with zero references, so a camera whose sub stream
+// is never watched costs nothing (#513). Decoded access units fan out through
+// a dedicated model.StreamHub, which egress endpoints (WS/FLV/HLS) consume
+// under the camera's "/sub" stream key.
+package substream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+var (
+	// ErrNoSubStream means the camera has no usable sub-stream configuration
+	// (no sub_stream_url and no discoverable secondary profile). Callers treat
+	// this as "quality negotiation falls back to main".
+	ErrNoSubStream = errors.New("sub-stream not configured for camera")
+
+	// ErrNotReady means a pull was started but no keyframe/parameter sets
+	// arrived within the ready timeout (camera offline or sub stream broken).
+	ErrNotReady = errors.New("sub-stream not ready in time")
+
+	// ErrStopped means the manager is shut down.
+	ErrStopped = errors.New("sub-stream manager stopped")
+)
+
+var subLogger = slog.Default().With("component", "substream")
+
+// Pull states reported by Source.State / Manager.Snapshot.
+const (
+	StateStarting     = "starting"
+	StateLive         = "live"
+	StateReconnecting = "reconnecting"
+	StateFailed       = "failed"
+)
+
+// Target describes where to pull a camera's sub-stream from. Credentials ride
+// separately so the puller can inject them into RTSP URLs that lack userinfo.
+type Target struct {
+	URL      string
+	Username string
+	Password string
+}
+
+// Resolver maps a camera ID to its sub-stream pull target. ok=false means the
+// camera has no sub-stream configuration (→ ErrNoSubStream). The resolver may
+// perform network I/O (ONVIF GetStreamUri); it runs OUTSIDE the manager lock.
+type Resolver func(ctx context.Context, cameraID string) (Target, bool, error)
+
+// Config configures a Manager. Zero durations fall back to defaults.
+type Config struct {
+	Resolver Resolver
+	// IdleTimeout is how long a source with zero references survives before
+	// the puller is stopped (default 30s).
+	IdleTimeout time.Duration
+	// ReadyTimeout bounds how long Acquire waits for the first parameter
+	// sets (default 8s — typical RTSP connect + first keyframe is 1-4s).
+	ReadyTimeout time.Duration
+	// DialTimeout bounds each connect/DESCRIBE/SETUP/PLAY sequence (default
+	// 5s per attempt; retries continue with backoff up to ReadyTimeout).
+	DialTimeout time.Duration
+	// FrameStallTimeout: no frames for this long while live → reconnect
+	// (default 15s, matching the recorder frame watchdog default).
+	FrameStallTimeout time.Duration
+	// WireHub attaches observability callbacks to each created hub (camera
+	// manager wires Prometheus; optional).
+	WireHub func(hub *model.StreamHub, cameraID string)
+}
+
+func (c *Config) normalize() {
+	if c.IdleTimeout <= 0 {
+		c.IdleTimeout = 30 * time.Second
+	}
+	if c.ReadyTimeout <= 0 {
+		c.ReadyTimeout = 8 * time.Second
+	}
+	if c.DialTimeout <= 0 {
+		c.DialTimeout = 5 * time.Second
+	}
+	if c.FrameStallTimeout <= 0 {
+		c.FrameStallTimeout = 15 * time.Second
+	}
+}
+
+// params is the codec parameter snapshot served to egress registration. The
+// SDP provides the initial copy; in-band parameter sets refresh it.
+type params struct {
+	codec model.Format
+	sps   []byte
+	pps   []byte
+	vps   []byte
+}
+
+// Source is a camera's live sub-stream: the fan-out hub plus the codec
+// parameters egress endpoints need to register players.
+type Source struct {
+	cameraID    string
+	hub         *model.StreamHub
+	params      atomic.Pointer[params]
+	ready       chan struct{}
+	readyOne    sync.Once
+	state       atomic.Value // string
+	lastFrameAt atomic.Int64 // unix nano
+}
+
+// CameraID returns the owning camera's ID.
+func (s *Source) CameraID() string { return s.cameraID }
+
+// Hub returns the fan-out hub for this sub-stream.
+func (s *Source) Hub() *model.StreamHub { return s.hub }
+
+// CodecParams returns the current codec parameter snapshot. Before the first
+// keyframe the codec is "" — egress endpoints treat that as "not ready".
+func (s *Source) CodecParams() (codec model.Format, sps, pps, vps []byte) {
+	if p := s.params.Load(); p != nil {
+		return p.codec, p.sps, p.pps, p.vps
+	}
+	return "", nil, nil, nil
+}
+
+// State returns the pull state (StateStarting/StateLive/…).
+func (s *Source) State() string {
+	if v, ok := s.state.Load().(string); ok && v != "" {
+		return v
+	}
+	return StateStarting
+}
+
+func (s *Source) publishParams(codec model.Format, sps, pps, vps []byte) {
+	s.params.Store(&params{codec: codec, sps: sps, pps: pps, vps: vps})
+	s.readyOne.Do(func() { close(s.ready) })
+}
+
+// entry couples a Source with the manager's bookkeeping.
+type entry struct {
+	src    *Source
+	cancel context.CancelFunc
+	done   chan struct{} // closed when the pull goroutine exited
+	target Target
+	refs   int
+	idle   *time.Timer
+	// lastPTS is the cross-session 90 kHz timeline high-water mark (see
+	// pullOnce's rebase logic). Atomic: RTP callbacks and session setup run
+	// on different goroutines across reconnects.
+	lastPTS atomic.Int64
+}
+
+// Manager owns per-camera sub-stream sources with reference counting and
+// idle recycling. All public methods are safe for concurrent use.
+type Manager struct {
+	cfg     Config
+	mu      sync.Mutex
+	sources map[string]*entry
+	stopped bool
+	// onRecycle is invoked (from a manager goroutine) after a source was torn
+	// down for idleness or failure. The hub is passed so the app layer can
+	// unsubscribe protocol consumers the managers cannot reach themselves
+	// (notably HLS's "hls" consumer — the HLS entry does not store its hub).
+	// Set once at wiring time via SetOnRecycle before traffic arrives.
+	onRecycle func(cameraID string, hub *model.StreamHub)
+}
+
+// NewManager creates a Manager. cfg.Resolver is required for Acquire to work.
+func NewManager(cfg Config) *Manager {
+	cfg.normalize()
+	return &Manager{
+		cfg:     cfg,
+		sources: make(map[string]*entry),
+	}
+}
+
+// SetOnRecycle registers the recycle callback (see Manager.onRecycle). Only
+// call during wiring, before the first Acquire.
+func (m *Manager) SetOnRecycle(fn func(cameraID string, hub *model.StreamHub)) {
+	m.mu.Lock()
+	m.onRecycle = fn
+	m.mu.Unlock()
+}
+
+// Acquire returns the camera's sub-stream source, starting the pull if
+// needed, and takes one reference. Each successful Acquire must be balanced
+// by exactly one Release. Acquire blocks until the source has codec
+// parameters (or the ready timeout / caller ctx expires — the pull keeps
+// retrying in the background either way).
+func (m *Manager) Acquire(ctx context.Context, cameraID string) (*Source, error) {
+	if cameraID == "" || m.cfg.Resolver == nil {
+		return nil, ErrNoSubStream
+	}
+
+	m.mu.Lock()
+	if m.stopped {
+		m.mu.Unlock()
+		return nil, ErrStopped
+	}
+	if e := m.sources[cameraID]; e != nil {
+		e.refs++
+		if e.idle != nil {
+			e.idle.Stop()
+			e.idle = nil
+		}
+		m.mu.Unlock()
+		if e.src.State() == StateFailed {
+			m.Release(cameraID)
+			return nil, fmt.Errorf("sub-stream pull failed permanently: %w", ErrNotReady)
+		}
+		if err := m.waitReady(ctx, e); err != nil {
+			m.Release(cameraID)
+			return nil, err
+		}
+		return e.src, nil
+	}
+	m.mu.Unlock()
+
+	// Resolve outside the lock — may perform ONVIF network I/O.
+	target, ok, err := m.cfg.Resolver(ctx, cameraID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sub-stream: %w", err)
+	}
+	if !ok || target.URL == "" {
+		return nil, ErrNoSubStream
+	}
+
+	m.mu.Lock()
+	if m.stopped {
+		m.mu.Unlock()
+		return nil, ErrStopped
+	}
+	if e := m.sources[cameraID]; e != nil {
+		// Another Acquire won the race and started the pull — join it.
+		e.refs++
+		if e.idle != nil {
+			e.idle.Stop()
+			e.idle = nil
+		}
+		m.mu.Unlock()
+		if err := m.waitReady(ctx, e); err != nil {
+			m.Release(cameraID)
+			return nil, err
+		}
+		return e.src, nil
+	}
+
+	src := &Source{
+		cameraID: cameraID,
+		hub:      model.NewStreamHub(),
+		ready:    make(chan struct{}),
+	}
+	src.hub.SetCameraID(cameraID)
+	src.hub.SetSource("substream")
+	if m.cfg.WireHub != nil {
+		m.cfg.WireHub(src.hub, cameraID)
+	}
+	src.state.Store(StateStarting)
+
+	pullCtx, cancel := context.WithCancel(context.Background())
+	e := &entry{src: src, cancel: cancel, done: make(chan struct{}), refs: 1, target: target}
+	m.sources[cameraID] = e
+	m.mu.Unlock()
+
+	go m.pull(pullCtx, e)
+
+	if err := m.waitReady(ctx, e); err != nil {
+		m.Release(cameraID)
+		return nil, err
+	}
+	return src, nil
+}
+
+// waitReady blocks until the source published codec parameters, bounded by
+// the ready timeout and the caller's context. Must be called WITHOUT m.mu.
+func (m *Manager) waitReady(ctx context.Context, e *entry) error {
+	select {
+	case <-e.src.ready:
+		return nil
+	default:
+	}
+	timeout := m.cfg.ReadyTimeout
+	if dl, ok := ctx.Deadline(); ok {
+		if t := time.Until(dl); t < timeout {
+			timeout = t
+		}
+	}
+	select {
+	case <-e.src.ready:
+		return nil
+	case <-e.done:
+		// Puller exited (permanent failure or teardown) without ever
+		// producing parameters.
+		if e.src.params.Load() != nil {
+			return nil
+		}
+		return fmt.Errorf("sub-stream pull exited before first keyframe: %w", ErrNotReady)
+	case <-time.After(timeout):
+		return ErrNotReady
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Release drops one reference. When the count reaches zero an idle timer is
+// armed; if no Acquire arrives before it fires, the puller is stopped and the
+// source deleted (onRecycle then runs).
+func (m *Manager) Release(cameraID string) {
+	m.mu.Lock()
+	e := m.sources[cameraID]
+	if e == nil {
+		m.mu.Unlock()
+		return
+	}
+	if e.refs > 0 {
+		e.refs--
+	}
+	if e.refs > 0 {
+		m.mu.Unlock()
+		return
+	}
+	if e.idle == nil {
+		idle := m.cfg.IdleTimeout
+		e.idle = time.AfterFunc(idle, func() { m.recycle(cameraID, "idle") })
+	}
+	m.mu.Unlock()
+}
+
+// recycle removes the source when it has no references, stops the puller,
+// and fires onRecycle with the (now dead) hub. The teardown itself runs
+// detached so the idle-timer goroutine (or a failing pull's self-cleanup)
+// never blocks on the puller's dial timeout.
+func (m *Manager) recycle(cameraID string, reason string) {
+	m.mu.Lock()
+	e := m.sources[cameraID]
+	if e == nil || e.refs > 0 {
+		// Re-acquired inside the window (timer fired late) — keep it.
+		m.mu.Unlock()
+		return
+	}
+	delete(m.sources, cameraID)
+	if e.idle != nil {
+		e.idle.Stop()
+		e.idle = nil
+	}
+	onRecycle := m.onRecycle
+	m.mu.Unlock()
+
+	subLogger.Info("sub-stream recycled", "camera_id", cameraID, "reason", reason)
+	go func() {
+		e.cancel()
+		<-e.done
+		if onRecycle != nil {
+			onRecycle(cameraID, e.src.hub)
+		}
+	}()
+}
+
+// StopCamera tears the camera's source down immediately (camera removed /
+// stopped / sub config changed). No-op when absent.
+func (m *Manager) StopCamera(cameraID string) {
+	m.recycle(cameraID, "camera")
+}
+
+// Stop tears down every source and prevents new Acquires.
+func (m *Manager) Stop() {
+	m.mu.Lock()
+	m.stopped = true
+	entries := make([]*entry, 0, len(m.sources))
+	for id, e := range m.sources {
+		entries = append(entries, e)
+		delete(m.sources, id)
+	}
+	onRecycle := m.onRecycle
+	m.mu.Unlock()
+
+	for _, e := range entries {
+		e.cancel()
+		<-e.done
+		if onRecycle != nil {
+			onRecycle(e.src.cameraID, e.src.hub)
+		}
+	}
+}
+
+// SourceStatus is the observability snapshot served to the app layer.
+type SourceStatus struct {
+	CameraID    string    `json:"camera_id"`
+	State       string    `json:"state"`
+	Refs        int       `json:"refs"`
+	LastFrameAt time.Time `json:"last_frame_at"`
+	Consumers   int       `json:"consumers"`
+}
+
+// Snapshot returns the status of every active source.
+func (m *Manager) Snapshot() []SourceStatus {
+	m.mu.Lock()
+	out := make([]SourceStatus, 0, len(m.sources))
+	for id, e := range m.sources {
+		out = append(out, SourceStatus{
+			CameraID:    id,
+			State:       e.src.State(),
+			Refs:        e.refs,
+			LastFrameAt: time.Unix(0, e.src.lastFrameAt.Load()),
+			Consumers:   e.src.hub.ConsumerCount(),
+		})
+	}
+	m.mu.Unlock()
+	return out
+}

--- a/internal/substream/substream_test.go
+++ b/internal/substream/substream_test.go
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the on-demand sub-stream puller (#513): Acquire readiness from
+// SDP parameter sets, frame fan-out through the hub, reference counting with
+// idle recycling, permanent-failure handling, and monotonic timestamps
+// across reconnects. The fake camera is a real gortsplib server (same pattern
+// as the RTSP output server tests).
+
+package substream
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// Parameter-set vectors borrowed from the RTSP output server tests (real
+// camera captures — structurally valid SPS/PPS the SDP parser accepts).
+var (
+	tSPS = []byte{0x67, 0x64, 0x00, 0x0c, 0xac, 0x3b, 0x50, 0xb0, 0x4b, 0x42, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x3d, 0x08}
+	tPPS = []byte{0x68, 0xee, 0x3c, 0x80}
+
+	tVPS    = []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0x95, 0x98, 0x09}
+	tSPS265 = []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0xa0, 0x03, 0xc0, 0x80, 0x10, 0xe5, 0x96, 0x66, 0x69, 0x24, 0xca, 0xe0, 0x10, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x03, 0x01, 0xe0, 0x80}
+	tPPS265 = []byte{0x44, 0x01, 0xc1, 0x72, 0xb4, 0x62, 0x40}
+
+	// Slice NALs: contents are opaque to the puller (nalutil only inspects
+	// the type bits).
+	h264IDR = []byte{0x65, 0x88, 0x84, 0x21, 0xa0}
+	h264P   = []byte{0x41, 0x9a, 0x22, 0x10}
+	h265IDR = []byte{0x26, 0x01, 0xaf, 0x08, 0x52}
+	h265P   = []byte{0x02, 0x3a, 0x71, 0xd4}
+)
+
+// rtpEncoder is the subset of the per-codec encoders the source writer needs.
+type rtpEncoder interface {
+	Encode(au [][]byte) ([]*rtp.Packet, error)
+}
+
+// testSource is a gortsplib server playing one video track in a loop.
+type testSource struct {
+	gs       *gortsplib.Server
+	media    *description.Media
+	enc      rtpEncoder
+	idr, pSl []byte
+	sps, pps []byte
+	stop     chan struct{}
+	done     chan struct{}
+	url      string
+	lastConn atomic.Pointer[gortsplib.ServerConn]
+
+	// streamReady gates the writer until the ServerStream exists. The stream
+	// is created lazily on the first DESCRIBE — ServerStream.Initialize
+	// requires the server to be started, and the server runs in a goroutine.
+	streamReady chan struct{}
+	stream      *gortsplib.ServerStream
+	once        sync.Once
+}
+
+func (s *testSource) OnConnOpen(ctx *gortsplib.ServerHandlerOnConnOpenCtx) {
+	s.lastConn.Store(ctx.Conn)
+}
+
+// ensureStream builds the ServerStream on the first request.
+func (s *testSource) ensureStream() {
+	s.once.Do(func() {
+		s.stream = &gortsplib.ServerStream{
+			Server: s.gs,
+			Desc:   &description.Session{Medias: []*description.Media{s.media}},
+		}
+		if err := s.stream.Initialize(); err != nil {
+			panic(err)
+		}
+		close(s.streamReady)
+	})
+}
+
+func (s *testSource) OnDescribe(*gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *testSource) OnSetup(*gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *testSource) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	return &base.Response{StatusCode: base.StatusOK}, nil
+}
+
+// writeLoop alternates IDR (with in-band parameter sets) and P frames at
+// ~40ms cadence — a plausible low-res sub-stream.
+func (s *testSource) writeLoop() {
+	defer close(s.done)
+	select {
+	case <-s.streamReady:
+	case <-s.stop:
+		return
+	}
+	ts := uint32(1600)
+	idr := true
+	for {
+		select {
+		case <-s.stop:
+			return
+		default:
+		}
+		var au [][]byte
+		if idr {
+			au = [][]byte{s.sps, s.pps, s.idr}
+		} else {
+			au = [][]byte{s.pSl}
+		}
+		pkts, err := s.enc.Encode(au)
+		if err == nil {
+			for _, p := range pkts {
+				p.Timestamp = ts
+				_ = s.stream.WritePacketRTP(s.media, p)
+			}
+		}
+		ts += 3600 // 40ms @ 90kHz
+		idr = !idr
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// newTestSource starts an H.264 or H.265 source server on a random local port.
+func newTestSource(t *testing.T, codec model.Format) (*testSource, string) {
+	t.Helper()
+
+	s := &testSource{
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		streamReady: make(chan struct{}),
+	}
+	switch codec {
+	case model.FormatH265:
+		f := &format.H265{PayloadTyp: 96, VPS: tVPS, SPS: tSPS265, PPS: tPPS265}
+		enc, err := f.CreateEncoder()
+		require.NoError(t, err)
+		s.enc, s.idr, s.pSl, s.sps, s.pps = enc, h265IDR, h265P, tSPS265, tPPS265
+		s.media = &description.Media{
+			Type:    description.MediaTypeVideo,
+			Control: "trackID=0",
+			Formats: []format.Format{f},
+		}
+	default:
+		f := &format.H264{PayloadTyp: 96, SPS: tSPS, PPS: tPPS, PacketizationMode: 1}
+		enc, err := f.CreateEncoder()
+		require.NoError(t, err)
+		s.enc, s.idr, s.pSl, s.sps, s.pps = enc, h264IDR, h264P, tSPS, tPPS
+		s.media = &description.Media{
+			Type:    description.MediaTypeVideo,
+			Control: "trackID=0",
+			Formats: []format.Format{f},
+		}
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s.url = "rtsp://" + ln.Addr().String() + "/cam"
+
+	s.gs = &gortsplib.Server{
+		Handler:     s,
+		RTSPAddress: "rtsp://" + ln.Addr().String(),
+	}
+	s.gs.Listen = func(_, _ string) (net.Listener, error) { return ln, nil }
+	// Note: no t.Logf from this goroutine — it can outlive the test, and
+	// touching *testing.T after tRunner returns is a data race.
+	go func() { _ = s.gs.StartAndWait() }()
+	go s.writeLoop()
+	t.Cleanup(func() {
+		close(s.stop)
+		select {
+		case <-s.streamReady:
+			s.stream.Close()
+		default:
+		}
+		<-s.done
+		s.gs.Close()
+	})
+	return s, s.url
+}
+
+// newMJPEGSource serves a video track that carries no H.264/H.265 format —
+// the puller must classify it as a permanent failure (errNoVideo).
+func newMJPEGSource(t *testing.T) string {
+	t.Helper()
+	h := &deadHandler{}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	h.gs = &gortsplib.Server{
+		Handler:     h,
+		RTSPAddress: "rtsp://" + ln.Addr().String(),
+	}
+	h.gs.Listen = func(_, _ string) (net.Listener, error) { return ln, nil }
+	go func() { _ = h.gs.StartAndWait() }()
+	t.Cleanup(func() {
+		h.mu.Lock()
+		stream := h.stream
+		h.mu.Unlock()
+		if stream != nil {
+			stream.Close()
+		}
+		h.gs.Close()
+	})
+	return "rtsp://" + ln.Addr().String() + "/cam"
+}
+
+// deadHandler answers DESCRIBE/SETUP/PLAY with a valid but codec-less session.
+type deadHandler struct {
+	gs     *gortsplib.Server
+	mu     sync.Mutex
+	stream *gortsplib.ServerStream
+}
+
+func (h *deadHandler) ensureStream() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.stream == nil {
+		h.stream = &gortsplib.ServerStream{
+			Server: h.gs,
+			Desc: &description.Session{Medias: []*description.Media{{
+				Type:    description.MediaTypeVideo,
+				Control: "trackID=0",
+				Formats: []format.Format{&format.MJPEG{}},
+			}}},
+		}
+		if err := h.stream.Initialize(); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (h *deadHandler) OnDescribe(*gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	h.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+}
+
+func (h *deadHandler) OnSetup(*gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	h.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+}
+
+func (h *deadHandler) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	return &base.Response{StatusCode: base.StatusOK}, nil
+}
+
+// newTestManager builds a manager resolving every camera to the given URL.
+func newTestManager(t *testing.T, url string, mut func(*Config)) *Manager {
+	t.Helper()
+	cfg := Config{
+		Resolver:          func(context.Context, string) (Target, bool, error) { return Target{URL: url}, true, nil },
+		IdleTimeout:       150 * time.Millisecond,
+		ReadyTimeout:      3 * time.Second,
+		DialTimeout:       2 * time.Second,
+		FrameStallTimeout: 10 * time.Second,
+	}
+	if mut != nil {
+		mut(&cfg)
+	}
+	m := NewManager(cfg)
+	t.Cleanup(m.Stop)
+	return m
+}
+
+// recvFrame subscribes to the hub and returns the first frame matching pred
+// (timeout 5s).
+func recvFrame(t *testing.T, src *Source, pred func(model.FrameMsg) bool) model.FrameMsg {
+	t.Helper()
+	frames := make(chan model.FrameMsg, 64)
+	require.NoError(t, src.Hub().SubscribeMsg("test", func(m model.FrameMsg) {
+		select {
+		case frames <- m:
+		default:
+		}
+	}))
+	t.Cleanup(func() { src.Hub().Unsubscribe("test") })
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case m := <-frames:
+			if pred(m) {
+				return m
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for frame")
+			return model.FrameMsg{}
+		}
+	}
+}
+
+func TestAcquireH264ReadyAndFrames(t *testing.T) {
+	src0, url := newTestSource(t, model.FormatH264)
+	_ = src0
+	m := newTestManager(t, url, nil)
+
+	src, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+	require.NotNil(t, src)
+
+	codec, sps, pps, vps := src.CodecParams()
+	require.Equal(t, model.FormatH264, codec)
+	require.Equal(t, tSPS, sps)
+	require.Equal(t, tPPS, pps)
+	require.Nil(t, vps)
+
+	// IDR reaches hub subscribers (either live or via the hub's IDR replay).
+	mf := recvFrame(t, src, func(m model.FrameMsg) bool { return m.IsKeyframe })
+	require.True(t, len(mf.AU) >= 3, "IDR AU should carry SPS/PPS + slice")
+	require.Eventually(t, func() bool { return src.State() == StateLive }, 3*time.Second, 50*time.Millisecond)
+
+	m.Release("cam-1")
+}
+
+func TestAcquireH265ReadyAndFrames(t *testing.T) {
+	_, url := newTestSource(t, model.FormatH265)
+	m := newTestManager(t, url, nil)
+
+	src, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+
+	codec, sps, pps, vps := src.CodecParams()
+	require.Equal(t, model.FormatH265, codec)
+	require.Equal(t, tSPS265, sps)
+	require.Equal(t, tPPS265, pps)
+	require.Equal(t, tVPS, vps)
+
+	mf := recvFrame(t, src, func(m model.FrameMsg) bool { return m.IsKeyframe })
+	require.NotEmpty(t, mf.AU)
+
+	m.Release("cam-1")
+}
+
+func TestAcquireSharesSourceAcrossConsumers(t *testing.T) {
+	_, url := newTestSource(t, model.FormatH264)
+	m := newTestManager(t, url, nil)
+
+	a, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+	b, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+	require.Same(t, a, b)
+	require.Same(t, a.Hub(), b.Hub())
+
+	// One release keeps the pull alive; the second recycles.
+	m.Release("cam-1")
+	time.Sleep(400 * time.Millisecond) // > 3× idle timeout
+	require.NotEmpty(t, m.Snapshot())  // still there
+
+	recycled := make(chan *model.StreamHub, 1)
+	m.SetOnRecycle(func(id string, hub *model.StreamHub) {
+		if id == "cam-1" {
+			recycled <- hub
+		}
+	})
+	m.Release("cam-1")
+	select {
+	case hub := <-recycled:
+		require.Same(t, a.Hub(), hub)
+	case <-time.After(2 * time.Second):
+		t.Fatal("recycle did not fire after last release")
+	}
+
+	// Next Acquire starts a fresh generation (different hub pointer).
+	c, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+	require.NotSame(t, a.Hub(), c.Hub())
+	m.Release("cam-1")
+}
+
+func TestAcquireNoSubStream(t *testing.T) {
+	m := NewManager(Config{
+		Resolver: func(context.Context, string) (Target, bool, error) { return Target{}, false, nil },
+	})
+	t.Cleanup(m.Stop)
+	_, err := m.Acquire(context.Background(), "cam-1")
+	require.ErrorIs(t, err, ErrNoSubStream)
+}
+
+func TestAcquireDialFailTimesOut(t *testing.T) {
+	// Bind then close: a port that refuses/errs immediately.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close()
+
+	m := newTestManager(t, "rtsp://"+addr+"/cam", func(c *Config) {
+		c.ReadyTimeout = 500 * time.Millisecond
+	})
+	start := time.Now()
+	_, err = m.Acquire(context.Background(), "cam-1")
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 3*time.Second, "Acquire must respect the ready timeout")
+	m.Release("cam-1")
+}
+
+func TestAcquireNoVideoTrackFailsPermanently(t *testing.T) {
+	url := newMJPEGSource(t)
+	m := newTestManager(t, url, nil)
+
+	_, err := m.Acquire(context.Background(), "cam-1")
+	require.Error(t, err)
+}
+
+func TestTimestampsMonotonicAcrossReconnect(t *testing.T) {
+	src0, url := newTestSource(t, model.FormatH264)
+	m := newTestManager(t, url, nil)
+
+	src, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+
+	frames := make(chan model.FrameMsg, 256)
+	require.NoError(t, src.Hub().SubscribeMsg("test", func(mf model.FrameMsg) {
+		select {
+		case frames <- mf:
+		default:
+		}
+	}))
+	t.Cleanup(func() { src.Hub().Unsubscribe("test") })
+
+	lastPTS := int64(0)
+	count := 0
+	deadline := time.After(2 * time.Second)
+	for count < 10 {
+		select {
+		case mf := <-frames:
+			require.Greater(t, mf.PTS, lastPTS, "PTS must be strictly increasing within a session")
+			lastPTS = mf.PTS
+			count++
+		case <-deadline:
+			t.Fatalf("only %d frames before disconnect", count)
+		}
+	}
+
+	// Sever the server side of the connection; the puller must reconnect and
+	// CONTINUE the timeline (rebased +1s, never backwards).
+	conn := src0.lastConn.Load()
+	require.NotNil(t, conn, "source should have seen a connection")
+	conn.Close()
+
+	deadline = time.After(8 * time.Second)
+	post := 0
+	for post < 5 {
+		select {
+		case mf := <-frames:
+			require.Greater(t, mf.PTS, lastPTS, "PTS must continue monotonically after reconnect")
+			lastPTS = mf.PTS
+			post++
+		case <-deadline:
+			t.Fatalf("no frames after reconnect (got %d)", post)
+		}
+	}
+
+	m.Release("cam-1")
+}
+
+func TestInjectCredentialsAndRedact(t *testing.T) {
+	in := injectCredentials("rtsp://192.168.1.10:554/sub", "admin", "secret")
+	require.Equal(t, "rtsp://admin:secret@192.168.1.10:554/sub", in)
+	// Existing userinfo preserved.
+	require.Equal(t, "rtsp://a:b@host/x", injectCredentials("rtsp://a:b@host/x", "admin", "secret"))
+	require.Equal(t, "rtsp://192.168.1.10:554/sub", redactURL(in))
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -494,6 +494,31 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	relayMgr := relay.NewManager(camMgr.GetHub, camMgr.GetSPS)
 	camMgr.SetRelayManager(relayMgr)
 
+	// Step 7.6c: sub-stream recycle callback (#513). When the on-demand
+	// puller for a camera is torn down (idle/failed/camera lifecycle), drop
+	// the egress entries registered under the camera's "/sub" key so stale
+	// entries don't sit subscribed to a dead hub. The hub comparison gates a
+	// race where a new viewer re-acquires and rebinds the entry between the
+	// recycle decision and this callback — an entry already on a FRESH hub
+	// belongs to the new pull generation and must survive. WS/FLV
+	// unregister their own hub consumers; the HLS entry does not track its
+	// hub consumer ID, so it is unsubscribed explicitly here.
+	if subMgr := camMgr.SubStreams(); subMgr != nil {
+		subMgr.SetOnRecycle(func(cameraID string, recycledHub *model.StreamHub) {
+			key := cameraID + "/sub"
+			if wsMgr.ActiveHub(key) == recycledHub {
+				wsMgr.UnregisterStream(key)
+			}
+			if flvMgr != nil && flvMgr.ActiveHub(key) == recycledHub {
+				flvMgr.UnregisterStream(key)
+			}
+			if hlsMgr.ActiveHub(key) == recycledHub {
+				hlsMgr.StopStream(key)
+				recycledHub.Unsubscribe("hls")
+			}
+		})
+	}
+
 	// Wire transcoding dependencies for relay targets (H.265→H.264 transcode).
 	// These must be set before Start so targets can resolve presets and hardware caps.
 	relayFFmpegPath := cfg.Transcoding.FFmpegPath


### PR DESCRIPTION
Closes the core of #513 (phase 2/3).

## What

**On-demand sub-stream puller** — new `internal/substream` package:
- `Manager.Acquire/Release` reference counting; zero references → idle timer (default 30s) → pull torn down. A camera whose sub stream is never watched costs nothing.
- gortsplib TCP pull with capped reconnect backoff, per-session stall watchdog (15s), and permanent-failure classification (SDP without H.264/H.265).
- SDP parameter sets make the source registration-ready immediately; in-band SPS/PPS(/VPS) refresh the snapshot mid-session.
- RTP timestamps are **rebased per session** (+1s gap) so the cross-session timeline stays strictly monotonic — a random new RTP base would otherwise trip every downstream muxer's non-monotonic-dts path (same failure class as #506).

**Target resolution** (camera manager):
- manual `sub_stream_url` (rtsp + onvif protocols) or the auto-discovered `sub_profile_token` (#512) via ONVIF `GetStreamUri`, including DHCP-stale host rewriting (exported `recorder.RewriteStaleStreamHost`).
- camera stop/remove and sub-config changes recycle the pull; `server.substream {idle_timeout_s, ready_timeout_s}` (defaults 30/8).

**Quality negotiation on the existing endpoints**:
- `GET /api/cameras/{id}/stream/ws?quality=sub`
- `GET /api/cameras/{id}/stream.flv?quality=sub`
- `GET /api/cameras/{id}/stream/sub/index.m3u8` (path form — HLS segments resolve relative, a query param would desync playlist/segment entries)
- Entries register under the camera's `"/sub"` key — the WS/FLV/HLS managers are key-agnostic, so viewer caps, GOP cache and idle watchdogs all apply unchanged.
- No usable sub stream → **fallback to main**, `X-Stream-Quality: main|sub` response header reports what was served.
- WHEP rejects `quality=sub` explicitly (v1): WHEP sessions outlive the creating request, so the puller's reference count needs a session-scoped release hook first — tracked in #513 for the follow-up.

**Recycle cleanup**: a callback wired in pkg/app drops stale `"/sub"` entries (WS/FLV unregister, HLS stop + hub consumer unsubscribe). It is gated on the entry's *current* hub matching the recycled hub, so a viewer that re-acquires in the race window keeps its fresh entry. FLV/HLS managers gained `RebindHub`/`ActiveHub` (mirroring wsstream) for the stale-hub recovery; FLV gained an exported `UnregisterStream`.

**Removed**: the legacy implicit "HLS auto-subscribes sub_stream_url" behavior — sub-stream selection is now explicit (`quality=sub` / path form). `hls.Manager.StartSubStreamReader` is kept but no longer called.

## Notes
- Sub hubs carry the camera_id Prometheus labels (frames_in etc. include sub traffic while active — that ingress work is real); `/api/streams` still lists main hubs only, sub sources are visible via logs (`sub-stream live/recycled`) and `Manager.Snapshot()`.
- Sub pulls are video-only (WS audio stays a main-stream feature).
- Full egress path (acquire → register → serve → recycle) is covered by the `internal/substream` round-trip tests against a real gortsplib source server (H.264 + H.265, refcount/recycle, dial-fail timeout, no-video permanent failure, monotonic timestamps across a server-side connection sever). Real-device verification on the M5 box follows this PR.

## Test plan
- [x] `internal/substream`: 8 tests incl. reconnect-timestamp monotonicity — green under `-race`
- [x] `internal/camera` resolver matrix + accessor nil-safety
- [x] `internal/api`: parseQuality / subKey / WHEP+WS+HLS rejection contracts
- [x] Full suites green in WSL: substream, camera, api, flv, hls, config, recorder, pkg/app; gofumpt clean; `go vet` clean
- [ ] M5 on-device: RTSP camera with sub_stream_url → WS/FLV `?quality=sub` + HLS `/stream/sub/index.m3u8` play sub stream; idle recycle observed in journal; fallback header on a camera without sub config