### PR TITLE
fix(xiaomi): quality fallback consecutive semantics + bounded SD→HD recovery (#502)

### DIFF
--- a/internal/api/xiaomi_local.go
+++ b/internal/api/xiaomi_local.go
@@ -113,7 +113,7 @@ func (a *LocalXiaomiAuth) CheckVendor(_ context.Context, did string) (string, er
 		Token:  a.cfg.Xiaomi.Token,
 		Region: a.cfg.Xiaomi.Region,
 	}
-	missURL, err := xiaomi.ResolveMISSURL(cloudCfg, did, "")
+	missURL, _, err := xiaomi.ResolveMISSURL(cloudCfg, did, "")
 	if err != nil {
 		return "", err
 	}

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -23,6 +23,11 @@ const (
 	// activation_state, source}. The frontend subscribes via
 	// /api/events?filter=camera. to refresh its camera list and toast the user.
 	TopicCameraAdded = "camera.added"
+	// TopicCameraQuality is published when a Xiaomi recorder's auto quality
+	// state machine transitions (HD→SD fallback or the bounded SD→HD recovery
+	// probe, issue #502). Payload: map[string]any{camera_id, from, to, reason,
+	// model}. Surfaces via /api/events?filter=camera. like camera.added.
+	TopicCameraQuality = "camera.quality"
 	// TopicGB28181Alarm is published when a GB/T 28181 device pushes an alarm
 	// notification (SUBSCRIBE/NOTIFY Alarm, or a MESSAGE-delivered alarm).
 	// Payload: event.GB28181AlarmEvent. Surfaces via /api/events SSE.

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -253,6 +253,10 @@ const (
 	HealthEventStreamAnomaly      HealthEventType = "stream_anomaly"
 	HealthEventFreezeDetected     HealthEventType = "freeze_detected"
 	HealthEventFreezeRecovered    HealthEventType = "freeze_recovered"
+	// HealthEventQualityChanged marks a Xiaomi auto quality transition
+	// (HD→SD fallback after repeated no-media failures, or the bounded
+	// SD→HD recovery probe). Issue #502.
+	HealthEventQualityChanged HealthEventType = "quality_changed"
 )
 
 // HealthReporter is the interface for reporting health events.

--- a/internal/xiaomi/cloud.go
+++ b/internal/xiaomi/cloud.go
@@ -320,10 +320,14 @@ func GetDeviceList(session *CloudSession) ([]CloudDevice, error) {
 	return raw.List, nil
 }
 
-func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, error) {
+// ResolveMISSURL resolves the miss:// P2P URL for a Xiaomi camera. The second
+// return value is the camera model: the passed-in model when set, otherwise
+// backfilled from the cloud device list (callers can cache it — issue #502:
+// production logs showed model="" because nobody persisted the lookup).
+func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, string, error) {
 	session, err := SignInWithToken(xiaomiCfg.UserID, xiaomiCfg.Token, xiaomiCfg.Region)
 	if err != nil {
-		return "", fmt.Errorf("xiaomi cloud auth: %w", err)
+		return "", model, fmt.Errorf("xiaomi cloud auth: %w", err)
 	}
 
 	// Get device LAN IP from cloud device list.
@@ -344,13 +348,13 @@ func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, err
 	}
 
 	if deviceIP == "" {
-		return "", fmt.Errorf("xiaomi: device %s has no LAN IP (not on local network or offline)", did)
+		return "", model, fmt.Errorf("xiaomi: device %s has no LAN IP (not on local network or offline)", did)
 	}
 
 	// Generate client key pair for key exchange.
 	clientPublic, clientPrivate, err := GenerateKey()
 	if err != nil {
-		return "", fmt.Errorf("generate key: %w", err)
+		return "", model, fmt.Errorf("generate key: %w", err)
 	}
 
 	// Call cloud API to get device's public key and authentication sign.
@@ -380,9 +384,10 @@ func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, err
 		if strings.Contains(err.Error(), "no available vendor") {
 			cloudLogger.Info("legacy TUTK-only camera detected, using devicepass API",
 				"did", did, "model", model)
-			return getLegacyURL(c, did, model, deviceIP, clientPublic, clientPrivate)
+			missURL, legacyErr := getLegacyURL(c, did, model, deviceIP, clientPublic, clientPrivate)
+			return missURL, model, legacyErr
 		}
-		return "", fmt.Errorf("miss_get_vendor API: %w", err)
+		return "", model, fmt.Errorf("miss_get_vendor API: %w", err)
 	}
 
 	var resp struct {
@@ -396,7 +401,7 @@ func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, err
 		Sign      string `json:"sign"`
 	}
 	if err := json.Unmarshal(result, &resp); err != nil {
-		return "", fmt.Errorf("parse miss_get_vendor response: %w", err)
+		return "", model, fmt.Errorf("parse miss_get_vendor response: %w", err)
 	}
 
 	// Map vendor ID to name (CS2=4).
@@ -426,7 +431,7 @@ func ResolveMISSURL(xiaomiCfg XiaomiCloudConfig, did, model string) (string, err
 
 	cloudLogger.Info("resolved xiaomi MISS URL", "did", did, "ip", deviceIP, "vendor", vendorName, "model", model)
 
-	return missURL.String(), nil
+	return missURL.String(), model, nil
 }
 
 // getLegacyURL resolves MISS URL for legacy TUTK-only cameras via the /device/devicepass API.

--- a/internal/xiaomi/plugin.go
+++ b/internal/xiaomi/plugin.go
@@ -63,6 +63,7 @@ func (p *XiaomiPlugin) NewRecorder(cfg config.CameraConfig, store *storage.Manag
 		CloudCfg:          cloudCfg,
 		SegmentDur:        30 * time.Second,
 		DB:                db,
+		HealthDB:          db, // quality-change health events (issue #502)
 		AudioEnabled:      cfg.AudioEnabled,
 		AudioInRecordings: cfg.AudioInRecordings,
 		Channel:           cfg.Channel,

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -99,8 +99,8 @@ type XiaomiRecorderConfig struct {
 	DB                RecordingDB
 	HealthDB          HealthEventWriter // Optional: persists quality-change health events (issue #502)
 	ErrReporter       ErrorReporter     // Optional: reports detailed errors (e.g. TUTK incompatibility)
-	AudioEnabled      bool          // Capture and broadcast audio via StreamHub when true
-	AudioInRecordings bool          // Keep the audio track in recorded segments (default off)
+	AudioEnabled      bool              // Capture and broadcast audio via StreamHub when true
+	AudioInRecordings bool              // Keep the audio track in recorded segments (default off)
 	IdleTimeout       time.Duration
 	Channel           string // Xiaomi dual-lens channel ("" or "0" = main, "1" = secondary)
 	Quality           string // Stream quality: "" or "auto" (HD→SD fallback), "hd", "sd"

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -41,6 +43,13 @@ type RecordingDB interface {
 	InsertRecordingWithRetry(ctx context.Context, r *model.Recording, maxRetries int, backoff time.Duration) error
 }
 
+// HealthEventWriter persists camera health events (camera_health_events
+// table). *storage.DB satisfies it; wired via XiaomiRecorderConfig.HealthDB
+// so quality transitions land in the health event timeline (issue #502).
+type HealthEventWriter interface {
+	InsertHealthEvent(ctx context.Context, event model.HealthEvent) error
+}
+
 // ErrorReporter abstracts camera error reporting to avoid circular imports.
 // CameraManager satisfies this interface.
 type ErrorReporter interface {
@@ -49,7 +58,29 @@ type ErrorReporter interface {
 
 const (
 	defaultSegmentDur = 10 * time.Minute
+
+	// Quality auto-fallback/restore tuning (issue #502).
+	// A connection that streamed at least qualityStableResetWindow before
+	// dying counts as "stable" — it resets the no-media failure sequence, so
+	// three failures spread across stable periods never trigger a downgrade
+	// (defect A: the old counter accumulated across weeks).
+	qualityStableResetWindow = 5 * time.Minute
+	// After a downgrade, an SD connection that streams stably for at least
+	// qualityUpgradeStableWindow earns one probe attempt back at HD
+	// (defect B: quality previously never recovered without a restart).
+	qualityUpgradeStableWindow = 10 * time.Minute
+	// maxQualityUpgradeAttempts bounds the downgrade→upgrade cycle per
+	// recorder lifecycle, preventing a downgrade/upgrade oscillation storm
+	// (the 2K PTZ camera logged 131 SPS changes in one day — the recovery
+	// must not feed that).
+	maxQualityUpgradeAttempts = 2
 )
+
+// errQualityUpgradeProbe is returned by connectAndRecord when a stable SD
+// connection reaches the upgrade window and should be deliberately reconnected
+// at HD (issue #502 defect B). It is a planned reconnect, not a failure —
+// the run loop skips the error metrics/backoff for it.
+var errQualityUpgradeProbe = errors.New("quality upgrade probe")
 
 // XiaomiCloudConfig holds Xiaomi cloud API credentials for URL resolution.
 type XiaomiCloudConfig struct {
@@ -66,7 +97,8 @@ type XiaomiRecorderConfig struct {
 	CloudCfg          XiaomiCloudConfig // Cloud API credentials for MISS URL resolution
 	SegmentDur        time.Duration
 	DB                RecordingDB
-	ErrReporter       ErrorReporter // Optional: reports detailed errors (e.g. TUTK incompatibility)
+	HealthDB          HealthEventWriter // Optional: persists quality-change health events (issue #502)
+	ErrReporter       ErrorReporter     // Optional: reports detailed errors (e.g. TUTK incompatibility)
 	AudioEnabled      bool          // Capture and broadcast audio via StreamHub when true
 	AudioInRecordings bool          // Keep the audio track in recorded segments (default off)
 	IdleTimeout       time.Duration
@@ -122,9 +154,17 @@ type XiaomiRecorder struct {
 	streamStart time.Time        // For PTS rebase (used by forwardHLS)
 
 	currentQuality   string // effective quality for next connectAndRecord attempt
-	noMediaFailCount int    // consecutive "no media data" failures at current quality
+	noMediaFailCount int    // no-media failures since the last stable-streaming window (issue #502: true consecutive semantics)
 	connectFailCount int    // consecutive connect/handshake failures (miss connect i/o timeout etc.)
 	lastMissURL      string // last resolved MISS URL (for error messages naming the unreachable host)
+
+	// Quality state machine (issue #502). Owned by the run goroutine.
+	mediaStart      time.Time // when StartMedia succeeded for the current connection; zero while connecting
+	upgradeAttempts int       // SD→HD probe attempts consumed this recorder lifecycle
+	// Test-overridable tuning (defaults from the consts above).
+	stableResetWindow   time.Duration
+	upgradeStableWindow time.Duration
+	maxUpgradeAttempts  int
 
 	// MISS client reference for external commands (MotorControl, GetDeviceInfo).
 	missClient *MISSClient
@@ -208,10 +248,13 @@ func NewXiaomiRecorder(cfg XiaomiRecorderConfig, store SegmentStore, opts ...*me
 		cfg.IdleTimeout = defaultIdleTimeout
 	}
 	return &XiaomiRecorder{
-		cfg:     cfg,
-		store:   store,
-		metrics: m,
-		status:  model.StatusStopped,
+		cfg:                 cfg,
+		store:               store,
+		metrics:             m,
+		status:              model.StatusStopped,
+		stableResetWindow:   qualityStableResetWindow,
+		upgradeStableWindow: qualityUpgradeStableWindow,
+		maxUpgradeAttempts:  maxQualityUpgradeAttempts,
 	}
 }
 
@@ -451,7 +494,13 @@ func (r *XiaomiRecorder) run(ctx context.Context) {
 		}
 
 		// Resolve xiaomi://deviceID to miss://... URL via cloud API.
-		missURL, err := ResolveMISSURL(r.cfg.CloudCfg, r.cfg.DID, r.cfg.Model)
+		missURL, resolvedModel, err := ResolveMISSURL(r.cfg.CloudCfg, r.cfg.DID, r.cfg.Model)
+		// Backfill the camera model from the cloud device list on first
+		// resolve — CameraConfig has no model field, so without this the
+		// quality/downgrade logs printed model="" (issue #502).
+		if r.cfg.Model == "" && resolvedModel != "" {
+			r.cfg.Model = resolvedModel
+		}
 		if err != nil {
 			if ctx.Err() != nil {
 				return
@@ -482,19 +531,25 @@ func (r *XiaomiRecorder) run(ctx context.Context) {
 			r.recordXiaomiReconnect()
 		}
 
-		// Quality auto-fallback: if "no media data" errors persist at HD, downgrade to SD.
-		// Some models (isa.camera.hlc8) silently refuse HD streaming — go2rtc issue #2114.
-		if err != nil && strings.Contains(err.Error(), "no media data") {
-			r.noMediaFailCount++
-			if r.noMediaFailCount >= 3 && r.currentQuality == "hd" && (r.cfg.Quality == "" || r.cfg.Quality == "auto") {
-				r.currentQuality = "sd"
-				xiaomiLogger.Warn("auto-downgrading quality HD→SD after repeated no-media failures",
-					"camera_id", r.cfg.CameraID, "failures", r.noMediaFailCount, "model", r.cfg.Model)
-				r.noMediaFailCount = 0
-			}
-		} else if connected {
-			r.noMediaFailCount = 0
+		// Planned SD→HD upgrade probe (issue #502 defect B): a stable SD
+		// connection earned a reconnect at HD. Not a failure — reconnect
+		// immediately, skip the error metrics and backoff below.
+		if errors.Is(err, errQualityUpgradeProbe) {
+			r.currentQuality = "hd"
+			r.upgradeAttempts++
+			r.recordQualityChange("sd", "hd", fmt.Sprintf(
+				"stable SD streaming for %s, probe attempt %d/%d",
+				r.upgradeStableWindow, r.upgradeAttempts, r.maxUpgradeAttempts))
+			r.setStatus(model.StatusReconnecting)
+			continue
 		}
+
+		// Quality auto-fallback: if "no media data" errors persist at HD,
+		// downgrade to SD. Some models (isa.camera.hlc8) silently refuse HD
+		// streaming — go2rtc issue #2114. A connection that streamed stably
+		// before dying resets the failure sequence (issue #502 defect A).
+		streamedStable := !r.mediaStart.IsZero() && time.Since(r.mediaStart) >= r.stableResetWindow
+		r.handleQualityFailure(err, streamedStable)
 		retryCount++
 		// Track persistent connect failures and surface an actionable error to
 		// the user after the threshold (issue #48: "reconnecting" forever with no
@@ -517,8 +572,100 @@ func (r *XiaomiRecorder) run(ctx context.Context) {
 	}
 }
 
+// qualityAuto reports whether the auto HD↔SD state machine is armed (quality
+// unset or "auto"). Explicit "hd"/"sd" pins the quality — no transitions.
+func (r *XiaomiRecorder) qualityAuto() bool {
+	return r.cfg.Quality == "" || r.cfg.Quality == "auto"
+}
+
+// handleQualityFailure updates the no-media failure state after a connection
+// ended with err (issue #502 defect A). streamedStable means the connection
+// streamed at least stableResetWindow before dying — that counts as a stable
+// period and resets the failure sequence, so three failures separated by
+// stable periods never trigger a downgrade. Only failures WITHOUT a stable
+// period between them (rapid reconnect cycles) accumulate to the threshold.
+func (r *XiaomiRecorder) handleQualityFailure(err error, streamedStable bool) {
+	if streamedStable {
+		r.noMediaFailCount = 0
+	}
+	if err == nil || !strings.Contains(err.Error(), "no media data") {
+		return
+	}
+	r.noMediaFailCount++
+	if r.noMediaFailCount < 3 || r.currentQuality != "hd" || !r.qualityAuto() {
+		return
+	}
+	r.currentQuality = "sd"
+	r.noMediaFailCount = 0
+	r.recordQualityChange("hd", "sd", fmt.Sprintf(
+		"%d consecutive no-media failures without a ≥%s stable window",
+		3, r.stableResetWindow))
+}
+
+// shouldProbeUpgrade reports whether the current SD connection has streamed
+// stably long enough to earn one bounded SD→HD probe attempt (issue #502
+// defect B). Called from the read loop; the probe itself is a deliberate
+// teardown + reconnect at HD, bounded by maxUpgradeAttempts per recorder
+// lifecycle so a camera that refuses HD cannot oscillate forever.
+func (r *XiaomiRecorder) shouldProbeUpgrade(now time.Time) bool {
+	return r.currentQuality == "sd" && r.qualityAuto() &&
+		r.upgradeAttempts < r.maxUpgradeAttempts &&
+		!r.mediaStart.IsZero() &&
+		now.Sub(r.mediaStart) >= r.upgradeStableWindow
+}
+
+// recordQualityChange logs a quality transition and records it in the health
+// event stream — both the camera_health_events table (via HealthDB, wired in
+// plugin.go) and the camera.quality SSE topic (issue #502: the M5 incident
+// showed downgrades were invisible outside grep).
+func (r *XiaomiRecorder) recordQualityChange(from, to, reason string) {
+	cameraModel := r.cfg.Model
+	if cameraModel == "" {
+		cameraModel = r.cfg.DID
+	}
+	if to == "sd" {
+		xiaomiLogger.Warn("auto-downgrading quality HD→SD after repeated no-media failures",
+			"camera_id", r.cfg.CameraID, "reason", reason, "model", cameraModel)
+	} else {
+		xiaomiLogger.Info("auto-upgrading quality SD→HD after stable streaming",
+			"camera_id", r.cfg.CameraID, "reason", reason, "model", cameraModel)
+	}
+
+	status := model.HealthStatusHealthy
+	if to == "sd" {
+		status = model.HealthStatusWarning
+	}
+	meta, _ := json.Marshal(map[string]string{"from": from, "to": to, "model": cameraModel})
+	if r.cfg.HealthDB != nil {
+		evt := model.HealthEvent{
+			CameraID:  r.cfg.CameraID,
+			EventType: string(model.HealthEventQualityChanged),
+			Status:    string(status),
+			Message:   fmt.Sprintf("stream quality %s→%s: %s", from, to, reason),
+			Metadata:  string(meta),
+			CreatedAt: time.Now(),
+		}
+		if err := r.cfg.HealthDB.InsertHealthEvent(context.Background(), evt); err != nil {
+			xiaomiLogger.Warn("failed to record quality-change health event",
+				"camera_id", r.cfg.CameraID, "error", err)
+		}
+	}
+	if r.cfg.EventBus != nil {
+		r.cfg.EventBus.Publish(context.Background(), event.TopicCameraQuality, map[string]any{
+			"camera_id": r.cfg.CameraID,
+			"from":      from,
+			"to":        to,
+			"reason":    reason,
+			"model":     cameraModel,
+		})
+	}
+}
+
 // connectAndRecord connects to the Xiaomi camera, starts media, and records packets.
 func (r *XiaomiRecorder) connectAndRecord(ctx context.Context, missURL string) (error, bool) {
+	// Zero until StartMedia succeeds — a failed connect must not inherit the
+	// previous connection's stable-streaming window (issue #502).
+	r.mediaStart = time.Time{}
 	client, err := NewMISSClient(missURL, r.cfg.IdleTimeout)
 	if err != nil {
 		return fmt.Errorf("miss connect: %w", err), false
@@ -542,6 +689,10 @@ func (r *XiaomiRecorder) connectAndRecord(ctx context.Context, missURL string) (
 	defer func() {
 		_ = client.StopMedia()
 	}()
+
+	// Media confirmed flowing — the stable-streaming window for the quality
+	// state machine starts here (issue #502).
+	r.mediaStart = time.Now()
 
 	r.setStatus(model.StatusRecording)
 	// Clear any previously-reported connect-failure detail now that we're live.
@@ -583,6 +734,14 @@ func (r *XiaomiRecorder) connectAndRecord(ctx context.Context, missURL string) (
 		if err != nil {
 			r.closeCurrentSegment()
 			return fmt.Errorf("miss read: %w", err), false
+		}
+
+		// SD→HD upgrade probe (issue #502 defect B): a healthy SD connection
+		// never disconnects on its own, so the recovery must tear it down
+		// deliberately once the stable window has been earned.
+		if r.shouldProbeUpgrade(time.Now()) {
+			r.closeCurrentSegment()
+			return errQualityUpgradeProbe, true
 		}
 
 		// Handle audio packets when AudioEnabled.

--- a/internal/xiaomi/recorder_quality_test.go
+++ b/internal/xiaomi/recorder_quality_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+//
+// Quality auto-fallback/restore state machine tests (issue #502):
+//   - defect A: no-media failures separated by stable-streaming windows must
+//     NOT accumulate to a downgrade
+//   - defect B: a stable SD connection earns a bounded HD probe; the probe
+//     budget prevents downgrade/upgrade oscillation
+//   - quality transitions land in the health event stream
+
+package xiaomi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// fakeHealthDB captures InsertHealthEvent calls.
+type fakeHealthDB struct {
+	events []model.HealthEvent
+	err    error
+}
+
+func (f *fakeHealthDB) InsertHealthEvent(_ context.Context, e model.HealthEvent) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.events = append(f.events, e)
+	return nil
+}
+
+func makeQualityTestRecorder(t *testing.T) *XiaomiRecorder {
+	t.Helper()
+	r := makeTestRecorder(t)
+	// Shrink the windows so tests reason about time explicitly, not real minutes.
+	r.stableResetWindow = 5 * time.Minute
+	r.upgradeStableWindow = 10 * time.Minute
+	r.maxUpgradeAttempts = 2
+	r.currentQuality = "hd"
+	return r
+}
+
+func noMediaErr() error {
+	return fmt.Errorf("miss read: cs2: no media data for %v", 15*time.Second)
+}
+
+// --- defect A: counter semantics ---
+
+func TestQualityFailuresSeparatedByStableWindowsNeverDowngrade(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+
+	// Three no-media failures, each preceded by a connection that streamed
+	// past the stable window — every failure starts a fresh sequence (count 1).
+	for i := 0; i < 3; i++ {
+		r.handleQualityFailure(noMediaErr(), true)
+		require.Equal(t, 1, r.noMediaFailCount, "iteration %d: counter should reset to 0 then count 1", i)
+	}
+	require.Equal(t, "hd", r.currentQuality, "stable-separated failures must not downgrade")
+}
+
+func TestQualityConsecutiveRapidFailuresDowngrade(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	hdb := &fakeHealthDB{}
+	r.cfg.HealthDB = hdb
+
+	// Three rapid no-media failures (no stable window between them).
+	r.handleQualityFailure(noMediaErr(), false)
+	r.handleQualityFailure(noMediaErr(), false)
+	require.Equal(t, "hd", r.currentQuality)
+	r.handleQualityFailure(noMediaErr(), false)
+
+	require.Equal(t, "sd", r.currentQuality)
+	require.Equal(t, 0, r.noMediaFailCount, "counter resets after the downgrade")
+
+	require.Len(t, hdb.events, 1)
+	evt := hdb.events[0]
+	require.Equal(t, string(model.HealthEventQualityChanged), evt.EventType)
+	require.Equal(t, string(model.HealthStatusWarning), evt.Status)
+	require.Contains(t, evt.Message, "hd→sd")
+
+	var meta map[string]string
+	require.NoError(t, json.Unmarshal([]byte(evt.Metadata), &meta))
+	require.Equal(t, "hd", meta["from"])
+	require.Equal(t, "sd", meta["to"])
+}
+
+func TestQualityDowngradeOnlyInAutoMode(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	r.cfg.Quality = "hd" // pinned — auto fallback disarmed
+
+	for i := 0; i < 5; i++ {
+		r.handleQualityFailure(noMediaErr(), false)
+	}
+	require.Equal(t, "hd", r.currentQuality, "pinned hd must not auto-downgrade")
+}
+
+func TestQualityNonNoMediaFailuresDoNotAccumulate(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+
+	for i := 0; i < 5; i++ {
+		r.handleQualityFailure(errors.New("cs2: EOF"), false)
+	}
+	require.Equal(t, 0, r.noMediaFailCount, "EOF failures are not no-media failures")
+	require.Equal(t, "hd", r.currentQuality)
+}
+
+func TestQualityStableNonNoMediaFailureResetsCounter(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+
+	r.handleQualityFailure(noMediaErr(), false) // count 1
+	require.Equal(t, 1, r.noMediaFailCount)
+	// A long-lived connection dying of EOF resets the sequence.
+	r.handleQualityFailure(errors.New("cs2: EOF"), true)
+	require.Equal(t, 0, r.noMediaFailCount)
+}
+
+// --- defect B: SD→HD recovery probe ---
+
+func TestShouldProbeUpgrade(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	start := time.Now()
+	r.mediaStart = start
+
+	require.False(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow)),
+		"hd quality never probes")
+
+	r.currentQuality = "sd"
+	require.False(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow-time.Second)),
+		"window not yet reached")
+	require.True(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow)),
+		"stable SD past the window probes")
+
+	r.cfg.Quality = "sd" // pinned — auto recovery disarmed
+	require.False(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow)))
+	r.cfg.Quality = ""
+
+	r.upgradeAttempts = r.maxUpgradeAttempts
+	require.False(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow)),
+		"probe budget exhausted")
+
+	r.upgradeAttempts = 0
+	r.mediaStart = time.Time{}
+	require.False(t, r.shouldProbeUpgrade(start.Add(r.upgradeStableWindow)),
+		"never-connected recorder does not probe")
+}
+
+// The probe budget bounds the downgrade→upgrade cycle: after
+// maxUpgradeAttempts failed probes the recorder stays at SD for the rest of
+// its lifecycle instead of oscillating (the 2K PTZ camera's 131 SPS changes
+// in one day show what oscillation costs).
+func TestQualityUpgradeOscillationBounded(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+
+	cycles := 0
+	for {
+		// Simulate the probe path: SD connection stable past the window.
+		r.currentQuality = "sd"
+		r.mediaStart = time.Now().Add(-r.upgradeStableWindow)
+		if !r.shouldProbeUpgrade(time.Now()) {
+			break
+		}
+		r.upgradeAttempts++ // run loop's probe branch consumes the budget
+		r.currentQuality = "hd"
+
+		// HD refuses again: three rapid no-media failures downgrade.
+		r.mediaStart = time.Time{}
+		for i := 0; i < 3; i++ {
+			r.handleQualityFailure(noMediaErr(), false)
+		}
+		require.Equal(t, "sd", r.currentQuality)
+		cycles++
+		require.Less(t, cycles, 10, "oscillation not bounded")
+	}
+
+	require.Equal(t, r.maxUpgradeAttempts, cycles)
+	require.Equal(t, "sd", r.currentQuality, "after the budget is spent, SD sticks")
+}
+
+func TestQualityProbeSentinelIsPlannedNotFailure(t *testing.T) {
+	t.Helper()
+	require.True(t, errors.Is(errQualityUpgradeProbe, errQualityUpgradeProbe))
+	// The sentinel must not match the no-media string check — the run loop
+	// handles it before handleQualityFailure and must never count it.
+	require.NotContains(t, errQualityUpgradeProbe.Error(), "no media data")
+}
+
+// --- health event stream ---
+
+func TestRecordQualityChangeUpgradeIsHealthy(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	r.cfg.Model = "isa.camera.hlc8"
+	hdb := &fakeHealthDB{}
+	r.cfg.HealthDB = hdb
+
+	r.recordQualityChange("sd", "hd", "stable SD streaming for 10m0s, probe attempt 1/2")
+
+	require.Len(t, hdb.events, 1)
+	evt := hdb.events[0]
+	require.Equal(t, "test-cam", evt.CameraID)
+	require.Equal(t, string(model.HealthStatusHealthy), evt.Status)
+	require.Contains(t, evt.Message, "sd→hd")
+
+	var meta map[string]string
+	require.NoError(t, json.Unmarshal([]byte(evt.Metadata), &meta))
+	require.Equal(t, "isa.camera.hlc8", meta["model"])
+}
+
+func TestRecordQualityChangeModelFallsBackToDID(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	hdb := &fakeHealthDB{}
+	r.cfg.HealthDB = hdb
+
+	r.recordQualityChange("hd", "sd", "3 consecutive no-media failures")
+
+	var meta map[string]string
+	require.NoError(t, json.Unmarshal([]byte(hdb.events[0].Metadata), &meta))
+	require.Equal(t, "test-device", meta["model"], "empty model falls back to DID")
+}
+
+func TestRecordQualityChangeDBErrorDoesNotPanic(t *testing.T) {
+	t.Helper()
+	r := makeQualityTestRecorder(t)
+	r.cfg.HealthDB = &fakeHealthDB{err: errors.New("db unavailable")}
+
+	require.NotPanics(t, func() {
+		r.recordQualityChange("hd", "sd", "3 consecutive no-media failures")
+	})
+}

--- a/internal/xiaomi/recorder_quality_test.go
+++ b/internal/xiaomi/recorder_quality_test.go
@@ -59,7 +59,7 @@ func TestQualityFailuresSeparatedByStableWindowsNeverDowngrade(t *testing.T) {
 
 	// Three no-media failures, each preceded by a connection that streamed
 	// past the stable window — every failure starts a fresh sequence (count 1).
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		r.handleQualityFailure(noMediaErr(), true)
 		require.Equal(t, 1, r.noMediaFailCount, "iteration %d: counter should reset to 0 then count 1", i)
 	}
@@ -98,7 +98,7 @@ func TestQualityDowngradeOnlyInAutoMode(t *testing.T) {
 	r := makeQualityTestRecorder(t)
 	r.cfg.Quality = "hd" // pinned — auto fallback disarmed
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		r.handleQualityFailure(noMediaErr(), false)
 	}
 	require.Equal(t, "hd", r.currentQuality, "pinned hd must not auto-downgrade")
@@ -108,7 +108,7 @@ func TestQualityNonNoMediaFailuresDoNotAccumulate(t *testing.T) {
 	t.Helper()
 	r := makeQualityTestRecorder(t)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		r.handleQualityFailure(errors.New("cs2: EOF"), false)
 	}
 	require.Equal(t, 0, r.noMediaFailCount, "EOF failures are not no-media failures")
@@ -178,7 +178,7 @@ func TestQualityUpgradeOscillationBounded(t *testing.T) {
 
 		// HD refuses again: three rapid no-media failures downgrade.
 		r.mediaStart = time.Time{}
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			r.handleQualityFailure(noMediaErr(), false)
 		}
 		require.Equal(t, "sd", r.currentQuality)


### PR DESCRIPTION
## Summary

Fixes both defects from #502 (M5 production: 3 Xiaomi cameras stuck at 640×360 after network blips).

**Defect A — counter accumulated forever**: `noMediaFailCount` never reset (the `else if connected` branch was dead code — `connected` is only true on ctx cancel), so three "no media data" events at ANY interval (even across weeks) triggered HD→SD. Now a connection that streamed ≥5min before dying resets the failure sequence (`handleQualityFailure`); only failures **without** a stable window between them count toward the 3-strike threshold.

**Defect B — no SD→HD recovery**: quality never recovered without a recorder restart. A healthy SD connection now deliberately tears down after 10min stable streaming (`errQualityUpgradeProbe` sentinel in the read loop) and reconnects at HD — a planned reconnect, not a failure (no error metrics, no backoff). Bounded to **2 probe attempts per recorder lifecycle** (`maxQualityUpgradeAttempts`) so an HD-refusing camera cannot oscillate (the 2K PTZ camera's 131 SPS changes/day show the cost of oscillation). Explicit `quality: hd`/`sd` pins stay pinned — the state machine only runs in auto mode.

**Observability**: quality transitions are now recorded to `camera_health_events` (`quality_changed` event type, warning on downgrade / healthy on upgrade, via new `XiaomiRecorderConfig.HealthDB`) and published on the new `camera.quality` SSE topic. Also fixed `model=""` in downgrade logs: `ResolveMISSURL` now returns the camera model (backfilled from the cloud device list) and the recorder caches it — `CameraConfig` has no model field, so it was never populated.

## Test plan

- [x] `TestQualityFailuresSeparatedByStableWindowsNeverDowngrade` — 3 stable-separated no-media events do NOT downgrade (acceptance criterion 1)
- [x] `TestQualityConsecutiveRapidFailuresDowngrade` — 3 rapid failures downgrade + health event with correct fields
- [x] `TestShouldProbeUpgrade` — window/budget/pin/never-connected guards (acceptance criterion 2)
- [x] `TestQualityUpgradeOscillationBounded` — probe budget exhausted → SD sticks (acceptance criterion 3)
- [x] Pinned-quality / EOF-failure / DB-error edge cases
- [x] Full suite: 4982 passed (`TestH264Adaptive_TLExitFlushAfterRotation` in internal/recorder is flaky on main — passes 3/3 on re-run, untouched by this PR)
- [ ] M5 真机观察: 降质后有回升日志、SPS change 频率无异常放大

Closes #502