### PR TITLE
fix(relay): stall watchdog + RTMP write deadline — dead targets reconnect instead of faking streaming (#429)

### DIFF
--- a/internal/relay/engine.go
+++ b/internal/relay/engine.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"runtime"
 	"strings"
@@ -16,6 +17,22 @@ import (
 )
 
 var engineLogger = slog.Default().With("component", "relay-engine")
+
+const (
+	// relayStallAfter is how long a target may report streaming with zero
+	// bytes sent before the connection is declared dead and reconnected
+	// (#429: after the receiver restarted, a target sat in streaming/kbps=0
+	// for hours — write errors were the only failure signal, and with no
+	// frames flowing there are no writes to fail).
+	relayStallAfter = 30 * time.Second
+	// relayStallPoll is the watchdog's sample interval.
+	relayStallPoll = 5 * time.Second
+	// relayWriteTimeout bounds each outbound RTMP write on the custom
+	// publish conn. Without it, a dead peer (receiver restart, silently
+	// dropped NAT state) lets writes block forever once the kernel send
+	// buffer fills (#429).
+	relayWriteTimeout = 10 * time.Second
+)
 
 // PushTargetConfig is the user-facing configuration for one push-out target.
 // Mirrors config.PushTargetConfig but kept local to avoid a config<->relay
@@ -96,6 +113,13 @@ type PushTarget struct {
 	activeDriftMonitor atomic.Pointer[DriftMonitor]
 	latestTemperatureC atomic.Int64
 	restartCount       atomic.Int64
+
+	// Stall watchdog threshold; overridable in tests, defaults to
+	// relayStallAfter (issue #429).
+	stallAfter time.Duration
+	// connectFn is the streaming attempt run under the stall watchdog;
+	// overridden in tests, nil = t.connectAndStream.
+	connectFn func(ctx context.Context) error
 }
 
 // NewPushTarget constructs an idle target. It does not connect until Run.
@@ -106,6 +130,7 @@ func NewPushTarget(cameraID string, cfg PushTargetConfig, hub *model.StreamHub, 
 		hub:         hub,
 		spsProvider: sps,
 		status:      StatusIdle,
+		stallAfter:  relayStallAfter,
 	}
 }
 
@@ -277,7 +302,7 @@ func (t *PushTarget) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		err := t.connectAndStream(ctx)
+		err := t.connectAndStreamWatched(ctx)
 		if ctx.Err() != nil {
 			return
 		}
@@ -291,6 +316,82 @@ func (t *PushTarget) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(bo):
+		}
+	}
+}
+
+// connectAndStreamWatched runs connectAndStream under the stall watchdog
+// (issue #429). Failure detection in the streaming loops is purely
+// write-error driven; when the source stalls or the peer dies without RST
+// there are no writes to fail, so the target sat in status=streaming with
+// kbps=0 for hours. The watchdog cancels the streaming context when no bytes
+// have been sent for stallAfter while the target reports streaming, turning
+// the silent stall into a normal reconnect-with-backoff.
+func (t *PushTarget) connectAndStreamWatched(ctx context.Context) error {
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stalled := make(chan struct{})
+	go t.stallMonitor(streamCtx, stalled, cancel)
+
+	inner := t.connectFn
+	if inner == nil {
+		inner = t.connectAndStream
+	}
+	err := inner(streamCtx)
+	select {
+	case <-stalled:
+		if ctx.Err() == nil {
+			return fmt.Errorf("stream stalled: no bytes sent for %v while streaming (dead target connection or stalled source)", t.stallAfter)
+		}
+	default:
+	}
+	return err
+}
+
+// stallMonitor samples bytesSent every relayStallPoll and cancels the
+// streaming context via cancel once the target has been streaming with a
+// frozen byte counter for stallAfter. The window resets while the target is
+// not yet streaming (connect/handshake phases have their own timeouts).
+// Exactly one of stalled is closed / cancel is called at most once, by this
+// goroutine alone.
+func (t *PushTarget) stallMonitor(ctx context.Context, stalled chan struct{}, cancel context.CancelFunc) {
+	poll := relayStallPoll
+	if t.stallAfter < 2*poll {
+		poll = max(t.stallAfter/2, 50*time.Millisecond)
+	}
+	lastBytes := t.bytesSent.Load()
+	lastChange := time.Now()
+	ticker := time.NewTicker(poll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			t.mu.RLock()
+			st := t.status
+			t.mu.RUnlock()
+			if st != StatusStreaming {
+				// Handshake/connect phase — reset the window.
+				lastBytes = t.bytesSent.Load()
+				lastChange = time.Now()
+				continue
+			}
+			cur := t.bytesSent.Load()
+			if cur != lastBytes {
+				lastBytes = cur
+				lastChange = time.Now()
+				continue
+			}
+			if time.Since(lastChange) >= t.stallAfter {
+				engineLogger.Warn("relay target stalled, forcing reconnect",
+					"camera_id", t.CameraID, "target_id", t.Config.ID,
+					"protocol", t.Config.Protocol, "stalled_for", time.Since(lastChange).Round(time.Second))
+				close(stalled)
+				cancel()
+				return
+			}
 		}
 	}
 }

--- a/internal/relay/rtmp_client.go
+++ b/internal/relay/rtmp_client.go
@@ -137,7 +137,16 @@ func (c *rtmpPublishConn) Write(msg message.Message) error {
 	// or accepted by the companion as Type 1 during handshake.
 	c.wmu.Lock()
 	defer c.wmu.Unlock()
+	c.setWriteDeadline()
 	return c.mrw.Write(msg)
+}
+
+// setWriteDeadline bounds the next outbound write (#429): a dead peer
+// (receiver restart, silently dropped NAT state) never RSTs, so once the
+// kernel send buffer fills a deadline-less write blocks forever and the
+// target wedges in status=streaming with kbps=0.
+func (c *rtmpPublishConn) setWriteDeadline() {
+	_ = c.nconn.SetWriteDeadline(time.Now().Add(relayWriteTimeout))
 }
 
 // buildFullMetadata takes gortmplib's sparse onMetaData payload
@@ -202,6 +211,7 @@ func (c *rtmpPublishConn) buildFullMetadata(orig amf0.Data) amf0.Data {
 func (c *rtmpPublishConn) writeRawMessage(chunkID, msgType byte, timeMS uint32, payload []byte) error {
 	c.wmu.Lock()
 	defer c.wmu.Unlock()
+	c.setWriteDeadline()
 
 	bodyLen := uint32(len(payload))
 	cs := c.chunkSize

--- a/internal/relay/watchdog_test.go
+++ b/internal/relay/watchdog_test.go
@@ -31,13 +31,13 @@ type deadlineRecorder struct {
 	deadlineCalls int
 }
 
-func (d *deadlineRecorder) Write(b []byte) (int, error)         { d.written += len(b); return len(b), nil }
-func (d *deadlineRecorder) Read(_ []byte) (int, error)          { return 0, io.EOF }
-func (d *deadlineRecorder) Close() error                        { return nil }
-func (d *deadlineRecorder) LocalAddr() net.Addr                 { return nil }
-func (d *deadlineRecorder) RemoteAddr() net.Addr                { return nil }
-func (d *deadlineRecorder) SetDeadline(_ time.Time) error       { return nil }
-func (d *deadlineRecorder) SetReadDeadline(_ time.Time) error   { return nil }
+func (d *deadlineRecorder) Write(b []byte) (int, error)       { d.written += len(b); return len(b), nil }
+func (d *deadlineRecorder) Read(_ []byte) (int, error)        { return 0, io.EOF }
+func (d *deadlineRecorder) Close() error                      { return nil }
+func (d *deadlineRecorder) LocalAddr() net.Addr               { return nil }
+func (d *deadlineRecorder) RemoteAddr() net.Addr              { return nil }
+func (d *deadlineRecorder) SetDeadline(_ time.Time) error     { return nil }
+func (d *deadlineRecorder) SetReadDeadline(_ time.Time) error { return nil }
 func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
 	d.deadlineCalls++
 	d.deadlineSet = true

--- a/internal/relay/watchdog_test.go
+++ b/internal/relay/watchdog_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+//
+// Stall watchdog tests (issue #429): a relay target whose receiver restarted
+// reported status=streaming with kbps=0 for hours — write errors were the
+// only failure signal, and with no frames flowing there are no writes to
+// fail. The watchdog turns a frozen byte counter into a forced reconnect,
+// and the RTMP publish conn bounds each write so dead-peer writes fail fast
+// instead of blocking forever on a full kernel send buffer.
+
+package relay
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/bluenviron/gortmplib/pkg/bytecounter"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineRecorder is a net.Conn that records SetWriteDeadline calls and
+// swallows writes.
+type deadlineRecorder struct {
+	written       int
+	deadlineSet   bool
+	lastDeadline  time.Time
+	deadlineCalls int
+}
+
+func (d *deadlineRecorder) Write(b []byte) (int, error)         { d.written += len(b); return len(b), nil }
+func (d *deadlineRecorder) Read(_ []byte) (int, error)          { return 0, io.EOF }
+func (d *deadlineRecorder) Close() error                        { return nil }
+func (d *deadlineRecorder) LocalAddr() net.Addr                 { return nil }
+func (d *deadlineRecorder) RemoteAddr() net.Addr                { return nil }
+func (d *deadlineRecorder) SetDeadline(_ time.Time) error       { return nil }
+func (d *deadlineRecorder) SetReadDeadline(_ time.Time) error   { return nil }
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	d.deadlineCalls++
+	d.deadlineSet = true
+	d.lastDeadline = t
+	return nil
+}
+
+var _ net.Conn = (*deadlineRecorder)(nil)
+
+func newWatchdogTarget(t *testing.T) *PushTarget {
+	t.Helper()
+	target := NewPushTarget("cam-test", PushTargetConfig{
+		ID:       "t1",
+		Protocol: "rtmp",
+		URL:      "rtmp://127.0.0.1:1935/live/key",
+		Enabled:  true,
+	}, &model.StreamHub{}, func() ([]byte, []byte, bool) { return nil, nil, false })
+	require.NotNil(t, target)
+	target.stallAfter = 200 * time.Millisecond
+	return target
+}
+
+// --- stallMonitor semantics ---
+
+func TestStallMonitorDetectsFrozenStream(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	target.setStatus(StatusStreaming, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stalled := make(chan struct{})
+	go target.stallMonitor(ctx, stalled, cancel)
+
+	select {
+	case <-stalled:
+		// watchdog fired — ctx was canceled too
+		require.Error(t, ctx.Err())
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchdog did not fire on a frozen streaming target")
+	}
+}
+
+func TestStallMonitorIgnoresFrozenConnecting(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	// Connecting (handshake) phases have their own timeouts — the watchdog
+	// window must reset while not streaming.
+	target.setStatus(StatusConnecting, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stalled := make(chan struct{})
+	go target.stallMonitor(ctx, stalled, cancel)
+
+	select {
+	case <-stalled:
+		t.Fatal("watchdog fired while target is still connecting")
+	case <-time.After(600 * time.Millisecond):
+		cancel()
+	}
+}
+
+func TestStallMonitorResetsOnByteProgress(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	target.setStatus(StatusStreaming, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stalled := make(chan struct{})
+	go target.stallMonitor(ctx, stalled, cancel)
+
+	// Keep the byte counter moving for longer than stallAfter.
+	deadline := time.Now().Add(700 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		target.bytesSent.Add(1024)
+		time.Sleep(50 * time.Millisecond)
+	}
+	select {
+	case <-stalled:
+		t.Fatal("watchdog fired while bytes are flowing")
+	default:
+		cancel()
+	}
+}
+
+// --- connectAndStreamWatched translation ---
+
+func TestConnectAndStreamWatchedTranslatesStall(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	target.setStatus(StatusStreaming, "")
+
+	// Simulate a streaming loop that only exits on context cancellation and
+	// reports ctx.Err() — the shape of every real connect method's select.
+	target.connectFn = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	err := target.connectAndStreamWatched(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stream stalled")
+	require.Contains(t, err.Error(), "dead target connection")
+}
+
+func TestConnectAndStreamWatchedPassesThroughNormalError(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	sentinel := errors.New("writer: connection reset")
+	target.connectFn = func(context.Context) error { return sentinel }
+
+	err := target.connectAndStreamWatched(context.Background())
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestConnectAndStreamWatchedParentCancelIsNotStall(t *testing.T) {
+	t.Helper()
+	target := newWatchdogTarget(t)
+	target.setStatus(StatusStreaming, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	target.connectFn = func(inner context.Context) error {
+		<-inner.Done()
+		return inner.Err()
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel() // NVR shutdown, not a stall
+	}()
+	err := target.connectAndStreamWatched(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotContains(t, err.Error(), "stream stalled")
+}
+
+// --- RTMP write deadline ---
+
+func TestWriteRawMessageSetsWriteDeadline(t *testing.T) {
+	t.Helper()
+	rec := &deadlineRecorder{}
+	c := &rtmpPublishConn{
+		nconn: rec,
+		bc:    bytecounter.NewReadWriter(rec),
+	}
+	before := time.Now()
+	err := c.writeRawMessage(6, 0x09, 0, []byte{0x10, 0x01, 0, 0, 0, 0xAA})
+	require.NoError(t, err)
+	require.True(t, rec.deadlineSet, "writeRawMessage must set a write deadline")
+	require.GreaterOrEqual(t, rec.lastDeadline, before.Add(relayWriteTimeout-time.Second))
+	require.LessOrEqual(t, rec.lastDeadline, time.Now().Add(relayWriteTimeout+time.Second))
+}
+
+func TestSetWriteDeadlineBounded(t *testing.T) {
+	t.Helper()
+	require.Equal(t, 10*time.Second, relayWriteTimeout, "write timeout changed — update the dead-peer fail-fast budget docs in engine.go")
+}


### PR DESCRIPTION
## Summary

Fixes #429. After the receiving RTMP server restarted, one push target stayed in fake `streaming` state for hours (`kbps:0`, uptime spanning the restart, zero relay error logs — the pushed camera went black on the receiver indefinitely).

**Root cause 1 — no stall detection**: every streaming loop (RTMP direct, RTSP direct, both transcode paths, FFmpeg) detects failure only via **write errors**. When the source stalls (transcoder stops producing, hub delivery freezes) or the peer dies without ever sending RST (silently dropped NAT state), there are no writes to fail — the loop blocks forever on channel receive and the status stays `streaming` with kbps=0.

**Root cause 2 — no write deadline on the custom RTMP publish conn**: `rtmpPublishConn.writeRawMessage` and the standard writer path wrote with no deadline. On a dead peer, writes keep "succeeding" into the kernel send buffer, then block forever once it fills — the callback goroutine wedges and `cbErr` never fires.

## Changes

- `engine.go` — `connectAndStreamWatched()` wraps every streaming attempt with a **stall watchdog** (`stallMonitor`): while `status==streaming`, 30s of frozen `bytesSent` cancels the streaming context → all four paths already select on `ctx.Done()` → deferred conns close (unblocking any stuck writer) → `Run()` reconnects with the normal tiered backoff. The stall is reported as a real error (`stream stalled: … dead target connection or stalled source`), so push-status degrades to `reconnecting` instead of lying.
- `rtmp_client.go` — `setWriteDeadline()` (10s) before every outbound write on the custom publish conn (raw-chunk path + standard writer path), so dead-peer writes fail fast on their own.
- RTSP paths already set `gortsplib` `ReadTimeout`/`WriteTimeout` — untouched.

Watchdog threshold and write timeout are consts (`relayStallAfter` 30s / `relayWriteTimeout` 10s); the threshold is test-overridable via `PushTarget.stallAfter`, and `connectFn` is a test seam for the wrapper.

## Test plan

- [x] `TestStallMonitorDetectsFrozenStream` — frozen bytes + streaming → watchdog fires
- [x] `TestStallMonitorIgnoresFrozenConnecting` — connect/handshake phase resets the window (no false trip during the 15s transcoder-ready wait)
- [x] `TestStallMonitorResetsOnByteProgress` — flowing bytes never trip it
- [x] `TestConnectAndStreamWatchedTranslatesStall` — stall surfaces as the "stream stalled" error
- [x] `TestConnectAndStreamWatchedParentCancelIsNotStall` — NVR shutdown is not misreported as a stall
- [x] `TestWriteRawMessageSetsWriteDeadline` — write path bounds each write
- [x] `go test -race` on the watchdog tests; full relay + api packages pass (762)
- [ ] M5 真机回归: 重启接收端 → 5 个 target 均应在 ~30s 内进入 reconnecting 并恢复

Closes #429