### PR TITLE
fix(auth): hide logout entry under auth.local_bypass (#516)

### DIFF
--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { t } from '$lib/i18n';
   import { withBase } from '$lib/base-path';
-  import { logout, getSettings, getUpdateStatus } from '$lib/api';
+  import { logout, isLocalBypass, getSettings, getUpdateStatus } from '$lib/api';
   import { getMiBeeVisionConnected, refreshMiBeeVisionStatus } from '$lib/mibeevision-status';
   import { getEffectiveTheme } from '$lib/preferences';
   import LanguageSwitcher from './LanguageSwitcher.svelte';
@@ -176,10 +176,15 @@
     <div class="navbar-right">
       <ThemeToggle />
       <LanguageSwitcher />
-      <button class="btn btn-ghost logout-btn" onclick={logout}>
-        <LogOut size={20} />
-        <span>{t('nav.logout')}</span>
-      </button>
+      <!-- #516: under auth.local_bypass the loopback session is not a
+           credential — there is nothing to log out of, and clearing the
+           token just bounces back to the dashboard. Hide the entry. -->
+      {#if !isLocalBypass()}
+        <button class="btn btn-ghost logout-btn" onclick={logout}>
+          <LogOut size={20} />
+          <span>{t('nav.logout')}</span>
+        </button>
+      {/if}
     </div>
   </div>
 </header>

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -193,6 +193,13 @@ export function isAuthenticated(): boolean {
   return getToken() !== null || localBypass;
 }
 
+// Whether the current browser session rides the auth.local_bypass loopback
+// exemption — there is no credential session to log out of, so the UI hides
+// the logout entry in this state (issue #516).
+export function isLocalBypass(): boolean {
+  return localBypass;
+}
+
 // Get the Authorization header value for API calls: "Bearer <session-token>".
 export function getAuthHeader(): string | null {
   const token = getToken();

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -9,6 +9,7 @@ export {
   clearToken,
   getTokenForUrl,
   isAuthenticated,
+  isLocalBypass,
   login,
   logout,
   healthCheck,


### PR DESCRIPTION
## Summary

Follow-up from #453 (tracked in #516). With `auth.local_bypass` enabled, a loopback browser is admitted without credentials — clicking logout cleared the token and bounced straight back to the dashboard (`isAuthenticated() = token || localBypass`), reading as a broken logout.

The loopback exemption is not a credential session, so there is nothing to log out of: the header logout entry is now hidden while `localBypass` is active (option 1 from the issue). Remote/credential sessions are unaffected.

Changes: new `isLocalBypass()` export in `web/src/lib/api/client.ts` (re-exported via `api/index.ts`), `{#if !isLocalBypass()}` guard around the logout button in `Header.svelte`. No backend changes, no new i18n strings.

## Test plan

- [x] `npm test` — 579 passed
- [x] `npm run build` — clean
- [x] prettier check on changed TS files
- [ ] Docker VM 手动验证: 开 `auth.local_bypass` 本机访问无登出按钮、远程访问正常显示

Closes #516