### PR TITLE
docs(camera-guide): replace RTSP relay ASCII chain with mermaid (#479)

### DIFF
--- a/docs/en/camera-guide.md
+++ b/docs/en/camera-guide.md
@@ -979,8 +979,11 @@ The camera card shows a badge with active/total targets (e.g. `↑ 2/2`). In the
 
 The most common use case — sending a camera from one NVR to another across the internet, with NO FFmpeg:
 
-```text
-[Camera] ──RTSP──▶ [NVR-A] ──push-out relay (RTMP)──▶ [NVR-B (push-in ingest)] ──▶ records + live
+```mermaid
+flowchart LR
+    Cam["Camera"] -- RTSP --> A["NVR-A"]
+    A -- "push-out relay (RTMP)" --> B["NVR-B (push-in ingest)"]
+    B --> Out["Records + live"]
 ```
 
 1. On **NVR-B** (the receiver): enable RTMP ingest, add a push-in camera with a stream key (e.g. `front-door-relay`).

--- a/docs/zh/camera-guide.md
+++ b/docs/zh/camera-guide.md
@@ -996,8 +996,11 @@ cameras:
 
 最常见的场景 —— 把摄像头从一台 NVR 送到另一台，跨互联网，**无 FFmpeg**：
 
-```text
-[摄像头] ──RTSP──▶ [NVR-A] ──转推 (RTMP)──▶ [NVR-B (推流接入)] ──▶ 录像 + 直播
+```mermaid
+flowchart LR
+    Cam["摄像头"] -- RTSP --> A["NVR-A"]
+    A -- "转推 (RTMP)" --> B["NVR-B（推流接入）"]
+    B --> Out["录像 + 直播"]
 ```
 
 1. 在 **NVR-B**（接收方）：启用 RTMP 接入，添加一个推流摄像头，设好 stream key（如 `front-door-relay`）。


### PR DESCRIPTION
## Summary

Replaces the last ASCII `text` topology in camera-guide.md (cross-network NVR relay chain, zh L999 / en L982) with a mermaid `flowchart LR` — the website docs center renders mermaid natively (sketch style, theme-adaptive, click-to-zoom). zh/en both converted, en with English node labels as specified in the issue.

After merge: the website needs its `sync-docs` re-run to pick this up (mibeestudio side, per the collaboration boundary an issue will be filed there separately).

Closes #479