### PR TITLE
feat(cs2): control-write failure observability + cmdAck race fix (#503)

### DIFF
--- a/internal/xiaomi/cs2.go
+++ b/internal/xiaomi/cs2.go
@@ -13,11 +13,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 )
+
+var cs2Logger = slog.Default().With("component", "xiaomi-cs2")
 
 // CS2Dial establishes a CS2 P2P connection to a Xiaomi device.
 // transport: "udp" (default), "tcp", or "" (tries both).
@@ -74,8 +77,18 @@ type CS2Conn struct {
 
 	channels [4]*cs2DataChannel
 
-	cmdMu  sync.Mutex
-	cmdAck func()
+	cmdMu sync.Mutex
+	// cmdAck holds the ACK callback for an in-flight UDP WriteCommand.
+	// atomic: the worker goroutine reads/fires it without cmdMu while
+	// WriteCommand stores it under cmdMu (issue #503 race fix).
+	cmdAck atomic.Pointer[func()]
+	// LogKey identifies the peer in control-write failure logs
+	// ("model@host", set by the MISS layer). Empty = fall back to
+	// RemoteAddr. Worker-goroutine only (#503).
+	LogKey string
+	// writeFail counts consecutive control-write failures per frame name.
+	// Worker-goroutine only — no lock needed (#503).
+	writeFail map[string]int
 }
 
 const (
@@ -175,7 +188,7 @@ func (c *CS2Conn) worker() {
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				// TCP: send keepalive ping on each timeout wakeup.
 				if c.isTCP && time.Now().After(keepaliveTS) {
-					_, _ = c.Conn.Write([]byte{cs2Magic, cs2MsgPing, 0, 0})
+					c.writeControl("keepalive-ping", []byte{cs2Magic, cs2MsgPing, 0, 0})
 					keepaliveTS = time.Now().Add(pingInterval)
 				}
 
@@ -204,7 +217,7 @@ func (c *CS2Conn) worker() {
 				// Send PING on data receive, matching official Mi Home app behavior.
 				// Ported from go2rtc: PING sent inside msgDrw handler, throttled to 1s.
 				if now := time.Now(); now.After(keepaliveTS) {
-					_, _ = c.Conn.Write([]byte{cs2Magic, cs2MsgPing, 0, 0})
+					c.writeControl("data-ping", []byte{cs2Magic, cs2MsgPing, 0, 0})
 					keepaliveTS = now.Add(pingInterval)
 				}
 				err = channel.Push(buf[8:n])
@@ -218,7 +231,7 @@ func (c *CS2Conn) worker() {
 				if pushed >= 0 {
 					// For UDP we should send ACK.
 					ack := []byte{cs2Magic, cs2MsgDrwAck, 0, 6, cs2MagicDrw, ch, 0, 1, seqHI, seqLO}
-					_, _ = c.Conn.Write(ack)
+					c.writeControl("drw-ack", ack)
 				}
 			}
 
@@ -230,11 +243,11 @@ func (c *CS2Conn) worker() {
 		case cs2MsgPing:
 			// Camera probes client liveness with PING; we MUST reply PONG or it
 			// tears down the connection after its retry window (~6s). go2rtc parity.
-			_, _ = c.Conn.Write([]byte{cs2Magic, cs2MsgPong, 0, 0})
+			c.writeControl("pong", []byte{cs2Magic, cs2MsgPong, 0, 0})
 		case cs2MsgPong, cs2MsgP2PRdyUDP, cs2MsgP2PRdyTCP, cs2MsgClose, cs2MsgCloseAck: // skip
 		case cs2MsgDrwAck: // only for UDP
-			if c.cmdAck != nil {
-				c.cmdAck()
+			if fn := c.cmdAck.Load(); fn != nil {
+				(*fn)()
 			}
 		default:
 			// unknown message type, silently ignore
@@ -259,6 +272,51 @@ func (c *CS2Conn) setErr(err error) {
 	c.mu.Lock()
 	c.err = err
 	c.mu.Unlock()
+}
+
+// peer returns the log identity for control-write failures: the MISS layer's
+// model@host key when set, else the remote address (#503).
+func (c *CS2Conn) peer() string {
+	if c.LogKey != "" {
+		return c.LogKey
+	}
+	if c.Conn != nil {
+		if addr := c.RemoteAddr(); addr != nil {
+			return addr.String()
+		}
+	}
+	return "unknown-peer"
+}
+
+// writeControl sends an outbound keepalive/ACK control frame (#503). Write
+// failures here were silently dropped — an undelivered PONG is followed ~6s
+// later by the camera tearing down the connection and a dropped DrwAck by
+// camera-side retransmit stalls, so without a log line the ensuing EOF /
+// no-media storms cannot be attributed to our side vs the camera (#167
+// lesson: silent ACK-write drops made the TUTK starvation invisible).
+// A single failure logs at debug (flaky P2P links blip routinely); three or
+// more consecutive failures escalate to warn with the running count, so
+// dead-link evidence survives even at default INFO level.
+//
+// Worker-goroutine only.
+func (c *CS2Conn) writeControl(frame string, b []byte) {
+	if c.writeFail == nil {
+		c.writeFail = make(map[string]int)
+	}
+	if _, err := c.Conn.Write(b); err != nil {
+		c.writeFail[frame]++
+		if c.writeFail[frame] >= 3 {
+			cs2Logger.Warn("cs2: control write failed (consecutive)",
+				"peer", c.peer(), "frame", frame,
+				"consecutive_failures", c.writeFail[frame], "error", err)
+		} else {
+			cs2Logger.Debug("cs2: control write failed",
+				"peer", c.peer(), "frame", frame,
+				"consecutive_failures", c.writeFail[frame], "error", err)
+		}
+		return
+	}
+	c.writeFail[frame] = 0
 }
 
 func (c *CS2Conn) getErr() error {
@@ -320,10 +378,12 @@ func (c *CS2Conn) WriteCommand(cmd uint32, data []byte) error {
 	timeout := time.NewTicker(time.Second)
 	defer timeout.Stop()
 
-	c.cmdAck = func() {
+	fn := func() {
 		repeat.Store(0)
 		timeout.Reset(1)
 	}
+	c.cmdAck.Store(&fn)
+	defer c.cmdAck.Store(nil) // a late DrwAck must not fire a stale callback
 
 	for {
 		if _, err := c.Conn.Write(req); err != nil {

--- a/internal/xiaomi/cs2_write_observability_test.go
+++ b/internal/xiaomi/cs2_write_observability_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+//
+// CS2 outbound control-write observability tests (issue #503): the four
+// silently-dropped writes (keepalive PING, data PING, DrwAck, PONG) now log
+// failures — debug per blip, warn from 3 consecutive — and the cmdAck
+// callback swap is race-free under -race.
+
+package xiaomi
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// failingWriteConn accepts reads but fails every Write.
+type failingWriteConn struct {
+	mockCS2Conn
+	writeErr error
+}
+
+func (f *failingWriteConn) Write(b []byte) (int, error) {
+	return 0, f.writeErr
+}
+
+// captureCS2Logger swaps the package cs2Logger for one writing to buf and
+// restores it on cleanup. Callers must not run parallel tests while active.
+func captureCS2Logger(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	old := cs2Logger
+	cs2Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { cs2Logger = old })
+	return &buf
+}
+
+func TestWriteControlEscalatesAfterConsecutiveFailures(t *testing.T) {
+	t.Helper()
+	buf := captureCS2Logger(t)
+
+	c := &CS2Conn{
+		Conn: &failingWriteConn{writeErr: errors.New("broken pipe")},
+	}
+	c.LogKey = "isa.camera.hlc8@192.168.63.9"
+
+	c.writeControl("pong", []byte{1, 2, 3, 4})
+	require.Contains(t, buf.String(), "level=DEBUG", "first failure logs at debug")
+	require.Contains(t, buf.String(), "frame=pong")
+	require.Contains(t, buf.String(), "consecutive_failures=1")
+	require.Contains(t, buf.String(), "peer=isa.camera.hlc8@192.168.63.9")
+
+	c.writeControl("pong", []byte{1, 2, 3, 4})
+	require.NotContains(t, buf.String(), "level=WARN", "second failure is still debug")
+
+	c.writeControl("pong", []byte{1, 2, 3, 4})
+	require.Contains(t, buf.String(), "level=WARN", "third consecutive failure escalates to warn")
+	require.Contains(t, buf.String(), "consecutive_failures=3")
+}
+
+func TestWriteControlResetsCounterOnSuccess(t *testing.T) {
+	t.Helper()
+	buf := captureCS2Logger(t)
+
+	c := &CS2Conn{Conn: &mockCS2Conn{}}
+
+	// Two failures, then a success, then one failure — the counter must have
+	// reset, so the post-success failure logs consecutive_failures=1 at debug,
+	// not warn.
+	for range 2 {
+		c.Conn = &failingWriteConn{writeErr: errors.New("broken pipe")}
+		c.writeControl("drw-ack", []byte{1})
+	}
+	c.Conn = &mockCS2Conn{}
+	c.writeControl("drw-ack", []byte{1})
+	c.Conn = &failingWriteConn{writeErr: errors.New("broken pipe")}
+	c.writeControl("drw-ack", []byte{1})
+
+	require.NotContains(t, buf.String(), "level=WARN")
+	require.Contains(t, buf.String(), "consecutive_failures=1")
+}
+
+func TestWorkerPongWriteFailureIsLogged(t *testing.T) {
+	t.Helper()
+	buf := captureCS2Logger(t)
+
+	// Camera PING arrives; every outbound Write (the PONG reply) fails, then
+	// the read stream ends and the worker exits.
+	pingPacket := []byte{cs2Magic, cs2MsgPing, 0, 0}
+	mock := &failingWriteConn{
+		writeErr: errors.New("connection refused"),
+	}
+	mock.reads = [][]byte{pingPacket}
+	mock.err = errors.New("read done")
+
+	c := &CS2Conn{
+		Conn:        mock,
+		isTCP:       false,
+		idleTimeout: time.Minute,
+		channels: [4]*cs2DataChannel{
+			newCS2DataChannel(0, 10), nil, newCS2DataChannel(250, 100), nil,
+		},
+		LogKey: "cam-x@10.0.0.1",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.worker()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not exit in time")
+	}
+
+	require.Contains(t, buf.String(), "frame=pong", "undelivered PONG must leave a log line (#503: camera tears down ~6s later)")
+	require.Contains(t, buf.String(), "peer=cam-x@10.0.0.1")
+}
+
+// TestCmdAckAtomicSwap drives concurrent Store/Load of the UDP command-ACK
+// callback — the data race the worker (DrwAck path) vs WriteCommand had
+// before #503 (plain func field under cmdMu, read without any lock).
+func TestCmdAckAtomicSwap(t *testing.T) {
+	t.Helper()
+	c := &CS2Conn{}
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(2)
+	go func() { // WriteCommand side (stores under cmdMu)
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			fn := func() {}
+			c.cmdAck.Store(&fn)
+		}
+	}()
+	go func() { // worker DrwAck side (loads + fires)
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if fn := c.cmdAck.Load(); fn != nil {
+				(*fn)()
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/internal/xiaomi/miss.go
+++ b/internal/xiaomi/miss.go
@@ -141,6 +141,12 @@ func NewMISSClient(rawURL string, idleTimeout time.Duration) (*MISSClient, error
 		return nil, err
 	}
 
+	// Identify the peer in CS2 control-write failure logs ("model@host",
+	// #503) so PONG/DrwAck write errors can be correlated with the camera.
+	if cs2c, ok := conn.(*CS2Conn); ok {
+		cs2c.LogKey = model + "@" + u.Host
+	}
+
 	// 3. Login with credentials.
 	err = missLogin(conn, query.Get("client_public"), query.Get("sign"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #503. The four outbound control writes in the CS2 worker silently dropped errors — the exact blindness pattern that hid TUTK ACK starvation (#167):

| Frame | Consequence of a dropped write |
|---|---|
| keepalive-ping / data-ping | peer judges us idle |
| drw-ack (per-packet, UDP) | camera-side retransmit stall → "camera silent" (M5 8/24: `no media data for 15s` ×40, unattributable) |
| pong | camera tears down the connection ~6s later → unexplained `cs2: EOF` storms |

**Changes**

- `CS2Conn.writeControl()` — each failure logs at **debug** (flaky P2P links blip routinely); **≥3 consecutive failures escalate to warn** with the running count, frame name, and peer identity (`model@host`, set by `NewMISSClient` via the new `LogKey` field — correlates with EOF/no-media events in production logs). Counter resets on success. Worker-goroutine only, no locking added to the hot path.
- **cmdAck data race fixed**: the worker read `c.cmdAck` (DrwAck path) without `cmdMu` while `WriteCommand` wrote it under `cmdMu` — now `atomic.Pointer[func()]`, additionally **cleared on WriteCommand exit** so a late DrwAck cannot fire a stale callback (latent bug beyond the race).
- `model=""` log field already fixed by #530 (ResolveMISSURL model backfill).

## Test plan

- [x] `TestWriteControlEscalatesAfterConsecutiveFailures` — debug → warn at 3, peer/frame/count in output
- [x] `TestWriteControlResetsCounterOnSuccess` — success resets the escalation
- [x] `TestWorkerPongWriteFailureIsLogged` — camera PING + failing socket leaves a PONG log line
- [x] `TestCmdAckAtomicSwap` — concurrent store/load/fire under `-race`
- [x] Full package with race detector: 292 passed
- [ ] M5 生产观察: 下次 EOF/no-media 风暴时日志可自证清白或定位自因

Closes #503