### PR TITLE
fix(spa): reactive sub-stream quality resolution + sw.js hash refresh (#534 follow-up)

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787704187071';
+const CACHE_VERSION = 'mibee-nvr-1787708179954';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787708179954';
+const CACHE_VERSION = 'mibee-nvr-1787708909239';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/lib/player/orchestrator.svelte.ts
+++ b/web/src/lib/player/orchestrator.svelte.ts
@@ -80,6 +80,11 @@ export interface CameraSlot {
   health: HealthState;
   /** True when the chain is pinned by a user override (no auto-adapt). */
   pinned: boolean;
+  /** Sub-stream capability from the last /protocols response (#513). Kept in
+   *  the REACTIVE slot (not `internal`) — H.265 cameras mount their wasm
+   *  player before the response arrives, and a non-reactive read would pin
+   *  the quality resolution to 'main' forever. */
+  sub: SubStreamDetail | null;
 }
 
 /** Callback fired when the active mode for a camera changes (degrade/upgrade). */
@@ -204,6 +209,7 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
       activeIndex: patch.activeIndex ?? prev?.activeIndex ?? 0,
       health: patch.health ?? prev?.health ?? health('ok'),
       pinned: patch.pinned ?? prev?.pinned ?? false,
+      sub: patch.sub ?? prev?.sub ?? null,
     };
     slots = { ...slots, [cameraId]: next };
     return next;
@@ -218,7 +224,7 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
     // now out of range, reset to the head. A pinned override always resets to 0.
     const prev = slots[cameraId];
     let activeIndex = pinned ? 0 : Math.min(prev?.activeIndex ?? 0, Math.max(0, chain.length - 1));
-    setSlot(cameraId, { chain, activeIndex, pinned, health: prev?.health ?? health('ok') }, prev);
+    setSlot(cameraId, { chain, activeIndex, pinned, sub: reg.resp?.sub_stream ?? null, health: prev?.health ?? health('ok') }, prev);
     clearTimers(it);
     it.okSince = null;
     it.cooldowns = {};
@@ -463,9 +469,10 @@ export function createPlayerOrchestrator(): PlayerOrchestrator {
   }
 
   function subStreamDetail(cameraId: string): SubStreamDetail | null {
-    const it = internal.get(cameraId);
-    const sub = it?.lastRegistration.resp?.sub_stream;
-    return sub ?? null;
+    // Read the REACTIVE slot (not the internal registration) — see the
+    // CameraSlot.sub comment: players mount before /protocols resolves and
+    // must re-resolve quality when it lands.
+    return slots[cameraId]?.sub ?? null;
   }
 
   function slot(cameraId: string): CameraSlot | null {


### PR DESCRIPTION
Field fix found during M5 verification of #534:

- **Reactive sub detail**: H.265 cameras mount their wasm player before the /protocols response lands (the no-resp chain already resolves to wasm via the HLS-trap guard). `subStreamDetail()` read the non-reactive internal registration, so `effectiveQuality` stayed pinned to 'main' and grid tiles never requested `quality=sub` (observed live: H80 tile connected to the main WS with the 流畅 toggle on). The sub detail now lives in the reactive `CameraSlot`, so the derived resolution re-runs and the `{#key}` remount reconnects with `?quality=sub`. M5-verified after redeploy: `stream/ws?token=…&quality=sub` → server serves `key=cam-…/sub` from the live sub pull; sub-less cameras stay on main.
- **sw.js**: refresh the tracked hash for the post-merge #534 SPA rebuild.