### PR TITLE
feat(vision): sub-stream analysis layer — per-camera dual-record tier + low-res segment push (#514)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -276,6 +276,17 @@ observability:
 #   push_mode: "notify"                 # "notify" = tell consumer to fetch; "upload" = push video bytes
 #   skip_cameras:                       # Cameras never pushed (e.g. MJPEG/JPEG encodings the
 #     - "cam-mjpeg-0000"                # consumer cannot decode) — saves the upload bandwidth
+#   sub_layer_cameras:                  # Cameras served from the on-demand SUB-stream analysis
+#     - "cam-4k-roof"                   # layer (#514): NVR records their low-res sub stream as
+#                                       # separate short-retention segments (storage root
+#                                       # /sublayer/<camera_id>/, deleted after a successful
+#                                       # push, retention secs bound offline pile-up) and the
+#                                       # consumer receives those instead of the main segments
+#                                       # (X-Layer: sub; X-Recording-Id still maps to the main
+#                                       # recording, so ai_status semantics are unchanged).
+#   sub_layer_segment_secs: 60          # Sub-layer segment duration (default 60)
+#   sub_layer_retention_secs: 7200      # On-disk bound when the consumer is offline (default 2h)
+#   sub_layer_push_interval_secs: 20    # Push sweep cadence — the disk is the queue (default 20)
 
 # Per-device API keys for the external AI consumer (Bearer tokens, "mbv_" prefix).
 # Managed via Settings → Features in the Web UI (generate/revoke, hot-reloaded,

--- a/internal/config/config_vision.go
+++ b/internal/config/config_vision.go
@@ -31,6 +31,28 @@ type VisionConfig struct {
 	// (如 MJPEG/JPEG 编码——视频字节流对其无意义,推送只是白白消耗带宽与 CPU)。
 	// 跳过的段不会推送,也不计入离线补偿重推窗口。
 	SkipCameras []string `yaml:"skip_cameras" json:"skipCameras"`
+
+	// SubLayerCameras 推送子流分析层的相机 ID 列表 (#514)。列表内的相机:
+	//   - NVR 按需拉取其子码流并录制成独立的分析段(不进录像库、不参与合并,
+	//     存放于 <storage.root>/sublayer/<camera_id>/,消费成功即删,保留时长兜底);
+	//   - 推送改走子流段(X-Layer: sub),主流段不再推送——低分辨率段解码成本
+	//     为主流的 1/4~1/16,单个消费者即可覆盖全部高分辨率相机;
+	//   - X-Recording-Id 关联同时段的主流录像 ID,ai_status/ai_processed_at
+	//     语义不变。子流不可用(无配置/拉流失败)期间不推送(不回退主流,避免
+	//     消费者端编码/分辨率抖动)。
+	// 需要 #512 的 sub_profile_token 或手填 sub_stream_url。
+	SubLayerCameras []string `yaml:"sub_layer_cameras" json:"subLayerCameras"`
+
+	// SubLayerSegmentSecs 子流分析段时长(秒),默认 60。
+	SubLayerSegmentSecs int `yaml:"sub_layer_segment_secs" json:"subLayerSegmentSecs"`
+
+	// SubLayerRetentionSecs 子流分析段磁盘保留上限(秒),默认 7200。推送成功
+	// 即删;此值仅兜底(消费者离线/推送失败时防止无限堆积)。
+	SubLayerRetentionSecs int `yaml:"sub_layer_retention_secs" json:"subLayerRetentionSecs"`
+
+	// SubLayerPushIntervalSecs 子流段推送扫描间隔(秒),默认 20。子流段不受
+	// 合并/删除窗口竞争,无需事件驱动——磁盘即队列,扫描推送。
+	SubLayerPushIntervalSecs int `yaml:"sub_layer_push_interval_secs" json:"subLayerPushIntervalSecs"`
 }
 
 // ShouldSkipCamera 报告 camera_id 是否在 SkipCameras 列表中。
@@ -41,4 +63,16 @@ func (v VisionConfig) ShouldSkipCamera(cameraID string) bool {
 		}
 	}
 	return false
+}
+
+// SubLayerCameraSet 返回子流分析层的相机集合(nil/空 → 空 集)。skip_cameras
+// 优先:同时出现在两个列表的相机按 skip 处理(消费者明确拒绝的相机没有分析层)。
+func (v VisionConfig) SubLayerCameraSet() map[string]bool {
+	set := make(map[string]bool, len(v.SubLayerCameras))
+	for _, c := range v.SubLayerCameras {
+		if !v.ShouldSkipCamera(c) {
+			set[c] = true
+		}
+	}
+	return set
 }

--- a/internal/config/config_vision_test.go
+++ b/internal/config/config_vision_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestShouldSkipCamera(t *testing.T) {
 	cfg := VisionConfig{SkipCameras: []string{"cam-a", "cam-b"}}
@@ -14,4 +18,20 @@ func TestShouldSkipCamera(t *testing.T) {
 	if empty.ShouldSkipCamera("cam-a") {
 		t.Fatal("nil/empty list skips nothing")
 	}
+}
+
+// SubLayerCameraSet: skip_cameras wins over sub_layer_cameras — a camera the
+// consumer explicitly rejected must not grow an analysis layer (#514).
+func TestSubLayerCameraSet(t *testing.T) {
+	cfg := VisionConfig{
+		SubLayerCameras: []string{"cam-a", "cam-b", "cam-c"},
+		SkipCameras:     []string{"cam-b"},
+	}
+	set := cfg.SubLayerCameraSet()
+	require.True(t, set["cam-a"])
+	require.True(t, set["cam-c"])
+	require.False(t, set["cam-b"], "skip_cameras must override sub_layer_cameras")
+	require.Len(t, set, 2)
+
+	require.Empty(t, VisionConfig{}.SubLayerCameraSet())
 }

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -56,10 +56,13 @@ type Coordinator struct {
 	runCtx       context.Context // 供恢复回调 goroutine 使用(Start 时设置)
 	pausedSince  time.Time       // 推送暂停窗口起点(mu 保护;零值=未暂停)
 	compensating atomic.Bool     // 补偿重推 single-flight
+	// subLayer 是子码流分析层 (#514)。nil(未接 provider)时整个层停用。
+	subLayer *SubLayerManager
 }
 
-// NewCoordinator 创建推送协调器。db 可为 nil(禁用离线补偿)。
-func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus, db Repusher) *Coordinator {
+// NewCoordinator 创建推送协调器。db 可为 nil(禁用离线补偿);provider 可为
+// nil(禁用子码流分析层)。
+func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus, db Repusher, provider SubLayerProvider) *Coordinator {
 	vcfg := cfg()
 	c := &Coordinator{
 		health:      NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
@@ -71,9 +74,20 @@ func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, e
 			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
 	}
+	if provider != nil {
+		c.subLayer = NewSubLayerManager(provider, cfg, storageRoot, SubLayerDeps{
+			Push:    c.pushSubSegment,
+			Healthy: c.health.IsHealthy,
+		})
+	}
 	// 心跳恢复(不健康→健康)触发离线补偿重推 (#329)。
 	c.health.SetOnRecovery(c.compensateOffline)
 	return c
+}
+
+// SubLayer exposes the sub-layer manager (observability/tests). May be nil.
+func (c *Coordinator) SubLayer() *SubLayerManager {
+	return c.subLayer
 }
 
 // Health 返回 HealthTracker,供 API handler 记录心跳。
@@ -98,9 +112,11 @@ func (c *Coordinator) Start(ctx context.Context) error {
 
 	c.wg.Add(1)
 	go c.eventLoop(ctx)
+	c.subLayer.Start(ctx)
 	slog.Info("vision coordinator started",
 		"push_mode", c.cfg().PushMode,
-		"vision_url", c.cfg().URL)
+		"vision_url", c.cfg().URL,
+		"sub_layer_cameras", len(c.cfg().SubLayerCameras))
 	return nil
 }
 
@@ -109,6 +125,7 @@ func (c *Coordinator) Stop() {
 	if c == nil {
 		return
 	}
+	c.subLayer.Stop()
 	c.mu.Lock()
 	if c.cancelFn != nil {
 		c.cancelFn()
@@ -143,6 +160,11 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	if !vcfg.Enabled || vcfg.URL == "" {
 		return
 	}
+	// Feed the sub-layer's recording-id join regardless of push outcome — a
+	// later sub segment must still map onto the covering main recording.
+	if c.subLayer != nil {
+		c.subLayer.NoteMainSegment(seg.CameraID, seg.RecordingID)
+	}
 	if !c.health.IsHealthy() {
 		c.markPaused()
 		slog.Debug("vision not healthy, skip push",
@@ -167,6 +189,15 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 			"recording_id", seg.RecordingID)
 		return
 	}
+	// 子流分析层相机 (#514):分析输入改由子流段提供(独立目录、磁盘即队
+	// 列),主流段不再推送——低分辨率段的解码成本才能让单消费者覆盖全部
+	// 高分辨率相机。
+	if vcfg.SubLayerCameraSet()[seg.CameraID] {
+		slog.Debug("vision push skipped — camera served by sub layer",
+			"camera_id", seg.CameraID,
+			"recording_id", seg.RecordingID)
+		return
+	}
 
 	// 解析段文件的绝对路径。NVR 的 file_path 已经是绝对路径(/mnt/data/nvr/...)。
 	absPath := seg.FilePath
@@ -174,53 +205,90 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 		absPath = filepath.Join(c.storageRoot(), absPath)
 	}
 
+	c.uploadSegment(ctx, absPath, seg.FileSize, map[string]string{
+		"X-Recording-Id": seg.RecordingID,
+		"X-Camera-Id":    seg.CameraID,
+		"X-Format":       seg.Format,
+		"X-Encoding":     seg.Encoding,
+		"X-Started-At":   seg.StartedAt,
+		"X-Ended-At":     seg.EndedAt,
+		"X-File-Size":    strconv.FormatInt(seg.FileSize, 10),
+	})
+}
+
+// uploadSegment POSTs a segment file's bytes to Vision. Headers carry the
+// metadata (Vision's minimal HTTP parser can't do chunked encoding — Content-
+// Length is set explicitly). Returns true on a 2xx response.
+func (c *Coordinator) uploadSegment(ctx context.Context, absPath string, fileSize int64, hdr map[string]string) bool {
 	file, err := os.Open(absPath)
 	if err != nil {
 		slog.Warn("open segment file for push failed",
 			"error", err,
-			"path", absPath,
-			"recording_id", seg.RecordingID)
-		return
+			"path", absPath)
+		return false
 	}
 	defer file.Close()
 
-	// POST 视频字节流到 Vision。元数据通过 HTTP headers 传递。
-	url := strings.TrimRight(vcfg.URL, "/") + "/vision/segment/upload"
+	url := strings.TrimRight(c.cfg().URL, "/") + "/vision/segment/upload"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, file)
 	if err != nil {
 		slog.Error("create upload request", "error", err)
-		return
+		return false
 	}
 	// 显式设置 Content-Length,避免 Go 使用 chunked encoding(Vision 的极简 HTTP 解析器不支持 chunked)。
-	req.ContentLength = seg.FileSize
+	req.ContentLength = fileSize
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("X-Recording-Id", seg.RecordingID)
-	req.Header.Set("X-Camera-Id", seg.CameraID)
-	req.Header.Set("X-Format", seg.Format)
-	req.Header.Set("X-Encoding", seg.Encoding)
-	req.Header.Set("X-Started-At", seg.StartedAt)
-	req.Header.Set("X-Ended-At", seg.EndedAt)
-	req.Header.Set("X-File-Size", strconv.FormatInt(seg.FileSize, 10))
+	for k, v := range hdr {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
 		slog.Warn("push video to vision failed",
 			"error", err,
-			"recording_id", seg.RecordingID)
-		return
+			"path", filepath.Base(absPath))
+		return false
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		slog.Warn("vision returned non-success status",
 			"status", resp.StatusCode,
-			"recording_id", seg.RecordingID)
-	} else {
-		slog.Info("pushed video to vision",
-			"recording_id", seg.RecordingID,
+			"path", filepath.Base(absPath))
+		return false
+	}
+	slog.Info("pushed video to vision",
+		"camera_id", hdr["X-Camera-Id"],
+		"size_mb", fileSize/1024/1024)
+	return true
+}
+
+// pushSubSegment pushes one sub-layer segment (#514). Same transport/headers
+// as the main layer, plus X-Layer: sub; the recording id already carries the
+// joined MAIN recording so consumer-side dedup and ai_status semantics are
+// unchanged. Returns true when the consumer accepted it (caller deletes).
+func (c *Coordinator) pushSubSegment(ctx context.Context, seg SubSegment) bool {
+	vcfg := c.cfg()
+	if !vcfg.Enabled || vcfg.URL == "" || !c.health.IsHealthy() {
+		return false
+	}
+	ok := c.uploadSegment(ctx, seg.Path, seg.FileSize, map[string]string{
+		"X-Recording-Id": seg.RecordingID,
+		"X-Camera-Id":    seg.CameraID,
+		"X-Format":       seg.Codec,
+		"X-Encoding":     seg.Codec,
+		"X-Started-At":   seg.StartedAt.UTC().Format(time.RFC3339Nano),
+		"X-Ended-At":     seg.EndedAt.UTC().Format(time.RFC3339Nano),
+		"X-File-Size":    strconv.FormatInt(seg.FileSize, 10),
+		"X-Layer":        "sub",
+	})
+	if ok {
+		slog.Info("pushed sub-layer video to vision",
 			"camera_id", seg.CameraID,
+			"recording_id", seg.RecordingID,
 			"size_mb", seg.FileSize/1024/1024)
 	}
+	return ok
 }
 
 // markPaused records the start of a push-pause window (first segment skipped

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -43,6 +43,7 @@ func TestCoordinatorPauseWindowTracking(t *testing.T) {
 		func() string { return t.TempDir() },
 		bus,
 		nil, // no DB → compensation disabled, but pause tracking still runs
+		nil, // no sub-layer provider
 	)
 
 	require.True(t, c.takePausedSince().IsZero(), "no pause before any skip")
@@ -104,6 +105,7 @@ func TestCoordinatorOfflineCompensation(t *testing.T) {
 		func() string { return t.TempDir() },
 		bus,
 		rp,
+		nil, // no sub-layer provider
 	)
 	require.NoError(t, c.Start(context.Background()))
 	t.Cleanup(c.Stop)
@@ -189,6 +191,7 @@ func TestCoordinatorSkipCameras(t *testing.T) {
 		func() string { return t.TempDir() },
 		bus,
 		nil,
+		nil, // no sub-layer provider
 	)
 	require.NoError(t, c.Start(context.Background()))
 	t.Cleanup(c.Stop)
@@ -241,6 +244,7 @@ func TestCoordinatorHeartbeatSkipCameras(t *testing.T) {
 		func() string { return t.TempDir() },
 		bus,
 		nil,
+		nil, // no sub-layer provider
 	)
 	require.NoError(t, c.Start(context.Background()))
 	t.Cleanup(c.Stop)

--- a/internal/vision/sublayer.go
+++ b/internal/vision/sublayer.go
@@ -1,0 +1,748 @@
+package vision
+
+// sublayer.go — 子码流分析层 (#514)。
+//
+// 为 vision.sub_layer_cameras 列表内的相机维护一个独立的低分辨率录像层:
+// 按需拉取子码流(持久引用,复用 #528 的 substream.Manager),按段写成 mp4,
+// 存放于 <storage.root>/sublayer/<camera_id>/。该层:
+//   - 不进录像库(无 recordings 行)、不参与合并/常规清理;
+//   - 生命周期自管: 推送成功即删,磁盘保留时长兜底(消费者离线防堆积);
+//   - 推送走磁盘扫描而非 segment.completed 事件——子流段不与合并/删除窗口
+//     竞争,磁盘本身就是队列。X-Recording-Id 关联同时段的主流录像 ID,
+//     消费端去重与 ai_status 语义与主流层完全一致。
+//
+// 主流让位: Coordinator.handleSegment 对 sub_layer 相机跳过主流段推送,
+// 该相机的分析输入完全来自本层(低分辨率段解码成本为主流的 1/4~1/16)。
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
+)
+
+const (
+	subLayerDir = "sublayer"
+	subLayerTmp = ".tmp"
+
+	defaultSubLayerSegmentSecs   = 60
+	defaultSubLayerRetentionSecs = 7200
+	defaultSubLayerPushInterval  = 20
+	subLayerReconcileInterval    = 15 * time.Second
+	subLayerStatePoll            = 5 * time.Second
+	subLayerReacquireBackoff     = 5 * time.Second
+	subLayerPushPacing           = 100 * time.Millisecond
+	// RTP video clock — the sub-stream hub's pts timeline is 90 kHz ticks
+	// (rebased cross-session by the puller).
+	subLayerTickHz = 90000
+	// Clamp a single sample's duration: the puller's cross-session rebase adds
+	// a 1s gap, and a stalled-then-resumed feed must not produce one giant
+	// frame that dwarfs the segment timeline.
+	subLayerMaxSampleDur = 500 * time.Millisecond
+	subLayerMinSampleDur = time.Millisecond
+)
+
+var subLayerLogger = slog.Default().With("component", "vision-sublayer")
+
+// SubLayerProvider abstracts the camera manager's on-demand sub-stream source
+// (AcquireSubStream/ReleaseSubStream) so the vision package doesn't import the
+// camera package.
+type SubLayerProvider interface {
+	AcquireSubStream(ctx context.Context, cameraID string) (*substream.Source, error)
+	ReleaseSubStream(cameraID string)
+}
+
+// SubSegment describes one finalized sub-layer segment, for the push headers
+// and the on-disk metadata registry.
+type SubSegment struct {
+	CameraID    string
+	Path        string
+	Codec       string // "h264" | "h265"
+	StartedAt   time.Time
+	EndedAt     time.Time
+	FileSize    int64
+	RecordingID string // joined main recording id; "sub-<nano>" when none
+}
+
+// SubLayerDeps are the coordinator-provided behaviors the layer needs.
+type SubLayerDeps struct {
+	// Push attempts one segment upload; true = consumer accepted (file may be
+	// deleted).
+	Push func(ctx context.Context, seg SubSegment) bool
+	// Healthy gates pushing (segments stay on disk, TTL-bounded, and are
+	// pushed on a later sweep once healthy — the disk is the queue).
+	Healthy func() bool
+}
+
+// SubLayerManager owns the per-camera sub-layer recorders plus the reconcile /
+// push / retention loops.
+type SubLayerManager struct {
+	provider    SubLayerProvider
+	cfg         func() config.VisionConfig
+	storageRoot func() string
+	deps        SubLayerDeps
+
+	mu        sync.Mutex
+	recorders map[string]*subLayerRecorder
+	// meta carries finalized-but-unpushed segment info (path → payload). Lost
+	// on restart — the sweep then degrades to filename-derived times and the
+	// consumer sniffs the codec from the MP4 payload anyway.
+	meta map[string]SubSegment
+	// mainIDs: cameraID → latest main recording id (event-fed join).
+	mainIDs map[string]string
+
+	cancelFn context.CancelFunc
+	wg       sync.WaitGroup
+	started  bool
+}
+
+// NewSubLayerManager creates the manager. A nil provider or nil deps disables
+// the layer entirely (Start is a no-op).
+func NewSubLayerManager(provider SubLayerProvider, cfg func() config.VisionConfig, storageRoot func() string, deps SubLayerDeps) *SubLayerManager {
+	return &SubLayerManager{
+		provider:    provider,
+		cfg:         cfg,
+		storageRoot: storageRoot,
+		deps:        deps,
+		recorders:   make(map[string]*subLayerRecorder),
+		meta:        make(map[string]SubSegment),
+		mainIDs:     make(map[string]string),
+	}
+}
+
+// Start launches the reconcile/push/retention loop. Cheap no-op when the layer
+// is disabled or the camera list is empty (the tick re-evaluates config each
+// pass, so cameras can be added at runtime).
+func (m *SubLayerManager) Start(ctx context.Context) {
+	if m == nil || m.provider == nil || m.deps.Push == nil || m.deps.Healthy == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return
+	}
+	m.started = true
+	ctx, m.cancelFn = context.WithCancel(ctx)
+	m.mu.Unlock()
+
+	m.wg.Add(1)
+	go m.loop(ctx)
+	subLayerLogger.Info("vision sub-layer manager started")
+}
+
+// Stop tears down every recorder and the loops.
+func (m *SubLayerManager) Stop() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if m.cancelFn != nil {
+		m.cancelFn()
+	}
+	recorders := make([]*subLayerRecorder, 0, len(m.recorders))
+	for _, r := range m.recorders {
+		recorders = append(recorders, r)
+	}
+	m.mu.Unlock()
+	for _, r := range recorders {
+		r.stop()
+	}
+	m.wg.Wait()
+	m.mu.Lock()
+	m.started = false
+	m.mu.Unlock()
+	subLayerLogger.Info("vision sub-layer manager stopped")
+}
+
+// NoteMainSegment records the latest main recording id for a camera — the
+// event-fed join that keeps X-Recording-Id pointing at real recordings rows.
+func (m *SubLayerManager) NoteMainSegment(cameraID, recordingID string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.mainIDs[cameraID] = recordingID
+	m.mu.Unlock()
+}
+
+// loop runs reconcile (recorder set vs config), retention cleanup, and the
+// push sweep. One goroutine, three cadences — they share no state beyond the
+// maps (mu-guarded) so a single loop keeps the ordering simple: reconcile →
+// push → expire.
+func (m *SubLayerManager) loop(ctx context.Context) {
+	defer m.wg.Done()
+	reconcile := time.NewTicker(subLayerReconcileInterval)
+	defer reconcile.Stop()
+	pushEvery := m.pushInterval()
+	push := time.NewTicker(pushEvery)
+	defer push.Stop()
+
+	m.reconcile(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-reconcile.C:
+			m.reconcile(ctx)
+			// Config may have changed the push cadence.
+			if next := m.pushInterval(); next != pushEvery {
+				pushEvery = next
+				push.Reset(pushEvery)
+			}
+		case <-push.C:
+			m.sweepPush(ctx)
+			m.sweepExpire()
+		}
+	}
+}
+
+func (m *SubLayerManager) pushInterval() time.Duration {
+	secs := m.cfg().SubLayerPushIntervalSecs
+	if secs <= 0 {
+		secs = defaultSubLayerPushInterval
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// reconcile aligns the active recorder set with cfg().SubLayerCameraSet().
+// An empty set (or vision disabled) stops everything — the layer exists only
+// for the consumer.
+func (m *SubLayerManager) reconcile(ctx context.Context) {
+	desired := map[string]bool{}
+	if m.cfg().Enabled {
+		desired = m.cfg().SubLayerCameraSet()
+	}
+
+	m.mu.Lock()
+	var toStop []*subLayerRecorder
+	for id, r := range m.recorders {
+		if !desired[id] {
+			toStop = append(toStop, r)
+			delete(m.recorders, id)
+		}
+	}
+	m.mu.Unlock()
+	for _, r := range toStop {
+		subLayerLogger.Info("sub-layer recorder stopping (removed from config)", "camera_id", r.cameraID)
+		r.stop()
+	}
+
+	for id := range desired {
+		m.mu.Lock()
+		_, active := m.recorders[id]
+		m.mu.Unlock()
+		if active {
+			continue
+		}
+		acqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		src, err := m.provider.AcquireSubStream(acqCtx, id)
+		cancel()
+		if err != nil {
+			subLayerLogger.Warn("sub-layer acquire failed, will retry", "camera_id", id, "error", err)
+			continue
+		}
+		r := newSubLayerRecorder(m, id, src)
+		m.mu.Lock()
+		m.recorders[id] = r
+		m.mu.Unlock()
+		r.start(ctx)
+		subLayerLogger.Info("sub-layer recorder started",
+			"camera_id", id, "segment_secs", m.segmentSecs())
+	}
+}
+
+func (m *SubLayerManager) segmentSecs() time.Duration {
+	secs := m.cfg().SubLayerSegmentSecs
+	if secs <= 0 {
+		secs = defaultSubLayerSegmentSecs
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func (m *SubLayerManager) retention() time.Duration {
+	secs := m.cfg().SubLayerRetentionSecs
+	if secs <= 0 {
+		secs = defaultSubLayerRetentionSecs
+	}
+	return time.Duration(secs) * time.Second
+}
+
+func (m *SubLayerManager) cameraDir(cameraID string) string {
+	return filepath.Join(m.storageRoot(), subLayerDir, cameraID)
+}
+
+// registerMeta records a finalized segment's push payload.
+func (m *SubLayerManager) registerMeta(seg SubSegment) {
+	m.mu.Lock()
+	m.meta[seg.Path] = seg
+	m.mu.Unlock()
+}
+
+// joinRecordingID picks the payload recording id: the latest main recording
+// for the camera when one exists (ai_status/ai_processed_at keep working),
+// else a synthetic id so the consumer can still dedup/report.
+func (m *SubLayerManager) joinRecordingID(cameraID string, startedAt time.Time) string {
+	m.mu.Lock()
+	id := m.mainIDs[cameraID]
+	m.mu.Unlock()
+	if id != "" {
+		return id
+	}
+	return "sub-" + strconv.FormatInt(startedAt.UnixNano(), 10)
+}
+
+// sweepPush walks the sub-layer tree and pushes finalized segments (oldest
+// first) while the consumer is healthy. The DIRS are the queue — not the
+// active recorder set — so files left by a restart (or a camera since removed
+// from the list) still drain. Files are deleted only after an accepted push.
+func (m *SubLayerManager) sweepPush(ctx context.Context) {
+	if ctx.Err() != nil || !m.deps.Healthy() || !m.cfg().Enabled {
+		return
+	}
+	root := filepath.Join(m.storageRoot(), subLayerDir)
+	dirs, err := os.ReadDir(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			subLayerLogger.Warn("sub-layer scan failed", "error", err)
+		}
+		return
+	}
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		cameraID := d.Name()
+		if m.cfg().ShouldSkipCamera(cameraID) {
+			continue
+		}
+		files, err := listSubLayerFiles(filepath.Join(root, cameraID))
+		if err != nil {
+			continue
+		}
+		for _, path := range files {
+			if ctx.Err() != nil {
+				return
+			}
+			if !m.deps.Push(ctx, m.segmentFor(path)) {
+				// Unhealthy mid-sweep or upload failed — stop this camera's
+				// pass; next sweep retries (oldest-first keeps ordering).
+				return
+			}
+			_ = os.Remove(path)
+			m.mu.Lock()
+			delete(m.meta, path)
+			m.mu.Unlock()
+			subLayerLogger.Debug("sub-layer segment pushed and removed", "path", path)
+			time.Sleep(subLayerPushPacing)
+		}
+	}
+}
+
+// sweepExpire drops segments older than the retention bound regardless of push
+// state — a permanently-offline consumer must not grow the layer unbounded.
+func (m *SubLayerManager) sweepExpire() {
+	cutoff := time.Now().Add(-m.retention())
+	root := filepath.Join(m.storageRoot(), subLayerDir)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			subLayerLogger.Warn("sub-layer retention scan failed", "error", err)
+		}
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		files, err := listSubLayerFiles(filepath.Join(root, e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, path := range files {
+			info, err := os.Stat(path)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().Before(cutoff) {
+				_ = os.Remove(path)
+				m.mu.Lock()
+				delete(m.meta, path)
+				m.mu.Unlock()
+				subLayerLogger.Info("sub-layer segment expired", "path", path, "age", time.Since(info.ModTime()).Round(time.Second))
+			}
+		}
+	}
+}
+
+// segmentFor assembles the push payload for a file, preferring the recorder's
+// registry entry and degrading to filename-derived values.
+func (m *SubLayerManager) segmentFor(path string) SubSegment {
+	m.mu.Lock()
+	seg, ok := m.meta[path]
+	m.mu.Unlock()
+	if ok {
+		return seg
+	}
+	cameraID := filepath.Base(filepath.Dir(path))
+	startedAt, codec := subLayerFilenameInfo(filepath.Base(path))
+	seg = SubSegment{
+		CameraID:    cameraID,
+		Path:        path,
+		Codec:       codec,
+		StartedAt:   startedAt,
+		EndedAt:     startedAt,
+		RecordingID: m.joinRecordingID(cameraID, startedAt),
+	}
+	if info, err := os.Stat(path); err == nil {
+		seg.FileSize = info.Size()
+	}
+	return seg
+}
+
+// listSubLayerFiles returns finalized segment paths in a camera dir, oldest
+// first (names embed the start unix-nano). Tmp files are skipped — the
+// recorder still owns them.
+func listSubLayerFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".mp4") || strings.HasSuffix(e.Name(), subLayerTmp) {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// subLayerFilenameInfo parses "<unixnano>-<codec>.mp4" back into its parts.
+func subLayerFilenameInfo(name string) (time.Time, string) {
+	base := strings.TrimSuffix(name, ".mp4")
+	codec := ""
+	if i := strings.LastIndex(base, "-"); i >= 0 {
+		if c := base[i+1:]; c == "h264" || c == "h265" {
+			codec = c
+			base = base[:i]
+		}
+	}
+	nano, err := strconv.ParseInt(base, 10, 64)
+	if err != nil {
+		return time.Time{}, codec
+	}
+	return time.Unix(0, nano), codec
+}
+
+// ─── per-camera recorder ────────────────────────────────────────────────────
+
+// subLayerRecorder pulls one camera's sub-stream (the acquisition is held for
+// the recorder's whole lifetime — the substream manager's idle recycle never
+// fires under a held reference) and rotates mp4 segments out of its hub feed.
+type subLayerRecorder struct {
+	mgr      *SubLayerManager
+	cameraID string
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	// The hub consumer callback runs on the hub's drain goroutine while the
+	// run loop may close the segment on source failure — smu guards the
+	// segment state.
+	smu          sync.Mutex
+	stopped      bool
+	src          *substream.Source
+	subID        string
+	mux          *muxer.MP4Muxer
+	trackID      int
+	tmpPath      string
+	segCodec     model.Format
+	segSPS       []byte
+	segStartTick int64
+	lastTick     int64
+	startedAt    time.Time
+	frames       int
+}
+
+func newSubLayerRecorder(m *SubLayerManager, cameraID string, src *substream.Source) *subLayerRecorder {
+	return &subLayerRecorder{mgr: m, cameraID: cameraID, src: src}
+}
+
+func (r *subLayerRecorder) start(ctx context.Context) {
+	ctx, r.cancel = context.WithCancel(ctx)
+	r.done = make(chan struct{})
+	go r.run(ctx)
+}
+
+func (r *subLayerRecorder) stop() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	if r.done != nil {
+		<-r.done
+	}
+}
+
+// run keeps a healthy source under the recorder: on permanent pull failure
+// (StateFailed → the source self-recycled) it releases and re-acquires with
+// backoff. Transient stalls are the substream manager's own reconnect's job.
+func (r *subLayerRecorder) run(ctx context.Context) {
+	defer close(r.done)
+	holding := true
+	for {
+		if ctx.Err() != nil {
+			break
+		}
+		if err := r.record(ctx); err != nil {
+			subLayerLogger.Warn("sub-layer recording ended", "camera_id", r.cameraID, "reason", err.Error())
+		}
+		r.smu.Lock()
+		r.stopped = ctx.Err() != nil
+		r.closeSegmentLocked()
+		r.unsubscribeLocked()
+		if holding {
+			r.mgr.provider.ReleaseSubStream(r.cameraID)
+			holding = false
+		}
+		r.smu.Unlock()
+		if ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(subLayerReacquireBackoff):
+		}
+		acqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		src, err := r.mgr.provider.AcquireSubStream(acqCtx, r.cameraID)
+		cancel()
+		if err != nil {
+			subLayerLogger.Warn("sub-layer re-acquire failed, retrying", "camera_id", r.cameraID, "error", err)
+			continue
+		}
+		r.smu.Lock()
+		r.src = src
+		r.stopped = false
+		r.smu.Unlock()
+		holding = true
+	}
+}
+
+// record subscribes to the source's hub and writes segments until the source
+// fails or the recorder is stopped.
+func (r *subLayerRecorder) record(ctx context.Context) error {
+	r.smu.Lock()
+	src := r.src
+	r.smu.Unlock()
+	if src == nil {
+		return fmt.Errorf("no source")
+	}
+
+	subID := "vision-sublayer-" + r.cameraID
+	if err := src.Hub().Subscribe(subID, func(pts int64, au [][]byte) {
+		r.onFrame(pts, au)
+	}); err != nil {
+		return fmt.Errorf("hub subscribe: %w", err)
+	}
+	r.smu.Lock()
+	r.subID = subID
+	r.smu.Unlock()
+
+	ticker := time.NewTicker(subLayerStatePoll)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if src.State() == substream.StateFailed {
+				return fmt.Errorf("sub-stream source failed (no video track)")
+			}
+		}
+	}
+}
+
+func (r *subLayerRecorder) unsubscribeLocked() {
+	if r.src != nil && r.subID != "" {
+		r.src.Hub().Unsubscribe(r.subID)
+		r.subID = ""
+	}
+}
+
+// onFrame writes one access unit into the current segment, opening/rotating
+// as needed. Runs on the hub's per-consumer drain goroutine.
+func (r *subLayerRecorder) onFrame(pts int64, au [][]byte) {
+	r.smu.Lock()
+	defer r.smu.Unlock()
+	if r.stopped || r.src == nil {
+		return
+	}
+
+	codec, sps, pps, vps := r.src.CodecParams()
+	if codec != model.FormatH264 && codec != model.FormatH265 {
+		return // params not ready yet
+	}
+	isH265 := codec == model.FormatH265
+	isIDR := nalutil.IsIDR(au, isH265)
+
+	if r.mux != nil && isIDR && !bytes.Equal(sps, r.segSPS) {
+		// Parameter-set change (camera reconfigured / fresh pull session with
+		// new params): the track description is stale — close and reopen with
+		// the current sets on this IDR.
+		r.closeSegmentLocked()
+	}
+	if r.mux == nil {
+		if !isIDR {
+			return // segments start on a keyframe
+		}
+		if sps == nil || pps == nil || (isH265 && vps == nil) {
+			return
+		}
+		if err := r.openSegmentLocked(codec, sps, pps, vps, pts); err != nil {
+			subLayerLogger.Warn("sub-layer segment open failed", "camera_id", r.cameraID, "error", err)
+			return
+		}
+	}
+
+	// Sample timing on the 90 kHz tick timeline: pts relative to the segment's
+	// first AU, duration from the AU delta (clamped — the cross-session rebase
+	// inserts a 1s gap that must not become one giant sample).
+	dur := ticksToDuration(pts - r.lastTick)
+	if dur < subLayerMinSampleDur {
+		dur = subLayerMinSampleDur
+	} else if dur > subLayerMaxSampleDur {
+		dur = subLayerMaxSampleDur
+	}
+	rel := ticksToDuration(pts - r.segStartTick)
+	r.lastTick = pts
+
+	for _, nalu := range au {
+		if !isVCLNALU(nalu, codec) {
+			continue // parameter sets live in the track, SEI is noise here
+		}
+		if err := r.mux.WriteSample(r.trackID, nalu, rel, dur); err != nil {
+			subLayerLogger.Warn("sub-layer write failed", "camera_id", r.cameraID, "error", err)
+			r.closeSegmentLocked()
+			return
+		}
+		r.frames++
+	}
+
+	if ticksToDuration(pts-r.segStartTick) >= r.mgr.segmentSecs() {
+		r.closeSegmentLocked()
+	}
+}
+
+func (r *subLayerRecorder) openSegmentLocked(codec model.Format, sps, pps, vps []byte, startTick int64) error {
+	dir := r.mgr.cameraDir(r.cameraID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	name := fmt.Sprintf("%d-%s.mp4%s", time.Now().UnixNano(), codec, subLayerTmp)
+	tmp := filepath.Join(dir, name)
+	m := muxer.NewMP4Muxer(tmp)
+	var (
+		trackID int
+		err     error
+	)
+	switch codec {
+	case model.FormatH264:
+		trackID, err = m.AddH264Track(sps, pps)
+	case model.FormatH265:
+		trackID, err = m.AddH265Track(vps, sps, pps)
+	default:
+		err = fmt.Errorf("unsupported codec %q", codec)
+	}
+	if err != nil {
+		_ = m.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	r.mux = m
+	r.trackID = trackID
+	r.tmpPath = tmp
+	r.segCodec = codec
+	r.segSPS = append([]byte(nil), sps...)
+	r.segStartTick = startTick
+	r.lastTick = startTick
+	r.startedAt = time.Now()
+	r.frames = 0
+	return nil
+}
+
+// closeSegmentLocked finalizes the current segment: close the muxer, publish
+// the file, and register its push payload. Callers hold smu.
+func (r *subLayerRecorder) closeSegmentLocked() {
+	if r.mux == nil {
+		return
+	}
+	m := r.mux
+	r.mux = nil
+	frames := r.frames
+	startedAt := r.startedAt
+	codec := r.segCodec
+	tmp := r.tmpPath
+	r.tmpPath = ""
+	if err := m.Close(); err != nil {
+		subLayerLogger.Warn("sub-layer muxer close failed", "camera_id", r.cameraID, "error", err)
+		_ = os.Remove(tmp)
+		return
+	}
+	if frames == 0 {
+		_ = os.Remove(tmp)
+		return
+	}
+	final := strings.TrimSuffix(tmp, subLayerTmp)
+	if err := os.Rename(tmp, final); err != nil {
+		subLayerLogger.Warn("sub-layer segment publish failed", "camera_id", r.cameraID, "error", err)
+		return
+	}
+	seg := SubSegment{
+		CameraID:    r.cameraID,
+		Path:        final,
+		Codec:       string(codec),
+		StartedAt:   startedAt,
+		EndedAt:     time.Now(),
+		RecordingID: r.mgr.joinRecordingID(r.cameraID, startedAt),
+	}
+	if info, err := os.Stat(final); err == nil {
+		seg.FileSize = info.Size()
+	}
+	r.mgr.registerMeta(seg)
+	subLayerLogger.Info("sub-layer segment finalized",
+		"camera_id", r.cameraID, "path", filepath.Base(final),
+		"frames", frames, "size", seg.FileSize,
+		"duration", seg.EndedAt.Sub(startedAt).Round(time.Second))
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+func ticksToDuration(ticks int64) time.Duration {
+	return time.Duration(ticks) * time.Second / subLayerTickHz
+}
+
+// isVCLNALU reports whether a raw NALU (no start code) is a video slice.
+func isVCLNALU(nalu []byte, codec model.Format) bool {
+	if len(nalu) == 0 {
+		return false
+	}
+	if codec == model.FormatH265 {
+		return (nalu[0]>>1)&0x3F <= 31 // IRSI..RSL_NST (0..31); params are 32+
+	}
+	return nalu[0]&0x1F > 0 && nalu[0]&0x1F <= 5
+}

--- a/internal/vision/sublayer_test.go
+++ b/internal/vision/sublayer_test.go
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: MIT
+//
+// Tests for the sub-stream analysis layer (#514): segment recording from a
+// live sub-stream pull, the disk-as-queue push loop (push → delete), retention
+// expiry, and the main-layer hand-off in the coordinator. The fake camera is
+// a real gortsplib server (harness copied from internal/substream tests).
+
+package vision
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
+)
+
+// --- fake camera harness (from internal/substream tests) ---------------------
+
+var (
+	tSPS = []byte{0x67, 0x64, 0x00, 0x0c, 0xac, 0x3b, 0x50, 0xb0, 0x4b, 0x42, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x3d, 0x08}
+	tPPS = []byte{0x68, 0xee, 0x3c, 0x80}
+
+	h264IDR = []byte{0x65, 0x88, 0x84, 0x21, 0xa0}
+	h264P   = []byte{0x41, 0x9a, 0x22, 0x10}
+)
+
+type testSource struct {
+	gs    *gortsplib.Server
+	media *description.Media
+	enc   interface {
+		Encode(au [][]byte) ([]*rtp.Packet, error)
+	}
+	sps, pps    []byte
+	idr, pSl    []byte
+	stop        chan struct{}
+	done        chan struct{}
+	streamReady chan struct{}
+	stream      *gortsplib.ServerStream
+	once        sync.Once
+}
+
+func (s *testSource) ensureStream() {
+	s.once.Do(func() {
+		s.stream = &gortsplib.ServerStream{
+			Server: s.gs,
+			Desc:   &description.Session{Medias: []*description.Media{s.media}},
+		}
+		if err := s.stream.Initialize(); err != nil {
+			panic(err)
+		}
+		close(s.streamReady)
+	})
+}
+
+func (s *testSource) OnDescribe(*gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *testSource) OnSetup(*gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *testSource) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	return &base.Response{StatusCode: base.StatusOK}, nil
+}
+
+func (s *testSource) writeLoop() {
+	defer close(s.done)
+	select {
+	case <-s.streamReady:
+	case <-s.stop:
+		return
+	}
+	ts := uint32(1600)
+	idr := true
+	for {
+		select {
+		case <-s.stop:
+			return
+		default:
+		}
+		var au [][]byte
+		if idr {
+			au = [][]byte{s.sps, s.pps, s.idr}
+		} else {
+			au = [][]byte{s.pSl}
+		}
+		if pkts, err := s.enc.Encode(au); err == nil {
+			for _, p := range pkts {
+				p.Timestamp = ts
+				_ = s.stream.WritePacketRTP(s.media, p)
+			}
+		}
+		ts += 3600 // 40ms @ 90kHz
+		idr = !idr
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func newTestSource(t *testing.T) string {
+	t.Helper()
+	f := &format.H264{PayloadTyp: 96, SPS: tSPS, PPS: tPPS, PacketizationMode: 1}
+	enc, err := f.CreateEncoder()
+	require.NoError(t, err)
+	s := &testSource{
+		enc:         enc,
+		sps:         tSPS,
+		pps:         tPPS,
+		idr:         h264IDR,
+		pSl:         h264P,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		streamReady: make(chan struct{}),
+	}
+	s.media = &description.Media{Type: description.MediaTypeVideo, Control: "trackID=0", Formats: []format.Format{f}}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s.gs = &gortsplib.Server{Handler: s, RTSPAddress: "rtsp://" + ln.Addr().String()}
+	s.gs.Listen = func(_, _ string) (net.Listener, error) { return ln, nil }
+	go func() { _ = s.gs.StartAndWait() }()
+	go s.writeLoop()
+	t.Cleanup(func() {
+		close(s.stop)
+		select {
+		case <-s.streamReady:
+			s.stream.Close()
+		default:
+		}
+		<-s.done
+		s.gs.Close()
+	})
+	return "rtsp://" + ln.Addr().String() + "/cam"
+}
+
+// --- provider over a real substream manager ----------------------------------
+
+type managerProvider struct{ m *substream.Manager }
+
+func (p managerProvider) AcquireSubStream(ctx context.Context, cameraID string) (*substream.Source, error) {
+	return p.m.Acquire(ctx, cameraID)
+}
+func (p managerProvider) ReleaseSubStream(cameraID string) { p.m.Release(cameraID) }
+
+func newSubStreamManager(t *testing.T, url string) *substream.Manager {
+	t.Helper()
+	m := substream.NewManager(substream.Config{
+		Resolver: func(context.Context, string) (substream.Target, bool, error) {
+			return substream.Target{URL: url}, true, nil
+		},
+		IdleTimeout:       24 * time.Hour, // the recorder holds the ref; recycle is not under test here
+		ReadyTimeout:      3 * time.Second,
+		DialTimeout:       2 * time.Second,
+		FrameStallTimeout: 10 * time.Second,
+	})
+	t.Cleanup(m.Stop)
+	return m
+}
+
+// --- tests --------------------------------------------------------------------
+
+// E2E: a camera on the sub layer records rotating mp4 segments from its live
+// sub-stream; the push sweep uploads them (X-Layer: sub, joined main recording
+// id) and deletes on success; the same camera's MAIN segments are no longer
+// pushed.
+func TestSubLayer_RecordPushAndMainHandoff(t *testing.T) {
+	url := newTestSource(t)
+	subMgr := newSubStreamManager(t, url)
+
+	var mu sync.Mutex
+	pushed := []map[string]string{}
+
+	visionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hdr := map[string]string{
+			"layer":     r.Header.Get("X-Layer"),
+			"camera":    r.Header.Get("X-Camera-Id"),
+			"recording": r.Header.Get("X-Recording-Id"),
+			"format":    r.Header.Get("X-Format"),
+		}
+		mu.Lock()
+		pushed = append(pushed, hdr)
+		mu.Unlock()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer visionSrv.Close()
+
+	root := t.TempDir()
+	cfg := config.VisionConfig{
+		Enabled:                  true,
+		URL:                      visionSrv.URL,
+		SubLayerCameras:          []string{"cam-1"},
+		SubLayerSegmentSecs:      1,
+		SubLayerPushIntervalSecs: 2,
+	}
+	bus := event.NewEventBus(64)
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return root },
+		bus,
+		nil,
+		managerProvider{subMgr},
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+	c.Health().RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+
+	// The main recorder publishes segments for the same camera — they must be
+	// handed off to the sub layer (no direct push).
+	mainSeg := filepath.Join(root, "main.mp4")
+	require.NoError(t, os.WriteFile(mainSeg, make([]byte, 32), 0o644))
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam-1", FilePath: mainSeg, Format: "mp4",
+		FileSize: 32, RecordingID: "rec-main-1",
+	})
+
+	// Sub segments appear under <root>/sublayer/cam-1/ and are pushed within
+	// a couple of sweep intervals, then deleted.
+	segDir := filepath.Join(root, subLayerDir, "cam-1")
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(pushed) >= 1
+	}, 20*time.Second, 200*time.Millisecond, "no sub-layer push arrived")
+
+	mu.Lock()
+	first := pushed[0]
+	mu.Unlock()
+	require.Equal(t, "sub", first["layer"], "sub pushes carry X-Layer: sub")
+	require.Equal(t, "cam-1", first["camera"])
+	require.Equal(t, "rec-main-1", first["recording"], "sub pushes join the main recording id")
+	require.Equal(t, "h264", first["format"])
+
+	// Pushed ⇒ deleted (disk queue drains).
+	require.Eventually(t, func() bool {
+		files, _ := listSubLayerFiles(segDir)
+		return len(files) == 0
+	}, 10*time.Second, 200*time.Millisecond, "pushed sub segment was not removed")
+
+	// The main segment itself was never uploaded (only sub pushes recorded).
+	mu.Lock()
+	defer mu.Unlock()
+	for _, p := range pushed {
+		require.Equal(t, "sub", p["layer"], "main-layer push must be suppressed for sub-layer cameras")
+	}
+	require.FileExists(t, mainSeg, "main segment file must stay (normal lifecycle owns it)")
+}
+
+// The sweep pushes and deletes pre-existing files even without recorder
+// metadata — restart resilience (headers degrade to filename-derived values).
+func TestSubLayer_SweepPushesWithoutMeta(t *testing.T) {
+	root := t.TempDir()
+	segDir := filepath.Join(root, subLayerDir, "cam-x")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+	path := filepath.Join(segDir, strconv.FormatInt(time.Now().UnixNano(), 10)+"-h264.mp4")
+	require.NoError(t, os.WriteFile(path, []byte("mp4"), 0o644))
+
+	var got atomic.Int32
+	m := NewSubLayerManager(nil, func() config.VisionConfig {
+		return config.VisionConfig{Enabled: true}
+	}, func() string { return root }, SubLayerDeps{
+		Push: func(ctx context.Context, seg SubSegment) bool {
+			require.Equal(t, "cam-x", seg.CameraID)
+			require.Equal(t, "h264", seg.Codec)
+			require.NotEmpty(t, seg.RecordingID)
+			got.Add(1)
+			return true
+		},
+		Healthy: func() bool { return true },
+	})
+	m.sweepPush(context.Background())
+	require.Equal(t, int32(1), got.Load(), "file pushed")
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "pushed file removed")
+}
+
+// Push failures keep the file on disk (retry queue); TTL expiry is the bound.
+func TestSubLayer_PushFailureKeepsFileAndTTLExpires(t *testing.T) {
+	root := t.TempDir()
+	segDir := filepath.Join(root, subLayerDir, "cam-x")
+	require.NoError(t, os.MkdirAll(segDir, 0o755))
+	path := filepath.Join(segDir, "111-h264.mp4")
+	require.NoError(t, os.WriteFile(path, []byte("mp4"), 0o644))
+
+	var attempts atomic.Int32
+	m := NewSubLayerManager(nil, func() config.VisionConfig {
+		return config.VisionConfig{
+			Enabled:               true,
+			SubLayerRetentionSecs: 3600,
+		}
+	}, func() string { return root }, SubLayerDeps{
+		Push: func(ctx context.Context, seg SubSegment) bool {
+			attempts.Add(1)
+			return false
+		},
+		Healthy: func() bool { return true },
+	})
+	m.sweepPush(context.Background())
+	require.Equal(t, int32(1), attempts.Load())
+	require.FileExists(t, path, "failed push keeps the file for retry")
+
+	// Age it past the retention bound and sweep again — expiry deletes it
+	// regardless of push state.
+	past := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(path, past, past))
+	m.sweepExpire()
+	_, err := os.Stat(path)
+	require.True(t, os.IsNotExist(err), "expired sub segment removed")
+}
+
+// Segment-start gating: the recorder must not open a segment before a
+// keyframe arrives (P-only AUs are dropped).
+func TestSubLayer_SegmentsStartOnKeyframe(t *testing.T) {
+	root := t.TempDir()
+	m := NewSubLayerManager(nil, func() config.VisionConfig { return config.VisionConfig{Enabled: true} },
+		func() string { return root }, SubLayerDeps{})
+	r := newSubLayerRecorder(m, "cam-k", nil) // src=nil: onFrame guards it
+	r.onFrame(1000, [][]byte{tSPS, tPPS, h264P})
+	// Without a source the frame is ignored entirely — no segment, no panic.
+	require.NoFileExists(t, filepath.Join(root, subLayerDir))
+}
+
+// Filename round-trip: the sweep's degraded path must recover start time and
+// codec from the name.
+func TestSubLayerFilenameInfo(t *testing.T) {
+	st := time.Now()
+	got, codec := subLayerFilenameInfo(strconv.FormatInt(st.UnixNano(), 10) + "-h265.mp4")
+	require.Equal(t, "h265", codec)
+	require.Equal(t, st.UnixNano(), got.UnixNano())
+	_, codec = subLayerFilenameInfo("junk.mp4")
+	require.Empty(t, codec)
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -308,20 +308,9 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	}
 	deps.transcodeMgr = transcodeMgr
 
-	// Step 5.6: Vision push coordinator (NVR → MiBeeVision active push).
-	// Subscribes to segment.completed; pushes segment info to Vision when healthy.
-	// Only active when [vision].enabled = true AND Vision sends heartbeats.
-	if cfg.Vision.Enabled {
-		deps.visionMgr = vision.NewCoordinator(
-			func() config.VisionConfig { return cfg.Vision },
-			func() string { return cfg.Storage.RootDir },
-			deps.eventBus,
-			db,
-		)
-		slog.Info("Vision push integration enabled",
-			"url", cfg.Vision.URL,
-			"push_mode", cfg.Vision.PushMode)
-	}
+	// Step 5.6: Vision push coordinator — moved below the camera manager
+	// construction (the sub-layer analysis tier needs it as its source
+	// provider, #514).
 
 	// Load display timezone for merge window alignment and camera scheduling.
 	appLoc := time.Local // Default: use server's local timezone
@@ -344,6 +333,25 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 
 	camMgr := camera.NewCameraManager(cfg, store, db, configPath, m, deps.mergeMgr, transcodeMgr, deps.rollingMergeMgr, appLoc, deps.eventBus)
 	deps.camMgr = camMgr
+
+	// Step 5.6b: Vision push coordinator (NVR → MiBeeVision active push).
+	// Subscribes to segment.completed; pushes segment info to Vision when healthy.
+	// Only active when [vision].enabled = true AND Vision sends heartbeats.
+	// Constructed AFTER the camera manager — the sub-layer analysis tier
+	// (#514) acquires its on-demand sub-stream sources through it.
+	if cfg.Vision.Enabled {
+		deps.visionMgr = vision.NewCoordinator(
+			func() config.VisionConfig { return cfg.Vision },
+			func() string { return cfg.Storage.RootDir },
+			deps.eventBus,
+			db,
+			camMgr,
+		)
+		slog.Info("Vision push integration enabled",
+			"url", cfg.Vision.URL,
+			"push_mode", cfg.Vision.PushMode,
+			"sub_layer_cameras", len(cfg.Vision.SubLayerCameras))
+	}
 
 	// Step 6.5: Health manager (after camera manager, before streaming)
 	healthMgr := health.NewManager(cfg.Health, db)


### PR DESCRIPTION
Phase 3 of the sub-stream plan, on top of #528/#529.

## What
- `vision.sub_layer_cameras`: cameras whose AI analysis input switches from main segments to a dedicated **sub-stream recording tier**.
- The tier holds a persistent reference on the #528 on-demand puller, rotates keyframe-gated mp4 segments (param-set-change aware) into `<storage root>/sublayer/<camera_id>/`, and is invisible to the recordings DB / merge pipeline / regular cleanup.
- **Main-layer hand-off**: the coordinator no longer pushes main segments for these cameras; it uploads sub segments instead (`X-Layer: sub`).
- **Disk is the queue**: sub segments don't race the merge/delete window, so pushing is a periodic sweep (oldest-first) rather than event-driven — files retry on failure, are deleted only after an accepted push, and `sub_layer_retention_secs` (default 2h) bounds offline pile-up. A restart loses only header metadata (times degrade to filename-derived; the consumer sniffs codec from the MP4 payload).
- **Recording-id join**: `X-Recording-Id` maps to the covering MAIN recording (fed from segment.completed events), so consumer-side dedup, `ai_status` and `ai_processed_at` semantics are unchanged. Live-only cameras (no main recording) get synthetic `sub-<nano>` ids.
- `skip_cameras` overrides the layer list — a camera the consumer explicitly rejected grows no tier.
- Source lifecycle: permanent pull failure self-recycles the source; the recorder releases, backs off, re-acquires.

## Why
A 2K main segment costs 4-16× the sub stream in decode pixels; the sub tier lets a single external consumer cover every high-resolution camera instead of excluding them by capacity. Storage budget: 0.5-1 Mbps ≈ 220-450 MB/h per enabled camera, bounded by the retention sweep.

## Tests
- E2E (real gortsplib camera): sub segments rotate, push carries `X-Layer: sub` + the joined main recording id, files delete after push, and the same camera's main segment is NOT pushed (hand-off).
- Restart resilience: pre-existing files push without recorder metadata; push failure keeps the file (retry), TTL expiry removes it.
- Keyframe gating + filename round-trip units; `SubLayerCameraSet` (skip precedence).
- Full vision suite + `-race` green; gofumpt clean.