### PR TITLE
fix(vision): unique sub-layer recording ids — consumer dedup dropped N:1 sub segments (#514 field fix)

### DIFF
--- a/internal/api/handlers_ai.go
+++ b/internal/api/handlers_ai.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -74,6 +75,13 @@ func (h *Handler) handleCreateAIEvent(w http.ResponseWriter, r *http.Request) {
 	severity := body.Severity
 	if severity == "" {
 		severity = "info"
+	}
+
+	// Sub-layer pushes (#514) identify as "<mainRecordingID>#<subStartNano>"
+	// so the consumer can dedup every sub segment; events reported against
+	// them map back onto the main recording row.
+	if i := strings.IndexByte(body.RecordingID, '#'); i >= 0 {
+		body.RecordingID = body.RecordingID[:i]
 	}
 
 	// Convert bbox to JSON string for storage

--- a/internal/api/handlers_ai_test.go
+++ b/internal/api/handlers_ai_test.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -108,6 +109,34 @@ func TestAI_CreateEvent_DefaultSeverity(t *testing.T) {
 	b, _ := json.Marshal(map[string]string{"camera_id": "cam-1", "event_type": "loitering"})
 	rr := doRequest(t, routes, "POST", "/api/ai/events", bytes.NewBuffer(b), "admin", "p")
 	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+}
+
+// Sub-layer pushes identify as "<mainRecordingID>#<subStartNano>" (#514) —
+// events reported against them must map back onto the main recording id.
+func TestAI_CreateEvent_StripsSubLayerSuffix(t *testing.T) {
+	t.Parallel()
+	h, routes := aiTestHandler(t, "admin", "p", "vision")
+
+	b, _ := json.Marshal(map[string]string{
+		"camera_id":    "cam-test",
+		"recording_id": "1787716624636592991#1787716544377969513",
+		"event_type":   "zone_intrusion",
+	})
+	rr := doRequest(t, routes, "POST", "/api/ai/events", bytes.NewBuffer(b), "admin", "p")
+	require.Equal(t, http.StatusCreated, rr.Code, "body=%s", rr.Body.String())
+
+	events, _, err := h.db.ListAIEvents(context.Background(), storage.AIEventFilter{CameraID: "cam-test", Limit: 10})
+	require.NoError(t, err)
+	require.NotEmpty(t, events)
+	var found bool
+	for _, e := range events {
+		if e.CameraID == "cam-test" {
+			require.Equal(t, "1787716624636592991", e.RecordingID,
+				"the #<nano> suffix must be stripped before storage")
+			found = true
+		}
+	}
+	require.True(t, found, "event row not found")
 }
 
 func TestAI_ListEvents_Empty(t *testing.T) {

--- a/internal/onvif/discovery.go
+++ b/internal/onvif/discovery.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/0x524a/onvif-go/discovery"
@@ -77,13 +78,20 @@ type deviceInfoEnvelope struct {
 }
 
 // discoverFunc is the backing implementation of Discover / DiscoverNoEnrich.
-// It is a package-level variable so that tests in this module can stub it out
-// (set discoverFunc = ...) to avoid the real UDP multicast WS-Discovery, which
-// is network-dependent and non-deterministic in CI sandboxes (issue #221:
+// It is a package-level indirection so that tests in this module can stub it
+// out to avoid the real UDP multicast WS-Discovery, which is
+// network-dependent and non-deterministic in CI sandboxes (issue #221:
 // TestONVIFDiscoverEndpoint assumed "no devices on the network" and asserted
 // len(devices)==0, which failed when a CI runner shared a LAN with a real ONVIF
-// camera). Production code must never reassign this; only test code does.
-var discoverFunc = discover
+// camera). Atomic: a parallel test's SetDiscoverFuncForTest restore races the
+// Discover calls other parallel tests are still serving (-race). Production
+// code must never reassign this; only test code does.
+var discoverFunc atomic.Pointer[func(ctx context.Context, timeout time.Duration, enrich bool) *DiscoveryResult]
+
+func init() {
+	defaultDiscover := discover
+	discoverFunc.Store(&defaultDiscover)
+}
 
 // SetDiscoverFuncForTest replaces the discovery implementation for the
 // duration of a test. Pass nil to restore the default (real WS-Discovery). It
@@ -98,12 +106,21 @@ var discoverFunc = discover
 //	})
 //	defer restore()
 func SetDiscoverFuncForTest(fn func(ctx context.Context, timeout time.Duration, enrich bool) *DiscoveryResult) (restore func()) {
-	prev := discoverFunc
+	prev := discoverFunc.Load()
 	if fn == nil {
-		fn = discover
+		defaultDiscover := discover
+		fn = defaultDiscover
 	}
-	discoverFunc = fn
-	return func() { discoverFunc = prev }
+	discoverFunc.Store(&fn)
+	return func() { discoverFunc.Store(prev) }
+}
+
+// callDiscover invokes the current discovery implementation.
+func callDiscover(ctx context.Context, timeout time.Duration, enrich bool) *DiscoveryResult {
+	if fn := discoverFunc.Load(); fn != nil {
+		return (*fn)(ctx, timeout, enrich)
+	}
+	return discover(ctx, timeout, enrich)
 }
 
 // Discover performs WS-Discovery to find ONVIF devices on the local network
@@ -118,7 +135,7 @@ func SetDiscoverFuncForTest(fn func(ctx context.Context, timeout time.Duration, 
 // Adder.HandleDiscovered) should use DiscoverNoEnrich to avoid a redundant
 // GetDeviceInformation round-trip per device (issue #161).
 func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
-	return discoverFunc(ctx, timeout, true)
+	return callDiscover(ctx, timeout, true)
 }
 
 // DiscoverNoEnrich is the same as Discover but WITHOUT the internal
@@ -130,7 +147,7 @@ func Discover(ctx context.Context, timeout time.Duration) *DiscoveryResult {
 // The returned devices have Endpoint/XAddrs/Scopes populated but
 // Manufacturer/Model/Firmware/Serial empty (filled in later by the caller).
 func DiscoverNoEnrich(ctx context.Context, timeout time.Duration) *DiscoveryResult {
-	return discoverFunc(ctx, timeout, false)
+	return callDiscover(ctx, timeout, false)
 }
 
 // discover is the shared core of Discover / DiscoverNoEnrich. When enrich is

--- a/internal/vision/sublayer.go
+++ b/internal/vision/sublayer.go
@@ -292,15 +292,21 @@ func (m *SubLayerManager) registerMeta(seg SubSegment) {
 	m.mu.Unlock()
 }
 
-// joinRecordingID picks the payload recording id: the latest main recording
-// for the camera when one exists (ai_status/ai_processed_at keep working),
-// else a synthetic id so the consumer can still dedup/report.
+// joinRecordingID picks the payload recording id: the covering main
+// recording for the camera when one exists (ai_status/ai_processed_at keep
+// working), else a synthetic id so the consumer can still dedup/report.
+//
+// The main id carries a "#<subStartNano>" suffix: consumers dedup pushes by
+// X-Recording-Id, and one 60s main recording spans multiple 30s sub segments
+// — an unsuffixed join would make every sub segment after the first look
+// like a duplicate re-push and get dropped. The NVR strips the suffix where
+// the id flows back in (AI event writeback), so the join semantics survive.
 func (m *SubLayerManager) joinRecordingID(cameraID string, startedAt time.Time) string {
 	m.mu.Lock()
 	id := m.mainIDs[cameraID]
 	m.mu.Unlock()
 	if id != "" {
-		return id
+		return id + "#" + strconv.FormatInt(startedAt.UnixNano(), 10)
 	}
 	return "sub-" + strconv.FormatInt(startedAt.UnixNano(), 10)
 }

--- a/internal/vision/sublayer_test.go
+++ b/internal/vision/sublayer_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -246,7 +247,11 @@ func TestSubLayer_RecordPushAndMainHandoff(t *testing.T) {
 	mu.Unlock()
 	require.Equal(t, "sub", first["layer"], "sub pushes carry X-Layer: sub")
 	require.Equal(t, "cam-1", first["camera"])
-	require.Equal(t, "rec-main-1", first["recording"], "sub pushes join the main recording id")
+	// The join carries a uniqueness suffix: one main recording spans multiple
+	// sub segments, and consumers dedup by X-Recording-Id — an unsuffixed id
+	// would drop every sub segment after the first (#514 field finding).
+	require.True(t, strings.HasPrefix(first["recording"], "rec-main-1#"),
+		"sub pushes join the main recording id with a # suffix, got %q", first["recording"])
 	require.Equal(t, "h264", first["format"])
 
 	// Pushed ⇒ deleted (disk queue drains).


### PR DESCRIPTION
Found during M5 field verification of #537: one 60s main recording spans multiple 30s sub segments, and the consumer dedups pushes by `X-Recording-Id` — the bare join id made every sub segment after the first in a window look like a duplicate re-push (three recovery pushes were observed carrying the same id; a dedup-consumer would silently drop two thirds of the analysis input).

Sub pushes now carry `<mainRecordingID>#<subStartNano>` (unique per segment); the NVR strips the suffix on AI event writeback so events still land on the main recording row — `ai_status`/`ai_processed_at` semantics unchanged. Live-only cameras keep the synthetic `sub-<nano>` ids (already unique).

Tests: E2E join assertion updated to require the suffix; new API test pins the suffix-strip on writeback.