### PR TITLE
feat(ws): send negotiated stream quality as first in-band message (#541)

### DIFF
--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -20,7 +20,9 @@ import (
 // video frames (CodecInfo first, then VideoFrame messages).
 // quality=sub (#513) registers the entry under the camera's "/sub" key and
 // streams the on-demand sub-stream; it falls back to main when the camera has
-// no usable sub-stream (X-Stream-Quality response header reports the outcome).
+// no usable sub-stream. Unlike FLV/HLS/WHEP there is no X-Stream-Quality
+// response header here (the 101 upgrade writes its own headers) — the
+// negotiated outcome is reported in-band as the first WS message (#541).
 func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
@@ -51,12 +53,17 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 
 	// quality=sub: acquire the on-demand pull and hold the reference for the
 	// whole ServeWS lifetime (the handler blocks until the viewer leaves).
+	// acquireSub stamps X-Stream-Quality for the pre-upgrade error paths, but
+	// the 101 upgrade response discards headers — the negotiated outcome is
+	// re-sent to the client in-band as the first WS message (#541).
 	key := id
+	servedQuality := qualityMain
 	var subSrc *substream.Source
 	if quality == qualitySub && h.camMgr != nil {
 		subSrc = h.acquireSub(w, r, id)
 		if subSrc != nil {
 			key = subKey(id)
+			servedQuality = qualitySub
 			defer h.camMgr.ReleaseSubStream(id)
 		}
 	}
@@ -163,10 +170,12 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	slog.Info("WS: serving", "camera_id", id, "key", key)
+	slog.Info("WS: serving", "camera_id", id, "key", key, "quality", servedQuality)
 
-	// Serve WebSocket stream (blocks until client disconnects)
-	if err := h.wsMgr.ServeWS(key, w, r); err != nil {
+	// Serve WebSocket stream (blocks until client disconnects). servedQuality
+	// is emitted as the first in-band message so clients detect sub→main
+	// fallback even though the 101 upgrade response drops headers (#541).
+	if err := h.wsMgr.ServeWS(key, servedQuality, w, r); err != nil {
 		if errors.Is(err, wsstream.ErrStreamNotActive) {
 			WriteError(w, http.StatusNotFound, "WebSocket stream not active")
 			return

--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -615,7 +615,11 @@ func (m *Manager) writeLoop(ctx context.Context, camID string, entry *streamEntr
 // ServeWS handles a WebSocket upgrade request for a camera stream.
 // On connect, it sends CodecInfo as the first message, then streams
 // VideoFrame messages as they arrive from the StreamHub.
-func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) error {
+// When quality is non-empty ("main"/"sub"), a QualityInfo message is sent
+// BEFORE CodecInfo so clients can detect sub→main fallback — the 101
+// upgrade response cannot carry X-Stream-Quality (#541). Clients that don't
+// know the message type ignore it.
+func (m *Manager) ServeWS(camID, quality string, w http.ResponseWriter, r *http.Request) error {
 	m.mu.RLock()
 	entry, ok := m.streams[camID]
 	m.mu.RUnlock()
@@ -660,6 +664,22 @@ func (m *Manager) ServeWS(camID string, w http.ResponseWriter, r *http.Request) 
 
 	// Check for audio-only mode (?audio_only=1 skips video frames)
 	audioOnly := r.URL.Query().Get("audio_only") == "1"
+
+	// QualityInfo first (#541): the WS 101 upgrade response discards headers
+	// set before Upgrade(), so X-Stream-Quality can't reach WS clients — send
+	// the negotiated quality in-band instead. Sent even to audio-only viewers;
+	// skipped entirely when the caller passes an empty quality (no negotiation).
+	if quality != "" {
+		qiData, err := EncodeQualityInfo(&QualityInfo{Quality: quality})
+		if err != nil {
+			conn.Close()
+			return err
+		}
+		if err := conn.WriteMessage(websocket.BinaryMessage, qiData); err != nil {
+			conn.Close()
+			return err
+		}
+	}
 
 	// Send CodecInfo as first message (skip for audio-only viewers)
 	if !audioOnly {
@@ -852,7 +872,7 @@ var _ interface {
 	viewerCount(camID string) int
 	writeH264(camID string, pts int64, au [][]byte)
 	writeH265(camID string, pts int64, au [][]byte)
-	ServeWS(camID string, w http.ResponseWriter, r *http.Request) error
+	ServeWS(camID string, quality string, w http.ResponseWriter, r *http.Request) error
 	SetAudioInfo(camID string, codec string, muLaw bool, sampleRate int, channels int, config []byte) error
 	StopAll()
 } = (*Manager)(nil)

--- a/internal/wsstream/manager_test.go
+++ b/internal/wsstream/manager_test.go
@@ -199,7 +199,7 @@ func TestServeWS_CodecInfoFirstMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -228,7 +228,7 @@ func TestServeWS_CodecInfoH265(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -254,7 +254,7 @@ func TestServeWS_FrameStreaming(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -294,7 +294,7 @@ func TestServeWS_MultipleFrames(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -336,7 +336,7 @@ func TestServeWS_NonexistentStream(t *testing.T) {
 	m := NewManager()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := m.ServeWS("nonexistent", w, r)
+		err := m.ServeWS("nonexistent", "", w, r)
 		require.ErrorIs(t, err, ErrStreamNotActive)
 	})
 	server := httptest.NewServer(handler)
@@ -356,7 +356,7 @@ func TestServeWS_MaxViewers(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -392,7 +392,7 @@ func TestServeWS_DisconnectCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -420,7 +420,7 @@ func TestNonBlockingChannelDrop(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -479,7 +479,7 @@ func TestFrameDropCounter(t *testing.T) {
 
 	// Start HTTP server and connect a viewer
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("test-cam", w, r)
+		_ = m.ServeWS("test-cam", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -548,7 +548,7 @@ func TestIdleTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -575,7 +575,7 @@ func TestServeWS_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r.Clone(ctx))
+		_ = m.ServeWS("cam1", "", w, r.Clone(ctx))
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -601,7 +601,7 @@ func TestUnregisterStream_DisconnectsViewers(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -627,7 +627,7 @@ func TestGoroutineCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -656,7 +656,7 @@ func TestNoGoroutineLeakOnViewerDisconnect(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -695,7 +695,7 @@ func TestMultipleViewers(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -757,7 +757,7 @@ func TestServeWS_ConcurrentStreams(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		camID := r.URL.Query().Get("cam")
-		_ = m.ServeWS(camID, w, r)
+		_ = m.ServeWS(camID, "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -809,7 +809,7 @@ func TestWriteFrame_H265KeyframeDetection(t *testing.T) {
 	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -845,7 +845,7 @@ func TestManagerInterface(t *testing.T) {
 		viewerCount(camID string) int
 		writeH264(camID string, pts int64, au [][]byte)
 		writeH265(camID string, pts int64, au [][]byte)
-		ServeWS(camID string, w http.ResponseWriter, r *http.Request) error
+		ServeWS(camID string, quality string, w http.ResponseWriter, r *http.Request) error
 		StopAll()
 	} = (*Manager)(nil)
 }
@@ -869,7 +869,7 @@ func TestServeWS_NoConcurrentWriteOnUnregister(t *testing.T) {
 	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -925,7 +925,7 @@ func TestServeWS_EOSDeliveredBeforeClose(t *testing.T) {
 	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -966,7 +966,7 @@ func TestServeWS_NoConcurrentWriteOnIdle(t *testing.T) {
 	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -1025,4 +1025,77 @@ func BenchmarkEncodeVideoFrame(b *testing.B) {
 	for range b.N {
 		_, _ = EncodeVideoFrame(vf)
 	}
+}
+
+// ─── QualityInfo first message (#541) ────────────────────────────────────
+//
+// The WS 101 upgrade response cannot carry X-Stream-Quality (gorilla writes
+// its own header set), so the negotiated quality must arrive in-band. These
+// tests pin the wire contract: non-empty quality → QualityInfo precedes
+// CodecInfo; empty quality → behavior unchanged (CodecInfo first).
+
+func TestServeWS_QualityInfoFirstMessage(t *testing.T) {
+	m := NewManager()
+	hub := newTestHub(t)
+	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", "sub", w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialWS(t, "ws"+strings.TrimPrefix(server.URL, "http")+"/")
+	defer conn.Close()
+
+	msg, err := readMessage(t, conn)
+	require.NoError(t, err)
+	assert.Equal(t, MsgTypeQualityInfo, msg[0])
+
+	qi, err := decodeQualityInfo(msg)
+	require.NoError(t, err)
+	assert.Equal(t, "sub", qi.Quality)
+
+	// CodecInfo follows immediately.
+	msg2, err := readMessage(t, conn)
+	require.NoError(t, err)
+	assert.Equal(t, MsgTypeCodecInfo, msg2[0])
+}
+
+func TestServeWS_EmptyQualitySkipsQualityInfo(t *testing.T) {
+	m := NewManager()
+	hub := newTestHub(t)
+	require.NoError(t, m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.ServeWS("cam1", "", w, r)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	conn := dialWS(t, "ws"+strings.TrimPrefix(server.URL, "http")+"/")
+	defer conn.Close()
+
+	msg, err := readMessage(t, conn)
+	require.NoError(t, err)
+	assert.Equal(t, MsgTypeCodecInfo, msg[0], "no negotiation → CodecInfo stays first")
+}
+
+func TestEncodeDecodeQualityInfo(t *testing.T) {
+	// Round-trip both negotiated values.
+	for _, q := range []string{"main", "sub"} {
+		data, err := EncodeQualityInfo(&QualityInfo{Quality: q})
+		require.NoError(t, err)
+		qi, err := decodeQualityInfo(data)
+		require.NoError(t, err)
+		assert.Equal(t, q, qi.Quality)
+	}
+
+	// Truncated / wrong-type payloads must error, not panic.
+	_, err := decodeQualityInfo([]byte{MsgTypeQualityInfo})
+	assert.Error(t, err)
+	_, err = decodeQualityInfo([]byte{MsgTypeQualityInfo, 4, 'm', 'a'})
+	assert.Error(t, err)
+	_, err = decodeQualityInfo([]byte{MsgTypeCodecInfo, 4, 'm', 'a', 'i', 'n'})
+	assert.Error(t, err)
 }

--- a/internal/wsstream/protocol.go
+++ b/internal/wsstream/protocol.go
@@ -279,6 +279,44 @@ func decodeVideoFrame(data []byte) (*VideoFrame, error) {
 	return vf, nil
 }
 
+// ─── QualityInfo encode/decode ───────────────────────────────────────
+
+// EncodeQualityInfo encodes a QualityInfo into binary wire format.
+//
+// Wire format:
+//
+//	{type:1}{quality_len:1}{quality}
+//
+// quality is the ASCII string "main" or "sub" (#541).
+func EncodeQualityInfo(qi *QualityInfo) ([]byte, error) {
+	if qi == nil {
+		return nil, errors.New("wsstream: nil QualityInfo")
+	}
+	if len(qi.Quality) > 255 {
+		return nil, fmt.Errorf("wsstream: quality string too long: %d", len(qi.Quality))
+	}
+	buf := make([]byte, 2+len(qi.Quality))
+	buf[0] = MsgTypeQualityInfo
+	buf[1] = byte(len(qi.Quality))
+	copy(buf[2:], qi.Quality)
+	return buf, nil
+}
+
+// decodeQualityInfo decodes binary wire format into a QualityInfo.
+func decodeQualityInfo(data []byte) (*QualityInfo, error) {
+	if len(data) < 2 {
+		return nil, fmt.Errorf("wsstream: quality info too short: %d bytes", len(data))
+	}
+	if data[0] != MsgTypeQualityInfo {
+		return nil, fmt.Errorf("wsstream: expected message type 0x06, got 0x%02x", data[0])
+	}
+	qLen := int(data[1])
+	if 2+qLen > len(data) {
+		return nil, fmt.Errorf("wsstream: quality info truncated at quality string")
+	}
+	return &QualityInfo{Quality: string(data[2 : 2+qLen])}, nil
+}
+
 // ─── AudioCodecInfo encode ────────────────────────────────────────────
 
 // EncodeAudioCodecInfo encodes an AudioCodecInfo into binary wire format.

--- a/internal/wsstream/rebind_test.go
+++ b/internal/wsstream/rebind_test.go
@@ -26,7 +26,7 @@ func TestRebindHub(t *testing.T) {
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = m.ServeWS("cam1", w, r)
+		_ = m.ServeWS("cam1", "", w, r)
 	})
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/internal/wsstream/types.go
+++ b/internal/wsstream/types.go
@@ -7,6 +7,7 @@ const (
 	MsgTypeAudioFrame     byte = 0x03 // audio_frame: server→client
 	MsgTypeKeyframeReq    byte = 0x04 // keyframe_request: client→server
 	MsgTypeAudioCodecInfo byte = 0x05 // audio_codec_info: server→client, sent before audio frames
+	MsgTypeQualityInfo    byte = 0x06 // quality_info: server→client, sent once at stream start (#541)
 	MsgTypeEOS            byte = 0xFF // eos: server→client, camera went offline
 )
 
@@ -66,6 +67,16 @@ type AudioCodecInfo struct {
 	// wire extension (config_len + config appended in EncodeAudioCodecInfo) is
 	// backwards-compatible.
 	Config []byte
+}
+
+// QualityInfo reports which stream variant the server is actually serving
+// ("main" or "sub"). Sent once as the first message on viewer connect when
+// quality negotiation applies (#541) — the WebSocket 101 upgrade response
+// cannot carry the X-Stream-Quality header (the upgrader writes its own
+// header set), so the negotiated outcome travels in-band instead. Clients
+// that don't know the type ignore the message (backwards-compatible).
+type QualityInfo struct {
+	Quality string // "main" or "sub"
 }
 
 // AudioFrameData contains a single audio frame's presentation timestamp,

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1486,11 +1486,19 @@ func TestWebSocketStreamIntegration(t *testing.T) {
 	// Wait for the WebSocket connection to be established
 	time.Sleep(200 * time.Millisecond)
 
-	// --- Step 6: Read and verify CodecInfo (first message) ---
+	// --- Step 6: Read and verify QualityInfo + CodecInfo (first messages) ---
+	// QualityInfo (#541) precedes CodecInfo: the WS 101 upgrade response
+	// cannot carry X-Stream-Quality, so the negotiated quality travels in-band.
 	_, msg, err := conn.ReadMessage()
 	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(msg), 2, "QualityInfo message too short: %d bytes", len(msg))
+	require.Equal(t, wsstream.MsgTypeQualityInfo, msg[0], "first message should be QualityInfo")
+	require.Equal(t, "main", string(msg[2:]), "default request serves main stream")
+
+	_, msg, err = conn.ReadMessage()
+	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(msg), 5, "CodecInfo message too short: %d bytes", len(msg))
-	require.Equal(t, wsstream.MsgTypeCodecInfo, msg[0], "first message should be CodecInfo")
+	require.Equal(t, wsstream.MsgTypeCodecInfo, msg[0], "second message should be CodecInfo")
 
 	// --- Step 7: Broadcast frames via hub and verify VideoFrame messages ---
 	idrNALU := []byte{0x65, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}

--- a/web/src/components/WasmPlayer.svelte
+++ b/web/src/components/WasmPlayer.svelte
@@ -25,6 +25,7 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
     tabVisible = true,
     quality = 'main',
     onFallbackNeeded,
+    onQualityServed,
   }: {
     cameraId: string;
     cameraName: string;
@@ -34,10 +35,14 @@ import { WebGPURenderer } from '$lib/webgpu-renderer';
     expanded?: boolean;
     tabVisible?: boolean;
     /** Stream quality (#513) — 'sub' appends ?quality=sub to the WS URL; the
-     *  server falls back to main (X-Stream-Quality header) when the camera has
-     *  no sub stream. The decoder is configured from the SERVER's codec info,
-     *  so a sub stream whose codec differs from the main is handled. */
+     *  server falls back to main when the camera has no sub stream. The
+     *  decoder is configured from the SERVER's codec info, so a sub stream
+     *  whose codec differs from the main is handled. */
     quality?: 'main' | 'sub';
+    /** Fired once per connection with the quality the server actually served
+     *  ('main' | 'sub', #541) — reported in-band because the WS 101 upgrade
+     *  response cannot carry X-Stream-Quality. */
+    onQualityServed?: (served: 'main' | 'sub') => void;
     onFallbackNeeded?: (fallback: 'hls') => void;
   } = $props();
 
@@ -577,6 +582,11 @@ function handleWebGpuLost() {
       url: buildWsUrl(),
       onStateChange: (state: ConnectionState) => {
         updateState(state);
+      },
+      onQualityInfo: (info) => {
+        if (info.quality === 'main' || info.quality === 'sub') {
+          onQualityServed?.(info.quality);
+        }
       },
       onCodecInfo: (ci) => {
         if (!worker) return;

--- a/web/src/lib/webcodecs-player/connection.ts
+++ b/web/src/lib/webcodecs-player/connection.ts
@@ -13,8 +13,8 @@
  */
 
 import { MsgType } from './protocol';
-import type { CodecInfo, AudioCodecInfo, AudioFrame } from './protocol';
-import { decodeAudioCodecInfo, decodeAudioFrame } from './protocol';
+import type { CodecInfo, AudioCodecInfo, AudioFrame, QualityInfo } from './protocol';
+import { decodeAudioCodecInfo, decodeAudioFrame, decodeQualityInfo } from './protocol';
 import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
 
 // ─── Types ───────────────────────────────────────────────────────────────
@@ -40,6 +40,13 @@ export interface ConnectionManagerOptions {
   onCameraOffline?: () => void;
   /** Optional callback when AudioCodecInfo message received */
   onAudioCodecInfo?: (info: AudioCodecInfo) => void;
+  /**
+   * Optional callback when QualityInfo message received (#541). Fired once
+   * per connection (first in-band message) — reports 'main' when the server
+   * fell back from a requested sub-stream, since the 101 upgrade response
+   * cannot carry X-Stream-Quality.
+   */
+  onQualityInfo?: (info: QualityInfo) => void;
   /** Optional callback for each AudioFrame */
   onAudioFrame?: (frame: AudioFrame) => void;
   /** Optional reconnect coordinator for thundering herd prevention */
@@ -284,6 +291,12 @@ export class ConnectionManager {
           } catch {
             // parse error — ignore
           }
+        } else if (msgType === MsgType.QualityInfo) {
+          try {
+            this._opts.onQualityInfo?.(decodeQualityInfo(data));
+          } catch {
+            // parse error — ignore
+          }
         } else if (msgType === MsgType.AudioFrame) {
           try {
             this._opts.onAudioFrame?.(decodeAudioFrame(data));
@@ -354,8 +367,11 @@ export class ConnectionManager {
         // orchestrator demotes. Unlike the zombie/handshake counters above,
         // this check is immune to reconnect-cycle resets — _firstConnectTime is
         // stamped once and _everReceivedFrame is never cleared by a reconnect.
-        if (!this._everReceivedFrame && this._firstConnectTime > 0 &&
-            Date.now() - this._firstConnectTime > NO_MEDIA_TOTAL_MS) {
+        if (
+          !this._everReceivedFrame &&
+          this._firstConnectTime > 0 &&
+          Date.now() - this._firstConnectTime > NO_MEDIA_TOTAL_MS
+        ) {
           this._setState('offline');
           this._opts.onCameraOffline?.();
           return; // do NOT reconnect — let the orchestrator demote
@@ -543,12 +559,19 @@ export class ConnectionManager {
         this._zombieMissCount = 0;
 
         // Wall-clock guard also applies here (OPEN + no frames).
-        if (!this._everReceivedFrame && this._firstConnectTime > 0 &&
-            Date.now() - this._firstConnectTime > NO_MEDIA_TOTAL_MS) {
+        if (
+          !this._everReceivedFrame &&
+          this._firstConnectTime > 0 &&
+          Date.now() - this._firstConnectTime > NO_MEDIA_TOTAL_MS
+        ) {
           this._stopZombieDetection();
           this._setState('offline');
           this._opts.onCameraOffline?.();
-          try { if (this._ws) this._ws.close(1000); } catch { /* closed */ }
+          try {
+            if (this._ws) this._ws.close(1000);
+          } catch {
+            /* closed */
+          }
           return;
         }
 

--- a/web/src/lib/webcodecs-player/protocol.test.ts
+++ b/web/src/lib/webcodecs-player/protocol.test.ts
@@ -4,6 +4,7 @@ import {
   AudioCodecId,
   decodeAudioCodecInfo,
   decodeAudioFrame,
+  decodeQualityInfo,
   type AudioCodecInfo,
 } from './protocol';
 
@@ -18,7 +19,12 @@ import {
  */
 
 /** Build a wire-format AudioCodecInfo packet (mirrors the Go encoder). */
-function buildAudioCodecInfoPacket(codec: number, sampleRate: number, channels: number, config?: Uint8Array): ArrayBuffer {
+function buildAudioCodecInfoPacket(
+  codec: number,
+  sampleRate: number,
+  channels: number,
+  config?: Uint8Array,
+): ArrayBuffer {
   const configLen = config ? config.length : 0;
   const buf = new ArrayBuffer(9 + configLen);
   const dv = new DataView(buf);

--- a/web/src/lib/webcodecs-player/protocol.ts
+++ b/web/src/lib/webcodecs-player/protocol.ts
@@ -7,6 +7,7 @@
  *   0x03 = audio_frame   (server → client)
  *   0x04 = keyframe_req  (client → server)
  *   0x05 = audio_codec_info (server → client)
+ *   0x06 = quality_info  (server → client, #541)
  *   0xff = eos           (server → client)
  *
  * All multi-byte integers are big-endian (network byte order).
@@ -22,6 +23,7 @@ export const MsgType = {
   AudioFrame: 0x03,
   KeyframeReq: 0x04,
   AudioCodecInfo: 0x05,
+  QualityInfo: 0x06,
   EOS: 0xff,
 } as const;
 
@@ -191,6 +193,35 @@ export function decodeVideoFrame(data: ArrayBuffer): VideoFrame {
   }
 
   return { pts, isKeyframe, nalus, ingestAtMs };
+}
+
+// ─── QualityInfo Decode (#541) ────────────────────────────────────────────
+
+/**
+ * QualityInfo: which stream variant the server is actually serving.
+ * Binary wire format: {type:1}{quality_len:1}{quality}
+ * Sent once as the FIRST message on connect — the WS 101 upgrade response
+ * cannot carry the X-Stream-Quality header, so the negotiated outcome
+ * (sub requested but main served = fallback) travels in-band instead.
+ */
+export interface QualityInfo {
+  quality: string; // 'main' | 'sub'
+}
+
+/** Decode a binary ArrayBuffer to a QualityInfo. */
+export function decodeQualityInfo(data: ArrayBuffer): QualityInfo {
+  if (data.byteLength < 2) {
+    throw new Error(`QualityInfo too short: ${data.byteLength} bytes`);
+  }
+  const dv = new DataView(data);
+  if (dv.getUint8(0) !== MsgType.QualityInfo) {
+    throw new Error(`Expected msg type 0x06, got 0x${dv.getUint8(0).toString(16)}`);
+  }
+  const len = dv.getUint8(1);
+  if (2 + len > data.byteLength) {
+    throw new Error('QualityInfo truncated at quality string');
+  }
+  return { quality: new TextDecoder().decode(new Uint8Array(data, 2, len)) };
 }
 
 // ─── AudioCodecInfo Decode ────────────────────────────────────────────────


### PR DESCRIPTION
## 问题（#541）

FLV / HLS / WHEP 都通过 `X-Stream-Quality` 响应头告知客户端实际服务的画质（main/sub），但 WebSocket 端点的这个头永远到不了客户端——gorilla/websocket 的 101 升级响应会接管连接并写入自己的响应头，丢弃升级前在 `w.Header()` 上设置的一切。浏览器 WebSocket API 本身也读不到响应头。结果是原生 WS 客户端无法区分「子码流」和「已回退主码流」。

## 方案

新增 **QualityInfo（0x06）** 二进制消息，线格式 `{type:1}{quality_len:1}{quality}`，在画质协商生效时作为连接的**第一条消息**发出（早于 CodecInfo）：

- 后端 `internal/wsstream/`：`MsgTypeQualityInfo`、`QualityInfo` 类型、`Encode/DecodeQualityInfo`；`ServeWS` 增加 `quality` 参数并在升级后首先发送（空串 = 不协商 = 行为完全不变）
- `handleStreamWS`：计算实际服务的画质（sub 拉流成功 = sub，否则 main）并传入 —— 与 FLV/HLS/WHEP 的 `acquireSub` 回退语义一致
- 前端：`protocol.ts` 解码 0x06；`connection.ts` 新增 `onQualityInfo` 回调；`WasmPlayer` 暴露 `onQualityServed` prop

**向后兼容**：旧客户端（含当前前端）按消息类型分发、未知类型直接忽略；`quality=` 缺省时完全不发这条消息。

## 测试

- 后端：`TestServeWS_QualityInfoFirstMessage`（0x06 先于 0x01）、`TestServeWS_EmptyQualitySkipsQualityInfo`（无协商时 CodecInfo 仍是首条）、`TestEncodeDecodeQualityInfo`（round-trip + 截断/错类型拒绝）
- 前端：`decodeQualityInfo` 三组用例（两值 round-trip / 截断 / 错类型）
- `rtk go test ./internal/wsstream/ ./internal/api/` 与 `npm test` 全绿

Closes #541