### PR TITLE
fix(vision): sub-layer recorder stop self-deadlock (CI internal/vision timeout flake)

### DIFF
--- a/internal/vision/sublayer.go
+++ b/internal/vision/sublayer.go
@@ -520,12 +520,22 @@ func (r *subLayerRecorder) run(ctx context.Context) {
 		r.smu.Lock()
 		r.stopped = ctx.Err() != nil
 		r.closeSegmentLocked()
-		r.unsubscribeLocked()
+		// Unsubscribe must run OUTSIDE smu: it waits for the hub's drain
+		// goroutine, which may be parked in onFrame's smu.Lock() — holding
+		// the mutex here self-deadlocks Stop (seen as the vision package's
+		// intermittent "test timed out" CI flake). stopped=true (set above)
+		// makes any in-flight onFrame return as soon as it gets the mutex.
+		unsubID := r.subID
+		r.subID = ""
+		unsubSrc := r.src
 		if holding {
 			r.mgr.provider.ReleaseSubStream(r.cameraID)
 			holding = false
 		}
 		r.smu.Unlock()
+		if unsubID != "" && unsubSrc != nil {
+			unsubSrc.Hub().Unsubscribe(unsubID)
+		}
 		if ctx.Err() != nil {
 			break
 		}
@@ -580,13 +590,6 @@ func (r *subLayerRecorder) record(ctx context.Context) error {
 				return fmt.Errorf("sub-stream source failed (no video track)")
 			}
 		}
-	}
-}
-
-func (r *subLayerRecorder) unsubscribeLocked() {
-	if r.src != nil && r.subID != "" {
-		r.src.Hub().Unsubscribe(r.subID)
-		r.subID = ""
 	}
 }
 


### PR DESCRIPTION
## 根因

`internal/vision` 的 `panic: test timed out after 5m0s` flake 今天起在 CI 连续复现（main 两次、PR #543/#544 各一次），本地约 1/3 概率复现。goroutine dump 显示：

```
SubLayerManager.Stop → subLayerRecorder.stop → <-r.done        (等待 run 结束)
run → src.Hub().Unsubscribe(subID)                              (等待 drain goroutine)
hub drain goroutine → subLayerRecorder.onFrame → r.smu.Lock()   (等 mutex)
                                     ↑ 而 run 正持有 r.smu —— 单锁自死锁
```

`run()` 在持有 `r.smu` 的情况下调用 `Unsubscribe`；Unsubscribe 会等 hub 的 per-consumer drain goroutine 排空，而 drain 可能正停在 `onFrame` 的 `smu.Lock()` 上。

## 修复

退订移到锁外执行：先在锁内置 `stopped=true`（in-flight `onFrame` 一旦拿到锁立即返回）、清空 `subID`，释放 `smu` 后再 `Unsubscribe`。删除不再使用的 `unsubscribeLocked`。

## 验证

- 本地 `go test ./internal/vision/ -count=1` 连续 12 次全部通过（修复前 ~1/3 挂起）
- `internal/vision` + `internal/substream` 全量测试通过