### PR TITLE
fix(gb28181): cascade catalog advertised cameras archived in the DB

### DIFF
--- a/internal/camera/cascade_source.go
+++ b/internal/camera/cascade_source.go
@@ -1,8 +1,11 @@
 package camera
 
 import (
+	"context"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/cascade"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
 // cascadeSource adapts the CameraManager to the cascade client's
@@ -10,10 +13,19 @@ import (
 // aggregated catalog, and forwards subscribe to their stream hubs.
 type cascadeSource struct {
 	cm *CameraManager
+	db *storage.DB
 }
 
-// NewCascadeSource builds the cascade view of the camera manager.
-func NewCascadeSource(cm *CameraManager) cascade.CameraSource { return cascadeSource{cm: cm} }
+// NewCascadeSource builds the cascade view of the camera manager. The DB is
+// the authority on which cameras are archived: archiving marks the DB row
+// archived=1, but a partially-failed archive can leave the config entry in
+// the YAML (the manager re-upserts the row at boot without touching the
+// archived flag). The camera list API is DB-backed, so the catalog must gate
+// on the same set — an archived camera must never be advertised to the upper
+// platform as a playable channel.
+func NewCascadeSource(cm *CameraManager, db *storage.DB) cascade.CameraSource {
+	return cascadeSource{cm: cm, db: db}
+}
 
 // Cameras lists cameras eligible for cascade forwarding. MJPEG/JPEG cameras
 // are excluded (no PS mux story); everything else is offered — GB28181
@@ -21,12 +33,18 @@ func NewCascadeSource(cm *CameraManager) cascade.CameraSource { return cascadeSo
 // forwarder sniffs the codec from the first NAL when the hint is empty.
 func (s cascadeSource) Cameras() []cascade.CameraInfo {
 	snap := s.cm.loadSnapshot()
+	active := s.activeCameraIDs()
 	out := make([]cascade.CameraInfo, 0, len(snap.configs))
 	for _, cfg := range snap.configs {
 		if cfg.Encoding == "mjpeg" || cfg.Encoding == "jpeg" {
 			continue
 		}
 		if cfg.Protocol == "timelapse" {
+			continue
+		}
+		if active != nil && !active[cfg.ID] {
+			// Archived (or DB-less residue) camera — not listed by the API,
+			// not advertised to the upper platform.
 			continue
 		}
 		out = append(out, cascade.CameraInfo{
@@ -41,6 +59,24 @@ func (s cascadeSource) Cameras() []cascade.CameraInfo {
 		})
 	}
 	return out
+}
+
+// activeCameraIDs returns the set of non-archived camera IDs, or nil when the
+// set cannot be determined (no DB / query error) — callers treat nil as "no
+// filtering", preserving the pre-fix behavior instead of blanking the catalog.
+func (s cascadeSource) activeCameraIDs() map[string]bool {
+	if s.db == nil {
+		return nil
+	}
+	rows, err := s.db.ListCameras(context.Background())
+	if err != nil {
+		return nil
+	}
+	set := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		set[r.ID] = true
+	}
+	return set
 }
 
 // Hub returns the camera's stream hub (nil when the camera has no hub —

--- a/internal/camera/cascade_source_test.go
+++ b/internal/camera/cascade_source_test.go
@@ -1,0 +1,59 @@
+package camera
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// The cascade catalog must only advertise cameras the DB still lists as
+// active. Archiving marks the row archived=1; a partially-failed archive can
+// leave the config entry in the YAML (boot re-upserts the row without
+// touching the archived flag), and the catalog must not advertise that
+// residue to the upper platform (found on M5: archived "Lower Cascade Test"
+// still allocated cascade channel …05 on the fnOS upper, dead forever).
+func TestCascadeSource_ExcludesArchivedCameras(t *testing.T) {
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "cam-live", Name: "Live", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/a"},
+		{ID: "cam-residue", Name: "Archived Residue", Protocol: "gb28181", Encoding: ""},
+		{ID: "cam-mjpeg", Name: "MJPEG", Protocol: "rtsp", Encoding: "mjpeg", URL: "rtsp://127.0.0.1:1/b"},
+	}
+	mgr, _, db, _ := newTestManagerWithCfg(t, cfg)
+	ctx := context.Background()
+
+	// DB knows only the live camera (the residue camera's row is archived or
+	// was never created by the API path).
+	require.NoError(t, db.UpsertCamera(ctx, "cam-live", "Live", "rtsp", "h264", "rtsp://127.0.0.1:1/a", "", "", "", "", "", ""))
+	// Mirror the M5 sequence: row created active -> archived (partial
+	// archive leaves the YAML entry) -> boot re-upsert must not resurrect.
+	require.NoError(t, db.UpsertCamera(ctx, "cam-residue", "Archived Residue", "gb28181", "", "", "", "", "", "", "", ""))
+	require.NoError(t, db.ArchiveCameraDB(ctx, "cam-residue"))
+	require.NoError(t, db.UpsertCamera(ctx, "cam-residue", "Archived Residue", "gb28181", "", "", "", "", "", "", "", ""))
+	// Boot-style re-upsert must not resurrect the archived row.
+	rows, err := db.ListCameras(ctx)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	require.False(t, ids["cam-residue"], "archived row should stay hidden after re-upsert")
+
+	src := NewCascadeSource(mgr, db)
+	var got []string
+	for _, c := range src.Cameras() {
+		got = append(got, c.ID)
+	}
+	require.Equal(t, []string{"cam-live"}, got, "catalog must exclude archived residue and MJPEG")
+
+	// nil DB (no filter) preserves the pre-fix behavior: everything but
+	// MJPEG/timelapse is offered.
+	var gotNil []string
+	for _, c := range (cascadeSource{cm: mgr}).Cameras() {
+		gotNil = append(gotNil, c.ID)
+	}
+	require.ElementsMatch(t, []string{"cam-live", "cam-residue"}, gotNil)
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -752,7 +752,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	// to the configured upper platform as a lower-level device; cameras are
 	// aggregated into its catalog and forwarded (PS mux) on INVITE.
 	if cfg.GB28181Cascade.Enabled {
-		deps.gb28181Cascade = cascade.New(cfg.GB28181Cascade, camera.NewCascadeSource(camMgr), db)
+		deps.gb28181Cascade = cascade.New(cfg.GB28181Cascade, camera.NewCascadeSource(camMgr, db), db)
 		slog.Info("GB28181 cascade client configured",
 			"upper", cfg.GB28181Cascade.ServerAddr, "device", cfg.GB28181Cascade.LocalDeviceID)
 	}


### PR DESCRIPTION
## Problem

Browser/E2E cascade testing against the fnOS upper platform found a dead channel (`34020000011320000005`, "Lower Cascade Test") that maps to a camera archived on the NVR back on 08-19.

Root cause chain:
- `ArchiveCamera` marks the DB row `archived=1` and removes the config entry from the YAML. For this camera the YAML removal half failed/partial — the entry survived.
- `CameraManager.Start` re-upserts the DB row for every config camera at boot; `UpsertCamera`'s ON CONFLICT does not touch `archived`, so the row stays archived — the camera list API (DB-backed) correctly hides it.
- The cascade catalog is built from the manager's **config snapshot**, so the residue camera kept being advertised to the upper platform as a playable channel, holding a persisted channel allocation and inviting permanent dead-channel churn on the upper side.

## Fix

Gate `cascadeSource.Cameras()` on the DB's active camera set (`ListCameras` = `archived=0`). This covers the catalog, INVITE resolution, and forwarding in one place since they all read the same `CameraSource`. A nil DB or query error fails open (previous behavior) instead of blanking the catalog.

## Testing

- New unit test `TestCascadeSource_ExcludesArchivedCameras` reproducing the exact M5 sequence (row created active → archived → boot re-upsert) — catalog excludes the residue camera, nil-DB path unchanged.
- Full `internal/cameras` package suite green.