### PR TITLE
feat(live-latency): FLV exact + HLS/WebRTC approximate end-to-end latency (#481)

### DIFF
--- a/internal/api/handlers_flow.go
+++ b/internal/api/handlers_flow.go
@@ -44,6 +44,10 @@ type FlowCamera struct {
 	// queue for this camera (#480; mirrors nvr_merge_pending_segments).
 	// Omitted when the merge manager isn't wired.
 	MergePending *int `json:"merge_pending,omitempty"`
+	// FLVClockMs is the wallclock base (unix ms) the FLV tag StreamID
+	// ingest deltas are measured from — players combine it with the delta
+	// to compute end-to-end live latency (#481). 0/omitted = no FLV entry.
+	FLVClockMs int64 `json:"flv_clock_ms,omitempty"`
 }
 
 // recordingStatsProvider is implemented by recorders embedding baseRecorder
@@ -151,6 +155,7 @@ func (h *Handler) buildFlowCamera(cameraID string, hub *model.StreamHub, status 
 	}
 	if h.flvMgr != nil {
 		fc.Viewers["flv"] = h.flvMgr.ViewerCount(cameraID)
+		fc.FLVClockMs = h.flvMgr.ClockMs(cameraID)
 	}
 	if h.webrtcMgr != nil {
 		fc.Viewers["webrtc"] = h.webrtcMgr.PeerCount(cameraID)

--- a/internal/flv/ingest_clock_test.go
+++ b/internal/flv/ingest_clock_test.go
@@ -1,0 +1,57 @@
+package flv
+
+// Tests for the ingest-wallclock piggyback in the FLV tag StreamID field
+// (#481): end-to-end live latency for the FLV egress path.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVideoFrameTag_EncodesIngestDelta(t *testing.T) {
+	// Keyframe with a 1234ms ingest offset.
+	tag := videoFrameTag(model.FormatH264, [][]byte{{0x65, 0x01}}, 90000, true, 1234)
+	require.GreaterOrEqual(t, len(tag), 16)
+	delta := int64(tag[8])<<16 | int64(tag[9])<<8 | int64(tag[10])
+	assert.Equal(t, int64(1234), delta, "StreamID carries the ingest offset")
+
+	// Unknown sentinel round-trips as 0xFFFFFF.
+	tag = videoFrameTag(model.FormatH264, [][]byte{{0x65}}, 0, true, flvIngestUnknown)
+	delta = int64(tag[8])<<16 | int64(tag[9])<<8 | int64(tag[10])
+	assert.Equal(t, int64(0xFFFFFF), delta)
+}
+
+func TestWriteLoopBakesDeltaAndClockMs(t *testing.T) {
+	m, hub := newTestManagerWithHub(t)
+	require.NoError(t, m.RegisterStream("clock-cam", model.FormatH264, minimalSPS, minimalPPS, nil, hub))
+	t.Cleanup(func() { m.UnregisterStream("clock-cam") })
+
+	base := m.ClockMs("clock-cam")
+	require.NotZero(t, base, "clock base set at registration")
+
+	// hub.Broadcast stamps IngestAt at entry; the baked delta must be a
+	// small non-negative offset — NOT the unknown sentinel.
+	hub.Broadcast(90000, [][]byte{{0x65, 0x01}}, true)
+
+	require.Eventually(t, func() bool {
+		m.mu.RLock()
+		entry := m.streams["clock-cam"]
+		m.mu.RUnlock()
+		if entry == nil {
+			return false
+		}
+		entry.gopMu.RLock()
+		defer entry.gopMu.RUnlock()
+		for _, f := range entry.gopCache.frames {
+			delta := int64(f.tag[8])<<16 | int64(f.tag[9])<<8 | int64(f.tag[10])
+			if delta >= 0 && delta < 10_000 {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond, "tag carries a real ingest delta (not the unknown sentinel)")
+}

--- a/internal/flv/manager.go
+++ b/internal/flv/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -51,6 +52,10 @@ type streamEntry struct {
 	cancel    context.CancelFunc
 	hub       *model.StreamHub
 	hubSubID  string
+	// clockBase is the unix-ms wallclock this entry's FLV tag StreamID
+	// deltas are measured from (#481). Fixed at registration so the shared
+	// per-frame tag encodes a viewer-independent ingest offset.
+	clockBase atomic.Int64
 }
 
 // viewerConn represents a connected FLV client.
@@ -145,12 +150,15 @@ func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps
 		hub:       hub,
 	}
 
-	// Subscribe to recorder's StreamHub for live frames
+	// Subscribe with the full FrameMsg so the hub-entry wallclock (IngestAt)
+	// reaches the wire — the StreamID field of every video tag carries the
+	// ingest offset from clockBase (#481, end-to-end latency for FLV).
+	entry.clockBase.Store(time.Now().UnixMilli())
 	if hub != nil {
 		hubSubID := "flv-" + camID
 		entry.hubSubID = hubSubID
-		_ = hub.Subscribe(hubSubID, func(pts int64, au [][]byte) {
-			m.writeFrame(camID, pts, au)
+		_ = hub.SubscribeMsg(hubSubID, func(msg model.FrameMsg) {
+			m.writeFrameMsg(camID, msg)
 		})
 	}
 
@@ -227,8 +235,8 @@ func (m *Manager) RebindHub(camID string, hub *model.StreamHub) {
 	if oldHub != nil && subID != "" {
 		oldHub.Unsubscribe(subID)
 	}
-	if hub.Subscribe(subID, func(pts int64, au [][]byte) {
-		m.writeFrame(camID, pts, au)
+	if hub.SubscribeMsg(subID, func(msg model.FrameMsg) {
+		m.writeFrameMsg(camID, msg)
 	}) != nil {
 		flvLogger.Warn("FLV rebind: hub subscribe failed", "camera_id", camID)
 		return
@@ -274,6 +282,13 @@ func (m *Manager) writeH265(camID string, pts int64, au [][]byte) {
 }
 
 func (m *Manager) writeFrame(camID string, pts int64, au [][]byte) {
+	m.writeFrameMsg(camID, model.FrameMsg{PTS: pts, AU: au})
+}
+
+// writeFrameMsg queues a full FrameMsg (carrying the hub-entry IngestAt
+// wallclock for the latency piggyback, #481). Non-blocking.
+func (m *Manager) writeFrameMsg(camID string, msg model.FrameMsg) {
+	pts, au := msg.PTS, msg.AU
 	if len(au) == 0 {
 		return
 	}
@@ -301,7 +316,7 @@ func (m *Manager) writeFrame(camID string, pts int64, au [][]byte) {
 
 	// Non-blocking send
 	select {
-	case entry.frameCh <- model.FrameMsg{PTS: pts, AU: au, IsKeyframe: isKeyframe}:
+	case entry.frameCh <- model.FrameMsg{PTS: pts, AU: au, IsKeyframe: isKeyframe, IngestAt: msg.IngestAt}:
 		frametrace.Log(
 			camID,
 			"trace_id", traceID,
@@ -328,7 +343,16 @@ func (m *Manager) writeLoop(ctx context.Context, camID string, entry *streamEntr
 		case <-ctx.Done():
 			return
 		case msg := <-entry.frameCh:
-			tag := videoFrameTag(entry.codec, msg.AU, msg.PTS, msg.IsKeyframe)
+			// Ingest offset (ms from clockBase) rides in the tag StreamID
+			// field — spec-receivers ignore it, our player reads it (#481).
+			// 0xFFFFFF = unknown (no IngestAt / out of the 4.6h 3-byte range).
+			var delta int64 = flvIngestUnknown
+			if msg.IngestAt > 0 {
+				if d := msg.IngestAt/1e6 - entry.clockBase.Load(); d >= 0 && d < flvIngestUnknown {
+					delta = d
+				}
+			}
+			tag := videoFrameTag(entry.codec, msg.AU, msg.PTS, msg.IsKeyframe, delta)
 
 			// Update GOP cache on keyframe
 			if msg.IsKeyframe {
@@ -371,6 +395,20 @@ func (m *Manager) writeLoop(ctx context.Context, camID string, entry *streamEntr
 			entry.viewerMu.Unlock()
 		}
 	}
+}
+
+// ClockMs returns the entry's ingest-clock base (unix ms) that the tag
+// StreamID deltas are measured from, or 0 when the stream is not active.
+// The flow API surfaces it so players can turn a delta into a wallclock
+// (#481).
+func (m *Manager) ClockMs(camID string) int64 {
+	m.mu.RLock()
+	entry, ok := m.streams[camID]
+	m.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+	return entry.clockBase.Load()
 }
 
 // ServeFLV handles an HTTP request for FLV live streaming.
@@ -452,7 +490,10 @@ func (m *Manager) ServeFLV(camID string, w http.ResponseWriter, r *http.Request)
 		return err
 	}
 
-	// Set response headers
+	// Set response headers. X-Stream-Wallclock-Ms anchors the StreamID
+	// ingest deltas for clients that read response headers (#481); the
+	// flow API exposes the same value for the rest.
+	w.Header().Set("X-Stream-Wallclock-Ms", strconv.FormatInt(entry.clockBase.Load(), 10))
 	w.Header().Set("Content-Type", "video/x-flv")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")

--- a/internal/flv/manager_test.go
+++ b/internal/flv/manager_test.go
@@ -141,7 +141,7 @@ func TestVideoFrameTag_H264(t *testing.T) {
 	pts := int64(90000) // 1 second at 90kHz
 	isKeyframe := true
 
-	tag := videoFrameTag(model.FormatH264, nalus, pts, isKeyframe)
+	tag := videoFrameTag(model.FormatH264, nalus, pts, isKeyframe, flvIngestUnknown)
 	require.NotNil(t, tag)
 
 	// Tag type: video
@@ -175,7 +175,7 @@ func TestVideoFrameTag_H265(t *testing.T) {
 	pts := int64(45000)
 	isKeyframe := true
 
-	tag := videoFrameTag(model.FormatH265, nalus, pts, isKeyframe)
+	tag := videoFrameTag(model.FormatH265, nalus, pts, isKeyframe, flvIngestUnknown)
 	require.NotNil(t, tag)
 
 	// FrameType + CodecID: 0x1C (keyframe + HEVC)
@@ -189,7 +189,7 @@ func TestVideoFrameTag_NonKeyframe(t *testing.T) {
 	pts := int64(3000)
 	isKeyframe := false
 
-	tag := videoFrameTag(model.FormatH264, nalus, pts, isKeyframe)
+	tag := videoFrameTag(model.FormatH264, nalus, pts, isKeyframe, flvIngestUnknown)
 
 	// FrameType + CodecID: 0x27 (inter-frame + AVC)
 	require.Equal(t, byte(0x27), tag[11])

--- a/internal/flv/writer.go
+++ b/internal/flv/writer.go
@@ -25,6 +25,12 @@ const (
 	avcPacketTypeEndOfSequence  = 0x02
 )
 
+// flvIngestUnknown is the StreamID sentinel for "no ingest wallclock"
+// (source had no IngestAt, or the offset exceeded the 3-byte ms range —
+// ~4.6h, which only multi-day streams can exceed). Players treat it as
+// "latency unknown" and keep the last known value (#481).
+const flvIngestUnknown = 0xFFFFFF
+
 // Frame type masks.
 const (
 	frameTypeKeyframe   = 0x10
@@ -210,7 +216,7 @@ func h265SequenceHeader(vps, sps, pps []byte) []byte {
 // videoData slice, then the flvTag buffer). The shared buffer is sent to multiple viewers
 // and cached in gopCache, so a sync.Pool is unsafe here — but collapsing the build into
 // one allocation still cuts per-frame GC pressure by ~⅔.
-func videoFrameTag(codec model.Format, nalus [][]byte, pts int64, isKeyframe bool) []byte {
+func videoFrameTag(codec model.Format, nalus [][]byte, pts int64, isKeyframe bool, ingestDeltaMs int64) []byte {
 	// Convert PTS from 90kHz to milliseconds
 	tsMs := pts / 90
 
@@ -236,10 +242,11 @@ func videoFrameTag(codec model.Format, nalus [][]byte, pts int64, isKeyframe boo
 	buf[5] = byte(ts >> 8)
 	buf[6] = byte(ts)
 	buf[7] = byte(tsMs >> 24) // timestamp extended
-	// StreamID: always 0
-	buf[8] = 0x00
-	buf[9] = 0x00
-	buf[10] = 0x00
+	// StreamID: spec-required 0; we carry the ingest wallclock offset here
+	// (#481) — receivers ignore the field, our player demuxes it.
+	buf[8] = byte(ingestDeltaMs >> 16)
+	buf[9] = byte(ingestDeltaMs >> 8)
+	buf[10] = byte(ingestDeltaMs)
 
 	// Video tag data starting at offset 11: frameType+codecID + packetType + compositionTime
 	var frameTypeAndCodec byte

--- a/web/src/components/FlvPlayer.svelte
+++ b/web/src/components/FlvPlayer.svelte
@@ -7,6 +7,9 @@
   import { getSnapshotUrl } from '$lib/api/cameras';
   import { captureFrame } from '$lib/freeze-frame';
   import { sendTelemetry } from '$lib/telemetry';
+  import { apiRequest } from '$lib/api';
+  import { LiveLatencyTracker, latencyBadgeClass } from '$lib/live-latency.svelte';
+  import { FLVIngestParser, createTeeLoader } from '$lib/flv-ingest-clock';
   import type { StreamState } from '$lib/hls-errors';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
   import { createStateDispatcher } from '$lib/player/dispatch';
@@ -33,6 +36,40 @@
      *  return false (or omit) to let this player fall back to a snapshot. */
     onProtocolFailed?: () => boolean;
   } = $props();
+
+  // End-to-end live latency (#481): the backend rides the hub-ingest
+  // wallclock offset in each video tag's StreamID field (see
+  // flv-ingest-clock.ts); combine with the clock base from the flow API.
+  const latency = new LiveLatencyTracker(cameraId, 'flv');
+  const flvParser = new FLVIngestParser();
+  let flvClockMs = 0;
+  let latencyTimer: ReturnType<typeof setInterval> | null = null;
+  let clockTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startLatencyTracking() {
+    if (latencyTimer) return;
+    latencyTimer = setInterval(() => {
+      const delta = flvParser.latestDeltaMs;
+      if (flvClockMs > 0 && delta != null) latency.track(flvClockMs + delta);
+    }, 2000);
+    const pollClock = async () => {
+      try {
+        const flow = await apiRequest<{ flv_clock_ms?: number }>(`/cameras/${cameraId}/flow`);
+        if (flow?.flv_clock_ms) flvClockMs = flow.flv_clock_ms;
+      } catch {
+        /* flow snapshot unavailable — latency display pauses, playback unaffected */
+      }
+    };
+    void pollClock();
+    clockTimer = setInterval(pollClock, 15_000);
+  }
+
+  function stopLatencyTracking() {
+    if (latencyTimer) clearInterval(latencyTimer);
+    if (clockTimer) clearInterval(clockTimer);
+    latencyTimer = null;
+    clockTimer = null;
+  }
 
   // Reconnection coordinator from Dashboard context
   const coordinator = getContext<ReconnectCoordinator | undefined>('reconnect-coordinator');
@@ -303,6 +340,11 @@ let videoEventAc: AbortController | null = null;
       const url = `${API_BASE}/cameras/${cameraId}/stream.flv${quality === 'sub' ? '?quality=sub' : ''}`;
       const authHeader = getAuthHeader();
 
+      const teeLoader = createTeeLoader(
+        mpegts.default,
+        (chunk) => flvParser.feed(chunk),
+        authHeader ? { Authorization: authHeader } : undefined,
+      );
       const player = mpegts.default.createPlayer({
         type: 'flv',
         isLive: true,
@@ -311,6 +353,7 @@ let videoEventAc: AbortController | null = null;
         hasVideo: true,
         cors: false,
       }, {
+        customLoader: teeLoader,
         headers: authHeader ? { Authorization: authHeader } : undefined,
         enableStashBuffer: false,
         stashInitialSize: 128,
@@ -325,6 +368,7 @@ let videoEventAc: AbortController | null = null;
       mpegtsPlayer = player;
       streamState = 'buffering';
       reconnectAttempts = 0;
+      startLatencyTracking();
 
       player.attachMediaElement(videoEl);
       player.load();
@@ -440,6 +484,7 @@ let videoEventAc: AbortController | null = null;
   onDestroy(() => {
     destroyed = true;
     stopSnapshotMode();
+    stopLatencyTracking();
     if (coordinatedTimer) { clearTimeout(coordinatedTimer); coordinatedTimer = null; }
     if (coordinator) coordinator.cancelRequest(cameraId);
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
@@ -528,6 +573,14 @@ let videoEventAc: AbortController | null = null;
     >
       {t('live.videoUnsupportedTag')}
     </video>
+    {#if latency.value != null}
+      <span
+        class="absolute top-1.5 left-2 text-xs tabular-nums z-20 {latencyBadgeClass(latency.value)}"
+        title={t('flow.liveLatency')}
+      >
+        {(latency.value / 1000).toFixed(1)}s
+      </span>
+    {/if}
   {/if}
 
   <!-- Overlay -->

--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -15,6 +15,7 @@
   import { captureFrame } from '$lib/freeze-frame';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
   import { createStateDispatcher } from '$lib/player/dispatch';
+  import { LiveLatencyTracker, latencyBadgeClass } from '$lib/live-latency.svelte';
 
   let {
     cameraId,
@@ -67,6 +68,24 @@
   let streamState: StreamState | 'loading' = $state('loading');
   let videoEl: HTMLVideoElement | undefined = $state();
   let hlsInstance: any = null;
+  // Approximate live latency (#481): HLS has no in-band ingest stamp —
+  // hls.js `latency` (playlist edge − playhead, i.e. buffered segments ×
+  // duration) is the accepted approximation. Live protocol only.
+  const latency = new LiveLatencyTracker(cameraId, 'hls');
+  let latencyTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startLatencyTracking() {
+    if (latencyTimer || !hlsInstance) return;
+    latencyTimer = setInterval(() => {
+      const l = hlsInstance?.latency;
+      if (typeof l === 'number' && l > 0) latency.trackLatencyMs(l * 1000);
+    }, 2000);
+  }
+
+  function stopLatencyTracking() {
+    if (latencyTimer) clearInterval(latencyTimer);
+    latencyTimer = null;
+  }
   let HlsConstructor: any = null;
   let recreateAttempts = { value: 0 };
   let zombieCleanup: (() => void) | null = null;
@@ -279,6 +298,7 @@
 
       hls.on(Hls.Events.MANIFEST_PARSED, () => {
         videoEl?.play().catch(() => {});
+        if (protocol === 'hls') startLatencyTracking();
       });
     } catch (e) { console.warn('HLS init failed:', e);
 streamState = 'error';
@@ -346,6 +366,7 @@ streamState = 'error';
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
     frozenFrameUrl = null;
     stateDispatcher.dispose();
+    stopLatencyTracking();
     destroyCurrentHls();
     destroyCurrentHls();
   });
@@ -407,6 +428,14 @@ streamState = 'error';
   >
     {t('live.videoUnsupportedTag')}
   </video>
+  {#if protocol === 'hls' && latency.value != null}
+    <span
+      class="absolute top-1.5 left-2 text-xs tabular-nums z-20 {latencyBadgeClass(latency.value)}"
+      title={t('flow.liveLatency')}
+    >
+      ≈{(latency.value / 1000).toFixed(1)}s
+    </span>
+  {/if}
 
   <!-- Overlay layer with CSS transition -->
   <div

--- a/web/src/components/WebRTCPlayer.svelte
+++ b/web/src/components/WebRTCPlayer.svelte
@@ -8,6 +8,8 @@
   import { getSnapshotUrl } from '$lib/api/cameras';
   import { captureFrame } from '$lib/freeze-frame';
   import { sendTelemetry } from '$lib/telemetry';
+  import { apiRequest } from '$lib/api';
+  import { LiveLatencyTracker, latencyBadgeClass } from '$lib/live-latency.svelte';
   import type { StreamState } from '$lib/hls-errors';
   import type { ReconnectCoordinator } from '$lib/reconnect-coordinator.svelte';
   import { createStateDispatcher } from '$lib/player/dispatch';
@@ -36,6 +38,38 @@
      *  when the sub stream isn't H.264 (WebRTC tracks are H.264-only). */
     quality?: 'main' | 'sub';
   } = $props();
+
+  // Approximate end-to-end live latency (#481): WebRTC has no in-band
+  // ingest stamp readable from the browser (RTP header extensions aren't
+  // exposed), so we use the camera's hub-ingest age from the flow snapshot
+  // — captures camera→NVR staleness; the jitter-buffer adds ~100-300ms
+  // on top. Displayed with the same badge/thresholds as the exact paths.
+  const latency = new LiveLatencyTracker(cameraId, 'webrtc');
+  let latencyTimer: ReturnType<typeof setInterval> | null = null;
+  let lastIngestAtMs = 0;
+
+  function startLatencyTracking() {
+    if (latencyTimer) return;
+    const poll = async () => {
+      try {
+        const flow = await apiRequest<{ last_frame_at?: string }>('/cameras/' + cameraId + '/flow');
+        const at = flow?.last_frame_at ? Date.parse(flow.last_frame_at) : 0;
+        if (at > 0) lastIngestAtMs = at;
+      } catch {
+        /* flow unavailable — latency pauses */
+      }
+    };
+    void poll();
+    latencyTimer = setInterval(() => {
+      void poll();
+      latency.track(lastIngestAtMs);
+    }, 3000);
+  }
+
+  function stopLatencyTracking() {
+    if (latencyTimer) clearInterval(latencyTimer);
+    latencyTimer = null;
+  }
 
   // Reconnection coordinator from Dashboard context
   const coordinator = getContext<ReconnectCoordinator | undefined>('reconnect-coordinator');
@@ -388,6 +422,7 @@ let destroyed = false;
           const onPlaying = () => {
             firstFramePlayed = true;
             reconnectAttempts = 0;
+            startLatencyTracking();
             // A real frame arrived — clear the connection-establishment timeout.
             if (connectTimeoutTimer) { clearTimeout(connectTimeoutTimer); connectTimeoutTimer = null; }
             videoEl?.removeEventListener('playing', onPlaying);
@@ -574,6 +609,7 @@ let destroyed = false;
   onDestroy(() => {
     destroyed = true;
     stopSnapshotMode();
+    stopLatencyTracking();
     if (coordinatedTimer) { clearTimeout(coordinatedTimer); coordinatedTimer = null; }
     if (coordinator) coordinator.cancelRequest(cameraId);
     if (freezeClearTimer) { clearTimeout(freezeClearTimer); freezeClearTimer = null; }
@@ -662,6 +698,14 @@ let destroyed = false;
     >
       {t('live.videoUnsupportedTag')}
     </video>
+    {#if latency.value != null}
+      <span
+        class="absolute top-1.5 left-2 text-xs tabular-nums z-20 {latencyBadgeClass(latency.value)}"
+        title={t('flow.liveLatency')}
+      >
+        ≈{(latency.value / 1000).toFixed(1)}s
+      </span>
+    {/if}
   {/if}
 
   <!-- Overlay -->

--- a/web/src/lib/__tests__/flv-ingest-clock.test.ts
+++ b/web/src/lib/__tests__/flv-ingest-clock.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { FLVIngestParser, FLV_INGEST_UNKNOWN } from '$lib/flv-ingest-clock';
+
+/** Build a minimal FLV byte stream: header + PreviousTagSize0 + tags. */
+function flvStream(tags: { type: number; ts: number; delta: number; payloadLen: number }[]): Uint8Array {
+  const chunks: number[] = [
+    0x46, 0x4c, 0x56, 0x01, 0x05, 0x00, 0x00, 0x00, 0x09, // FLV header
+    0x00, 0x00, 0x00, 0x00, // PreviousTagSize0
+  ];
+  for (const tag of tags) {
+    const size = tag.payloadLen;
+    chunks.push(
+      tag.type,
+      (size >> 16) & 0xff, (size >> 8) & 0xff, size & 0xff,
+      (tag.ts >> 16) & 0xff, (tag.ts >> 8) & 0xff, tag.ts & 0xff, (tag.ts >> 24) & 0xff,
+      (tag.delta >> 16) & 0xff, (tag.delta >> 8) & 0xff, tag.delta & 0xff, // StreamID = ingest delta
+    );
+    for (let i = 0; i < size; i++) chunks.push(0x00);
+    const prev = 11 + size;
+    chunks.push((prev >>> 24) & 0xff, (prev >>> 16) & 0xff, (prev >>> 8) & 0xff, prev & 0xff);
+  }
+  return new Uint8Array(chunks);
+}
+
+describe('FLVIngestParser', () => {
+  it('extracts the latest video tag ingest delta', () => {
+    const p = new FLVIngestParser();
+    p.feed(flvStream([
+      { type: 0x09, ts: 0, delta: 100, payloadLen: 4 },
+      { type: 0x09, ts: 1000, delta: 1100, payloadLen: 4 },
+    ]).buffer);
+    expect(p.latestDeltaMs).toBe(1100);
+  });
+
+  it('ignores audio and script tags', () => {
+    const p = new FLVIngestParser();
+    p.feed(flvStream([
+      { type: 0x08, ts: 0, delta: 999, payloadLen: 2 },
+      { type: 0x09, ts: 0, delta: 250, payloadLen: 2 },
+    ]).buffer);
+    expect(p.latestDeltaMs).toBe(250);
+  });
+
+  it('keeps the last known value on unknown sentinel', () => {
+    const p = new FLVIngestParser();
+    p.feed(flvStream([{ type: 0x09, ts: 0, delta: 300, payloadLen: 2 }]).buffer);
+    p.feed(flvStream([{ type: 0x09, ts: 40, delta: FLV_INGEST_UNKNOWN, payloadLen: 2 }]).buffer.slice(13));
+    expect(p.latestDeltaMs).toBe(300);
+  });
+
+  it('handles chunked delivery across tag boundaries', () => {
+    const bytes = flvStream([{ type: 0x09, ts: 0, delta: 4200, payloadLen: 64 }]);
+    const p = new FLVIngestParser();
+    // Feed in 7-byte slices.
+    for (let off = 0; off < bytes.length; off += 7) {
+      p.feed(bytes.slice(off, off + 7).buffer);
+    }
+    expect(p.latestDeltaMs).toBe(4200);
+  });
+});

--- a/web/src/lib/flv-ingest-clock.ts
+++ b/web/src/lib/flv-ingest-clock.ts
@@ -1,0 +1,176 @@
+/**
+ * FLV ingest-clock reader (#481).
+ *
+ * The backend piggybacks each video tag's hub-ingest wallclock offset (ms
+ * from the stream's clock base, exposed as flv_clock_ms on /api/streams and
+ * X-Stream-Wallclock-Ms on the FLV response) in the tag header StreamID
+ * field — spec receivers ignore the field, so mpegts.js plays the stream
+ * unchanged. This module walks the raw FLV byte stream to extract the
+ * latest (timestamp, ingestDelta) so the player can compute end-to-end
+ * latency: now − (clockBase + delta).
+ *
+ * 0xFFFFFF is the "unknown" sentinel (source had no ingest stamp or the
+ * offset exceeded the 3-byte range).
+ */
+
+export const FLV_INGEST_UNKNOWN = 0xffffff;
+
+/** Incremental FLV tag walker. Feed arbitrary response chunks in order. */
+export class FLVIngestParser {
+  private buf = new Uint8Array(0);
+  /** Latest video-tag ingest delta (ms from clock base), null before the
+   *  first tag / after an unknown sentinel. */
+  latestDeltaMs: number | null = null;
+
+  feed(chunk: ArrayBuffer): void {
+    if (chunk.byteLength === 0) return;
+    const merged = new Uint8Array(this.buf.length + chunk.byteLength);
+    merged.set(this.buf);
+    merged.set(new Uint8Array(chunk), this.buf.length);
+    this.buf = merged;
+    this.consume();
+  }
+
+  private consume(): void {
+    let off = 0;
+    const b = this.buf;
+    // Stream can start either with the 9-byte FLV header + PreviousTagSize0
+    // or mid-stream after a reconnect; find tag starts by scanning for
+    // valid tag headers (0x08/0x09 preceded by enough bytes).
+    // Simplest robust approach: expect header first iff first bytes are "FLV".
+    if (b.length >= 9 && b[0] === 0x46 && b[1] === 0x4c && b[2] === 0x56) {
+      off = 9 + 4; // header + PreviousTagSize0
+    }
+    for (;;) {
+      if (off + 11 > b.length) break;
+      const tagType = b[off];
+      if (tagType !== 0x08 && tagType !== 0x09 && tagType !== 0x12) {
+        // Lost sync (mid-stream join) — resync heuristically: this parser is
+        // best-effort latency metadata only; bail and wait for more data.
+        break;
+      }
+      const dataSize = (b[off + 1] << 16) | (b[off + 2] << 8) | b[off + 3];
+      const total = 11 + dataSize + 4;
+      if (off + total > b.length) break; // wait for the rest of the tag
+      if (tagType === 0x09) {
+        const delta = (b[off + 8] << 16) | (b[off + 9] << 8) | b[off + 10];
+        if (delta !== FLV_INGEST_UNKNOWN) this.latestDeltaMs = delta;
+      }
+      off += total;
+    }
+    if (off > 0) this.buf = b.slice(off);
+    // Cap the carry-over buffer so a desynced stream can't grow unbounded.
+    if (this.buf.length > 1 << 20) this.buf = this.buf.slice(-11);
+  }
+}
+
+/**
+ * Builds an mpegts.js customLoader that tees every response chunk to
+ * `onChunk` while delegating all loading to mpegts's own fetch-stream
+ * loader (headers, abort, reconnect semantics untouched).
+ */
+/**
+ * Builds an mpegts.js customLoader (BaseLoader subclass) that streams the
+ * FLV response via fetch and tees every chunk to `onChunk` for latency
+ * parsing. mpegts 1.8 exports BaseLoader/LoaderStatus/LoaderErrors but NOT
+ * its own FetchStreamLoader, so this is a self-contained fetch
+ * implementation for the live-FLV case (no range seeks — live streams are
+ * consumed sequentially). Auth headers must be passed in (the loader
+ * config's `headers` only reach mpegts's built-in loaders).
+ */
+export function createTeeLoader(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mpegtsNS: any,
+  onChunk: (data: ArrayBuffer) => void,
+  headers?: Record<string, string>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): any {
+  const Base = mpegtsNS.BaseLoader;
+  if (!Base || typeof fetch === 'undefined') return undefined;
+
+  function TeeLoader(this: any, _seekHandler: unknown, _config: unknown) {
+    if (!(this instanceof TeeLoader)) return new (TeeLoader as any)(_seekHandler, _config);
+    Base.call(this, 'x-flv-tee-loader');
+    this._needStash = true;
+    this._controller = null as AbortController | null;
+    this._abortRequested = false;
+    this._receivedLength = 0;
+  }
+  TeeLoader.prototype = Object.create(Base.prototype);
+  TeeLoader.prototype.constructor = TeeLoader;
+  TeeLoader.isSupported = () => typeof ReadableStream !== 'undefined' && typeof fetch !== 'undefined';
+
+  TeeLoader.prototype.open = function (this: any, dataSource: { url: string }, range: { from: number; to: number }) {
+    this._status = mpegtsNS.LoaderStatus.kConnecting;
+    const controller = new AbortController();
+    this._controller = controller;
+    const reqHeaders: Record<string, string> = { ...headers };
+    if (range && range.from !== 0) {
+      const to = range.to >= 0 ? range.to : '';
+      reqHeaders.Range = `bytes=${range.from}-${to}`;
+    }
+
+    fetch(dataSource.url, { headers: reqHeaders, signal: controller.signal, credentials: 'same-origin' })
+      .then(async (resp: Response) => {
+        if (!resp.ok) {
+          this._status = mpegtsNS.LoaderStatus.kError;
+          this.onError(mpegtsNS.LoaderErrors.HTTP_STATUS_CODE_INVALID, {
+            code: resp.status,
+            msg: `HTTP ${resp.status}`,
+          });
+          return;
+        }
+        const len = resp.headers.get('Content-Length');
+        if (len) this.onContentLengthKnown(parseInt(len, 10));
+        if (!resp.body) {
+          // No streaming body — read whole buffer once (tiny/edge servers).
+          const buf = await resp.arrayBuffer();
+          this._status = mpegtsNS.LoaderStatus.kBuffering;
+          this._emit(buf);
+          this._status = mpegtsNS.LoaderStatus.kComplete;
+          this.onComplete(0, this._receivedLength - 1);
+          return;
+        }
+        const reader = resp.body.getReader();
+        this._status = mpegtsNS.LoaderStatus.kBuffering;
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          // Tee BEFORE handing to mpegts: latency metadata must never affect
+          // playback, and errors are swallowed in _emit's onChunk wrapper.
+          this._emit(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+        }
+        this._status = mpegtsNS.LoaderStatus.kComplete;
+        this.onComplete(0, this._receivedLength - 1);
+      })
+      .catch((err: unknown) => {
+        if (this._abortRequested || this._status === mpegtsNS.LoaderStatus.kComplete) return;
+        this._status = mpegtsNS.LoaderStatus.kError;
+        const msg = err instanceof Error ? err.message : String(err);
+        this.onError(mpegtsNS.LoaderErrors.EXCEPTION, { code: -1, msg });
+      });
+  };
+
+  TeeLoader.prototype._emit = function (this: any, chunk: ArrayBuffer) {
+    const byteStart = this._receivedLength;
+    this._receivedLength += chunk.byteLength;
+    try {
+      onChunk(chunk);
+    } catch {
+      /* latency metadata must never break playback */
+    }
+    this.onDataArrival(chunk, byteStart, this._receivedLength);
+  };
+
+  TeeLoader.prototype.abort = function (this: any) {
+    this._abortRequested = true;
+    this._controller?.abort();
+    this._controller = null;
+  };
+  TeeLoader.prototype.destroy = function (this: any) {
+    this.abort();
+    Base.prototype.destroy?.call(this);
+  };
+
+  return TeeLoader;
+}

--- a/web/src/lib/live-latency.svelte.ts
+++ b/web/src/lib/live-latency.svelte.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared end-to-end live-latency tracker (#469/#481).
+ *
+ * Every player protocol reports "browser now − frame ingest wallclock".
+ * WS gets the exact ingest stamp in-band (VideoFrame trailer); FLV gets it
+ * via the tag StreamID piggyback (#481); HLS/WebRTC feed approximations
+ * (segment-based / hub-ingest age). The tracker smooths samples with an EMA
+ * and reports to /api/telemetry every 10s tagged with the protocol.
+ */
+import { sendTelemetry } from '$lib/telemetry';
+
+export class LiveLatencyTracker {
+  value = $state<number | null>(null);
+  private lastReport = 0;
+
+  constructor(
+    private cameraId: string,
+    private protocol: string,
+  ) {}
+
+  /** Feed one sample: the ingest wallclock (unix ms) of a recently
+   *  displayed frame, or null/undefined to skip (unknown sentinel). */
+  track(ingestAtMs?: number | null): void {
+    if (!ingestAtMs || ingestAtMs <= 0) return;
+    const now = Date.now();
+    const sample = now - ingestAtMs;
+    if (sample < 0 || sample > 60_000) return; // clock-skew / stale-replay guard
+    this.value = this.value == null ? sample : this.value * 0.9 + sample * 0.1;
+    if (now - this.lastReport >= 10_000) {
+      this.lastReport = now;
+      sendTelemetry('live_latency', this.cameraId, Math.round(this.value), { protocol: this.protocol });
+    }
+  }
+
+  /** Feed an already-computed latency sample (ms) directly — for
+   *  approximations like hls.js `latency` where there is no ingest stamp. */
+  trackLatencyMs(latencyMs: number): void {
+    if (latencyMs < 0 || latencyMs > 60_000) return;
+    this.track(Date.now() - latencyMs);
+  }
+}
+
+/** Badge color classes shared by all players (<1s green / <3s yellow / rest red). */
+export function latencyBadgeClass(ms: number | null): string {
+  if (ms == null) return 'text-white/50';
+  if (ms > 3000) return 'text-red-400/80';
+  if (ms > 1000) return 'text-yellow-400/80';
+  return 'text-green-400/70';
+}


### PR DESCRIPTION
## 背景（#481）

#469 只在 WS 路径透传了 hub 入口时间戳（`FrameMsg.IngestAt` → 消息尾 8 字节），FLV/HLS/WebRTC 播放器无法显示真实延迟。

## 实现

**FLV（精确，按 issue 建议走 in-band 注入）**
- 后端：FLV manager 改用 `SubscribeMsg` 拿到 `IngestAt`，把每帧的入口墙钟偏移（ms，相对注册时的 entry 级 clock base）写进 video tag 头部的 **StreamID 字段**（规范要求恒 0、所有接收端忽略该字段 → 完全兼容标准播放器）；`0xFFFFFF` 为未知哨兵（无 IngestAt / 超 4.6h 3 字节范围）。基准墙钟通过 `X-Stream-Wallclock-Ms` 响应头 + `/api/streams` 的 `flv_clock_ms` 暴露
- 前端：自实现 mpegts `BaseLoader` 子类（fetch 流式，tee 每个 chunk——mpegts 1.8 不导出它自己的 FetchStreamLoader）+ 增量 FLV tag 解析器（支持跨 chunk 边界/未知哨兵保尾值）

**HLS（近似，按 issue 允许）**：`hls.js` 的 `latency`（分片时长 × 缓冲分片数），角标带 ≈

**WebRTC（近似）**：浏览器读不到 RTP header extension，用 flow 快照的相机 hub 入口时间（`last_frame_at`）作为 ingest 参考 + ≈ 标注。若后续要做精确值需要 DataChannel 或 RTP script transform（Chrome-only），单独评估

**公共**：从 WasmPlayer 抽出 `LiveLatencyTracker`（EMA 平滑 + 每 10s telemetry `{protocol}`）与角标配色（<1s 绿 / <3s 黄 / >3s 红），四个协议统一

## 测试

- 后端 `internal/flv`：tag StreamID 编码/哨兵 round-trip、writeLoop 烘焙真实 delta、`ClockMs` 基准（33 通过）
- 前端：FLV tag 解析器 4 测（最新值/忽略音频与 script tag/哨兵保持/7 字节分片喂入）
- 前端 build + vitest 591 全绿；`rtk go build ./...` 通过

## 备注

FLV custom loader 在真实浏览器的播放兼容性（mpegts 内部对 customLoader 的调用契约）尚需 Docker VM/M5 实测确认——loader 失败时按 mpegts 语义走 onError → 既有重连/降级路径，不影响其它协议。

Closes #481