### PR TITLE
refactor(onvif): switch to our onvif-go continuation v1.2.0 (service-facade API)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/Mi-Bee-Studio/MiBeeNvr
 go 1.26.2
 
 require (
-	github.com/0x524a/onvif-go v1.1.5
 	github.com/Eyevinn/hi264 v0.10.0
 	github.com/abema/go-mp4 v1.7.1
 	github.com/bluenviron/gohlslib/v2 v2.4.0
@@ -18,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/klauspost/compress v1.19.0
+	github.com/mickeyzzc/onvif-go v1.2.0
 	github.com/pion/interceptor v0.1.46
 	github.com/pion/rtp v1.10.5
 	github.com/pion/webrtc/v4 v4.2.17
@@ -76,7 +76,7 @@ require (
 	github.com/tevino/abool v0.0.0-20170917061928-9b9efcf221b5 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
@@ -86,15 +86,6 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-// Use our Mi-Bee-Studio fork of onvif-go, which:
-// 1. Rewrites stale advertised IPs in capability XAddrs (v1.1.7): fixServiceURL
-//    (superset of the old fixLocalhostURL) corrects any capability XAddr whose
-//    host disagrees with the device_service endpoint — the address we used to
-//    reach the camera, which is guaranteed current. Without this, after a camera
-//    IP change rediscovery finds the camera at its new IP but every service call
-//    (GetProfiles etc.) still hits the old, unreachable IP the camera advertises
-//    in GetCapabilities.
-// 2. Adds clock-skew-aware WS-Security digest (v1.1.6): SetClockSkew on the
-//    Client applies the device's time offset to the UsernameToken digest's
-//    Created timestamp, fixing Hikvision auth failures caused by clock divergence.
-replace github.com/0x524a/onvif-go => github.com/Mi-Bee-Studio/onvif-go v1.1.7
+// onvif-go is our own maintained continuation of 0x524a/onvif-go
+// (github.com/mickeyzzc/onvif-go, v1.2.0+): service-facade API, capability
+// XAddr repair, clock-skew-aware WS-Security digest. No replace needed.

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/Eyevinn/hi264 v0.10.0 h1:4CgeRcBT8Y03BuHHr9u7ErMN5Iiw1mGbvKNU9s4QFPg=
 github.com/Eyevinn/hi264 v0.10.0/go.mod h1:ag1j/wxUs7EvZu6qEZBRyLJ0bJW4OUjO8ip8c2TfLTQ=
 github.com/Eyevinn/mp4ff v0.50.0 h1:vFlsvpQh5Jfz++cuaeTI90vbID5dAabebvvN/l9lom0=
 github.com/Eyevinn/mp4ff v0.50.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
-github.com/Mi-Bee-Studio/onvif-go v1.1.7 h1:mrsUbCIpWK89NgfyKT8uc9QmP0NzrTuVxODtwxv/qSQ=
-github.com/Mi-Bee-Studio/onvif-go v1.1.7/go.mod h1:QRsmatmBZXM5zOHHI4SBaV6X2NdkSU+DXLDDRzM+xS4=
 github.com/abema/go-mp4 v1.7.1 h1:2nFaCWSXLiqyr6LfH16knVsVfvP4QRHdNEA6P5rnz5w=
 github.com/abema/go-mp4 v1.7.1/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/asticode/go-astikit v0.30.0/go.mod h1:h4ly7idim1tNhaVkdVBeXQZEE3L0xblP7fCWbgwipF0=
@@ -98,6 +96,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mickeyzzc/onvif-go v1.2.0 h1:Jb3ntXu2ZPHi/NIGtlFCYb5HiHfKY0TcYhNOcpjsI0I=
+github.com/mickeyzzc/onvif-go v1.2.0/go.mod h1:xjjlFumja8C+PhS08zwkiHZJeRNgsXCij1G49V7q6Fw=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/internal/onvif/client.go
+++ b/internal/onvif/client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 var logger = slog.Default().With("component", "onvif-client")
@@ -100,7 +100,7 @@ func (c *Client) GetDeviceInformation(ctx context.Context) (*DeviceInfo, error) 
 		return nil, fmt.Errorf("onvif client not connected, call Connect() first")
 	}
 
-	info, err := c.client.GetDeviceInformation(ctx)
+	info, err := c.client.Device().GetDeviceInformation(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get device information: %w", err)
 	}
@@ -116,7 +116,7 @@ func (c *Client) GetProfiles(ctx context.Context) ([]DeviceProfile, error) {
 		return nil, fmt.Errorf("onvif client not connected, call Connect() first")
 	}
 
-	profiles, err := c.client.GetProfiles(ctx)
+	profiles, err := c.client.Media().GetProfiles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get profiles: %w", err)
 	}
@@ -135,7 +135,7 @@ func (c *Client) GetStreamURI(ctx context.Context, profileToken string) (*Stream
 		return nil, fmt.Errorf("onvif client not connected, call Connect() first")
 	}
 
-	uri, err := c.client.GetStreamURI(ctx, profileToken)
+	uri, err := c.client.Media().GetStreamURI(ctx, profileToken)
 	if err != nil {
 		return nil, fmt.Errorf("get stream URI: %w", err)
 	}
@@ -256,7 +256,7 @@ func (c *Client) GetCapabilities(ctx context.Context) (*DeviceCapabilitiesDetail
 		return nil, fmt.Errorf("onvif client not connected, call Connect() first")
 	}
 
-	caps, err := c.client.GetCapabilities(ctx)
+	caps, err := c.client.Device().GetCapabilities(ctx)
 	if err != nil {
 		logger.Debug("failed to get capabilities from device, returning minimal capabilities", "error", err)
 		minimal := &DeviceCapabilitiesDetailed{}

--- a/internal/onvif/client_test.go
+++ b/internal/onvif/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/onvif/device_mgmt.go
+++ b/internal/onvif/device_mgmt.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"sync"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 // ErrUnsupported indicates the operation is not supported.
@@ -49,7 +49,7 @@ func (d *DeviceManagerImpl) SystemReboot(ctx context.Context) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	message, err := d.client.SystemReboot(ctx)
+	message, err := d.client.Device().SystemReboot(ctx)
 	if err != nil {
 		return fmt.Errorf("system reboot failed: %w", err)
 	}
@@ -63,7 +63,7 @@ func (d *DeviceManagerImpl) GetNetworkInterfaces(ctx context.Context) ([]Network
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	ifaces, err := d.client.GetNetworkInterfaces(ctx)
+	ifaces, err := d.client.Device().GetNetworkInterfaces(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get network interfaces failed: %w", err)
 	}
@@ -120,7 +120,7 @@ func (d *DeviceManagerImpl) GetUsers(ctx context.Context) ([]ONVIFUser, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	users, err := d.client.GetUsers(ctx)
+	users, err := d.client.Device().GetUsers(ctx)
 	if err == nil || !isAuthError(err) {
 		if err != nil {
 			return nil, fmt.Errorf("get users failed: %w", err)
@@ -145,7 +145,7 @@ func (d *DeviceManagerImpl) CreateUsers(ctx context.Context, users []ONVIFUser) 
 		}
 	}
 
-	if err := d.client.CreateUsers(ctx, onvifUsers); err != nil {
+	if err := d.client.Device().CreateUsers(ctx, onvifUsers); err != nil {
 		return fmt.Errorf("create users failed: %w", err)
 	}
 
@@ -158,7 +158,7 @@ func (d *DeviceManagerImpl) DeleteUsers(ctx context.Context, usernames []string)
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if err := d.client.DeleteUsers(ctx, usernames); err != nil {
+	if err := d.client.Device().DeleteUsers(ctx, usernames); err != nil {
 		return fmt.Errorf("delete users failed: %w", err)
 	}
 
@@ -171,7 +171,7 @@ func (d *DeviceManagerImpl) SetUser(ctx context.Context, username, password stri
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if err := d.client.SetUser(ctx, &onvifgo.User{
+	if err := d.client.Device().SetUser(ctx, &onvifgo.User{
 		Username: username,
 		Password: password,
 	}); err != nil {

--- a/internal/onvif/device_mgmt_test.go
+++ b/internal/onvif/device_mgmt_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/discovery.go
+++ b/internal/onvif/discovery.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/0x524a/onvif-go/discovery"
+	"github.com/mickeyzzc/onvif-go/discovery"
 )
 
 const defaultDiscoveryTimeout = 5 * time.Second

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 var eventLogger = slog.Default().With("component", "onvif-events")
@@ -137,7 +137,7 @@ func (e *EventSubscriberImpl) Subscribe(ctx context.Context, cameraID string) er
 	}
 
 	// Create PullPoint subscription via onvif-go
-	sub, err := e.client.CreatePullPointSubscription(ctx, "", &e.subDuration, "")
+	sub, err := e.client.Events().CreatePullPointSubscription(ctx, "", &e.subDuration, "")
 	if err != nil {
 		// Some cameras advertise the event service in GetCapabilities but reject
 		// the actual subscription as unimplemented. Surface a sentinel so callers
@@ -192,7 +192,7 @@ func (e *EventSubscriberImpl) Unsubscribe(ctx context.Context, cameraID string) 
 
 	// Unsubscribe via onvif-go (fire-and-forget on error, nil client means test mode)
 	if e.client != nil {
-		if err := e.client.Unsubscribe(ctx, ps.subscriptionRef); err != nil {
+		if err := e.client.Events().Unsubscribe(ctx, ps.subscriptionRef); err != nil {
 			eventLogger.Warn("failed to unsubscribe from PullPoint",
 				"camera_id", cameraID,
 				"subscription_ref", ps.subscriptionRef,
@@ -279,7 +279,7 @@ func (e *EventSubscriberImpl) pollAndPublish(ctx context.Context, cameraID strin
 	}
 
 	// Pull messages from the subscription
-	messages, err := e.client.PullMessages(ctx, ps.subscriptionRef, e.pullTimeout, e.messageLimit)
+	messages, err := e.client.Events().PullMessages(ctx, ps.subscriptionRef, e.pullTimeout, e.messageLimit)
 	if err != nil {
 		eventLogger.Warn("PullMessages failed",
 			"camera_id", cameraID,
@@ -313,7 +313,7 @@ func (e *EventSubscriberImpl) pollAndPublish(ctx context.Context, cameraID strin
 
 // renewSubscription attempts to renew the PullPoint subscription before expiry.
 func (e *EventSubscriberImpl) renewSubscription(ctx context.Context, cameraID string, ps *pullPointSubscription) bool {
-	_, newTermination, err := e.client.RenewSubscription(ctx, ps.subscriptionRef, e.subDuration)
+	_, newTermination, err := e.client.Events().RenewSubscription(ctx, ps.subscriptionRef, e.subDuration)
 	if err != nil {
 		eventLogger.Warn("failed to renew PullPoint subscription",
 			"camera_id", cameraID,

--- a/internal/onvif/events_test.go
+++ b/internal/onvif/events_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/imaging.go
+++ b/internal/onvif/imaging.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 var imagingLogger = slog.Default().With("component", "onvif-imaging")

--- a/internal/onvif/onvifgo.go
+++ b/internal/onvif/onvifgo.go
@@ -3,7 +3,7 @@ package onvif
 import (
 	"strings"
 
-	"github.com/0x524a/onvif-go/discovery"
+	"github.com/mickeyzzc/onvif-go/discovery"
 )
 
 // MapDiscoveredDevice converts an onvif-go discovery.Device to the project's DiscoveredDevice.

--- a/internal/onvif/onvifgo_test.go
+++ b/internal/onvif/onvifgo_test.go
@@ -3,7 +3,7 @@ package onvif
 import (
 	"testing"
 
-	"github.com/0x524a/onvif-go/discovery"
+	"github.com/mickeyzzc/onvif-go/discovery"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/ptz.go
+++ b/internal/onvif/ptz.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"sync"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 var ptzLogger = slog.Default().With("component", "onvif-ptz")
@@ -51,7 +51,7 @@ func (p *PTZControllerImpl) ContinuousMove(ctx context.Context, velocity PTZVect
 
 	// Provide default timeout — some cameras reject ContinuousMove without it
 	timeout := "PT10S"
-	return p.client.ContinuousMove(ctx, p.profileToken, toOnvifPTZSpeed(velocity), &timeout)
+	return p.client.PTZ().ContinuousMove(ctx, p.profileToken, toOnvifPTZSpeed(velocity), &timeout)
 }
 
 // AbsoluteMove moves PTZ to an absolute position.
@@ -60,7 +60,7 @@ func (p *PTZControllerImpl) AbsoluteMove(ctx context.Context, position PTZVector
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	err := p.client.AbsoluteMove(ctx, p.profileToken, toOnvifPTZVector(position), nil)
+	err := p.client.PTZ().AbsoluteMove(ctx, p.profileToken, toOnvifPTZVector(position), nil)
 	if err == nil || !isAuthError(err) {
 		return err
 	}
@@ -74,7 +74,7 @@ func (p *PTZControllerImpl) RelativeMove(ctx context.Context, displacement PTZVe
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	err := p.client.RelativeMove(ctx, p.profileToken, toOnvifPTZVector(displacement), nil)
+	err := p.client.PTZ().RelativeMove(ctx, p.profileToken, toOnvifPTZVector(displacement), nil)
 	if err == nil || !isAuthError(err) {
 		return err
 	}
@@ -87,7 +87,7 @@ func (p *PTZControllerImpl) Stop(ctx context.Context, stopPanTilt, stopZoom bool
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.client.Stop(ctx, p.profileToken, stopPanTilt, stopZoom)
+	return p.client.PTZ().Stop(ctx, p.profileToken, stopPanTilt, stopZoom)
 }
 
 // GetStatus returns the current PTZ position and whether the camera is moving.
@@ -96,7 +96,7 @@ func (p *PTZControllerImpl) GetStatus(ctx context.Context) (position PTZVector, 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	status, err := p.client.GetStatus(ctx, p.profileToken)
+	status, err := p.client.PTZ().GetStatus(ctx, p.profileToken)
 	if err == nil || !isAuthError(err) {
 		return fromOnvifPTZStatus(status)
 	}
@@ -109,7 +109,7 @@ func (p *PTZControllerImpl) GetPresets(ctx context.Context) ([]PTZPreset, error)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	presets, err := p.client.GetPresets(ctx, p.profileToken)
+	presets, err := p.client.PTZ().GetPresets(ctx, p.profileToken)
 	if err != nil {
 		return nil, fmt.Errorf("get PTZ presets failed: %w", err)
 	}
@@ -132,7 +132,7 @@ func (p *PTZControllerImpl) SetPreset(ctx context.Context, name string) (string,
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	token, err := p.client.SetPreset(ctx, p.profileToken, name, "")
+	token, err := p.client.PTZ().SetPreset(ctx, p.profileToken, name, "")
 	if err == nil || !isAuthError(err) {
 		return token, err
 	}
@@ -145,7 +145,7 @@ func (p *PTZControllerImpl) GoToPreset(ctx context.Context, token string) error 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.client.GotoPreset(ctx, p.profileToken, token, nil)
+	return p.client.PTZ().GotoPreset(ctx, p.profileToken, token, nil)
 }
 
 // RemovePreset deletes a PTZ preset.
@@ -153,7 +153,7 @@ func (p *PTZControllerImpl) RemovePreset(ctx context.Context, token string) erro
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.client.RemovePreset(ctx, p.profileToken, token)
+	return p.client.PTZ().RemovePreset(ctx, p.profileToken, token)
 }
 
 // --- Type conversion helpers ---

--- a/internal/onvif/ptz_test.go
+++ b/internal/onvif/ptz_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/snapshot.go
+++ b/internal/onvif/snapshot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	onvifgo "github.com/0x524a/onvif-go"
+	onvifgo "github.com/mickeyzzc/onvif-go"
 )
 
 // SnapshotProviderImpl implements SnapshotProvider by delegating to onvif-go's media service.
@@ -28,7 +28,7 @@ func (s *SnapshotProviderImpl) GetSnapshotUri(ctx context.Context) (string, erro
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	mediaURI, err := s.client.GetSnapshotURI(ctx, s.profileToken)
+	mediaURI, err := s.client.Media().GetSnapshotURI(ctx, s.profileToken)
 	if err != nil {
 		return "", fmt.Errorf("get snapshot URI failed: %w", err)
 	}

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787708909239';
+const CACHE_VERSION = 'mibee-nvr-1787790747298';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives


### PR DESCRIPTION
## Summary

Replace the `0x524a/onvif-go` replace-directive consumption with a **direct require of `github.com/mickeyzzc/onvif-go v1.2.0`** — our own maintained continuation of the barely-maintained upstream (MIT, attribution preserved).

The library's v1.2.0 is a full rebase onto a service-facade API (`client.Device()/Media()/PTZ()/Imaging()/Events()/DeviceIO()/Security()`), Go 1.26, zero third-party deps, gofumpt+goimports + golangci-lint v2 at zero findings. This PR migrates the `internal/onvif` wrapper's imports and call sites to the facade; the wrapper's own public surface is unchanged, so nothing outside `internal/onvif` is touched.

## Changes

- `go.mod`: drop replace + old fork comment, direct `require github.com/mickeyzzc/onvif-go v1.2.0`
- `internal/onvif` (27 files): imports + library calls → facade form (`.Media().GetProfiles`, `.Device().GetCapabilities`, `.Security()`→`.Device().GetUsers` family, `.PTZ().*`, `.Events().*`)
- `sw.js`: regenerated hash from the node-24 SPA rebuild shipping with this binary

## Hardware verification (done before opening this PR)

- **M5 (bare metal, production)**: binary `v0.11.0-93-gcd98115-onvif12` — 12 cameras healthy/recording incl. every ONVIF cam (工作室内/视通-9楼/H80/IPCAM-HI), discovery + enrichment + Hello listener normal, sub-layer segments + vision push normal, zero new ERRORs. Backup chain: `mibee-nvr.bak-0827-preonvif`.
- **R4S (fnOS)**: same binary md5 `fed68a6e` via overlay image, 15 cameras recording, health ok, zero ERRORs.

## Test plan

- [x] `go test ./internal/onvif/` green; `GOOS=linux` full build green
- [x] M5 + R4S on-hardware verification (above)
- [ ] CI