### PR TITLE
fix(autodiscover): apply the #266 non-ONVIF filter to the passive Hello path

### DIFF
--- a/internal/onvif/discovery_listener.go
+++ b/internal/onvif/discovery_listener.go
@@ -79,21 +79,39 @@ func entryToDevice(e wsdEntry) *DiscoveredDevice {
 	}
 }
 
+// entryIfONVIF applies the shared ONVIF-ness gate (#266/#554) to a parsed
+// Hello/ProbeMatch entry: generic WS-Discovery responders (Windows machines,
+// NAS boxes, printers) announce Hellos with Types like "wsdiscovery:Device"
+// and non-ONVIF scopes — without this gate they auto-enroll as camera shells
+// that can never connect (the mickeybeessd/mickeybeehome zombies, #554).
+// Matching either signal (NetworkVideoTransmitter in Types, or an
+// onvif://www.onvif.org/ scope prefix) keeps the device, mirroring the active
+// Discover path's filter.
+func entryIfONVIF(e wsdEntry) *DiscoveredDevice {
+	if !isONVIFSignal(e.Types, strings.Fields(e.Scopes)) {
+		logger.Debug("dropping non-ONVIF WS-Discovery message",
+			"types", e.Types, "xaddrs", e.XAddrs)
+		return nil
+	}
+	return entryToDevice(e)
+}
+
 // parseWSDMessage parses a UDP datagram received on the WS-Discovery multicast
 // socket and returns the device it advertises, if any. It handles Hello (device
 // announcing itself on power-on) and ProbeMatches (a device answering someone
-// else's Probe). Returns nil for Bye, unmatched message types, and parse errors
-// — the caller treats nil as "ignore".
+// else's Probe); entries that carry no ONVIF signal are dropped at this
+// boundary (#554). Returns nil for Bye, unmatched message types, non-ONVIF
+// responders, and parse errors — the caller treats nil as "ignore".
 func parseWSDMessage(data []byte) *DiscoveredDevice {
 	var env helloEnvelope
 	if err := xml.Unmarshal(data, &env); err != nil {
 		return nil
 	}
 	if env.Body.Hello != nil {
-		return entryToDevice(*env.Body.Hello)
+		return entryIfONVIF(*env.Body.Hello)
 	}
 	if len(env.Body.ProbeMatches.ProbeMatch) > 0 {
-		return entryToDevice(env.Body.ProbeMatches.ProbeMatch[0])
+		return entryIfONVIF(env.Body.ProbeMatches.ProbeMatch[0])
 	}
 	return nil
 }

--- a/internal/onvif/discovery_listener_test.go
+++ b/internal/onvif/discovery_listener_test.go
@@ -64,6 +64,42 @@ func TestParseWSDMessage_ByeIgnored(t *testing.T) {
 	}
 }
 
+// windowsWSDHello mirrors the WS-Discovery Hello a Windows/WSD host sends when
+// it joins the network: Types "wsdiscovery:Device", vendor scopes, an XAddr on
+// :5000/wsd/. Before #554 these auto-enrolled as camera shells that could
+// never connect (the mickeybeessd/mickeybeehome zombies on M5).
+const windowsWSDHello = `<?xml version="1.0" encoding="UTF-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><Hello xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"><EndpointReference><Address>urn:uuid:a5d3d2d8-41ed-4a64-8c8b-0cc9cdbe62f8</Address></EndpointReference><Types>wsdiscovery:Device</Types><Scopes>http://schemas.xmlsoap.org/ws/2005/04/discovery/contract</Scopes><XAddrs>http://mickeybeessd:5000/wsd/a5d3d2d8-41ed-4a64-8c8b-0cc9cdbe62f8</XAddrs><MetadataVersion>1</MetadataVersion></Hello></s:Body></s:Envelope>`
+
+func TestParseWSDMessage_NonONVIFHelloDropped(t *testing.T) {
+	t.Helper()
+	if dev := parseWSDMessage([]byte(windowsWSDHello)); dev != nil {
+		t.Errorf("non-ONVIF WSD Hello must be dropped at the parse boundary (#554), got %+v", dev)
+	}
+}
+
+func TestParseWSDMessage_NeitherSignalDropped(t *testing.T) {
+	t.Helper()
+	// No Types and no ONVIF scope: a responder that advertises nothing ONVIF-ish.
+	const neither = `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><Hello xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"><EndpointReference><Address>urn:uuid:x</Address></EndpointReference><XAddrs>http://192.168.1.99:80/onvif/device_service</XAddrs></Hello></s:Body></s:Envelope>`
+	if dev := parseWSDMessage([]byte(neither)); dev != nil {
+		t.Errorf("Hello without any ONVIF signal must be dropped, got %+v", dev)
+	}
+}
+
+func TestParseWSDMessage_ScopeOnlySignalKept(t *testing.T) {
+	t.Helper()
+	// Marginal implementations may leave Types empty but populate ONVIF scopes;
+	// matching either signal keeps the device (permissive gate, mirrors #266).
+	const scopeOnly = `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><Hello xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery"><EndpointReference><Address>urn:uuid:y</Address></EndpointReference><Scopes>onvif://www.onvif.org/name/MarginalCam</Scopes><XAddrs>http://192.168.1.98:80/onvif/device_service</XAddrs></Hello></s:Body></s:Envelope>`
+	dev := parseWSDMessage([]byte(scopeOnly))
+	if dev == nil {
+		t.Fatal("Hello with an ONVIF scope but empty Types must be kept")
+	}
+	if dev.Name != "MarginalCam" {
+		t.Errorf("Name = %q, want MarginalCam", dev.Name)
+	}
+}
+
 func TestParseWSDMessage_GarbageReturnsNil(t *testing.T) {
 	t.Helper()
 	cases := [][]byte{

--- a/internal/onvif/onvifgo.go
+++ b/internal/onvif/onvifgo.go
@@ -52,14 +52,24 @@ func MapDiscoveredDevice(d *discovery.Device) DiscoveredDevice {
 // This avoids false-negative drops of marginal ONVIF implementations that
 // populate Scopes but leave Types empty (or vice versa).
 func isONVIFDevice(d *discovery.Device) bool {
-	for _, t := range d.Types {
+	return isONVIFSignal(strings.Join(d.Types, " "), d.Scopes)
+}
+
+// isONVIFSignal reports whether a WS-Discovery Types line (space-separated
+// QNames) or Scopes list carries an ONVIF device signal: a Types entry whose
+// local part contains NetworkVideoTransmitter, or any scope in the ONVIF
+// namespace. Shared by the active Discover path (ProbeMatch filtering, #266)
+// and the passive Hello listener (#554) so both ingress routes apply the same
+// permissive-but-real gate — matching either signal keeps the device.
+func isONVIFSignal(typesLine string, scopes []string) bool {
+	for _, t := range strings.Fields(typesLine) {
 		// Type entries are QNames like "dp0:NetworkVideoTransmitter"; match on
 		// the local part so the prefix (dp0 / tns / etc.) doesn't matter.
 		if strings.Contains(t, "NetworkVideoTransmitter") {
 			return true
 		}
 	}
-	for _, s := range d.Scopes {
+	for _, s := range scopes {
 		if strings.HasPrefix(s, "onvif://www.onvif.org/") {
 			return true
 		}


### PR DESCRIPTION
Fixes #554.

## Root cause

`isONVIFDevice` only gated the **active** Discover path. The passive WS-Discovery listener (`parseWSDMessage → dispatch → Adder.HandleDiscovered`) had no ONVIF check, so Windows/WSD hosts announcing Hellos (Types `wsdiscovery:Device`, XAddr `:5000/wsd/`) auto-enrolled as camera shells — the two zombies archived this morning on M5 (created 08-21 and 08-26 evenings, zero recordings).

## Fix

- Extract the signal check into `isONVIFSignal(typesLine, scopes)`, shared by both ingress routes (same permissive-but-real semantics as #266: QName local part `NetworkVideoTransmitter` **or** `onvif://www.onvif.org/` scope prefix).
- `parseWSDMessage` drops non-ONVIF Hello/ProbeMatches at the parse boundary with a debug log.

## Tests

- [x] Windows-style WSD Hello → dropped (fixture mirrors the mickeybeessd incident)
- [x] Hello with neither signal → dropped
- [x] Scope-only marginal Hello → kept
- [x] Existing real ESP32 Hello / IPC ProbeMatches fixtures unchanged and green
- [x] `go test ./internal/onvif/` ✓, `GOOS=linux` build ✓, golangci-lint 0 issues