### PR TITLE
fix(rtsp/cascade): field findings from #556's first deploy

### DIFF
--- a/internal/gb28181/cascade/cascade_test.go
+++ b/internal/gb28181/cascade/cascade_test.go
@@ -289,87 +289,31 @@ type hubSource struct {
 
 func (f hubSource) Hub(string) *model.StreamHub { return f.hub }
 
-func TestSelectForwardHub(t *testing.T) {
-	mainHub := model.NewStreamHub()
-	subHub := model.NewStreamHub()
-
-	t.Run("sub camera uses the sub tier", func(t *testing.T) {
-		svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
-		acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
-		svc.SetSubStreamAcquirer(acq)
-
-		hub := mainHub
-		release, usingSub := svc.selectForwardHub(&hub, "cam-1")
-		require.True(t, usingSub)
-		require.Equal(t, subHub, hub, "forward must target the sub hub")
-		require.NotNil(t, release)
-		release()
-		select {
-		case <-acq.release:
-		default:
-			t.Fatal("release func not wired to the acquirer")
-		}
-	})
-
-	t.Run("main camera never touches the acquirer", func(t *testing.T) {
-		svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1"}}}, mainHub}, nil)
-		acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
-		svc.SetSubStreamAcquirer(acq)
-
-		hub := mainHub
-		release, usingSub := svc.selectForwardHub(&hub, "cam-1")
-		require.False(t, usingSub)
-		require.Equal(t, mainHub, hub)
-		require.Nil(t, release)
-		require.Zero(t, acq.calls)
-	})
-
-	t.Run("acquire failure degrades to main", func(t *testing.T) {
-		svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
-		svc.SetSubStreamAcquirer(&fakeSubAcquirer{err: errNoSubForTest, release: make(chan struct{}, 1)})
-
-		hub := mainHub
-		release, usingSub := svc.selectForwardHub(&hub, "cam-1")
-		require.False(t, usingSub)
-		require.Equal(t, mainHub, hub, "failed sub acquisition must fall back to main")
-		require.Nil(t, release)
-	})
-
-	t.Run("no acquirer wired stays on main", func(t *testing.T) {
-		svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
-		hub := mainHub
-		release, usingSub := svc.selectForwardHub(&hub, "cam-1")
-		require.False(t, usingSub)
-		require.Nil(t, release)
-	})
-}
-
-// errNoSubForTest keeps the failure path readable without importing substream.
 var errNoSubForTest = &testError{"no sub-stream configured"}
 
 type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
 
-// A session created for a sub forward must unsubscribe from the SUB hub (not
-// the camera's main hub) and drop its acquisition reference on close.
-func TestMediaSessionSubStreamTeardown(t *testing.T) {
-	mainHub := model.NewStreamHub()
-	subHub := model.NewStreamHub()
+// A wanted sub forward subscribes to the SUB hub, records the swap, and drops
+// the acquisition reference on close.
+func TestMediaSessionSubStreamForward(t *testing.T) {
+	mainHub, subHub := model.NewStreamHub(), model.NewStreamHub()
 	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
 	acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
 	svc.SetSubStreamAcquirer(acq)
 
-	hub := mainHub
-	release, _ := svc.selectForwardHub(&hub, "cam-1")
 	ms := &mediaSession{
 		svc: svc, callID: "c1", channel: "ch", camera: "cam-1",
-		hub: hub, releaseSub: release, mux: psmux.New(),
+		wantSub: true, mux: psmux.New(),
 	}
+	ms.hub = mainHub
+	ms.run(mainHub)
 
-	ms.run(hub)
+	require.Equal(t, 1, acq.calls, "run must acquire the sub tier for a wanted camera")
 	require.Equal(t, 1, subHub.ConsumerCount(), "session must subscribe on the sub hub")
 	require.Equal(t, 0, mainHub.ConsumerCount(), "main hub untouched by the sub forward")
+	require.Equal(t, subHub, ms.hub, "session must record the swapped hub for close()")
 
 	ms.stop()
 	require.Equal(t, 0, subHub.ConsumerCount(), "close must unsubscribe from the sub hub")
@@ -378,4 +322,44 @@ func TestMediaSessionSubStreamTeardown(t *testing.T) {
 	default:
 		t.Fatal("close must drop the sub-stream reference")
 	}
+}
+
+// Acquisition failure degrades to a main-stream forward — never a dead session.
+func TestMediaSessionSubStreamFallbackToMain(t *testing.T) {
+	mainHub := model.NewStreamHub()
+	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
+	svc.SetSubStreamAcquirer(&fakeSubAcquirer{err: errNoSubForTest, release: make(chan struct{}, 1)})
+
+	ms := &mediaSession{
+		svc: svc, callID: "c1", channel: "ch", camera: "cam-1",
+		wantSub: true, mux: psmux.New(),
+	}
+	ms.hub = mainHub
+	ms.run(mainHub)
+
+	require.Equal(t, 1, mainHub.ConsumerCount(), "failed acquisition must fall back to main")
+	require.Equal(t, mainHub, ms.hub)
+	ms.stop()
+	require.Equal(t, 0, mainHub.ConsumerCount())
+}
+
+// A BYE racing the acquisition: close() first ⇒ run drops the freshly granted
+// reference and never subscribes.
+func TestMediaSessionSubStreamCloseDuringAcquire(t *testing.T) {
+	mainHub, subHub := model.NewStreamHub(), model.NewStreamHub()
+	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
+	acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
+	svc.SetSubStreamAcquirer(acq)
+
+	ms := &mediaSession{
+		svc: svc, callID: "c1", channel: "ch", camera: "cam-1",
+		wantSub: true, mux: psmux.New(),
+	}
+	ms.hub = mainHub
+	ms.closed.Store(true) // BYE won the race before run() acquired
+
+	ms.run(mainHub)
+	require.Equal(t, 0, acq.calls, "a session closed before the acquire must not pull the sub tier at all")
+	require.Equal(t, 0, subHub.ConsumerCount(), "closed session must not subscribe")
+	require.Equal(t, 0, mainHub.ConsumerCount(), "closed session must not subscribe to main either")
 }

--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -43,10 +43,16 @@ type mediaSession struct {
 	codecHint string
 	// hub is the stream hub the session subscribed to — the sub hub for a
 	// sub-stream forward (#512), otherwise the camera's main hub. close()
-	// unsubscribes through it.
+	// unsubscribes through it. Guarded by mu: run()'s async sub acquisition
+	// can swap it while a concurrent BYE runs close().
 	hub *model.StreamHub
-	// releaseSub drops the sub-stream reference acquired at INVITE (#512).
+	// releaseSub drops the sub-stream reference acquired for the sub tier.
 	releaseSub func()
+	// wantSub: the camera opted into the low-res cascade tier; run()
+	// acquires it after the INVITE is answered (never inside the SIP
+	// handler — the ready wait would block the transaction).
+	wantSub bool
+	mu      sync.Mutex
 	// withAudio: the upper's INVITE carried an audio m-line — hub audio
 	// frames are PS-muxed alongside video (#370).
 	withAudio    bool
@@ -205,7 +211,6 @@ func (s *Service) onInvite(req sip.Request, _ sip.ServerTransaction) {
 		_, _ = s.srv.RespondOnRequest(req, 500, "Stream Unavailable", "", nil)
 		return
 	}
-	releaseSub, usingSub := s.selectForwardHub(&hub, cameraID)
 
 	// Supersede: a new-dialog INVITE for a channel that is already forwarding
 	// means the upper recycled the session (its BYE may be lost or still in
@@ -254,14 +259,19 @@ func (s *Service) onInvite(req sip.Request, _ sip.ServerTransaction) {
 		mux:       psmux.New(),
 		withAudio: strings.Contains(string(req.Body()), "m=audio"),
 	}
-	ms.hub = hub
-	ms.releaseSub = releaseSub
-	// The main stream's codec is a wrong hint for the sub tier (profiles can
-	// differ) — sub forwards sniff the codec from the first NAL instead.
-	if cam, ok := s.cameraInfo(cameraID); ok && !usingSub && cam.Encoding != "" {
+	// Sub-stream forwarding (#512): acquisition happens in run() AFTER the
+	// INVITE is answered — the ready wait (first keyframe) must never block
+	// the SIP transaction. Cameras on the sub tier also skip the main
+	// stream's codec hint (profiles can differ) and sniff instead.
+	if cam, ok := s.cameraInfo(cameraID); ok && cam.SubStream && s.subAcq != nil {
+		ms.wantSub = true
+	} else if cam, ok := s.cameraInfo(cameraID); ok && cam.Encoding != "" {
 		ms.codecHint = cam.Encoding
 		ms.mux.SetVideoCodec(cam.Encoding)
 	}
+	ms.mu.Lock()
+	ms.hub = hub
+	ms.mu.Unlock()
 	if sd.tcp {
 		ms.rtp = psmux.NewRTPPacketizerTCP(conn, sd.ssrc, uint16(time.Now().UnixNano()&0xFFFF))
 	} else {
@@ -326,28 +336,48 @@ func (ms *mediaSession) localPort() int {
 }
 
 // run subscribes to the camera's hub and pumps frames until stopped.
-// selectForwardHub swaps *hub for the camera's on-demand sub-stream when the
-// camera opted into the low-res cascade tier (#512). Returns the reference's
-// release func (nil for main) and whether the sub tier is in use. Acquisition
-// failure (no sub config / pull not ready) degrades to main — quality
-// negotiation never fails the INVITE.
-func (s *Service) selectForwardHub(hub **model.StreamHub, cameraID string) (func(), bool) {
-	cam, ok := s.cameraInfo(cameraID)
-	if !ok || !cam.SubStream || s.subAcq == nil {
-		return nil, false
-	}
-	subHub, release, err := s.subAcq.AcquireSubHub(context.Background(), cameraID)
-	if err != nil || subHub == nil {
-		slog.Warn("gb28181-cascade: sub-stream forward unavailable, serving main",
-			"camera", cameraID, "reason", errString(err))
-		return nil, false
-	}
-	*hub = subHub
-	slog.Info("gb28181-cascade: forwarding sub-stream", "camera", cameraID)
-	return release, true
-}
-
 func (ms *mediaSession) run(hub *model.StreamHub) {
+	// Sub-stream tier (#512): swap the forwarded hub for the on-demand
+	// low-res pull. Bounded by the manager's ready timeout; failure (no sub
+	// config / pull not ready) degrades to main — quality negotiation never
+	// kills the forward. The swap happens before any subscription, under the
+	// same mutex close() reads through, so a BYE racing the acquisition
+	// either sees the sub hub (and releases the reference) or closes first
+	// (and the reference is dropped here).
+	if ms.wantSub && !ms.closed.Load() {
+		acqCtx := context.Background()
+		if ms.svc.ctx != nil {
+			acqCtx = ms.svc.ctx
+		}
+		subHub, release, err := ms.svc.subAcq.AcquireSubHub(acqCtx, ms.camera)
+		switch {
+		case err != nil || subHub == nil:
+			slog.Warn("gb28181-cascade: sub-stream forward unavailable, serving main",
+				"camera", ms.camera, "reason", errString(err))
+		case ms.closed.Load():
+			release()
+			return
+		default:
+			ms.mu.Lock()
+			if ms.closed.Load() {
+				ms.mu.Unlock()
+				release()
+				return
+			}
+			hub = subHub
+			ms.hub = subHub
+			ms.releaseSub = release
+			ms.mu.Unlock()
+			slog.Info("gb28181-cascade: forwarding sub-stream", "camera", ms.camera)
+		}
+	}
+
+	// A BYE that won the race into close() before we got here must not leave
+	// an orphaned subscription (close already read ms.subID as empty).
+	if ms.closed.Load() {
+		return
+	}
+
 	// Unique per dialog: the upper platform may re-INVITE the same channel in
 	// a NEW dialog while an old one lingers — a channel-only ID collides in
 	// the hub's consumer registry.
@@ -487,18 +517,22 @@ func (ms *mediaSession) teardown(reason string) {
 
 func (ms *mediaSession) close() {
 	ms.closed.Store(true)
-	if ms.hub != nil {
+	ms.mu.Lock()
+	hub := ms.hub
+	releaseSub := ms.releaseSub
+	ms.releaseSub = nil
+	ms.mu.Unlock()
+	if hub != nil {
 		if ms.audioSubID != "" {
-			ms.hub.UnsubscribeAudio(ms.audioSubID)
+			hub.UnsubscribeAudio(ms.audioSubID)
 			ms.audioSubID = ""
 		}
 		if ms.subID != "" {
-			ms.hub.Unsubscribe(ms.subID)
+			hub.Unsubscribe(ms.subID)
 		}
 	}
-	if ms.releaseSub != nil {
-		ms.releaseSub()
-		ms.releaseSub = nil
+	if releaseSub != nil {
+		releaseSub()
 	}
 	if ms.conn != nil {
 		_ = ms.conn.Close()

--- a/internal/rtsp/server.go
+++ b/internal/rtsp/server.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net"
 	"strings"
 	"sync"
@@ -87,6 +88,15 @@ type rtpEncoder interface {
 type rtspReader struct {
 	stream *gortsplib.ServerStream
 	media  *description.Media
+	// seq numbers this reader's stream emits. gortsplib sends the packet's
+	// own SequenceNumber (assigned by the shared encoder at Encode time), so
+	// without per-reader renumbering a replayed GOP (old seqs) followed by
+	// live frames (current seqs) — or an injected parameter AU — arrives with
+	// sequence jumps that strict RTP clients score as massive loss. Cloning
+	// the header and renumbering per reader also keeps one stream's SSRC
+	// rewrite (gortsplib mutates pkt.SSRC per stream) from clobbering the
+	// shared packet other readers are writing.
+	seq uint16
 	// active flips in OnPlay; frames are only written to PLAYing readers —
 	// a SETUP→TEARDOWN without PLAY must not receive or hold traffic.
 	active bool
@@ -180,12 +190,23 @@ func (cs *cameraStream) deliver(m model.FrameMsg) {
 		// the live AU alone is a clean start. Both rs flags are written only
 		// by this goroutine (the hub's single drain), so mutation under the
 		// read lock is race-free.
+		injectParams := false
 		if rs.replayPending {
 			rs.replayPending = false
-			if !m.IsKeyframe {
-				for _, e := range cs.gop {
+			if !m.IsKeyframe && len(cs.gop) > 0 {
+				for i, e := range cs.gop {
+					if i == 0 {
+						// In-band parameter sets ahead of any picture data:
+						// pullers don't reliably consume the SDP's sprop, and
+						// hub AUs don't consistently carry params per-IDR
+						// (recorder-dependent) — without this a replayed GOP
+						// head decodes as reference-missing noise.
+						cs.writeParamSets(rs, e.ts)
+					}
 					cs.writePkts(rs, e.pkts)
 				}
+			} else {
+				injectParams = true // replay skipped; the live AU opens the stream
 			}
 		}
 		if rs.skipUntilIDR {
@@ -193,6 +214,10 @@ func (cs *cameraStream) deliver(m model.FrameMsg) {
 				continue // mid-GOP join with no replayable GOP: wait for the IDR
 			}
 			rs.skipUntilIDR = false
+			injectParams = true
+		}
+		if injectParams {
+			cs.writeParamSets(rs, ts)
 		}
 		cs.writePkts(rs, pkts)
 	}
@@ -217,15 +242,51 @@ func (cs *cameraStream) deliver(m model.FrameMsg) {
 	cs.rmu.Unlock()
 }
 
-// writePkts pushes one AU's packets to a reader stream. A write error aborts
-// that reader's AU (the session is closing); other readers are unaffected.
+// writeParamSets pushes the camera's cached parameter sets as their own AU.
+// Cheap (three small NALs → one aggregation packet) and idempotent for
+// decoders when the following AU also carries them in-band.
+func (cs *cameraStream) writeParamSets(rs *rtspReader, ts uint32) {
+	var au [][]byte
+	switch cs.codec {
+	case model.FormatH264:
+		au = [][]byte{cs.sps, cs.pps}
+	case model.FormatH265:
+		au = [][]byte{cs.vps, cs.sps, cs.pps}
+	default:
+		return
+	}
+	pkts, err := cs.enc.Encode(au)
+	if err != nil {
+		return
+	}
+	for _, p := range pkts {
+		p.Timestamp = ts
+		if err := rs.write(p); err != nil {
+			return
+		}
+	}
+}
+
+// writePkts pushes one AU's packets to a reader stream via rs.write (header
+// clone + per-reader sequence renumbering). A write error aborts that
+// reader's AU (the session is closing); other readers are unaffected.
 func (cs *cameraStream) writePkts(rs *rtspReader, pkts []*rtp.Packet) {
 	for _, p := range pkts {
-		if err := rs.stream.WritePacketRTP(rs.media, p); err != nil {
+		if err := rs.write(p); err != nil {
 			rtspLogger.Warn("rtsp write failed", "camera_id", cs.cameraID, "error", err)
 			return
 		}
 	}
+}
+
+// write sends one packet on the reader's private stream with a locally
+// contiguous sequence number. The payload slice stays shared (read-only in
+// the write path); only the header is cloned.
+func (rs *rtspReader) write(pkt *rtp.Packet) error {
+	c := *pkt
+	c.SequenceNumber = rs.seq
+	rs.seq++
+	return rs.stream.WritePacketRTP(rs.media, &c)
 }
 
 func pktBytes(pkts []*rtp.Packet) int {
@@ -247,7 +308,7 @@ func (cs *cameraStream) addReader(sess *gortsplib.ServerSession) (*rtspReader, e
 	if err := stream.Initialize(); err != nil {
 		return nil, err
 	}
-	rs := &rtspReader{stream: stream, media: media}
+	rs := &rtspReader{stream: stream, media: media, seq: uint16(rand.Uint32())}
 	cs.rmu.Lock()
 	cs.sessReaders[sess] = rs
 	cs.rmu.Unlock()

--- a/internal/rtsp/server_test.go
+++ b/internal/rtsp/server_test.go
@@ -212,21 +212,35 @@ func TestRTSPServeH265(t *testing.T) {
 	}
 }
 
+// feedIDRBare pushes an IDR AU WITHOUT parameter sets — mirrors recorders
+// whose hub AUs carry the codec params only via CodecParams, not per-IDR
+// in-band (the case that motivated param-set injection on join).
+func (ts *testServer) feedIDRBare() {
+	ts.hub.Broadcast(0, [][]byte{{0x26, 0x01, 0x02, 0x03}}, true)
+}
+
 // feedP pushes one synthetic non-keyframe AU through the hub.
 func (ts *testServer) feedP() {
 	ts.hub.Broadcast(0, [][]byte{{0x41, 0x01, 0x02, 0x03}}, false)
 }
 
-// firstNALType drains pkts until the first H.264 packet and returns the NAL
-// type it carries (7=SPS 8=PPS 5=IDR 1=P). STAP-A (24) aggregates several
-// NALs — the first sub-NAL decides.
-func firstNALType(t *testing.T, pkts <-chan *rtp.Packet) byte {
+// firstNALType drains pkts until the first packet and returns the NAL type
+// it carries. h264: 7=SPS 8=PPS 5=IDR 1=P, STAP-A (24) aggregates several
+// NALs (first sub-NAL decides); h265: types shift by 1 bit, AP is 48.
+func firstNALType(t *testing.T, pkts <-chan *rtp.Packet, h265 bool) byte {
 	t.Helper()
 	deadline := time.After(5 * time.Second)
 	for {
 		select {
 		case p := <-pkts:
 			if len(p.Payload) > 0 {
+				if h265 {
+					typ := (p.Payload[0] >> 1) & 0x3F
+					if typ == 48 && len(p.Payload) >= 4 { // AP: 2 hdr + 2 size + NAL
+						return (p.Payload[4] >> 1) & 0x3F
+					}
+					return typ
+				}
 				typ := p.Payload[0] & 0x1F
 				if typ == 24 && len(p.Payload) >= 4 { // STAP-A: 1 hdr + 2 size + NAL
 					return p.Payload[3] & 0x1F
@@ -294,7 +308,7 @@ func TestRTSPMidGOPJoinStartsAtKeyframe(t *testing.T) {
 	// The replay rides the first post-PLAY frame — feed one to trigger it.
 	ts.feedP()
 
-	switch n := firstNALType(t, pktsB); n {
+	switch n := firstNALType(t, pktsB, false); n {
 	case 7, 8, 5: // SPS / PPS / IDR — GOP head AU
 	default:
 		t.Fatalf("late joiner's first packet NAL type %d — mid-GOP P-frames leaked to a fresh reader", n)
@@ -337,8 +351,63 @@ func TestRTSPJoinBeforeFirstIDRWaitsForKeyframe(t *testing.T) {
 	}
 
 	ts.feedIDR()
-	if n := firstNALType(t, pkts); n != 7 && n != 8 && n != 5 {
+	if n := firstNALType(t, pkts, false); n != 7 && n != 8 && n != 5 {
 		t.Fatalf("first packet after IDR is NAL %d, want SPS/PPS/IDR", n)
+	}
+}
+
+// Late joiners must receive the parameter sets IN-BAND before any picture
+// data even when the hub's IDR AUs don't carry them (recorder-dependent) —
+// the SDP sprop is not reliably consumed by every puller.
+func TestRTSPJoinInjectsParamSets(t *testing.T) {
+	ts := startTestServer(t, Config{})
+	ts.codec = model.FormatH265
+	ts.sps = tSPS265
+	ts.pps = tPPS265
+
+	a := dialClient(t, ts.url)
+	descA, _, err := a.Describe(mustURL(t, ts.url))
+	require.NoError(t, err)
+	_, err = a.Setup(descA.BaseURL, descA.Medias[0], 0, 0)
+	require.NoError(t, err)
+	pktsA := make(chan *rtp.Packet, 32)
+	a.OnPacketRTP(descA.Medias[0], descA.Medias[0].Formats[0], func(pkt *rtp.Packet) {
+		select {
+		case pktsA <- pkt:
+		default:
+		}
+	})
+	_, err = a.Play(nil)
+	require.NoError(t, err)
+
+	// GOP whose head carries no in-band params.
+	ts.hub.Broadcast(0, [][]byte{tVPS, tSPS265, tPPS265, {0x26, 0x01, 0x02}}, true) // first-ever AU seeds the encoder
+	for range 3 {
+		ts.feedIDRBare()
+		ts.feedP()
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	b := dialClient(t, ts.url)
+	descB, _, err := b.Describe(mustURL(t, ts.url))
+	require.NoError(t, err)
+	_, err = b.Setup(descB.BaseURL, descB.Medias[0], 0, 0)
+	require.NoError(t, err)
+	pktsB := make(chan *rtp.Packet, 64)
+	b.OnPacketRTP(descB.Medias[0], descB.Medias[0].Formats[0], func(pkt *rtp.Packet) {
+		select {
+		case pktsB <- pkt:
+		default:
+		}
+	})
+	_, err = b.Play(nil)
+	require.NoError(t, err)
+	ts.feedIDRBare() // trigger the deferred replay
+
+	switch n := firstNALType(t, pktsB, true); n {
+	case 32, 33, 34, 48: // VPS/SPS/PPS or an aggregation carrying them
+	default:
+		t.Fatalf("late joiner's first packet NAL type %d — parameter sets not injected before picture data", n)
 	}
 }
 


### PR DESCRIPTION
Field verification of #556 on the M5 box caught two real defects before they could bite anyone else.

## RTSP: incomplete join fix
Packet capture of a mid-GOP join showed the first RTP packets were pure FU fragments of the IDR slice — **no VPS/SPS/PPS ahead of them**:
- recorder hub AUs don't consistently carry parameter sets per-IDR (recorder-dependent), so the replayed GOP head was slice-only;
- pullers don't reliably consume the SDP sprop.

Result: decoders still opened the join with `SPS 0 does not exist` + a missing-reference frame (muted, but exactly what #524 set out to kill).

**Fixes**
1. **Parameter-set injection**: the camera's cached VPS/SPS/PPS is sent as its own AU ahead of a reader's first picture data (replay head, first live keyframe, or the IDR that ends a skip-until-IDR wait). Idempotent when the AU also carries them in-band.
2. **Per-reader seq renumbering + header clone**: gortsplib sends the packet's own SequenceNumber (assigned by the shared encoder at Encode time) and rewrites `pkt.SSRC` per stream **in place** — shared packets across reader streams produced seq jumps strict clients score as massive loss (`65534 RTP packets lost` in tests) and a cross-stream SSRC clobbering race. Each reader now emits a locally coherent RTP stream (payload slices stay shared; only headers are cloned).

## Cascade: sub acquisition blocked the INVITE
`selectForwardHub` acquired the sub-stream inside the SIP handler — the ready wait (first keyframe of the pull) delayed the 200 OK past the upper's transaction timers (field: `invite_sent` with no `INVITE accepted`).

**Fix**: acquisition moved into the session goroutine after the INVITE is answered; the hub swap + reference are mutex-guarded against a racing BYE (close-before-acquire never pulls; close-during-acquire releases through the swap). `run()` now refuses to subscribe once closed — a BYE racing session start previously orphaned the subscription.

## Testing
- New `TestRTSPJoinInjectsParamSets`: bare-IDR GOP (no in-band params) → late joiner's first packet is the parameter AU.
- New cascade tests: sub forward lifecycle, fallback-to-main, close-race matrix.
- `internal/rtsp` + `internal/gb28181/cascade` green under `-race`.