### PR TITLE
fix(recorder): H265 parameter-set snapshot was rotated on every re-store

### DIFF
--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -44,7 +44,7 @@ func (d H265NALDriver) isIDR(typ int) bool          { return typ == 19 || typ ==
 func (d H265NALDriver) isParameterSet(typ int) bool { return typ == 32 || typ == 33 || typ == 34 }
 func (d H265NALDriver) isVCL(typ int) bool          { return typ < 32 }
 func (d H265NALDriver) paramSetsReady(b *baseRecorder) bool {
-	vps, sps, pps := b.codecSnapshot()
+	sps, pps, vps := b.codecSnapshot()
 	return vps != nil && sps != nil && pps != nil
 }
 
@@ -53,29 +53,34 @@ func (d H265NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) boo
 	// writeFrames goroutine, so load-then-store is race-free. We always rebuild
 	// and store the full triplet (VPS/SPS/PPS) so a concurrent reader (live
 	// preview via codecSnapshot) never sees a torn mix of old+new params (#219).
-	vps, sps, pps := b.codecSnapshot()
+	// codecSnapshot returns (sps, pps, vps): keep the labels aligned — the
+	// previous (vps, sps, pps) unpack silently rotated the triplet, and every
+	// re-store below wrote mislabeled bytes back into the snapshot (SDP sprop,
+	// the RTSP server's parameter injection, and the MP4 track config all
+	// served VPS/SPS/PPS in each other's slots).
+	sps, pps, vps := b.codecSnapshot()
 	switch typ {
 	case 32: // VPS
 		if vps != nil && !bytes.Equal(vps, nalu) {
 			b.log.Info("VPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(nalu, sps, pps)
+			b.setCodecParams(sps, pps, nalu)
 			return true
 		}
-		b.setCodecParams(nalu, sps, pps)
+		b.setCodecParams(sps, pps, nalu)
 	case 33: // SPS
 		if sps != nil && !bytes.Equal(sps, nalu) {
 			b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(vps, nalu, pps)
+			b.setCodecParams(nalu, pps, vps)
 			return true
 		}
-		b.setCodecParams(vps, nalu, pps)
+		b.setCodecParams(nalu, pps, vps)
 	case 34: // PPS
 		if pps != nil && !bytes.Equal(pps, nalu) {
 			b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(vps, sps, nalu)
+			b.setCodecParams(sps, nalu, vps)
 			return true
 		}
-		b.setCodecParams(vps, sps, nalu)
+		b.setCodecParams(sps, nalu, vps)
 	}
 	return false
 }
@@ -93,7 +98,7 @@ func (d H265NALDriver) extractParamSets(b *baseRecorder, au [][]byte) {
 }
 
 func (d H265NALDriver) addTrack(m *muxer.MP4Muxer, b *baseRecorder) (int, error) {
-	vps, sps, pps := b.codecSnapshot()
+	sps, pps, vps := b.codecSnapshot()
 	return m.AddH265Track(vps, sps, pps)
 }
 

--- a/internal/recorder/h265_test.go
+++ b/internal/recorder/h265_test.go
@@ -347,3 +347,27 @@ func TestH265Recorder_AudioEnabled_NoAudioInStream(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, files, "expected video recording even when no audio in stream")
 }
+
+// Regression: the H265 NAL driver's codecSnapshot call sites unpacked the
+// (sps, pps, vps) tuple as (vps, sps, pps), silently rotating the triplet on
+// every parameter re-store — the SDP sprop / RTSP param injection then served
+// VPS/SPS/PPS in each other's slots and pullers opened every join with
+// "SPS 0 does not exist" until the camera's bare parameter AUs healed it.
+func TestH265ParamSetLabelsNotRotated(t *testing.T) {
+	d := H265NALDriver{}
+	b := &baseRecorder{}
+
+	vps := []byte{0x40, 0x01, 0x0c}
+	sps := []byte{0x42, 0x01, 0x01}
+	pps := []byte{0x44, 0x01, 0xc1}
+
+	// Feed the triplet in camera order; each NAL re-stores the snapshot.
+	require.False(t, d.handleParamSet(b, vps, 32))
+	require.False(t, d.handleParamSet(b, sps, 33))
+	require.False(t, d.handleParamSet(b, pps, 34))
+
+	gotSPS, gotPPS, gotVPS := b.codecSnapshot()
+	require.Equal(t, sps, gotSPS, "SPS slot must hold the SPS")
+	require.Equal(t, pps, gotPPS, "PPS slot must hold the PPS")
+	require.Equal(t, vps, gotVPS, "VPS slot must hold the VPS")
+}


### PR DESCRIPTION
Found while verifying #557 on the box: RTSP joins still opened with `SPS 0 does not exist` despite the GOP replay + parameter-set injection. Decoding the live SDP's sprop slots showed the triplet **rotated**: `sprop-pps` carried the SPS, `sprop-sps` the VPS, `sprop-vps` the PPS.

## Root cause
`baseRecorder.codecSnapshot()` returns **(sps, pps, vps)**, but the H265 NAL driver unpacked it as **(vps, sps, pps)** at three sites — and `handleParamSet`'s per-type `setCodecParams` calls also passed the slots positionally wrong. The first parameter NAL after connect re-stored a mislabeled triplet, permanently corrupting the snapshot; every `CodecParams()` consumer (RTSP SDP sprop, the #557 parameter injection, MP4 track config) then served rotated bytes.

Playback masked it: cameras periodically emit bare parameter AUs in-band, which heal the decoder regardless of the snapshot.

## Fix
Align the unpack labels with the tuple at all three call sites and correct the positional slots in `handleParamSet`'s re-stores.

## Testing
- `TestH265ParamSetLabelsNotRotated`: feeds VPS/SPS/PPS through `handleParamSet`, asserts each slot holds its own bytes (pre-fix: rotated).
- Full `internal/recorder` suite green, incl. `-race` (100s).