### PR TITLE
test(api): storage-root migration flake — done requires the job observed

### DIFF
--- a/internal/api/handlers_storage_migrate_test.go
+++ b/internal/api/handlers_storage_migrate_test.go
@@ -86,26 +86,27 @@ func TestCameraStorageRoot_SwitchAndBackgroundMigrate(t *testing.T) {
 	// Run the background migration to completion.
 	mig.Start(context.Background())
 	defer mig.Stop()
+	// "Done" requires the cam-one job to have been OBSERVED — under CI-runner
+	// load the first Status() snapshot can land before the queue is visible,
+	// and an idle+empty poll must keep waiting instead of reading as "nothing
+	// to migrate" (flaked on main as `job = <nil>` in 0.13s).
 	deadline := time.Now().Add(15 * time.Second)
+	var job *migration.Job
 	for time.Now().Before(deadline) {
 		state, jobs := mig.Status()
 		done := state == "idle"
 		for _, j := range jobs {
-			if j.CameraID == "cam-one" && j.State != "done" && j.State != "failed" {
-				done = false
+			if j.CameraID == "cam-one" {
+				job = j
+				if j.State != "done" && j.State != "failed" {
+					done = false
+				}
 			}
 		}
-		if done {
+		if done && job != nil {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
-	}
-	_, jobs := mig.Status()
-	var job *migration.Job
-	for _, j := range jobs {
-		if j.CameraID == "cam-one" {
-			job = j
-		}
 	}
 	if job == nil || job.State != "done" {
 		t.Fatalf("job = %+v", job)


### PR DESCRIPTION
Main's CI flaked on the #558 merge run (`TestCameraStorageRoot_SwitchAndBackgroundMigrate`: `job = <nil>` after 0.13s) while the identical tree passed its PR run — runner-load jitter, not a regression.

The completion poll treated an idle+empty first `Status()` snapshot as done, so a queue not yet visible ended the loop before the job was ever observed. Done now also requires the cam-one job to have been seen, and the finished job is carried out of the poll loop.