### PR TITLE
fix(live): FLV black screen — infinite destroy/init churn + protocol-switch wedge (#549)

### DIFF
--- a/web/src/components/CameraPlayer.svelte
+++ b/web/src/components/CameraPlayer.svelte
@@ -20,6 +20,10 @@
    * component renders nothing and the parent's snapshot/unsupported branch takes
    * over. The parent must call `orchestrator.registerCamera()` for each camera
    * and read `activeMode()` to decide whether to mount `<CameraPlayer>` at all.
+   * Unregistering is ALSO the parent's job (route unmount / camera leaving the
+   * grid) — this component unmounts transiently during a manual protocol switch
+   * (LiveView's switchingProtocol placeholder) and must NOT drop the slot there,
+   * or the page wedges on "live not supported" until reload (issue #549).
    *
    * The orchestrator owns degrade/upgrade decisions; players keep their own
    * internal resilience (HLS recreate, FLV retry, WebRTC ICE restart). This
@@ -154,11 +158,13 @@
   });
 
   onMount(() => {
-    return () => {
-      // On unmount, drop this camera from the orchestrator so its timers/cooldowns
-      // don't leak. The parent route owns the initial register() call.
-      orchestrator?.unregisterCamera(cameraId);
-    };
+    // NOTE: deliberately NO unregisterCamera() on unmount — this component
+    // unmounts transiently during a manual protocol switch (LiveView's
+    // switchingProtocol placeholder swaps it out for ~100ms); dropping the
+    // orchestrator slot there wedged the page on "live not supported"
+    // (issue #549). Both consumers own cleanup themselves: LiveView.onDestroy
+    // unregisters, Surveillance unregisters cameras leaving the grid and
+    // disposes the orchestrator on route destroy.
   });
 
   function getHlsStreamUrl(): string {

--- a/web/src/components/FlvPlayer.svelte
+++ b/web/src/components/FlvPlayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, getContext } from 'svelte';
+  import { onDestroy, getContext, untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import { AlertCircle, RefreshCw, ImageIcon } from 'lucide-svelte';
   import CameraAudioButton from './CameraAudioButton.svelte';
@@ -100,6 +100,10 @@
   let videoEl: HTMLVideoElement | undefined = $state();
   let mpegtsPlayer: any = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  // Init generation: destroyPlayer() bumps it so an in-flight initFlv (still
+  // awaiting the mpegts.js import) aborts instead of resurrecting a player on
+  // a torn-down element (issue #549).
+  let initGeneration = 0;
   // Loading watchdog: a failed dynamic import or a wedged mpegts load() can
   // leave streamState at 'loading' forever with no network request issued
   // (observed on degraded GB28181 streams — the tile stuck at "connecting"
@@ -243,6 +247,7 @@ let videoEventAc: AbortController | null = null;
   }
 
   function destroyPlayer() {
+    initGeneration++;
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
@@ -317,6 +322,7 @@ let videoEventAc: AbortController | null = null;
     }
 
     streamState = 'loading';
+    const gen = ++initGeneration;
     if (loadingWatchdog) clearTimeout(loadingWatchdog);
     loadingWatchdog = setTimeout(() => {
       loadingWatchdog = null;
@@ -329,7 +335,21 @@ let videoEventAc: AbortController | null = null;
 
     try {
       const mpegts = await import('mpegts.js');
-      if (destroyed) return;
+      // Stale-run guard: destroyPlayer() (reconnect, visibility rebuild,
+      // protocol switch) invalidates any initFlv still awaiting the import —
+      // without this the old coroutine attaches a player to a torn-down
+      // element and the two runs double-rebuild on every state transition.
+      if (destroyed || gen !== initGeneration) return;
+      if (snapshotMode || !videoEl) {
+        // The <video> lives in the {:else} branch of {#if snapshotMode} — it
+        // leaves the DOM (videoEl → undefined) when snapshot fallback flips the
+        // branch while the import is in flight. attachMediaElement(null) throws
+        // "Cannot set properties of null (setting 'src')".
+        if (!snapshotMode) {
+          setTimeout(() => { if (!destroyed && !snapshotMode) initFlv(); }, 250);
+        }
+        return;
+      }
 
       if (!mpegts.default.isSupported()) {
         console.warn('mpegts.js not supported');
@@ -470,14 +490,21 @@ let videoEventAc: AbortController | null = null;
         try { mpegtsPlayer.pause(); } catch { /* ignore */ }
       }
     } else {
-      // Tab visible — resume: rebuild stream for fresh state
-      if (!destroyed && streamState !== 'loading') {
-        stopSnapshotMode();
-        reconnectAttempts = 0;
-        captureFreezeFrame();
-        destroyPlayer();
-        initFlv();
-      }
+      // Tab visible — resume: rebuild stream for fresh state.
+      // untrack the streamState read: this effect must re-run ONLY on
+      // tabVisible flips. Reading it reactively made every loading→buffering
+      // transition re-run the rebuild branch → destroyPlayer()+initFlv() →
+      // buffering → … an infinite destroy/init churn that kept the FLV tile
+      // permanently black (issue #549). WebRTCPlayer has the same untrack.
+      untrack(() => {
+        if (!destroyed && streamState !== 'loading') {
+          stopSnapshotMode();
+          reconnectAttempts = 0;
+          captureFreezeFrame();
+          destroyPlayer();
+          initFlv();
+        }
+      });
     }
   });
 

--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, getContext } from 'svelte';
+  import { onDestroy, getContext, untrack } from 'svelte';
   import { t } from '$lib/i18n';
   import { Maximize, Minimize, AlertCircle, RefreshCw } from 'lucide-svelte';
   import CameraAudioButton from './CameraAudioButton.svelte';
@@ -350,12 +350,18 @@ streamState = 'error';
       // recreateAttempts and restart the death-loop (issue #112). Only a
       // streamUrl/camera change legitimately resets streamGaveUp (see the
       // streamUrl $effect prelude).
-      if (!destroyed && !streamGaveUp && streamState !== 'loading' && !hlsInstance) {
-        captureFreezeFrame();
-        recreateAttempts.value = 0;
-        streamState = 'loading';
-        initHls();
-      }
+      // untrack the state reads: this effect must re-run ONLY on tabVisible
+      // flips — a reactive streamState read re-triggers the rebuild on every
+      // loading→buffering transition (the destroy/init churn of issue #549;
+      // the !hlsInstance guard mostly masked it here, but don't rely on that).
+      untrack(() => {
+        if (!destroyed && !streamGaveUp && streamState !== 'loading' && !hlsInstance) {
+          captureFreezeFrame();
+          recreateAttempts.value = 0;
+          streamState = 'loading';
+          initHls();
+        }
+      });
     }
   });
 


### PR DESCRIPTION
## Root causes (verified by live instrumentation on the Docker VM)

Reproduced the black screen in the same headless Chromium + main-baseline environment as the report, with per-step logging inside `initFlv`. Four defects, all fixed:

### 1. FlvPlayer tabVisible $effect infinite destroy/init churn (the black screen)
The visibility effect read `streamState` **reactively**. `initFlv` writes `loading`→`buffering`, which re-ran the effect's rebuild branch → `destroyPlayer()+initFlv()` → `buffering` → effect → … forever. Instrumentation showed the exact loop (`attach(src=blob) → destroyed → attach → …`); the video never reached `playing`, so the zombie detector (armed only on `playing`) never fired. **WebRTCPlayer already carries the `untrack` fix with a comment describing this exact loop** — FlvPlayer's copy never got it. Fixed identically; VideoPlayer (HLS) got the same `untrack` for its latent variant (so far masked by its `!hlsInstance` guard).

### 2. Stale initFlv coroutines survived destroyPlayer
`destroyPlayer()` didn't cancel an `initFlv` still awaiting the `mpegts.js` dynamic import; it resumed and resurrected a player on a torn-down element, doubling rebuild loops (paired log lines). Added an `initGeneration` counter bumped by `destroyPlayer`; stale runs abort at the post-await checkpoint.

### 3. `attachMediaElement(null)` crash window
The `videoEl` guard ran before the `await import`; the `{#if snapshotMode}` branch swap can null `videoEl` mid-flight → `TypeError: Cannot set properties of null (setting 'src')` (the exception captured during #547 instrumentation). Re-check after the await + bind-race retry.

### 4. Manual protocol switch wedged LiveView on 「不支持实时播放」
`CameraPlayer` unregistered its orchestrator slot on **every unmount**; LiveView's `switchingProtocol` placeholder unmounts it for ~100ms per manual switch → slot deleted → `canStream()` false → the unsupported card replaces the player area *including the ProtocolSwitcher*, so the page can't recover without a reload (and the FLV pin then re-drove the whole failure). Unregistering is now solely the parent route's job — LiveView `onDestroy` and Surveillance (grid diff + `dispose`) already do it.

## Also ruled out / environment notes

- **Headless decode capability is fine**: native MP4 H.264 playback worked (640×480, readyState 4) and MSE `isTypeSupported` was honest — the black screen was purely the churn above, **not** a headless codec gap.
- **VM environment defect found during verification**: `/data/hls` was left root-owned by an earlier docker-mode run → every on-demand HLS start failed with `permission denied` (500), so *every* demote chain ended dead. Fixed by `chown` on the host; worth knowing when this VM shows all-HLS-black grids.
- mpegts logs a benign `Meet tag which has StreamID != 0!` warning per tag for the #481/#547 ingest-wallclock piggyback — tolerated, playback unaffected.

## Verification (Docker VM 192.168.63.197, headless Chromium, same env as the report)

- **FLV plays end-to-end**: 640px testsrc2 rendering (screenshots in tmp/), `currentTime` advancing (+28s over the observation window), latency badge 0.1–0.3s, no spinner.
- **WebRTC ↔ HTTP-FLV manual switching** remounts cleanly both directions (the exact path that previously wedged the page).
- WebRTC tiles unaffected; the churn fix also removes a per-tile CPU burn.
- `cd web && npm test` — 591 passed; `go test ./internal/...` — 4883 passed.

Closes #549