### PR TITLE
docs(ingest): recommend -bf 0 for external push encoders (#459)

### DIFF
--- a/docs/en/srt-rtmp.md
+++ b/docs/en/srt-rtmp.md
@@ -41,7 +41,7 @@ For example:
 
 ```bash
 # FFmpeg push-stream test
-ffmpeg -re -i input.mp4 -c:v libx264 -f mpegts \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -f mpegts \
   "srt://192.168.1.50:9000?streamid=#!:r=test-cam,m=publish"
 ```
 
@@ -75,7 +75,7 @@ srt:
 Push source:
 
 ```bash
-ffmpeg -re -i input.mp4 -c:v libx264 -f mpegts \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -f mpegts \
   "srt://192.168.1.50:9000?streamid=#!:r=test-cam,m=publish&passphrase=my-secret-key-123"
 ```
 
@@ -101,7 +101,7 @@ For example:
 
 ```bash
 # FFmpeg push-stream test
-ffmpeg -re -i input.mp4 -c:v libx264 -c:a aac -f flv \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -c:a aac -f flv \
   "rtmp://192.168.1.50:1935/live/test-cam"
 ```
 
@@ -118,6 +118,18 @@ ffmpeg -re -i input.mp4 -c:v libx264 -c:a aac -f flv \
 |-----------|---------|-------------|
 | `port` | `1935` | RTMP listening port |
 | `chunk_size` | `4096` | Chunk size |
+
+## Encoder Recommendation: Disable B-Frames (`-bf 0`)
+
+The recording pipeline works on a write-as-encoded, low-latency model: the recorder writes frames to MP4 in arrival order with `pts == dts` and no `ctts` composition offsets. Surveillance cameras almost universally emit baseline/main streams without B-frames, where this model is exact. **Generic encoder defaults, however, enable B-frames** (e.g. `libx264` defaults to `bframes=3`) — with B-frames the decode order ≠ presentation order, so a pts==dts write produces out-of-order playback, and remuxing (`-c copy`) makes ffmpeg report `co located POCs unavailable` (verified in the #435 long-run test).
+
+For push-in sources (SRT/RTMP/WHIP, and externally-encoded RTSP pulls) disable B-frames at the encoder:
+
+```bash
+-c:v libx264 -bf 0        # FFmpeg
+```
+
+For surveillance, disabling B-frames costs almost no bitrate (their benefit is mainly VOD) and stays fully compatible with the NVR's streaming write path, on-demand HLS, and merge pipeline.
 
 ## Push-Out Relay
 

--- a/docs/zh/srt-rtmp.md
+++ b/docs/zh/srt-rtmp.md
@@ -41,7 +41,7 @@ SRT URL: srt://你的NVR地址:9000?streamid=#!:r=摄像头ID,m=publish
 
 ```bash
 # FFmpeg 推流测试
-ffmpeg -re -i input.mp4 -c:v libx264 -f mpegts \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -f mpegts \
   "srt://192.168.1.50:9000?streamid=#!:r=test-cam,m=publish"
 ```
 
@@ -75,7 +75,7 @@ srt:
 推流端：
 
 ```bash
-ffmpeg -re -i input.mp4 -c:v libx264 -f mpegts \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -f mpegts \
   "srt://192.168.1.50:9000?streamid=#!:r=test-cam,m=publish&passphrase=my-secret-key-123"
 ```
 
@@ -101,7 +101,7 @@ RTMP URL: rtmp://你的NVR地址:1935/live/摄像头ID
 
 ```bash
 # FFmpeg 推流测试
-ffmpeg -re -i input.mp4 -c:v libx264 -c:a aac -f flv \
+ffmpeg -re -i input.mp4 -c:v libx264 -bf 0 -c:a aac -f flv \
   "rtmp://192.168.1.50:1935/live/test-cam"
 ```
 
@@ -118,6 +118,18 @@ ffmpeg -re -i input.mp4 -c:v libx264 -c:a aac -f flv \
 |------|--------|------|
 | `port` | `1935` | RTMP 监听端口 |
 | `chunk_size` | `4096` | 分块大小 |
+
+## 编码器建议：关闭 B 帧（`-bf 0`）
+
+录像管线按「每帧编码即可写」的低延迟模型工作：录制器以帧到达顺序写入 MP4，`pts == dts`、不写 `ctts` 补偿表。监控相机几乎都输出 baseline/main 无 B 帧码流，此模型精确。但**通用编码器的默认配置会启用 B 帧**（如 `libx264` 默认 `bframes=3`）——B 帧的重建顺序 ≠ 显示顺序，按 pts==dts 写入会在播放时出现时序错乱观感，转封装（`-c copy`）时 ffmpeg 还会报 `co located POCs unavailable`（#435 长测实证）。
+
+推流接入（SRT/RTMP/WHIP，以及 RTSP 拉流的外部编码源）建议在编码端关闭 B 帧：
+
+```bash
+-c:v libx264 -bf 0        # FFmpeg
+```
+
+监控场景关闭 B 帧几乎没有码率损失（B 帧收益主要在点播 VOD），且与 NVR 的流式直写、按需 HLS、合并管线全部兼容。
 
 ## 推流转发（Push-Out）
 


### PR DESCRIPTION
Option 2 of #459 (documentation): the muxer's pts==dts no-ctts write model is exact for no-B-frame surveillance streams, but generic encoder defaults enable B-frames — producing temporally jumbled playback and `co located POCs unavailable` on `-c copy` remux (evidence from the #435 48h long-run).

- All ffmpeg examples in zh/en `srt-rtmp.md` now carry `-bf 0` (users copy examples, so this is where the fix propagates).
- New dedicated section in both languages explaining the why (B-frame benefit is VOD-centric; surveillance loses almost no bitrate) and that the note applies to SRT/RTMP/WHIP push-in and externally-encoded RTSP pulls alike.
- Option 1 (muxer ctts from real RTP pts/dts) stays a future enhancement if real demand appears — impact is low per the issue.

Docs link + zh/en parity check passes locally (`scripts/check-docs-links.py`).