### PR TITLE
feat(gb28181): vendor-convention sub-channel probing + GB sub-stream pull (#560)

### DIFF
--- a/docs/en/gb28181-guide.md
+++ b/docs/en/gb28181-guide.md
@@ -128,6 +128,8 @@ Audio is off by default. Turn on the **Audio** toggle in the camera's edit page 
 | `subscribe_mobile_position` | bool | `false` | Mobile-position subscription |
 | `subscribe_expires` | string | `"3600s"` | Subscription lifetime (auto-renewed at 80%) |
 | `allowed_device_ids` | `[]string` | `[]` | Registration allowlist (empty = allow all) |
+| `sub_channel_probe` | string | `"auto"` | Sub-channel prober mode: `auto` (probe only Hikvision/Dahua devices) / `on` (probe every device) / `off`, #560 |
+| `sub_channel_probe_offset` | int | `1` | Sub-channel candidate code = main channel code + this offset (Hikvision convention is +1; 0 disables probing). Range 0–99 |
 
 > `tcp_mode` (bool) is a legacy alias of `media_transport`, kept for YAML compatibility. It no longer influences the default (tcp-passive since v0.12.0, #460) — set `media_transport: "udp"` explicitly for UDP.
 
@@ -138,7 +140,18 @@ Audio is off by default. Turn on the **Audio** toggle in the camera's edit page 
 | `protocol` | string | Must be `"gb28181"` |
 | `gb28181.device_id` | string | Device 20-digit code |
 | `gb28181.channel_id` | string | Channel 20-digit code |
+| `gb28181.sub_channel_id` | string | Probed sub-stream channel code (auto backfilled, fill-once; clear + restart to re-probe). When set, `?quality=sub` and sub-stream cascade forwarding work, #560 |
 | `audio_enabled` | bool | Audio toggle (default false; enables MP4 audio tracks + live audio) |
+
+## Sub-Stream (Sub-Channel Probing, #560)
+
+GB devices usually do NOT list their sub stream in the catalog — Hikvision-family devices expose it implicitly at a channel-code offset (main code +1). Once a device has registered and its main streams settled, the NVR probes the vendor-convention sub candidate once per bound camera (one extra INVITE, at most once per process lifetime):
+
+- **Success** (media flows on the candidate): the code is persisted to `gb28181.sub_channel_id` (fill-once), `/api/cameras/{id}/protocols` reports `sub_stream.available=true`, and `?quality=sub` (WS/FLV/HLS/WHEP grid + cascade sub forwarding) becomes usable
+- **Failure** (404/timeout/486): silently dropped — the camera keeps its no-sub-stream degradation path with **zero error state**
+- The offset is configurable (`sub_channel_probe_offset`, default 1); in `auto` mode only devices whose DeviceInfo manufacturer is Hikvision or Dahua are probed, leaving self-developed devices untouched
+- A persisted `sub_channel_id` is never overwritten; clear the field and restart the NVR to re-arm probing
+- Sibling codes already present in the catalog (e.g. channels 02/03 of a multi-channel NVR) are NEVER repurposed as sub streams
 
 ## Audio
 

--- a/docs/zh/gb28181-guide.md
+++ b/docs/zh/gb28181-guide.md
@@ -128,6 +128,8 @@ cameras:
 | `subscribe_mobile_position` | bool | `false` | 移动位置订阅（静止相机无需开启） |
 | `subscribe_expires` | string | `"3600s"` | 订阅有效期（80% 时自动续订） |
 | `allowed_device_ids` | `[]string` | `[]` | 注册白名单（空 = 允许所有） |
+| `sub_channel_probe` | string | `"auto"` | 子通道探测模式：`auto`（仅探测厂商为海康/大华的设备）/ `on`（探测所有设备）/ `off`（关闭），#560 |
+| `sub_channel_probe_offset` | int | `1` | 子通道候选码 = 主通道码 + 该偏移（海康惯例 +1；0 = 禁用探测），范围 0–99 |
 
 > `tcp_mode`（bool）是 `media_transport` 的旧别名，保留仅为 YAML 兼容，**已不再影响默认值**（v0.12.0 起默认即 `tcp-passive`，#460）；需要 UDP 请显式设置 `media_transport: "udp"`。
 
@@ -139,6 +141,17 @@ cameras:
 | `gb28181.device_id` | string | 设备 20 位国标编码 |
 | `gb28181.channel_id` | string | 通道 20 位国标编码 |
 | `audio_enabled` | bool | 音频开关（默认 false，开启后录 MP4 音轨 + 直播音频） |
+| `gb28181.sub_channel_id` | string | 探测到的子码流通道编码（自动回填，fill-once；清空后重启可重新探测）。有值时 `?quality=sub` 与子流转发可用，#560 |
+
+## 子码流（子通道探测，#560）
+
+GB 设备的子码流通常**不在目录里**——海康系设备按通道编码偏移（主码流码 +1）隐式存在。NVR 在设备入册并稳定取流后，按厂商惯例对每个已绑定相机的主通道做一次子通道探测（一次额外 INVITE，进程生命周期内最多一次）：
+
+- **成功**（子通道有媒体流）：探测码自动落 `gb28181.sub_channel_id`（fill-once），`/api/cameras/{id}/protocols` 如实回报 `sub_stream.available=true`，`?quality=sub`（WS/FLV/HLS/WHEP 宫格与级联子流转发）即可用
+- **失败**（404/超时/486）：静默放弃，相机保持无子流的降级路径，**零错误状态**
+- 偏移量可配（`sub_channel_probe_offset`，默认 1）；`auto` 模式只对 DeviceInfo 厂商为海康（Hikvision/海康）/大华（Dahua/大华）的设备探测，自研设备零打扰
+- 已回填的 `sub_channel_id` 不会被覆盖；清空该字段并重启 NVR 可重新触发探测
+- 目录里已存在的兄弟通道码（如多通道 NVR 的 02/03）**绝不**会被当作子码流复用
 
 ## 音频
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -667,6 +667,8 @@ func (h *Handler) subStreamDetailFor(cameraID string) subStreamDetail {
 		return h.withSubStreamCodec(subStreamDetail{Available: true, Source: "manual"}, cameraID)
 	case cam.SubProfileToken != "":
 		return h.withSubStreamCodec(subStreamDetail{Available: true, Source: "onvif"}, cameraID)
+	case cam.Protocol == string(model.ProtoGB28181) && strings.TrimSpace(cam.GB28181.SubChannelID) != "":
+		return h.withSubStreamCodec(subStreamDetail{Available: true, Source: "gb-sub-channel"}, cameraID)
 	}
 	switch cam.Protocol {
 	case "onvif":
@@ -676,7 +678,10 @@ func (h *Handler) subStreamDetailFor(cameraID string) subStreamDetail {
 	case "rtsp_h264", "rtsp_mjpeg", string(model.ProtoRTSP):
 		return subStreamDetail{Reason: "set sub_stream_url to use this camera's sub stream"}
 	case "gb28181":
-		return subStreamDetail{Reason: "GB28181 sub-channel selection not supported yet"}
+		// Prober (#560) runs once per channel per boot after the catalog
+		// merges (vendor-gated in auto mode); no code = device has no
+		// usable sub channel — degrade to main, never an error state.
+		return subStreamDetail{Reason: "no sub-channel probed (device has no vendor-convention sub stream, or probe pending)"}
 	default:
 		// xiaomi (proprietary single stream), srt/rtmp push (publisher owns
 		// the encode), http_jpeg/mjpeg (already low-bitrate stills).

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -420,3 +420,52 @@ func (cm *CameraManager) GB28181RecordingWanted(deviceID, channelID string) bool
 	}
 	return cam.RecordingEnabled == nil || *cam.RecordingEnabled
 }
+
+// GB28181SubChannelID returns the persisted sub-channel code for the camera
+// bound to a main channel ("" when unbound or none), #560.
+func (cm *CameraManager) GB28181SubChannelID(deviceID, channelID string) string {
+	cameraID, ok := cm.GB28181CameraIDByChannel(deviceID, channelID)
+	if !ok {
+		return ""
+	}
+	cam := cm.snapshotConfig(cameraID)
+	if cam == nil {
+		return ""
+	}
+	return cam.GB28181.SubChannelID
+}
+
+// SetGB28181SubChannel persists the probed sub-channel code on the camera
+// bound to a main channel (#560). Fill-once: an existing value (manual or a
+// raced probe) always wins. YAML is the source of truth for GB28181 bindings
+// (the DB row injects it at API response time), so persisting means the
+// config file. The camera's on-demand sub puller re-resolves on its next
+// Acquire — no restart needed for a newly probed code.
+func (cm *CameraManager) SetGB28181SubChannel(deviceID, channelID, subChannelID string) error {
+	cameraID, ok := cm.GB28181CameraIDByChannel(deviceID, channelID)
+	if !ok {
+		return fmt.Errorf("camera bound to device %s channel %s not found", deviceID, channelID)
+	}
+	cm.configMu.Lock()
+	set := false
+	for i := range cm.cfg.Cameras {
+		if cm.cfg.Cameras[i].ID == cameraID {
+			if cm.cfg.Cameras[i].GB28181.SubChannelID != "" { // raced a manual write
+				cm.configMu.Unlock()
+				return nil
+			}
+			cm.cfg.Cameras[i].GB28181.SubChannelID = subChannelID
+			set = true
+			break
+		}
+	}
+	cm.configMu.Unlock()
+	if !set {
+		return fmt.Errorf("camera %s not found in config", cameraID)
+	}
+	if err := cm.persistConfig(); err != nil {
+		return fmt.Errorf("persist config: %w", err)
+	}
+	slog.Info("gb28181: persisted probed sub_channel_id", "camera", cameraID, "sub_channel_id", subChannelID)
+	return nil
+}

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -744,9 +744,10 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 	// no recorder restart. Compared against savedCam outside configMu
 	// instead of scattering change flags through the apply block above.
 	if cm.subStreams != nil &&
-		(savedCam.Protocol != camCopy.Protocol || savedCam.Username != camCopy.Username ||
+		(savedCam.Protocol != camCopy.Protocol || savedCam.Username != cam.Username ||
 			savedCam.Password != camCopy.Password || savedCam.ONVIFEndpoint != camCopy.ONVIFEndpoint ||
-			savedCam.SubStreamURL != camCopy.SubStreamURL || savedCam.SubProfileToken != camCopy.SubProfileToken) {
+			savedCam.SubStreamURL != camCopy.SubStreamURL || savedCam.SubProfileToken != camCopy.SubProfileToken ||
+			savedCam.GB28181.SubChannelID != camCopy.GB28181.SubChannelID) {
 		cm.subStreams.StopCamera(cameraID)
 	}
 

--- a/internal/camera/substream.go
+++ b/internal/camera/substream.go
@@ -23,12 +23,16 @@ import (
 // configs:
 //
 //   - rtsp protocol: sub_stream_url must be set manually.
+//
 //   - onvif protocol: sub_stream_url wins when present; otherwise the
 //     auto-discovered sub_profile_token (#512) is resolved via GetStreamUri,
 //     with the same DHCP-stale host rewriting the main stream path applies.
 //
-// Everything else (gb28131 sub-channels, push ingest, xiaomi) is not
-// supported yet — ok=false → ErrNoSubStream → the caller falls back to main.
+//   - gb28181 protocol: the probed sub_channel_id (#560) is served by the GB
+//     pull path (SIP INVITE to the vendor-convention sub-channel code).
+//
+// Everything else (push ingest, xiaomi) is not supported yet — ok=false →
+// ErrNoSubStream → the caller falls back to main.
 func (cm *CameraManager) resolveSubTarget(ctx context.Context, cameraID string) (substream.Target, bool, error) {
 	cam := cm.snapshotConfig(cameraID)
 	if cam == nil {
@@ -40,6 +44,18 @@ func (cm *CameraManager) resolveSubTarget(ctx context.Context, cameraID string) 
 			return substream.Target{}, false, nil
 		}
 		return substream.Target{URL: cam.SubStreamURL, Username: cam.Username, Password: cam.Password}, true, nil
+
+	case string(model.ProtoGB28181):
+		// Probed sub-channel (#560): the persisted code is INVITE'd on
+		// demand by the GB pull path. No code → ErrNoSubStream → main.
+		if sub := strings.TrimSpace(cam.GB28181.SubChannelID); sub != "" {
+			return substream.Target{
+				Kind:        substream.KindGB28181,
+				GBDeviceID:  cam.GB28181.DeviceID,
+				GBChannelID: sub,
+			}, true, nil
+		}
+		return substream.Target{}, false, nil
 
 	case string(model.ProtoONVIF):
 		if strings.TrimSpace(cam.SubStreamURL) != "" {

--- a/internal/camera/substream_test.go
+++ b/internal/camera/substream_test.go
@@ -35,6 +35,12 @@ func TestResolveSubTarget(t *testing.T) {
 		{ID: "cam-onvif-manual", Protocol: "onvif", URL: "http://192.168.1.13/onvif/device_service", SubStreamURL: "rtsp://192.168.1.13:554/sub2"},
 		{ID: "cam-onvif-nothing", Protocol: "onvif", URL: "http://192.168.1.14/onvif/device_service"},
 		{ID: "cam-xiaomi", Protocol: "xiaomi"},
+		{
+			ID:       "cam-gb-sub",
+			Protocol: "gb28181",
+			GB28181:  config.GB28181ChannelConfig{DeviceID: "34020000001320000099", ChannelID: "34020000001320000001", SubChannelID: "34020000001320000002"},
+		},
+		{ID: "cam-gb-nosub", Protocol: "gb28181", GB28181: config.GB28181ChannelConfig{DeviceID: "34020000001320000098", ChannelID: "34020000001320000011"}},
 	}}
 	cm := NewCameraManager(cfg, nil, nil, "")
 
@@ -48,6 +54,21 @@ func TestResolveSubTarget(t *testing.T) {
 
 	// rtsp without sub_stream_url: not available.
 	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-rtsp-nosub")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// gb28181 with a probed sub channel (#560): the GB pull target carries
+	// the device/sub-channel pair, not an RTSP URL.
+	tgt, ok, err = cm.resolveSubTarget(context.Background(), "cam-gb-sub")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, substream.KindGB28181, tgt.Kind)
+	require.Equal(t, "34020000001320000099", tgt.GBDeviceID)
+	require.Equal(t, "34020000001320000002", tgt.GBChannelID)
+	require.Empty(t, tgt.URL)
+
+	// gb28181 without a probed sub: not available.
+	_, ok, err = cm.resolveSubTarget(context.Background(), "cam-gb-nosub")
 	require.NoError(t, err)
 	require.False(t, ok)
 

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -369,6 +369,12 @@ func applyConfigDefaults(cfg *Config) {
 	if strings.TrimSpace(cfg.GB28181.CatalogInterval) == "" {
 		cfg.GB28181.CatalogInterval = "30m"
 	}
+	if strings.TrimSpace(cfg.GB28181.SubChannelProbe) == "" {
+		cfg.GB28181.SubChannelProbe = "auto"
+	}
+	if cfg.GB28181.SubChannelProbeOffset == 0 {
+		cfg.GB28181.SubChannelProbeOffset = 1
+	}
 	if strings.TrimSpace(cfg.GB28181.PortRange) == "" {
 		cfg.GB28181.PortRange = "30000-30050"
 	}

--- a/internal/config/config_gb28181.go
+++ b/internal/config/config_gb28181.go
@@ -34,6 +34,20 @@ type GB28181ServerConfig struct {
 	// CatalogInterval is how often the platform refreshes the device catalog.
 	CatalogInterval string `yaml:"catalog_interval"` // default "30m"
 
+	// SubChannelProbe gates the sub-channel prober (#560): "auto" (default —
+	// probe only devices whose DeviceInfo Manufacturer matches a known
+	// offset-convention vendor), "on" (probe every device), "off" (never).
+	// A probe is one extra INVITE per channel per process lifetime; failures
+	// are silent (no camera error state — the camera keeps its no-sub-stream
+	// degradation path).
+	SubChannelProbe string `yaml:"sub_channel_probe,omitempty"` // default "auto"
+
+	// SubChannelProbeOffset is the channel-code numeric offset the prober
+	// applies to a main channel code to derive the sub-channel candidate
+	// (Hikvision convention: +1). 0 disables probing regardless of
+	// SubChannelProbe. Range 1–99.
+	SubChannelProbeOffset int `yaml:"sub_channel_probe_offset,omitempty"` // default 1
+
 	// TCPMode forces TCP media transport (passive).
 	//
 	// Deprecated: superseded by MediaTransport — no longer influences the
@@ -129,4 +143,11 @@ type GB28181ChannelConfig struct {
 	DeviceID     string `yaml:"device_id,omitempty" json:"device_id,omitempty"`   // GB 20-digit device code
 	ChannelID    string `yaml:"channel_id,omitempty" json:"channel_id,omitempty"` // GB 20-digit channel code
 	Manufacturer string `yaml:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	// SubChannelID is the probed sub-stream channel code (#560): the vendor-
+	// convention offset of ChannelID (Hikvision: channel number +1) that the
+	// on-demand sub-stream puller INVITEs for quality=sub. Auto-populated by
+	// the probe (fill-once — an existing value is never overwritten, clearing
+	// it re-arms probing). Empty = no sub stream (negotiation falls back to
+	// main).
+	SubChannelID string `yaml:"sub_channel_id,omitempty" json:"sub_channel_id,omitempty"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -622,6 +622,14 @@ func validateConfigDetails(cfg *Config) error {
 		if _, err := time.ParseDuration(cfg.GB28181.HeartbeatInterval); err != nil {
 			return fmt.Errorf("gb28181.heartbeat_interval invalid duration: %w", err)
 		}
+		switch cfg.GB28181.SubChannelProbe {
+		case "", "auto", "on", "off":
+		default:
+			return fmt.Errorf("gb28181.sub_channel_probe must be auto/on/off (got %q)", cfg.GB28181.SubChannelProbe)
+		}
+		if cfg.GB28181.SubChannelProbeOffset < 0 || cfg.GB28181.SubChannelProbeOffset > 99 {
+			return fmt.Errorf("gb28181.sub_channel_probe_offset must be between 0 and 99 (got %d)", cfg.GB28181.SubChannelProbeOffset)
+		}
 		if _, err := time.ParseDuration(cfg.GB28181.CatalogInterval); err != nil {
 			return fmt.Errorf("gb28181.catalog_interval invalid duration: %w", err)
 		}

--- a/internal/gb28181/channel.go
+++ b/internal/gb28181/channel.go
@@ -27,4 +27,9 @@ type Channel struct {
 	// PTZType is the GB/T 28181-2016 § 5.4.12 PTZ capability code from the
 	// Catalog item: 0 = no PTZ, 1 = pan/tilt, 2 = pan/tilt + zoom.
 	PTZType int
+	// SubProbe marks a channel that was NOT in the device catalog but was
+	// registered by the sub-channel prober (#560) from the vendor-convention
+	// code offset. Catalog refreshes never list it, so the flag distinguishes
+	// "real channel the device advertises" from "synthetic pull target".
+	SubProbe bool
 }

--- a/internal/gb28181/sip/server.go
+++ b/internal/gb28181/sip/server.go
@@ -104,6 +104,13 @@ type CameraEnroller interface {
 	// wants recording (alarm linkage leaves those sessions to the record
 	// loop, #355).
 	GB28181RecordingWanted(deviceID, channelID string) bool
+	// GB28181SubChannelID returns the persisted sub-channel code bound to a
+	// main channel's camera ("" = none), #560.
+	GB28181SubChannelID(deviceID, channelID string) string
+	// SetGB28181SubChannel persists the probed sub-channel code on the
+	// camera bound to a main channel (fill-once — never overwrites a
+	// non-empty value), #560.
+	SetGB28181SubChannel(deviceID, channelID, subChannelID string) error
 }
 
 // inviteDialog remembers the INVITE request and its final response for an
@@ -604,7 +611,34 @@ func (s *Server) InviteChannel(deviceID, channelID string) error {
 		return fmt.Errorf("gb28181: recorder for camera %q not running — deferring INVITE for channel %s", cameraID, channelID)
 	}
 
-	// Allocate port, create SDP, start receiver.
+	if err := s.inviteCore(deviceID, ch, netAddr, serverHost, onAU, onAudio); err != nil {
+		return err
+	}
+
+	_ = s.sessionMgr.MarkPlaying(channelID)
+	if cameraID != "" {
+		if enrol := s.enroller(); enrol != nil {
+			enrol.OnGB28181Invite(cameraID)
+		}
+	}
+	// Session watchdog: some device firmwares emit SPS/PPS+IDR only at
+	// stream start and never again (recordings open segments on IDR), and
+	// some stall their stream mid-session — a zombie receiver then blocks
+	// every future auto-INVITE. Recycling the session forces a fresh stream
+	// (and a fresh IDR) from the device.
+	go s.watchSession(deviceID, channelID)
+	slog.Info("gb28181: INVITE answered, ACK sent", "channel", channelID, "device", deviceID)
+	return nil
+}
+
+// inviteCore establishes one media session for ch: allocates the RTP port and
+// receiver (building the SDP answer), sends the SIP INVITE, completes the
+// 2xx/ACK handshake and records the dialog. It is the shared machinery of the
+// recorder-oriented InviteChannel and the sub-stream puller's InviteSubChannel
+// (#560) — the caller supplies the AU/audio callbacks and owns post-answer
+// policy (watchdog, recorder notification, teardown).
+func (s *Server) inviteCore(deviceID string, ch *gb28181.Channel, netAddr, serverHost string, onAU func(au [][]byte, ptsTicks int64, isIDR bool), onAudio gb28181.AudioFrameHandler) error {
+	channelID := ch.ID
 	sdp, err := s.sessionMgr.Invite(ch, serverHost, netAddr, nil, onAU, onAudio)
 	if err != nil {
 		return fmt.Errorf("gb28181: session setup for %s: %w", channelID, err)
@@ -697,18 +731,6 @@ func (s *Server) InviteChannel(deviceID, channelID string) error {
 		slog.Info("gb28181: INVITE confirmed via first RTP (non-compliant device response)", "channel", channelID, "device", deviceID)
 	}
 
-	_ = s.sessionMgr.MarkPlaying(channelID)
-	if cameraID != "" {
-		if enrol := s.enroller(); enrol != nil {
-			enrol.OnGB28181Invite(cameraID)
-		}
-	}
-	// Session watchdog: some device firmwares emit SPS/PPS+IDR only at
-	// stream start and never again (recordings open segments on IDR), and
-	// some stall their stream mid-session — a zombie receiver then blocks
-	// every future auto-INVITE. Recycling the session forces a fresh stream
-	// (and a fresh IDR) from the device.
-	go s.watchSession(deviceID, channelID)
 	slog.Info("gb28181: INVITE answered, ACK sent", "channel", channelID, "device", deviceID)
 	return nil
 }
@@ -1458,6 +1480,10 @@ func (s *Server) mergeCatalogChannels(deviceID string, items []manscdp.Item) {
 	// session. Also covers NVR restarts — cameras persist, sessions do
 	// not, and catalog channels are only known after this response.
 	go s.autoInviteDevice(deviceID)
+	// Sub-channel probing (#560): after the main sessions settle, probe the
+	// vendor-convention sub candidate per bound channel (silent on failure;
+	// re-registers persisted codes after an NVR restart).
+	go s.maybeProbeSubChannels(deviceID)
 
 	// Channel-level Manufacturer/Model backfill: the DeviceInfo response
 	// often races (and loses to) async auto-enrollment, but the catalog

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -619,9 +619,11 @@ func TestServer_Register_PortRotationKeepsAddressStable(t *testing.T) {
 // Mutex-guarded: mergeCatalogChannels calls it from spawned goroutines while
 // assertions read the recorded calls (-race clean).
 type fakeEnroller struct {
-	mu       sync.Mutex
-	enrolled []string // "deviceID/channelID"
-	archived []string // "deviceID/channelID"
+	mu           sync.Mutex
+	enrolled     []string // "deviceID/channelID"
+	archived     []string // "deviceID/channelID"
+	subSet       []string // "deviceID/channelID->subChannelID"
+	subPersisted map[string]string
 }
 
 func (f *fakeEnroller) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
@@ -781,6 +783,25 @@ func TestRetireDeviceSelfChannel_NoRealChannels(t *testing.T) {
 }
 
 func (f *fakeEnroller) GB28181RecordingWanted(deviceID, channelID string) bool { return false }
+
+func (f *fakeEnroller) GB28181SubChannelID(deviceID, channelID string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.subPersisted[deviceID+"/"+channelID]
+}
+
+func (f *fakeEnroller) SetGB28181SubChannel(deviceID, channelID, subChannelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.subSet = append(f.subSet, deviceID+"/"+channelID+"->"+subChannelID)
+	return nil
+}
+
+func (f *fakeEnroller) subSetEmpty() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.subSet) == 0
+}
 
 // TestServer_InviteChannel_DefersWhenRecorderNotRunning: a channel bound to
 // a camera whose recorder isn't up yet must NOT be INVITE'd. The media would

--- a/internal/gb28181/sip/subchannel.go
+++ b/internal/gb28181/sip/subchannel.go
@@ -1,0 +1,251 @@
+package sip
+
+// GB28181 sub-channel probing + sub-stream pull sessions (#560).
+//
+// Vendor-convention sub channels (Hikvision: channel code +1) are not listed
+// in the device catalog — the only way to discover them is to INVITE the
+// derived code and see whether media arrives. The prober does exactly that,
+// once per main channel per process lifetime, silently: a camera whose device
+// has no usable sub channel keeps the plain no-sub-stream degradation path
+// and never shows an error state.
+//
+// The discovered code is persisted on the camera (GB28181.SubChannelID,
+// fill-once) and consumed by the on-demand sub-stream puller via
+// InviteSubChannel, which feeds the demuxed AUs into the camera's sub hub.
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+)
+
+// subProbeWait delays probing after a catalog merge so the main channels'
+// auto-INVITE sessions settle first — single-stream firmwares would otherwise
+// see the probe INVITE race the main INVITE. Vars (not consts) so tests can
+// shrink them.
+var (
+	subProbeWait    = 5 * time.Second
+	subProbeTimeout = 6 * time.Second
+)
+
+// subProbed memoizes probed main channels for the process lifetime (success
+// AND failure — the probe never repeats within one boot; clearing the
+// persisted sub_channel_id and restarting re-arms it).
+var subProbed sync.Map // "deviceID/channelID" -> struct{}
+
+// EnsureSubChannelRegistered registers a probe-discovered sub-channel as a
+// synthetic pull target when the device's catalog does not advertise it.
+// Catalog refreshes never list the code, so the SubProbe flag distinguishes
+// it from real channels (nothing enrolls a camera for it). Idempotent.
+func (s *Server) EnsureSubChannelRegistered(deviceID, channelID string) error {
+	if _, ok := s.deviceMgr.FindChannel(deviceID, channelID); ok {
+		return nil
+	}
+	if _, ok := s.deviceMgr.Device(deviceID); !ok {
+		return fmt.Errorf("gb28181: device %q not registered", deviceID)
+	}
+	s.deviceMgr.RegisterChannel(deviceID, &gb28181.Channel{
+		DeviceID: deviceID,
+		ID:       channelID,
+		Name:     "sub " + channelID,
+		SubProbe: true,
+	})
+	return nil
+}
+
+// InviteSubChannel establishes a media session for a probed sub-channel whose
+// demuxed video AUs feed the on-demand sub-stream puller (NOT a recorder).
+// The returned release func BYEs the session and drops the dialog. Stall
+// handling is the caller's: the substream manager reconnects on its own
+// timers, so the recorder-oriented watchSession is deliberately NOT armed
+// (it would re-INVITE with recorder callbacks this channel does not have).
+func (s *Server) InviteSubChannel(deviceID, channelID string, onAU func(au [][]byte, ptsTicks int64, isIDR bool)) (func(), error) {
+	s.mu.Lock()
+	srv := s.gosipSrv
+	s.mu.Unlock()
+	if srv == nil {
+		return nil, fmt.Errorf("gb28181: SIP server not started")
+	}
+
+	dev, ok := s.deviceMgr.Device(deviceID)
+	if !ok {
+		return nil, fmt.Errorf("gb28181: device %q not registered", deviceID)
+	}
+	ch, ok := s.deviceMgr.FindChannel(deviceID, channelID)
+	if !ok {
+		return nil, fmt.Errorf("gb28181: sub-channel %q not registered on device %q", channelID, deviceID)
+	}
+
+	dev.Mu.RLock()
+	netAddr := dev.NetAddr
+	dev.Mu.RUnlock()
+	serverHost := s.localIPFor(netAddr)
+
+	if err := s.inviteCore(deviceID, ch, netAddr, serverHost, onAU, nil); err != nil {
+		return nil, err
+	}
+	_ = s.sessionMgr.MarkPlaying(channelID)
+
+	return func() {
+		s.mu.Lock()
+		delete(s.dialogs, channelID)
+		s.mu.Unlock()
+		_ = s.sessionMgr.Bye(channelID)
+	}, nil
+}
+
+// maybeProbeSubChannels runs the prober for one device's channels after its
+// catalog merged (and on later refreshes — the per-channel memo makes those
+// no-ops). Cameras that already carry a persisted sub_channel_id only get
+// their synthetic channel re-registered (NVR restart wiped the in-memory
+// channel table; the catalog never lists it).
+func (s *Server) maybeProbeSubChannels(deviceID string) {
+	mode := s.cfg.SubChannelProbe
+	offset := s.cfg.SubChannelProbeOffset
+	if mode == "off" || offset <= 0 {
+		return
+	}
+
+	if mode != "on" {
+		mfr := ""
+		if dev, ok := s.deviceMgr.Device(deviceID); ok {
+			dev.Mu.RLock()
+			mfr = dev.Manufacturer
+			dev.Mu.RUnlock()
+		}
+		if !knownOffsetVendor(mfr) {
+			return
+		}
+	}
+
+	enrol := s.enroller()
+	if enrol == nil {
+		return
+	}
+
+	for _, ch := range s.deviceMgr.Channels(deviceID) {
+		if ch.SubProbe {
+			continue
+		}
+		cameraID, ok := enrol.GB28181CameraIDByChannel(deviceID, ch.ID)
+		if !ok {
+			continue // no camera bound — nothing to attach a sub stream to
+		}
+		mainCh := ch
+		go func() {
+			time.Sleep(subProbeWait) // let the main INVITE settle first
+			s.probeSubChannel(deviceID, mainCh, offset, cameraID)
+		}()
+	}
+}
+
+// probeSubChannel probes ONE main channel's vendor-convention sub candidate:
+// derive the code, INVITE it with a throwaway frame signal, and persist on
+// first media. Every failure path is silent (Debug) — incapable devices must
+// show zero error state (#560 acceptance).
+func (s *Server) probeSubChannel(deviceID string, ch *gb28181.Channel, offset int, cameraID string) {
+	enrol := s.enroller()
+	if enrol == nil {
+		return
+	}
+
+	// A persisted sub_channel_id means a prior probe (or manual config)
+	// already resolved this camera's sub — just make sure the synthetic
+	// channel is registered for the puller, then stop. Fill-once: an existing
+	// value is never re-probed.
+	if sub := enrol.GB28181SubChannelID(deviceID, ch.ID); sub != "" {
+		if err := s.EnsureSubChannelRegistered(deviceID, sub); err != nil {
+			slog.Debug("gb28181: re-register sub-channel failed", "device", deviceID, "sub_channel", sub, "error", err)
+		}
+		return
+	}
+
+	probeKey := deviceID + "/" + ch.ID
+	if _, done := subProbed.LoadOrStore(probeKey, struct{}{}); done {
+		return
+	}
+
+	candidate := offsetChannelCode(ch.ID, offset)
+	if candidate == "" {
+		return
+	}
+	// Never repurpose an advertised channel: on multi-channel devices (NVRs)
+	// the +1 code is a REAL sibling channel with its own camera. Only codes
+	// the catalog does not list qualify as sub candidates.
+	if _, exists := s.deviceMgr.FindChannel(deviceID, candidate); exists {
+		return
+	}
+
+	if err := s.EnsureSubChannelRegistered(deviceID, candidate); err != nil {
+		slog.Debug("gb28181: sub-channel register failed", "device", deviceID, "candidate", candidate, "error", err)
+		return
+	}
+
+	gotFrame := make(chan struct{}, 1)
+	onAU := func(au [][]byte, ptsTicks int64, isIDR bool) {
+		select {
+		case gotFrame <- struct{}{}:
+		default:
+		}
+	}
+	release, err := s.InviteSubChannel(deviceID, candidate, onAU)
+	if err != nil {
+		slog.Debug("gb28181: sub-channel probe INVITE failed (silent — no sub stream)",
+			"device", deviceID, "channel", ch.ID, "candidate", candidate, "error", err)
+		s.deviceMgr.UnregisterChannel(deviceID, candidate)
+		return
+	}
+
+	select {
+	case <-gotFrame:
+		release()
+		if err := enrol.SetGB28181SubChannel(deviceID, ch.ID, candidate); err != nil {
+			slog.Warn("gb28181: persist sub_channel_id failed", "camera", cameraID, "error", err)
+			s.deviceMgr.UnregisterChannel(deviceID, candidate)
+			return
+		}
+		slog.Info("gb28181: sub-channel probed — sub stream available",
+			"device", deviceID, "channel", ch.ID, "sub_channel", candidate, "camera", cameraID)
+	case <-time.After(subProbeTimeout):
+		release()
+		s.deviceMgr.UnregisterChannel(deviceID, candidate)
+		slog.Debug("gb28181: sub-channel probe timed out (silent — no sub stream)",
+			"device", deviceID, "channel", ch.ID, "candidate", candidate)
+	}
+}
+
+// offsetChannelCode adds offset to a GB 20-digit decimal channel code,
+// carrying from the last digit, preserving the length (a carry past the first
+// digit, or any non-digit code, yields "" — not a usable candidate).
+func offsetChannelCode(id string, offset int) string {
+	if offset <= 0 || len(id) == 0 {
+		return ""
+	}
+	digits := []byte(id)
+	for _, d := range digits {
+		if d < '0' || d > '9' {
+			return ""
+		}
+	}
+	for i := len(digits) - 1; i >= 0 && offset > 0; i-- {
+		v := int(digits[i]-'0') + offset
+		digits[i] = byte('0' + v%10)
+		offset = v / 10
+	}
+	if offset > 0 {
+		return "" // overflow past the most significant digit
+	}
+	return string(digits)
+}
+
+// knownOffsetVendor reports whether the DeviceInfo manufacturer is known to
+// follow the channel-code offset convention (probe gate for "auto" mode).
+func knownOffsetVendor(manufacturer string) bool {
+	m := strings.ToLower(manufacturer)
+	return strings.Contains(m, "hikvision") || strings.Contains(m, "海康") ||
+		strings.Contains(m, "dahua") || strings.Contains(m, "大华")
+}

--- a/internal/gb28181/sip/subchannel.go
+++ b/internal/gb28181/sip/subchannel.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
@@ -25,12 +26,17 @@ import (
 
 // subProbeWait delays probing after a catalog merge so the main channels'
 // auto-INVITE sessions settle first — single-stream firmwares would otherwise
-// see the probe INVITE race the main INVITE. Vars (not consts) so tests can
-// shrink them.
+// see the probe INVITE race the main INVITE. Atomic nanosecond counters (not
+// plain vars) so tests can shrink them without racing probe goroutines.
 var (
-	subProbeWait    = 5 * time.Second
-	subProbeTimeout = 6 * time.Second
+	subProbeWait    atomic.Int64
+	subProbeTimeout atomic.Int64
 )
+
+func init() {
+	subProbeWait.Store(int64(5 * time.Second))
+	subProbeTimeout.Store(int64(6 * time.Second))
+}
 
 // subProbed memoizes probed main channels for the process lifetime (success
 // AND failure — the probe never repeats within one boot; clearing the
@@ -121,7 +127,7 @@ func (s *Server) maybeProbeSubChannels(deviceID string) {
 		}
 		mainCh := ch
 		go func() {
-			time.Sleep(subProbeWait) // let the main INVITE settle first
+			time.Sleep(time.Duration(subProbeWait.Load())) // let the main INVITE settle first
 			// BOTH gates resolve INSIDE the delayed goroutine — at merge time
 			// the catalog-driven camera enrollment (EnsureGB28181Camera) is
 			// typically still in flight, and the DeviceInfo response carrying
@@ -215,7 +221,7 @@ func (s *Server) probeSubChannel(deviceID string, ch *gb28181.Channel, offset in
 		cameraID, _ := enrol.GB28181CameraIDByChannel(deviceID, ch.ID)
 		slog.Info("gb28181: sub-channel probed — sub stream available",
 			"device", deviceID, "channel", ch.ID, "sub_channel", candidate, "camera", cameraID)
-	case <-time.After(subProbeTimeout):
+	case <-time.After(time.Duration(subProbeTimeout.Load())):
 		release()
 		s.deviceMgr.UnregisterChannel(deviceID, candidate)
 		slog.Debug("gb28181: sub-channel probe timed out (silent — no sub stream)",

--- a/internal/gb28181/sip/subchannel.go
+++ b/internal/gb28181/sip/subchannel.go
@@ -110,18 +110,6 @@ func (s *Server) maybeProbeSubChannels(deviceID string) {
 		return
 	}
 
-	if mode != "on" {
-		mfr := ""
-		if dev, ok := s.deviceMgr.Device(deviceID); ok {
-			dev.Mu.RLock()
-			mfr = dev.Manufacturer
-			dev.Mu.RUnlock()
-		}
-		if !knownOffsetVendor(mfr) {
-			return
-		}
-	}
-
 	enrol := s.enroller()
 	if enrol == nil {
 		return
@@ -131,14 +119,30 @@ func (s *Server) maybeProbeSubChannels(deviceID string) {
 		if ch.SubProbe {
 			continue
 		}
-		cameraID, ok := enrol.GB28181CameraIDByChannel(deviceID, ch.ID)
-		if !ok {
-			continue // no camera bound — nothing to attach a sub stream to
-		}
 		mainCh := ch
 		go func() {
 			time.Sleep(subProbeWait) // let the main INVITE settle first
-			s.probeSubChannel(deviceID, mainCh, offset, cameraID)
+			// BOTH gates resolve INSIDE the delayed goroutine — at merge time
+			// the catalog-driven camera enrollment (EnsureGB28181Camera) is
+			// typically still in flight, and the DeviceInfo response carrying
+			// the manufacturer races the catalog response to the same
+			// millisecond. Resolving either at trigger time skipped every
+			// freshly-registered device.
+			if mode != "on" {
+				mfr := ""
+				if dev, ok := s.deviceMgr.Device(deviceID); ok {
+					dev.Mu.RLock()
+					mfr = dev.Manufacturer
+					dev.Mu.RUnlock()
+				}
+				if !knownOffsetVendor(mfr) {
+					return
+				}
+			}
+			if _, ok := enrol.GB28181CameraIDByChannel(deviceID, mainCh.ID); !ok {
+				return // no camera bound — nothing to attach a sub stream to
+			}
+			s.probeSubChannel(deviceID, mainCh, offset)
 		}()
 	}
 }
@@ -147,7 +151,7 @@ func (s *Server) maybeProbeSubChannels(deviceID string) {
 // derive the code, INVITE it with a throwaway frame signal, and persist on
 // first media. Every failure path is silent (Debug) — incapable devices must
 // show zero error state (#560 acceptance).
-func (s *Server) probeSubChannel(deviceID string, ch *gb28181.Channel, offset int, cameraID string) {
+func (s *Server) probeSubChannel(deviceID string, ch *gb28181.Channel, offset int) {
 	enrol := s.enroller()
 	if enrol == nil {
 		return
@@ -204,10 +208,11 @@ func (s *Server) probeSubChannel(deviceID string, ch *gb28181.Channel, offset in
 	case <-gotFrame:
 		release()
 		if err := enrol.SetGB28181SubChannel(deviceID, ch.ID, candidate); err != nil {
-			slog.Warn("gb28181: persist sub_channel_id failed", "camera", cameraID, "error", err)
+			slog.Warn("gb28181: persist sub_channel_id failed", "device", deviceID, "channel", ch.ID, "error", err)
 			s.deviceMgr.UnregisterChannel(deviceID, candidate)
 			return
 		}
+		cameraID, _ := enrol.GB28181CameraIDByChannel(deviceID, ch.ID)
 		slog.Info("gb28181: sub-channel probed — sub stream available",
 			"device", deviceID, "channel", ch.ID, "sub_channel", candidate, "camera", cameraID)
 	case <-time.After(subProbeTimeout):

--- a/internal/gb28181/sip/subchannel_test.go
+++ b/internal/gb28181/sip/subchannel_test.go
@@ -1,0 +1,241 @@
+package sip
+
+// Sub-channel prober tests (#560): candidate arithmetic, vendor gating, the
+// silent negative path (INVITE answered but no media → timeout → synthetic
+// channel removed, camera untouched), and persisted-code re-registration.
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/ghettovoice/gosip/log"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/ghettovoice/gosip/sip/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// nextRequest reads one datagram and returns it when it is a SIP REQUEST
+// (server-initiated INVITE/catalog query); nil on timeout or non-request.
+func (c *sipClient) nextRequest(timeout time.Duration) sip.Request {
+	buf := make([]byte, 65535)
+	if err := c.conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		return nil
+	}
+	n, _, err := c.conn.ReadFromUDP(buf)
+	if err != nil {
+		return nil
+	}
+	msg, err := parser.ParseMessage(buf[:n], log.NewDefaultLogrusLogger())
+	if err != nil {
+		return nil
+	}
+	if req, ok := msg.(sip.Request); ok {
+		return req
+	}
+	return nil
+}
+
+// respond200 answers a server-initiated request with a bare 200 OK (no SDP —
+// the probe then times out waiting for media, which is exactly the negative
+// path under test). Raw-string construction mirroring gbsim's reply200 —
+// gosip's response builder produces a message the server-side parser routes
+// back through the request path (nil Uri panic in requestIDs).
+func (c *sipClient) respond200(req sip.Request) {
+	var b strings.Builder
+	b.WriteString("SIP/2.0 200 OK\r\n")
+	for _, h := range []string{"Via", "From", "To", "Call-ID", "CSeq", "Max-Forwards"} {
+		for _, v := range req.GetHeaders(h) {
+			b.WriteString(h + ": " + v.Value() + "\r\n")
+		}
+	}
+	b.WriteString("Content-Length: 0\r\n\r\n")
+	if _, err := c.conn.WriteToUDP([]byte(b.String()), c.addr); err != nil {
+		c.t.Fatalf("respond200: write: %v", err)
+	}
+}
+
+func TestOffsetChannelCode(t *testing.T) {
+	t.Helper()
+	cases := []struct {
+		id     string
+		offset int
+		want   string
+	}{
+		{"34020000001320000001", 1, "34020000001320000002"},
+		{"34020000001320000099", 1, "34020000001320000100"},  // carry
+		{"34020000001320000099", 40, "34020000001320000139"}, // multi-carry
+		{"99999999999999999999", 1, ""},                      // overflow past MSD
+		{"34020000001320000001", 0, ""},                      // disabled
+		{"3402000000132A000001", 1, ""},                      // non-digit
+		{"", 1, ""},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, offsetChannelCode(c.id, c.offset), "id=%s offset=%d", c.id, c.offset)
+	}
+}
+
+func TestKnownOffsetVendor(t *testing.T) {
+	t.Helper()
+	require.True(t, knownOffsetVendor("Hikvision"))
+	require.True(t, knownOffsetVendor("HIKVISION DIGITAL TECHNOLOGY"))
+	require.True(t, knownOffsetVendor("海康威视"))
+	require.True(t, knownOffsetVendor("Dahua"))
+	require.True(t, knownOffsetVendor("浙江大华"))
+	require.False(t, knownOffsetVendor("gbsim"))
+	require.False(t, knownOffsetVendor("mibee-rec"))
+	require.False(t, knownOffsetVendor(""))
+}
+
+// TestProbeSubChannel_TimeoutSilent: a probe whose INVITE is answered but
+// never delivers media times out silently — the synthetic channel is
+// unregistered, nothing is persisted, and the negative result is memoized
+// (a second trigger does not re-INVITE).
+func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
+	t.Helper()
+	subProbeWait, subProbeTimeout = 20*time.Millisecond, 200*time.Millisecond
+	t.Cleanup(func() { subProbeWait, subProbeTimeout = 5*time.Second, 6*time.Second })
+
+	cfg := testConfig(t)
+	cfg.SubChannelProbe = "on"
+	cfg.SubChannelProbeOffset = 1
+	srv, dm := startTestServer(t, cfg)
+	fe := &fakeEnroller{}
+	srv.SetCameraEnroller(fe)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: deviceAddrOf(client)})
+
+	const mainCh = "34020000001320000071"
+	sendCatalog(t, client, cfg, []manscdp.Item{{DeviceID: mainCh, Name: "Probe Cam", Parental: 0}})
+
+	const candidate = "34020000001320000072"
+	// The probe INVITE arrives (device answers 200 with SDP but — critically —
+	// no RTP ever follows). Drain it so the transaction completes.
+	deadline := time.Now().Add(3 * time.Second)
+	invited := false
+	for time.Now().Before(deadline) {
+		if req := client.nextRequest(200 * time.Millisecond); req != nil && string(req.Method()) == "INVITE" {
+			if to, ok := req.To(); ok {
+				if to.Address.User().String() == candidate {
+					invited = true
+				}
+			}
+			client.respond200(req)
+		}
+		if invited {
+			break
+		}
+	}
+	require.True(t, invited, "probe must INVITE the +1 candidate code")
+
+	// Timeout elapses → synthetic channel removed, nothing persisted.
+	require.Eventually(t, func() bool {
+		_, ok := dm.FindChannel(testDeviceID, candidate)
+		return !ok
+	}, 3*time.Second, 50*time.Millisecond, "synthetic sub-channel must be unregistered after probe timeout")
+	require.True(t, fe.subSetEmpty(), "no sub_channel_id may be persisted on probe timeout")
+
+	// Memoized: re-running the probe path issues no second INVITE.
+	srv.maybeProbeSubChannels(testDeviceID)
+	time.Sleep(300 * time.Millisecond)
+	require.Never(t, func() bool {
+		if req := client.nextRequest(50 * time.Millisecond); req != nil && string(req.Method()) == "INVITE" {
+			return true
+		}
+		return false
+	}, 300*time.Millisecond, 50*time.Millisecond, "memoized probe must not re-INVITE")
+}
+
+// TestProbeSubChannels_VendorGateAutoMode: in "auto" mode a device whose
+// manufacturer is unknown never gets probed.
+func TestProbeSubChannels_VendorGateAutoMode(t *testing.T) {
+	t.Helper()
+	subProbeWait = 10 * time.Millisecond
+	t.Cleanup(func() { subProbeWait = 5 * time.Second })
+
+	cfg := testConfig(t) // SubChannelProbe defaults empty → "auto" via ApplyDefaults? tests set explicit:
+	cfg.SubChannelProbe = "auto"
+	cfg.SubChannelProbeOffset = 1
+	srv, dm := startTestServer(t, cfg)
+	fe := &fakeEnroller{}
+	srv.SetCameraEnroller(fe)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	// gbsim-like manufacturer — not a known offset vendor.
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: deviceAddrOf(client), Manufacturer: "mibee-rec", Model: "X1"})
+
+	sendCatalog(t, client, cfg, []manscdp.Item{{DeviceID: "34020000001320000081", Name: "Gate Cam", Parental: 0}})
+	time.Sleep(200 * time.Millisecond)
+
+	require.Never(t, func() bool {
+		if req := client.nextRequest(50 * time.Millisecond); req != nil && string(req.Method()) == "INVITE" {
+			return true
+		}
+		return false
+	}, 300*time.Millisecond, 50*time.Millisecond, "auto mode must skip unknown vendors entirely")
+}
+
+// TestProbeSubChannels_PersistedCodeReregisters: a camera that already carries
+// a sub_channel_id gets its synthetic channel re-registered (post-restart
+// state) without any probe INVITE.
+func TestProbeSubChannels_PersistedCodeReregisters(t *testing.T) {
+	t.Helper()
+	subProbeWait = 10 * time.Millisecond
+	t.Cleanup(func() { subProbeWait = 5 * time.Second })
+
+	cfg := testConfig(t)
+	cfg.SubChannelProbe = "on"
+	cfg.SubChannelProbeOffset = 1
+	srv, dm := startTestServer(t, cfg)
+
+	const mainCh = "34020000001320000091"
+	const subCh = "34020000001320000101"
+	fe := &fakeEnroller{subPersisted: map[string]string{testDeviceID + "/" + mainCh: subCh}}
+	srv.SetCameraEnroller(fe)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: deviceAddrOf(client), Manufacturer: "Hikvision"})
+
+	sendCatalog(t, client, cfg, []manscdp.Item{{DeviceID: mainCh, Name: "Persist Cam", Parental: 0}})
+
+	require.Eventually(t, func() bool {
+		_, ok := dm.FindChannel(testDeviceID, subCh)
+		return ok
+	}, 3*time.Second, 50*time.Millisecond, "persisted sub code must be re-registered after restart")
+
+	require.Never(t, func() bool {
+		if req := client.nextRequest(50 * time.Millisecond); req != nil && string(req.Method()) == "INVITE" {
+			return true
+		}
+		return false
+	}, 300*time.Millisecond, 50*time.Millisecond, "persisted code must not be re-probed")
+}
+
+// deviceAddrOf returns the fake device's own socket address (the sipClient's
+// addr field is the SERVER's address — the probe INVITE must come TO the
+// device socket, not loop back to the server).
+func deviceAddrOf(c *sipClient) string {
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(c.localPort()))
+}
+
+// sendCatalog delivers a catalog MESSAGE for testDeviceID and awaits the 200.
+func sendCatalog(t *testing.T, client *sipClient, cfg config.GB28181ServerConfig, items []manscdp.Item) {
+	t.Helper()
+	body, err := manscdp.Encode(manscdp.Catalog{
+		CmdType:  manscdp.CmdCatalog,
+		SN:       1,
+		DeviceID: testDeviceID,
+		SumNum:   len(items),
+		Item:     items,
+	})
+	require.NoError(t, err)
+	req := buildRequest(t, sip.MESSAGE, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), string(body))
+	res := client.roundTrip(req)
+	require.EqualValues(t, 200, res.StatusCode())
+}

--- a/internal/gb28181/sip/subchannel_test.go
+++ b/internal/gb28181/sip/subchannel_test.go
@@ -98,8 +98,12 @@ func TestKnownOffsetVendor(t *testing.T) {
 // (a second trigger does not re-INVITE).
 func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
 	t.Helper()
-	subProbeWait, subProbeTimeout = 20*time.Millisecond, 200*time.Millisecond
-	t.Cleanup(func() { subProbeWait, subProbeTimeout = 5*time.Second, 6*time.Second })
+	subProbeWait.Store(int64(20 * time.Millisecond))
+	subProbeTimeout.Store(int64(200 * time.Millisecond))
+	t.Cleanup(func() {
+		subProbeWait.Store(int64(5 * time.Second))
+		subProbeTimeout.Store(int64(6 * time.Second))
+	})
 
 	cfg := testConfig(t)
 	cfg.SubChannelProbe = "on"
@@ -156,8 +160,8 @@ func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
 // manufacturer is unknown never gets probed.
 func TestProbeSubChannels_VendorGateAutoMode(t *testing.T) {
 	t.Helper()
-	subProbeWait = 10 * time.Millisecond
-	t.Cleanup(func() { subProbeWait = 5 * time.Second })
+	subProbeWait.Store(int64(10 * time.Millisecond))
+	t.Cleanup(func() { subProbeWait.Store(int64(5 * time.Second)) })
 
 	cfg := testConfig(t) // SubChannelProbe defaults empty → "auto" via ApplyDefaults? tests set explicit:
 	cfg.SubChannelProbe = "auto"
@@ -186,8 +190,8 @@ func TestProbeSubChannels_VendorGateAutoMode(t *testing.T) {
 // state) without any probe INVITE.
 func TestProbeSubChannels_PersistedCodeReregisters(t *testing.T) {
 	t.Helper()
-	subProbeWait = 10 * time.Millisecond
-	t.Cleanup(func() { subProbeWait = 5 * time.Second })
+	subProbeWait.Store(int64(10 * time.Millisecond))
+	t.Cleanup(func() { subProbeWait.Store(int64(5 * time.Second)) })
 
 	cfg := testConfig(t)
 	cfg.SubChannelProbe = "on"

--- a/internal/substream/pull.go
+++ b/internal/substream/pull.go
@@ -41,7 +41,12 @@ func (m *Manager) pull(ctx context.Context, e *entry) {
 		if ctx.Err() != nil {
 			return
 		}
-		err := m.pullOnce(ctx, e, &backoff)
+		var err error
+		if e.target.Kind == KindGB28181 {
+			err = m.pullGBOnce(ctx, e, &backoff)
+		} else {
+			err = m.pullOnce(ctx, e, &backoff)
+		}
 		if ctx.Err() != nil {
 			return
 		}

--- a/internal/substream/pull_gb.go
+++ b/internal/substream/pull_gb.go
@@ -1,0 +1,152 @@
+package substream
+
+// GB28181 sub-channel pull path (#560): a camera whose probed sub-channel
+// code is persisted pulls its sub stream over a GB media session (SIP INVITE
+// + RTP/PS) instead of RTSP. The AU callback mirrors pullOnce's contract —
+// rebase RTP timestamps onto the cross-session monotonic timeline, refresh
+// in-band parameter sets, broadcast on the source hub — but the session's
+// lifecycle (stall detection, reconnect) is owned here rather than by the
+// recorder-oriented watchSession.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+)
+
+// pullGBOnce runs one GB session to exhaustion. It blocks until the session
+// stalls, errors, or ctx is done; the reconnect loop in pull() re-invokes it.
+func (m *Manager) pullGBOnce(ctx context.Context, e *entry, backoff *time.Duration) error {
+	m.mu.Lock()
+	puller := m.gbPuller
+	m.mu.Unlock()
+	if puller == nil {
+		return errors.New("gb28181 sub-stream puller not wired")
+	}
+
+	src := e.src
+	cameraID := src.cameraID
+	if err := puller.EnsureSubChannelRegistered(e.target.GBDeviceID, e.target.GBChannelID); err != nil {
+		return err
+	}
+
+	// Codec resolution from in-band parameter sets only — the GB SDP answer
+	// carries no codec information worth parsing (PS streams declare in-band).
+	var codec model.Format
+	isH265 := false
+	var tsOffset int64
+	haveOffset := false
+	handleAU := func(au [][]byte, pktTS int64, _ bool) {
+		if ctx.Err() != nil {
+			return
+		}
+		if codec == "" {
+			switch detectCodecGB(au) {
+			case model.FormatH264:
+				codec = model.FormatH264
+			case model.FormatH265:
+				codec = model.FormatH265
+				isH265 = true
+			}
+			if codec == "" {
+				return // no parameter-set NALU yet — cannot publish or broadcast
+			}
+		}
+		ts := pktTS
+		if !haveOffset {
+			haveOffset = true
+			if prev := e.lastPTS.Load(); prev > 0 {
+				tsOffset = prev + sessionGapPTS - ts
+			}
+		}
+		pts := ts + tsOffset
+		if minGap := e.lastPTS.Load() + 3600; pts < minGap { // ~40ms floor
+			pts = minGap
+		}
+		e.lastPTS.Store(pts)
+		refreshParamSets(src, codec, au)
+		src.lastFrameAt.Store(time.Now().UnixNano())
+		src.hub.Broadcast(pts, au, nalutil.IsIDR(au, isH265))
+	}
+
+	release, err := puller.InviteSubChannel(e.target.GBDeviceID, e.target.GBChannelID, handleAU)
+	if err != nil {
+		return err
+	}
+
+	*backoff = time.Second
+	if src.State() != StateLive && codec != "" {
+		src.state.Store(StateLive)
+	}
+	if codec == "" {
+		src.state.Store(StateStarting)
+	}
+	subLogger.Info("gb28181 sub-stream session up", "camera_id", cameraID,
+		"device", e.target.GBDeviceID, "channel", e.target.GBChannelID)
+
+	// Stall watchdog: recycle the session when frames stop, so the reconnect
+	// loop re-INVITEs (fresh IDR from the device).
+	stalled := make(chan struct{})
+	watchStop := make(chan struct{})
+	defer close(watchStop)
+	go func() {
+		t := time.NewTicker(m.cfg.FrameStallTimeout / 3)
+		defer t.Stop()
+		for {
+			select {
+			case <-watchStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if since := time.Since(time.Unix(0, src.lastFrameAt.Load())); since > m.cfg.FrameStallTimeout {
+					close(stalled)
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		release()
+		return nil
+	case <-stalled:
+		release()
+		return errors.New("gb28181 sub-stream stalled")
+	}
+}
+
+// detectCodecGB identifies the codec from parameter-set NALUs only (H.264
+// SPS/PPS/AUD vs H.265 VPS/SPS/PPS) — the same ambiguity rules as the
+// recorder's detectCodec: H.264 slice NALUs collide with H.265 param-set
+// slots under the 6-bit shift (0x41→VPS 32), so slices never decide. Returns
+// "" until a parameter set arrives.
+func detectCodecGB(au [][]byte) model.Format {
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		firstByte := nalu[0]
+		if firstByte&0x80 != 0 {
+			continue // forbidden_zero bit set — corrupt NALU
+		}
+		t264 := firstByte & 0x1F
+		if t264 == 7 || t264 == 8 || t264 == 9 {
+			return model.FormatH264
+		}
+		if t264 == 1 || t264 == 5 {
+			// H.264 slices — ambiguous under the H.265 6-bit shift; wait for
+			// a real parameter-set NALU.
+			continue
+		}
+		t265 := (firstByte >> 1) & 0x3F
+		if t265 == 32 || t265 == 33 || t265 == 34 {
+			return model.FormatH265
+		}
+	}
+	return ""
+}

--- a/internal/substream/pull_gb.go
+++ b/internal/substream/pull_gb.go
@@ -11,6 +11,7 @@ package substream
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -35,14 +36,19 @@ func (m *Manager) pullGBOnce(ctx context.Context, e *entry, backoff *time.Durati
 
 	// Codec resolution from in-band parameter sets only — the GB SDP answer
 	// carries no codec information worth parsing (PS streams declare in-band).
+	// auMu guards codec/isH265: the AU callback runs on the RTP receiver's
+	// goroutine while the session-setup section below reads the resolved codec
+	// on this one (race-detector clean).
+	var auMu sync.Mutex
 	var codec model.Format
-	isH265 := false
+	var isH265 bool
 	var tsOffset int64
 	haveOffset := false
 	handleAU := func(au [][]byte, pktTS int64, _ bool) {
 		if ctx.Err() != nil {
 			return
 		}
+		auMu.Lock()
 		if codec == "" {
 			switch detectCodecGB(au) {
 			case model.FormatH264:
@@ -52,9 +58,11 @@ func (m *Manager) pullGBOnce(ctx context.Context, e *entry, backoff *time.Durati
 				isH265 = true
 			}
 			if codec == "" {
+				auMu.Unlock()
 				return // no parameter-set NALU yet — cannot publish or broadcast
 			}
 		}
+		curCodec, curH265 := codec, isH265
 		ts := pktTS
 		if !haveOffset {
 			haveOffset = true
@@ -63,13 +71,14 @@ func (m *Manager) pullGBOnce(ctx context.Context, e *entry, backoff *time.Durati
 			}
 		}
 		pts := ts + tsOffset
+		auMu.Unlock()
 		if minGap := e.lastPTS.Load() + 3600; pts < minGap { // ~40ms floor
 			pts = minGap
 		}
 		e.lastPTS.Store(pts)
-		refreshParamSets(src, codec, au)
+		refreshParamSets(src, curCodec, au)
 		src.lastFrameAt.Store(time.Now().UnixNano())
-		src.hub.Broadcast(pts, au, nalutil.IsIDR(au, isH265))
+		src.hub.Broadcast(pts, au, nalutil.IsIDR(au, curH265))
 	}
 
 	release, err := puller.InviteSubChannel(e.target.GBDeviceID, e.target.GBChannelID, handleAU)
@@ -78,10 +87,12 @@ func (m *Manager) pullGBOnce(ctx context.Context, e *entry, backoff *time.Durati
 	}
 
 	*backoff = time.Second
-	if src.State() != StateLive && codec != "" {
+	auMu.Lock()
+	resolved := codec
+	auMu.Unlock()
+	if resolved != "" {
 		src.state.Store(StateLive)
-	}
-	if codec == "" {
+	} else {
 		src.state.Store(StateStarting)
 	}
 	subLogger.Info("gb28181 sub-stream session up", "camera_id", cameraID,

--- a/internal/substream/pull_gb_test.go
+++ b/internal/substream/pull_gb_test.go
@@ -1,0 +1,239 @@
+package substream
+
+// GB pull-path tests (#560): a fake GBPuller drives the KindGB28181 target
+// through the Manager's acquire/ready/broadcast contract — codec detection
+// from in-band parameter sets, monotonic rebased timestamps, stall-triggered
+// reconnect, and release on recycle.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGBPuller simulates the SIP side: registers the channel, hands the test
+// the AU callback, and records releases.
+type fakeGBPuller struct {
+	mu        sync.Mutex
+	ensured   []string
+	invited   []string
+	released  []string
+	onAU      func(au [][]byte, ptsTicks int64, isIDR bool)
+	inviteErr error
+}
+
+func (f *fakeGBPuller) EnsureSubChannelRegistered(deviceID, channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensured = append(f.ensured, deviceID+"/"+channelID)
+	return nil
+}
+
+func (f *fakeGBPuller) InviteSubChannel(deviceID, channelID string, onAU func(au [][]byte, ptsTicks int64, isIDR bool)) (func(), error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.inviteErr != nil {
+		return nil, f.inviteErr
+	}
+	f.invited = append(f.invited, deviceID+"/"+channelID)
+	f.onAU = onAU
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.released = append(f.released, deviceID+"/"+channelID)
+	}, nil
+}
+
+func (f *fakeGBPuller) feed(au [][]byte, pts int64, idr bool) {
+	f.mu.Lock()
+	cb := f.onAU
+	f.mu.Unlock()
+	if cb != nil {
+		cb(au, pts, idr)
+	}
+}
+
+// h264SPS/PPS NAL headers (type 7/8) + an IDR slice (type 5).
+var h264ParamAU = [][]byte{{0x67, 0x64, 0x00, 0x1e}, {0x68, 0xee, 0x3c, 0x80}, {0x65, 0x01, 0x02, 0x03}}
+
+// h265 VPS/SPS/PPS (types 32/33/34) + an IDR slice (type 19).
+var h265ParamAU = [][]byte{{0x40, 0x01}, {0x42, 0x01}, {0x44, 0x01}, {0x26, 0x01, 0x02}}
+
+func TestAcquireGB_H264ReadyAndFrames(t *testing.T) {
+	t.Helper()
+	puller := &fakeGBPuller{}
+	m := NewManager(Config{
+		Resolver: func(ctx context.Context, cameraID string) (Target, bool, error) {
+			return Target{Kind: KindGB28181, GBDeviceID: "dev-1", GBChannelID: "ch-sub"}, true, nil
+		},
+		ReadyTimeout:      2 * time.Second,
+		FrameStallTimeout: 5 * time.Second,
+	})
+	m.SetGBPuller(puller)
+	t.Cleanup(m.Stop)
+
+	acq := make(chan acqRes, 1)
+	go func() {
+		s, e := m.Acquire(context.Background(), "cam-gb")
+		acq <- acqRes{s, e}
+	}()
+	waitFeeder := func() {
+		require.Eventually(t, func() bool {
+			puller.mu.Lock()
+			defer puller.mu.Unlock()
+			return puller.onAU != nil
+		}, 2*time.Second, 10*time.Millisecond, "GB session must come up")
+	}
+	waitFeeder()
+
+	// A slice-only AU must not make the source ready (codec is unknowable
+	// from the GB SDP answer; slice NALUs never decide — see detectCodecGB).
+	puller.feed([][]byte{{0x41, 0x01}}, 1000, false)
+	select {
+	case r := <-acq:
+		t.Fatalf("slice-only AU must not unblock Acquire (params=%v)", r.src != nil && r.src.params.Load() != nil)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	puller.feed(h264ParamAU, 3600, true)
+	r := <-acq
+	require.NoError(t, r.err)
+	src := r.src
+	require.Eventually(t, func() bool {
+		codec, sps, pps, vps := src.CodecParams()
+		return codec == model.FormatH264 && len(sps) > 0 && len(pps) > 0 && vps == nil
+	}, 2*time.Second, 20*time.Millisecond)
+
+	// Frames broadcast with rebased monotonic timestamps.
+	got := make(chan int64, 4)
+	subErr := src.Hub().Subscribe("test-sub", func(pts int64, au [][]byte) {
+		select {
+		case got <- pts:
+		default:
+		}
+	})
+	require.NoError(t, subErr)
+	puller.feed(h264ParamAU, 7200, false)
+	select {
+	case pts := <-got:
+		require.Greater(t, pts, int64(0))
+	case <-time.After(time.Second):
+		t.Fatal("no broadcast after feed")
+	}
+	src.Hub().Unsubscribe("test-sub")
+
+	m.Release("cam-gb")
+	require.Equal(t, []string{"dev-1/ch-sub"}, puller.invited)
+}
+
+func TestAcquireGB_H265CodecDetection(t *testing.T) {
+	t.Helper()
+	puller := &fakeGBPuller{}
+	m := NewManager(Config{
+		Resolver: func(ctx context.Context, cameraID string) (Target, bool, error) {
+			return Target{Kind: KindGB28181, GBDeviceID: "dev-2", GBChannelID: "ch-sub2"}, true, nil
+		},
+		ReadyTimeout:      2 * time.Second,
+		FrameStallTimeout: 5 * time.Second,
+	})
+	m.SetGBPuller(puller)
+	t.Cleanup(m.Stop)
+
+	acq2 := make(chan acqRes, 1)
+	go func() {
+		s, e := m.Acquire(context.Background(), "cam-gb265")
+		acq2 <- acqRes{s, e}
+	}()
+	require.Eventually(t, func() bool {
+		puller.mu.Lock()
+		defer puller.mu.Unlock()
+		return puller.onAU != nil
+	}, 2*time.Second, 10*time.Millisecond)
+	puller.feed(h265ParamAU, 9000, true)
+	r2 := <-acq2
+	require.NoError(t, r2.err)
+	src := r2.src
+	require.Eventually(t, func() bool {
+		codec, _, _, vps := src.CodecParams()
+		return codec == model.FormatH265 && len(vps) > 0
+	}, 2*time.Second, 20*time.Millisecond)
+	m.Release("cam-gb265")
+}
+
+func TestAcquireGB_StallReconnects(t *testing.T) {
+	t.Helper()
+	puller := &fakeGBPuller{}
+	m := NewManager(Config{
+		Resolver: func(ctx context.Context, cameraID string) (Target, bool, error) {
+			return Target{Kind: KindGB28181, GBDeviceID: "dev-3", GBChannelID: "ch-sub3"}, true, nil
+		},
+		ReadyTimeout:      2 * time.Second,
+		FrameStallTimeout: 300 * time.Millisecond,
+	})
+	m.SetGBPuller(puller)
+	t.Cleanup(m.Stop)
+
+	acq3 := make(chan acqRes, 1)
+	go func() {
+		s, e := m.Acquire(context.Background(), "cam-gb-stall")
+		acq3 <- acqRes{s, e}
+	}()
+	require.Eventually(t, func() bool {
+		puller.mu.Lock()
+		defer puller.mu.Unlock()
+		return puller.onAU != nil
+	}, 2*time.Second, 10*time.Millisecond)
+	puller.feed(h264ParamAU, 1000, true)
+	r3 := <-acq3
+	require.NoError(t, r3.err)
+	src := r3.src
+	require.Eventually(t, func() bool {
+		codec, _, _, _ := src.CodecParams()
+		return codec == model.FormatH264
+	}, 2*time.Second, 20*time.Millisecond)
+
+	// Silence: the stall watchdog must recycle (release) and the reconnect
+	// loop must re-INVITE.
+	require.Eventually(t, func() bool {
+		puller.mu.Lock()
+		defer puller.mu.Unlock()
+		return len(puller.released) >= 1 && len(puller.invited) >= 2
+	}, 4*time.Second, 50*time.Millisecond, "stall must BYE and re-INVITE")
+
+	m.Release("cam-gb-stall")
+}
+
+func TestAcquireGB_PullerNotWired(t *testing.T) {
+	t.Helper()
+	m := NewManager(Config{
+		Resolver: func(ctx context.Context, cameraID string) (Target, bool, error) {
+			return Target{Kind: KindGB28181, GBDeviceID: "dev-4", GBChannelID: "ch-sub4"}, true, nil
+		},
+		ReadyTimeout: 300 * time.Millisecond,
+	})
+	t.Cleanup(m.Stop)
+
+	_, err := m.Acquire(context.Background(), "cam-gb-nowire")
+	require.ErrorIs(t, err, ErrNotReady)
+}
+
+// acqRes carries an asynchronous Acquire result.
+type acqRes struct {
+	src *Source
+	err error
+}
+
+func TestDetectCodecGB(t *testing.T) {
+	t.Helper()
+	require.Equal(t, model.FormatH264, detectCodecGB(h264ParamAU))
+	require.Equal(t, model.FormatH265, detectCodecGB(h265ParamAU))
+	// H.264 slice (0x41/0x45) — collides with H.265 param slots under the
+	// 6-bit shift; must stay ambiguous, never decide.
+	require.Equal(t, model.Format(""), detectCodecGB([][]byte{{0x41, 0x01}, {0x45, 0x02}}))
+	require.Equal(t, model.Format(""), detectCodecGB([][]byte{{}}))
+	require.Equal(t, model.Format(""), detectCodecGB(nil))
+}

--- a/internal/substream/substream.go
+++ b/internal/substream/substream.go
@@ -44,12 +44,39 @@ const (
 	StateFailed       = "failed"
 )
 
+// Pull target kinds: KindRTSP (default — Target.URL is dialed over RTSP) and
+// KindGB28181 (a probed GB28181 sub-channel INVITE'd via the GBPuller).
+const (
+	KindRTSP    = "rtsp"
+	KindGB28181 = "gb28181"
+)
+
 // Target describes where to pull a camera's sub-stream from. Credentials ride
 // separately so the puller can inject them into RTSP URLs that lack userinfo.
+// Kind KindGB28181 ignores URL/credentials and uses the GB device/channel pair
+// instead (#560).
 type Target struct {
 	URL      string
 	Username string
 	Password string
+	Kind     string // "" / KindRTSP / KindGB28181
+	// GBDeviceID/GBChannelID carry the probed sub-channel binding for
+	// KindGB28181 targets.
+	GBDeviceID  string
+	GBChannelID string
+}
+
+// GBPuller starts GB28181 sub-channel media sessions. Implemented by the SIP
+// server (internal/gb28181/sip) and injected at app wiring — the substream
+// package stays free of gb28181 imports.
+type GBPuller interface {
+	// EnsureSubChannelRegistered registers the probe-discovered channel code
+	// as an INVITEable pull target (idempotent; no-op when the catalog
+	// already lists it).
+	EnsureSubChannelRegistered(deviceID, channelID string) error
+	// InviteSubChannel establishes the media session feeding onAU; the
+	// returned func BYEs it.
+	InviteSubChannel(deviceID, channelID string, onAU func(au [][]byte, ptsTicks int64, isIDR bool)) (func(), error)
 }
 
 // Resolver maps a camera ID to its sub-stream pull target. ok=false means the
@@ -168,6 +195,9 @@ type Manager struct {
 	// (notably HLS's "hls" consumer — the HLS entry does not store its hub).
 	// Set once at wiring time via SetOnRecycle before traffic arrives.
 	onRecycle func(cameraID string, hub *model.StreamHub)
+	// gbPuller serves KindGB28181 targets (nil → those targets error and the
+	// source reconnects until wired). Set at app wiring via SetGBPuller.
+	gbPuller GBPuller
 }
 
 // NewManager creates a Manager. cfg.Resolver is required for Acquire to work.
@@ -184,6 +214,14 @@ func NewManager(cfg Config) *Manager {
 func (m *Manager) SetOnRecycle(fn func(cameraID string, hub *model.StreamHub)) {
 	m.mu.Lock()
 	m.onRecycle = fn
+	m.mu.Unlock()
+}
+
+// SetGBPuller wires the GB28181 sub-channel session starter (#560). Only call
+// during wiring, before the first Acquire.
+func (m *Manager) SetGBPuller(p GBPuller) {
+	m.mu.Lock()
+	m.gbPuller = p
 	m.mu.Unlock()
 }
 
@@ -226,7 +264,7 @@ func (m *Manager) Acquire(ctx context.Context, cameraID string) (*Source, error)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sub-stream: %w", err)
 	}
-	if !ok || target.URL == "" {
+	if !ok || (target.URL == "" && target.Kind != KindGB28181) {
 		return nil, ErrNoSubStream
 	}
 

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1787802478512';
+const CACHE_VERSION = 'mibee-nvr-1787826728073';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -865,6 +865,12 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		// Auto-INVITE when GB28181 recorders start (pull media on camera creation).
 		camMgr.SetGB28181Inviter(deps.gb28181Server)
 		camMgr.SetGB28181SessionEnder(deps.gb28181Server)
+		// GB sub-channel pull sessions (#560): the SIP server structurally
+		// implements substream.GBPuller (EnsureSubChannelRegistered +
+		// InviteSubChannel).
+		if subs := camMgr.SubStreams(); subs != nil {
+			subs.SetGBPuller(deps.gb28181Server)
+		}
 		// Naive GB device-clock timestamps follow the app timezone — hosts in
 		// a different zone than the devices (UTC container, CST cameras) would
 		// otherwise skew every record window by the TZ offset.


### PR DESCRIPTION
Implements #560 (last item split from #512). GB devices registered to this NVR get their sub stream discovered by probing the vendor-convention channel-code offset (Hikvision: +1) — one extra INVITE per bound main channel per process lifetime, fully silent on failure.

## Prober (`internal/gb28181/sip/subchannel.go`)
- Fires after each catalog merge (main sessions settle first via a 5s delay); candidate = main code + `sub_channel_probe_offset` (decimal carry on the 20-digit code; default 1, 0 disables).
- **Never repurposes catalog-listed sibling codes** — on a multi-channel NVR, channel 02 is a real camera, not channel 01's sub stream.
- Registers the candidate as a `SubProbe`-marked synthetic channel, INVITEs through the shared core, waits one bounded window (6s) for first media.
- Success → persists `gb28181.sub_channel_id` on the camera (fill-once; YAML source of truth; clearing re-arms). Failure (404/timeout/busy) → silent unregister, camera keeps the no-sub degradation path — **zero error state**, memoized for the process lifetime.
- Gating: `sub_channel_probe: auto` (default — DeviceInfo manufacturer Hikvision/Dahua only) / `on` / `off`. `auto` leaves mibee-rec fleets zero-touched. Restart recovery: persisted codes are re-registered as synthetic channels (catalogs never list them).

## Pull path (`internal/substream/pull_gb.go`)
- `KindGB28181` targets INVITE the persisted code via new `Server.InviteSubChannel` (recorder-less: no watchSession — the manager owns stall detection and reconnect), rebasing RTP timestamps onto the cross-session monotonic timeline (same failure class as #506 otherwise), codec from parameter-set NALUs only (slice NALUs never decide — same rule as the recorder), in-band param-set refresh, broadcast on the sub hub.
- `InviteChannel` refactored into shared `inviteCore`; recorder path behavior unchanged.
- Wired through `resolveSubTarget` → generic Acquire → existing quality=sub egress (WS/FLV/HLS/WHEP) and cascade sub forwarding, no egress changes needed.
- `/protocols` reports `available=true, source=gb-sub-channel` once a code is persisted.

## gbsim
- `-manufacturer` (report as Hikvision to arm the auto gate) and `-no-sub` (404 non-main INVITEs — negative probe path).

## Tests
Probe arithmetic (carry/overflow/non-digit), vendor gate (auto skips unknown makers entirely), silent-timeout negative path with memoization (no re-INVITE), persisted-code re-registration, GB pull ready/codec-detect (incl. the H.264-slice vs H.265-VPS ambiguity)/stall-reconnect/not-wired, resolver cases. Full suite: 5049 Go tests green; golangci-lint clean.

## Verification plan
Docker VM with a Hikvision-branded gbsim (probe → persist → `/protocols` → browser quality=sub live view) and M5 regression (auto gate → zero behavioral change for the mibee-rec fleet). Real-device Hikvision/Dahua validation remains tracked by #351.

Docs: zh/en gb28181-guide (new Sub-Stream section + config reference rows).