### PR TITLE
test(cleanup): deletion-path coverage 48.7%→76.7% + dark-segment timezone fix (#565, #571)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,34 @@ explicitly in your pull request so they can be reviewed before merge.
    (this file is gitignored — see the repository conventions in
    existing packages).
 
+## Writing tests that don't flake in CI (#571)
+
+These rules are distilled from the root causes of past recurring CI
+failures. Every new test must satisfy them:
+
+- **One SQLite instance per test.** Create the DB under `t.TempDir()`
+  (see the `newTestEnv` helper in `internal/cleanup/cleanup_test.go`).
+  Never share one `*storage.DB` across parallel tests — WAL writer
+  contention is what produced the historical `database is locked`
+  failures.
+- **Assert on observable state, never on elapsed time.** For async
+  work, poll the observable end state with `require.Eventually`
+  (generous timeout, short interval) instead of `time.Sleep` followed
+  by an assertion. The #559 storage-root migration flake was exactly
+  this: asserting "done" before the job had been observed.
+- **Race-clean or don't ship.** `go test -race ./internal/<pkg>/`
+  must pass locally before you push. Shared package-level state in
+  tests must be atomic or guarded.
+- **Backdate fixtures via SQL, and build timestamps in UTC.** When a
+  test needs "a record completed 2 hours ago", insert the row and then
+  `UPDATE ... SET completed_at = ?` with a UTC timestamp — never depend
+  on the test running fast. All DB times are stored UTC; comparing
+  them against a local-time `time.Now()` is a bug (see the
+  `ListDarkRecordings` timezone bug caught while writing these rules).
+- **Keep fixtures lightweight.** Prefer hermetic stubs (fake shell
+  scripts, `httptest`, UDP loopback) over real external processes so
+  CI wall-time stays flat as the suite grows.
+
 ## Commit / PR conventions
 
 - Branch from `main`; open a PR (squash-merge only, linear history).

--- a/internal/cleanup/dark_segments_test.go
+++ b/internal/cleanup/dark_segments_test.go
@@ -1,0 +1,63 @@
+package cleanup
+
+// Tests for the dark-segment cleanup strategy (dark_segments.go): recordings
+// marked merge_status='dark' are deleted after a 1h grace period. Both sides
+// of the grace boundary are asserted. See #565.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// insertDarkRecording inserts a recording with merge_status='dark' and a file
+// on disk, ended at the given time.
+func insertDarkRecording(t *testing.T, env *testEnv, id string, endedAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	env.insertTestRecording(t, id, "cam1", "cam1/"+id+".mp4", endedAt, false)
+	require.NoError(t, env.db.SetMergeStatus(ctx, []string{id}, "dark"))
+	rec, err := env.db.GetRecording(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, model.MergeStatusDark, rec.MergeStatus, "fixture setup: recording must be dark before cleanup runs")
+}
+
+func TestDarkSegmentCleanup_AfterGraceDeleted(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// Ended 2h ago — beyond the 1h grace period.
+	insertDarkRecording(t, env, "dark-old", time.Now().UTC().Add(-2*time.Hour))
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.False(t, recordingExists(t, env, "dark-old"), "dark segment past grace should be deleted from DB")
+	_, err = os.Stat(filepath.Join(env.store.RootDir(), "cam1", "dark-old.mp4"))
+	require.True(t, os.IsNotExist(err), "dark segment file past grace should be deleted")
+}
+
+func TestDarkSegmentCleanup_WithinGraceKept(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// Ended 10m ago — inside the 1h grace period, still briefly visible.
+	insertDarkRecording(t, env, "dark-fresh", time.Now().UTC().Add(-10*time.Minute))
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.True(t, recordingExists(t, env, "dark-fresh"), "dark segment within grace must survive one cleanup cycle")
+}

--- a/internal/cleanup/errorpaths_test.go
+++ b/internal/cleanup/errorpaths_test.go
@@ -1,0 +1,93 @@
+package cleanup
+
+// Error-path tests for ArchiveDeleter.processTask (closed DB forces every
+// step to fail — non-fatal logging paths must hold) and the fragmentation
+// branch of performDatabaseMaintenance. See #565.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessTask_AllStepsFail_NoPanic(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	createPendingTask(t, env.db, "doomed")
+	d := NewArchiveDeleter(env.db, env.store)
+
+	// Close the DB first: every step inside processTask now errors. The worker
+	// must survive (log + continue) — a cleanup task failing must never crash
+	// the loop.
+	env.db.Close()
+	d.processTask(context.Background(), storage.ArchiveCleanupTask{CameraID: "doomed", Status: "pending"})
+}
+
+func TestProcessTask_RecordsFailureStatus(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// Recording delete fails because the recordings table was dropped.
+	_, err := env.db.DB().ExecContext(context.Background(), `DROP TABLE recordings;`)
+	require.NoError(t, err)
+	createPendingTask(t, env.db, "broken")
+
+	d := NewArchiveDeleter(env.db, env.store)
+	d.processTask(context.Background(), storage.ArchiveCleanupTask{CameraID: "broken", Status: "pending"})
+
+	tasks, err := env.db.ListActiveArchiveCleanupTasks(context.Background())
+	require.NoError(t, err)
+	for _, task := range tasks {
+		if task.CameraID == "broken" {
+			require.Equal(t, "failed", task.Status, "recording-delete failure should mark the task failed")
+		}
+	}
+}
+
+func TestPerformDatabaseMaintenance_FragmentationChurn(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	// Create free pages: insert rows with ~2KB payloads, then delete most.
+	payload := strings.Repeat("x", 2048)
+	for i := range 200 {
+		require.NoError(t, env.db.InsertRecording(ctx, &model.Recording{
+			ID:        fmt.Sprintf("frag-%03d-%s", i, payload[:8]),
+			CameraID:  "cam1",
+			FilePath:  payload,
+			Format:    model.FormatH264,
+			StartedAt: time.Now().UTC(),
+			EndedAt:   time.Now().UTC(),
+			Duration:  1,
+		}))
+	}
+	ids := make([]string, 0, 150)
+	rows, err := env.db.DB().QueryContext(ctx, `SELECT id FROM recordings;`)
+	require.NoError(t, err)
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Close())
+	if len(ids) > 50 {
+		_, err := env.db.DeleteRecordingsBatch(ctx, ids[:len(ids)-50])
+		require.NoError(t, err)
+	}
+
+	// Whatever branch the actual ratio selects (no-op / incremental vacuum /
+	// online compaction), maintenance must complete without error.
+	cm.performDatabaseMaintenance(ctx)
+}

--- a/internal/cleanup/lifecycle_test.go
+++ b/internal/cleanup/lifecycle_test.go
@@ -1,0 +1,220 @@
+package cleanup
+
+// Lifecycle and wiring tests: ArchiveDeleter Start/Stop loop, event-bus
+// publication on deletion, active-camera provider, adaptive batch sleep,
+// and SQLite metrics updates. See #565.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveDeleter_Lifecycle(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// A second camera with recordings + files + directory, plus a pending task.
+	require.NoError(t, env.db.UpsertCamera(ctx, "cam2", "Doomed Cam", "rtsp", "", "rtsp://localhost/x", "", "", "", "", "", ""))
+	env.insertTestRecording(t, "arch-1", "cam2", "cam2/seg1.mp4", time.Now().UTC(), false)
+	env.insertTestRecording(t, "arch-2", "cam2", "cam2/seg2.mp4", time.Now().UTC(), false)
+	createPendingTask(t, env.db, "cam2")
+
+	d := NewArchiveDeleter(env.db, env.store)
+	require.Equal(t, "archive-deleter", d.Name())
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, d.Start(runCtx))
+
+	// The loop polls every 3s — poll the observable end state (task 'done')
+	// instead of sleeping a fixed amount. See #571 anti-flake rules.
+	require.Eventually(t, func() bool {
+		recent, err := env.db.ListRecentArchiveCleanupTasks(context.Background(), time.Now().Add(-time.Hour))
+		if err != nil {
+			return false
+		}
+		for _, task := range recent {
+			if task.CameraID == "cam2" && task.Status == "done" {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 100*time.Millisecond, "task should be processed to done within one poll cycle")
+
+	require.NoError(t, d.Stop())
+
+	require.False(t, recordingExists(t, env, "arch-1"))
+	require.False(t, recordingExists(t, env, "arch-2"))
+	_, err := os.Stat(filepath.Join(env.store.RootDir(), "cam2"))
+	require.True(t, os.IsNotExist(err), "camera directory should be removed")
+	cams, err := env.db.ListCameras(ctx)
+	require.NoError(t, err)
+	for _, cam := range cams {
+		require.NotEqual(t, "cam2", cam.ID, "camera row should be removed")
+	}
+}
+
+func TestArchiveDeleter_MaybePrune(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	createPendingTask(t, env.db, "prune-old")
+	require.NoError(t, env.db.UpdateArchiveCleanupTaskStatus(ctx, "prune-old", "done", ""))
+	// Backdate completion past the 1h prune cutoff (deterministic).
+	_, err := env.db.DB().ExecContext(ctx,
+		`UPDATE archive_cleanup_tasks SET completed_at=? WHERE camera_id=?;`,
+		time.Now().UTC().Add(-2*time.Hour), "prune-old")
+	require.NoError(t, err)
+
+	createPendingTask(t, env.db, "prune-fresh")
+	require.NoError(t, env.db.UpdateArchiveCleanupTaskStatus(ctx, "prune-fresh", "done", ""))
+
+	d := NewArchiveDeleter(env.db, env.store)
+	d.maybePrune(ctx)
+
+	tasks, err := env.db.ListRecentArchiveCleanupTasks(ctx, time.Now().Add(-3*time.Hour))
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, task := range tasks {
+		ids[task.CameraID] = true
+	}
+	require.False(t, ids["prune-old"], "done task older than 1h should be pruned")
+	require.True(t, ids["prune-fresh"], "recently completed task must survive pruning")
+}
+
+func TestRunOnce_TranscodeOrphanHookCalled(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	called := 0
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.SetTranscodeOrphanCleanup(func(ctx context.Context) error {
+		called++
+		return nil
+	})
+	require.NoError(t, cm.RunOnce(ctx))
+	require.Equal(t, 1, called, "transcode orphan hook should run exactly once per cycle")
+}
+
+func TestBatchDelete_PublishesSegmentDeletedEvents(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// One expired recording owned by cam1.
+	env.insertTestRecording(t, "evt-1", "cam1", "cam1/evt1.mp4", time.Now().UTC(), false)
+
+	bus := event.NewEventBus(16)
+	ch := make(chan event.Event, 16)
+	require.NoError(t, bus.Subscribe(event.TopicSegmentDeleted, ch, 16))
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.SetEventBus(bus)
+
+	rec, err := env.db.GetRecording(ctx, "evt-1")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+
+	deleted, err := cm.BatchDeleteRecordingsWithFiles(ctx, []model.Recording{*rec}, "disk_threshold")
+	require.NoError(t, err)
+	require.Equal(t, []string{"evt-1"}, deleted)
+
+	// Publish is a synchronous non-blocking send — the event is already in the
+	// channel buffer when the delete call returns.
+	select {
+	case evt := <-ch:
+		require.Equal(t, event.TopicSegmentDeleted, evt.Topic)
+		sd, ok := evt.Data.(event.SegmentDeleted)
+		require.True(t, ok, "event payload should be event.SegmentDeleted")
+		require.Equal(t, "evt-1", sd.RecordingID)
+		require.Equal(t, "cam1", sd.CameraID)
+		require.Equal(t, "disk_threshold", sd.Reason)
+	default:
+		t.Fatal("segment.deleted event should have been published for the deleted recording")
+	}
+	require.False(t, recordingExists(t, env, "evt-1"))
+}
+
+func TestAdaptiveBatchSleep_ContextCancellation(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	cm.adaptiveBatchSleep(ctx) // must return immediately on cancelled ctx
+	require.Less(t, time.Since(start), 500*time.Millisecond, "cancelled context must skip the sleep")
+
+	cm.adaptiveBatchSleep(context.Background()) // fresh DB → WAL < 5MB → ~10ms sleep
+}
+
+func TestActiveCameraIDs_ProviderPath(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	cm.SetActiveCameraProvider(func() []config.CameraConfig {
+		return []config.CameraConfig{
+			{ID: "cam1"},
+			{ID: "  "}, // blank entries must be filtered
+			{ID: " cam9 "},
+		}
+	})
+	ids, err := cm.activeCameraIDs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cam1", "cam9"}, ids, "provider IDs should be trimmed and blanks dropped")
+
+	// nil provider → legacy DB fallback (cam1 from the fixture).
+	cm.SetActiveCameraProvider(nil)
+	ids, err = cm.activeCameraIDs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cam1"}, ids)
+}
+
+func TestSetters_NilReceiverSafe(t *testing.T) {
+	var cm *CleanupManager
+	cm.SetActiveCameraProvider(func() []config.CameraConfig { return nil })
+	cm.SetEventBus(nil)
+}
+
+func TestUpdateSQLiteMetrics_WithMetricsWired(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	m := metrics.NewMetrics()
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg, m)
+	require.NoError(t, err)
+
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.Greater(t, testutil.ToFloat64(m.SQLiteDBSizeBytes), float64(0),
+		"DB size metric should be populated after a cleanup cycle")
+	require.GreaterOrEqual(t, testutil.ToFloat64(m.SQLiteOpenConnections), float64(0))
+}

--- a/internal/cleanup/repair_test.go
+++ b/internal/cleanup/repair_test.go
@@ -1,0 +1,186 @@
+package cleanup
+
+// Tests for the DB self-repair strategies (repair.go): zero-duration repair
+// via the pure-Go probe + fake-ffprobe fallback, and stale MJPEG record
+// marking. The ffprobe fallback is exercised with a stub shell script so the
+// tests stay hermetic (no real ffprobe binary, works on any CI runner). See #565.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFakeFFprobe creates an executable stub that prints the given single
+// line of stdout, mimicking `ffprobe -show_entries format=duration`.
+func writeFakeFFprobe(t *testing.T, output string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-ffprobe")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nprintf '%s\\n' \""+output+"\"\n"), 0o755))
+	return path
+}
+
+// writeGarbageMedia writes a non-MP4 file so mediaprobe fails and the ffprobe
+// fallback path is taken.
+func writeGarbageMedia(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("definitely-not-an-mp4"), 0o644))
+}
+
+func TestProbeDuration_FFprobeFallback(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	file := filepath.Join(env.dir, "garbage.mp4")
+	writeGarbageMedia(t, file)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.ffprobePath = writeFakeFFprobe(t, "32.4")
+
+	d := cm.probeDuration(context.Background(), file)
+	require.InDelta(t, 32.4, d, 0.001, "ffprobe fallback should return the stub duration")
+}
+
+func TestProbeDuration_FFprobeParseFailure(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	file := filepath.Join(env.dir, "garbage.mp4")
+	writeGarbageMedia(t, file)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.ffprobePath = writeFakeFFprobe(t, "not-a-number")
+
+	require.Equal(t, 0.0, cm.probeDuration(context.Background(), file), "unparseable ffprobe output must yield 0, not panic")
+}
+
+func TestProbeDuration_NoFFprobeConfigured(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	file := filepath.Join(env.dir, "garbage.mp4")
+	writeGarbageMedia(t, file)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, 0.0, cm.probeDuration(context.Background(), file),
+		"non-MP4 input with no ffprobe configured must return 0 (best-effort)")
+}
+
+// insertZeroDurationRecording inserts a duration=0 recording matching the
+// repair candidates query (file_size>1MB, non-MJPEG, ended_at set, pending).
+func insertZeroDurationRecording(t *testing.T, env *testEnv, id, filePath string, fileExists bool) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := env.db.DB().ExecContext(ctx,
+		`INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status)
+		 VALUES(?,?,?,?,?,?,0,?,?,?);`,
+		id, "cam1", filePath, model.FormatH264,
+		time.Now().UTC().Add(-time.Hour), time.Now().UTC(),
+		2*1024*1024, 0, model.MergeStatusPending)
+	require.NoError(t, err)
+	if fileExists {
+		writeGarbageMedia(t, filePath)
+	}
+}
+
+func TestRepairZeroDuration_RepairsViaFFprobeFallback(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	file := filepath.Join(env.dir, "repair.mp4")
+	insertZeroDurationRecording(t, env, "repair-me", file, true)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.ffprobePath = writeFakeFFprobe(t, "32.4")
+
+	cm.repairZeroDurationRecordings(ctx)
+
+	rec, err := env.db.GetRecording(ctx, "repair-me")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.InDelta(t, 32.4, rec.Duration, 0.001, "duration should be updated from the probe result")
+	expectedEnd := rec.StartedAt.Add(32400 * time.Millisecond)
+	require.WithinDuration(t, expectedEnd, rec.EndedAt, 2*time.Second,
+		"ended_at should be recomputed as started_at + probed duration")
+}
+
+func TestRepairZeroDuration_SkipsMissingFile(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	insertZeroDurationRecording(t, env, "gone", filepath.Join(env.dir, "missing.mp4"), false)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.ffprobePath = writeFakeFFprobe(t, "32.4")
+
+	cm.repairZeroDurationRecordings(ctx)
+
+	rec, err := env.db.GetRecording(ctx, "gone")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, 0.0, rec.Duration, "recording with missing file must be left untouched")
+}
+
+// insertPendingMJPEG inserts an mjpeg-format pending recording; onDisk
+// controls whether the backing file exists.
+func insertPendingMJPEG(t *testing.T, env *testEnv, id string, onDisk bool) string {
+	t.Helper()
+	ctx := context.Background()
+	fullPath := filepath.Join(env.store.RootDir(), "cam1", id+".mjpeg")
+	_, err := env.db.DB().ExecContext(ctx,
+		`INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status)
+		 VALUES(?,?,?,?,?,?,?,?,?,?);`,
+		id, "cam1", fullPath, model.FormatMJPEG,
+		time.Now().UTC().Add(-time.Hour), time.Now().UTC(),
+		60, 1024, 0, model.MergeStatusPending)
+	require.NoError(t, err)
+	if onDisk {
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+		require.NoError(t, os.WriteFile(fullPath, []byte("mjpeg-data"), 0o644))
+	}
+	return fullPath
+}
+
+func TestStaleRecordCleanup_MarksMissingMJPEGFailed(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	insertPendingMJPEG(t, env, "stale-mjpeg", false) // file gone → stale
+	insertPendingMJPEG(t, env, "live-mjpeg", true)   // file present → untouched
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, cm.fixStaleMJPEGRecords(ctx, "cam1"), "exactly the missing-file record should be fixed")
+
+	stale, err := env.db.GetRecording(ctx, "stale-mjpeg")
+	require.NoError(t, err)
+	require.NotNil(t, stale)
+	require.Equal(t, model.MergeStatusFailed, stale.MergeStatus, "stale MJPEG record should be marked failed")
+
+	live, err := env.db.GetRecording(ctx, "live-mjpeg")
+	require.NoError(t, err)
+	require.NotNil(t, live)
+	require.Equal(t, model.MergeStatusPending, live.MergeStatus, "record with file on disk must stay pending")
+}

--- a/internal/cleanup/time_retention_test.go
+++ b/internal/cleanup/time_retention_test.go
@@ -1,0 +1,203 @@
+package cleanup
+
+// Tests for the archived-recording retention strategy (time_retention.go) and
+// transcode-task history retention. These paths delete user data, so every
+// guard (keep-forever, AI-processing protection, empty-group teardown) is
+// asserted explicitly. See #565.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// archiveCamera inserts a camera row and flags it archived with the given
+// archive retention (0 = keep forever).
+func archiveCamera(t *testing.T, env *testEnv, id string, archiveRetentionDays int) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, env.db.UpsertCamera(ctx, id, "Archived Cam", "rtsp", "", "rtsp://localhost/"+id, "", "", "", "", "", ""))
+	_, err := env.db.DB().ExecContext(ctx,
+		`UPDATE cameras SET archived=1, archived_at=?, archive_retention_days=? WHERE id=?;`,
+		time.Now().UTC().Add(-24*time.Hour), archiveRetentionDays, id)
+	require.NoError(t, err)
+}
+
+func recordingExists(t *testing.T, env *testEnv, id string) bool {
+	t.Helper()
+	rec, err := env.db.GetRecording(context.Background(), id)
+	require.NoError(t, err)
+	return rec != nil
+}
+
+// markRecordingArchived flags the recording row itself as archived — the
+// expired-archived query filters on recordings.archived, not just the camera.
+func markRecordingArchived(t *testing.T, env *testEnv, id string) {
+	t.Helper()
+	_, err := env.db.DB().ExecContext(context.Background(),
+		`UPDATE recordings SET archived=1 WHERE id=?;`, id)
+	require.NoError(t, err)
+}
+
+func TestArchivedRetentionCleanup_ExpiredDeleted(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	archiveCamera(t, env, "archcam", 7)
+	// Ended 10 days ago — beyond the 7-day archive retention.
+	env.insertTestRecording(t, "arch-expired", "archcam", "archcam/seg1.mp4", time.Now().UTC().Add(-10*24*time.Hour), false)
+	markRecordingArchived(t, env, "arch-expired")
+	// Well within global retention (30d) so timeBasedCleanup must not touch it either way.
+	env.insertTestRecording(t, "live-kept", "cam1", "cam1/seg1.mp4", time.Now().UTC().Add(-2*24*time.Hour), false)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.False(t, recordingExists(t, env, "arch-expired"), "expired archived recording should be deleted from DB")
+	_, err = os.Stat(filepath.Join(env.store.RootDir(), "archcam", "seg1.mp4"))
+	require.True(t, os.IsNotExist(err), "expired archived recording file should be deleted")
+
+	require.True(t, recordingExists(t, env, "live-kept"), "active camera recording within retention must survive")
+}
+
+func TestArchivedRetentionCleanup_KeepForeverWhenZero(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	// archive_retention_days=0 means keep forever.
+	archiveCamera(t, env, "archcam", 0)
+	env.insertTestRecording(t, "arch-old", "archcam", "archcam/seg1.mp4", time.Now().UTC().Add(-400*24*time.Hour), false)
+	markRecordingArchived(t, env, "arch-old")
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.True(t, recordingExists(t, env, "arch-old"), "archive_retention_days=0 must keep recordings forever")
+}
+
+func TestArchivedRetentionCleanup_EmptyGroupTornDown(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	archiveCamera(t, env, "archcam", 7)
+	env.insertTestRecording(t, "arch-last", "archcam", "archcam/seg1.mp4", time.Now().UTC().Add(-10*24*time.Hour), false)
+	markRecordingArchived(t, env, "arch-last")
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.False(t, recordingExists(t, env, "arch-last"), "last expired recording should be deleted")
+
+	// Empty archived group: camera row and directory are removed.
+	archived, err := env.db.ListArchivedCameras(ctx)
+	require.NoError(t, err)
+	for _, cam := range archived {
+		require.NotEqual(t, "archcam", cam.ID, "empty archived camera row should be deleted")
+	}
+	_, err = os.Stat(filepath.Join(env.store.RootDir(), "archcam"))
+	require.True(t, os.IsNotExist(err), "empty archived camera directory should be deleted")
+}
+
+func TestArchivedRetentionCleanup_AIProcessingProtected(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	archiveCamera(t, env, "archcam", 7)
+	env.insertTestRecording(t, "arch-ai", "archcam", "archcam/seg1.mp4", time.Now().UTC().Add(-10*24*time.Hour), false)
+	markRecordingArchived(t, env, "arch-ai")
+	require.NoError(t, env.db.UpdateRecordingAIStatus(ctx, "arch-ai", "processing", ""))
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	require.True(t, recordingExists(t, env, "arch-ai"),
+		"recording being processed by MiBeeVision must never be deleted by retention")
+
+	// Camera row must survive too — the recording is still there, so the group
+	// is not empty.
+	archived, err := env.db.ListArchivedCameras(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, cam := range archived {
+		if cam.ID == "archcam" {
+			found = true
+		}
+	}
+	require.True(t, found, "archived camera with remaining recordings must not be removed")
+}
+
+// enqueueCompletedTaskOld inserts a transcode task marked completed with
+// completed_at backdated past the given duration (deterministic — no sleeps).
+func enqueueCompletedTaskOld(t *testing.T, env *testEnv, age time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, env.db.EnqueueTask(ctx, &storage.TranscodeTask{
+		CameraID:     "cam1",
+		RecordingID:  "rec-tc",
+		InputPath:    "/tmp/in.mp4",
+		InputFormat:  "h265",
+		OutputPath:   "/tmp/out.mp4",
+		OutputFormat: "h264",
+	}))
+	var id int64
+	require.NoError(t, env.db.DB().QueryRowContext(ctx, `SELECT MAX(id) FROM transcoding_tasks;`).Scan(&id))
+	require.NotZero(t, id)
+	require.NoError(t, env.db.UpdateTaskStatus(ctx, id, "completed", 100, ""))
+	_, err := env.db.DB().ExecContext(ctx,
+		`UPDATE transcoding_tasks SET completed_at=? WHERE id=?;`,
+		time.Now().UTC().Add(-age), id)
+	require.NoError(t, err)
+}
+
+func TestTranscodeHistoryCleanup(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	enqueueCompletedTaskOld(t, env, 2*time.Hour)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	cm.SetTranscodeHistoryRetention(time.Hour)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	_, total, err := env.db.ListTranscodeTasks(ctx, storage.TranscodeTaskFilter{})
+	require.NoError(t, err)
+	require.Equal(t, 0, total, "completed task older than retention should be deleted")
+}
+
+func TestTranscodeHistoryCleanup_DisabledByDefault(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	enqueueCompletedTaskOld(t, env, 72*time.Hour)
+
+	// No SetTranscodeHistoryRetention → retention 0 → disabled.
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+	require.NoError(t, cm.RunOnce(ctx))
+
+	_, total, err := env.db.ListTranscodeTasks(ctx, storage.TranscodeTaskFilter{})
+	require.NoError(t, err)
+	require.Equal(t, 1, total, "transcode history cleanup disabled (retention=0) must keep tasks")
+}

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -1127,7 +1127,10 @@ func (d *DB) BatchGetRecordingAIStatus(ctx context.Context, ids []string) (map[s
 // the given grace period (from ended_at). These are night/no-IR segments
 // excluded from merge and pending cleanup.
 func (d *DB) ListDarkRecordings(ctx context.Context, gracePeriod time.Duration) ([]model.Recording, error) {
-	cutoff := time.Now().Add(-gracePeriod).Format("2006-01-02 15:04:05.999999999")
+	// UTC is mandatory here: ended_at is stored UTC (timeToDB), so a local-time
+	// cutoff would sit hours in the future on non-UTC hosts and delete fresh
+	// dark segments immediately, voiding the grace period (found by #565 tests).
+	cutoff := time.Now().UTC().Add(-gracePeriod).Format("2006-01-02 15:04:05.999999999")
 	q := selectRecordingColumns + ` WHERE merge_status = 'dark' AND ended_at IS NOT NULL AND ended_at < ? ORDER BY ended_at ASC LIMIT 500;`
 	rows, err := d.readConn().QueryContext(ctx, q, cutoff)
 	if err != nil {


### PR DESCRIPTION
Closes #565
Partially addresses #571 (anti-flaky rules; remaining packages in follow-up PRs)

## What

Coverage audit follow-up: `internal/cleanup` was 48.7% with the gaps concentrated in **data-deleting paths**. Now 76.7%.

### New tests (5 files)
- **archivedRetentionCleanup**: expired deleted / `archive_retention_days=0` keep-forever / empty-group teardown (row+dir) / **AI-processing recordings never deleted**
- **transcodeHistoryCleanup**: enabled + disabled-by-default, fixtures backdated via SQL (deterministic)
- **repair.go**: `probeDuration` ffprobe fallback via hermetic fake-ffprobe stub (echo script — no real binary, runs anywhere), parse-failure, no-ffprobe; `repairZeroDurationRecordings` happy + missing-file skip; `fixStaleMJPEGRecords`
- **darkSegmentCleanup**: both sides of the 1h grace boundary
- **lifecycle**: ArchiveDeleter Start/runLoop/Stop (polls observable done-state via require.Eventually), maybePrune, processTask error paths (closed DB — log-and-continue holds), segment.deleted event publication, activeCameraIDs provider path, adaptiveBatchSleep, updateSQLiteMetrics

### Production bug found & fixed
`ListDarkRecordings` built its grace cutoff with local `time.Now()` while `ended_at` is stored UTC. On UTC+8 hosts the cutoff sat 8h in the future → dark segments deleted **immediately**, grace period voided. (Local UTC+8 dev machine caught it; a UTC-only CI would not have.) Fixed to `time.Now().UTC()` with a comment.

### #571 anti-flaky rules → CONTRIBUTING.md
Per-test SQLite instance, assert observable state (require.Eventually, never sleep-then-assert), race-clean before push, UTC+SQL backdating for time fixtures, lightweight hermetic fixtures. All new tests in this PR follow them; verified with \`go test -race\`.

## Verification
- `go test -race ./internal/cleanup/ ./internal/storage/` — PASS
- `golangci-lint run ./internal/cleanup/ ./internal/storage/` — 0 issues
- coverage: cleanup 48.7% → **76.7%**