### PR TITLE
test(gb28181): cascade 29.6%→75.0%, sip 45.5%→63.0% + mediaSession race fix (#566)

### DIFF
--- a/internal/gb28181/cascade/loopback_test.go
+++ b/internal/gb28181/cascade/loopback_test.go
@@ -1,0 +1,431 @@
+package cascade
+
+// Protocol-level loopback tests: the Service runs its real SIP server on a
+// free localhost UDP port and a raw-UDP "upper platform" socket exchanges
+// SIP messages with it. Covers the request handlers (INVITE/BYE/SUBSCRIBE/
+// MESSAGE/INFO/OPTIONS) and the service lifecycle without any real device.
+// Harness ported from internal/gb28181/sip/server_test.go. See #566.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/ghettovoice/gosip/log"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/ghettovoice/gosip/sip/parser"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	lbUpperDevice = "34020000002000000002" // fake upper platform's device ID
+	lbChannelOne  = "34020000001320000001" // first allocated channel
+	lbLocalHost   = "127.0.0.1"
+)
+
+// freeUDPPort returns a free UDP port on loopback.
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).Port
+}
+
+var lbSeq atomic.Int64
+
+// upperSocket is the fake upper platform: one UDP socket that sends requests
+// to the cascade's SIP server and receives responses plus server-initiated
+// requests (NOTIFY / record-info MESSAGEs).
+type upperSocket struct {
+	t    *testing.T
+	conn *net.UDPConn
+	sip  *net.UDPAddr // cascade SIP listen address
+}
+
+func newUpperSocket(t *testing.T, sipAddr string) *upperSocket {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	addr, err := net.ResolveUDPAddr("udp", sipAddr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return &upperSocket{t: t, conn: conn, sip: addr}
+}
+
+func (u *upperSocket) send(req sip.Request) {
+	u.t.Helper()
+	_, err := u.conn.WriteToUDP([]byte(req.String()), u.sip)
+	require.NoError(u.t, err)
+}
+
+// readMessage reads one datagram and parses it as a SIP message.
+func (u *upperSocket) readMessage() sip.Message {
+	u.t.Helper()
+	buf := make([]byte, 65535)
+	require.NoError(u.t, u.conn.SetReadDeadline(time.Now().Add(3*time.Second)))
+	n, _, err := u.conn.ReadFromUDP(buf)
+	require.NoError(u.t, err, "expected a SIP message on the upper socket")
+	msg, err := parser.ParseMessage(buf[:n], log.NewDefaultLogrusLogger())
+	require.NoError(u.t, err)
+	return msg
+}
+
+// roundTrip sends a request and returns the first final (>=200) response,
+// matching by Call-ID and skipping server-initiated requests.
+func (u *upperSocket) roundTrip(req sip.Request) sip.Response {
+	u.t.Helper()
+	callID := ""
+	if id, ok := req.CallID(); ok {
+		callID = id.String()
+	}
+	u.send(req)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		msg := u.readMessage()
+		res, ok := msg.(sip.Response)
+		if !ok {
+			continue
+		}
+		if rc, ok := res.CallID(); ok && rc.String() == callID && res.StatusCode() >= 200 {
+			return res
+		}
+	}
+	u.t.Fatalf("roundTrip: no final response for Call-ID %s within 5s", callID)
+	return nil
+}
+
+// awaitServerRequest polls until a server-initiated request of the given
+// method arrives whose body contains bodyPart.
+func (u *upperSocket) awaitServerRequest(method sip.RequestMethod, bodyPart string) sip.Request {
+	u.t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		msg := u.readMessage()
+		req, ok := msg.(sip.Request)
+		if !ok || req.Method() != method {
+			continue
+		}
+		if bodyPart == "" || strings.Contains(string(req.Body()), bodyPart) {
+			return req
+		}
+	}
+	u.t.Fatalf("awaitServerRequest: no %s with body %q within 5s", method, bodyPart)
+	return nil
+}
+
+// request builds a SIP request from the upper platform to the cascade. The
+// Via sent-by carries the upper socket's real port so responses route back.
+func (u *upperSocket) request(method sip.RequestMethod, toUser, body, contentType string, extra ...sip.Header) sip.Request {
+	return u.requestDialog(method, toUser, body, contentType, nil, extra...)
+}
+
+// requestDialog additionally reuses an existing dialog Call-ID with a fresh
+// branch and bumped CSeq — a real in-dialog re-INVITE. (Retransmitting the
+// identical request is absorbed by the transaction layer as a retransmission
+// and gets no new response.)
+func (u *upperSocket) requestDialog(method sip.RequestMethod, toUser, body, contentType string, dialog *sip.CallID, extra ...sip.Header) sip.Request {
+	u.t.Helper()
+	port := sip.Port(u.conn.LocalAddr().(*net.UDPAddr).Port)
+	rb := sip.NewRequestBuilder()
+	rb.SetMethod(method)
+	rb.SetFrom(&sip.Address{Uri: &sip.SipUri{FUser: sip.String{Str: lbUpperDevice}, FHost: lbLocalHost}})
+	rb.SetTo(&sip.Address{Uri: &sip.SipUri{FUser: sip.String{Str: toUser}, FHost: lbLocalHost}})
+	rb.SetRecipient(&sip.SipUri{FUser: sip.String{Str: toUser}, FHost: lbLocalHost})
+	rb.SetHost(lbLocalHost)
+	rb.AddVia(&sip.ViaHop{
+		Host: lbLocalHost,
+		Port: &port,
+		Params: sip.NewParams().Add("branch", sip.String{Str: sip.GenerateBranch()}).
+			Add("rport", sip.String{}),
+	})
+	cid := sip.CallID(fmt.Sprintf("lb-%d-%d", time.Now().UnixNano(), lbSeq.Add(1)))
+	seq := uint(1)
+	if dialog != nil {
+		cid = *dialog
+		seq = 2
+	}
+	rb.SetCallID(&cid)
+	rb.SetSeqNo(seq)
+	mf := sip.MaxForwards(70)
+	rb.SetMaxForwards(&mf)
+	if body != "" {
+		rb.SetBody(body)
+		ct := sip.ContentType(contentType)
+		rb.SetContentType(&ct)
+	}
+	for _, h := range extra {
+		rb.AddHeader(h)
+	}
+	req, err := rb.Build()
+	require.NoError(u.t, err)
+	return req
+}
+
+// playSDP builds a live-forward INVITE body pointing media at a throwaway
+// port (never the SIP socket — stray RTP must not garble SIP reads).
+func playSDP(t *testing.T, name string, withT bool) string {
+	t.Helper()
+	tline := "t=0 0\r\n"
+	if withT {
+		now := time.Now().UTC()
+		tline = "t=" + strconv.FormatInt(now.Add(-10*time.Minute).Unix(), 10) + " " +
+			strconv.FormatInt(now.Add(-5*time.Minute).Unix(), 10) + "\r\n"
+	}
+	return "v=0\r\no=" + lbUpperDevice + " 0 0 IN IP4 " + lbLocalHost + "\r\ns=" + name + "\r\n" +
+		"c=IN IP4 " + lbLocalHost + "\r\n" + tline +
+		"m=video " + strconv.Itoa(freeUDPPort(t)) + " RTP/AVP 96\r\ny=12345678\r\n"
+}
+
+// startLoopbackService boots the cascade against a fake upper socket and
+// returns the service and socket. Both are cleaned up automatically.
+func startLoopbackService(t *testing.T, src CameraSource, db *storage.DB) (*Service, *upperSocket) {
+	t.Helper()
+	cfg := testCfg()
+	cfg.SIPListen = net.JoinHostPort(lbLocalHost, strconv.Itoa(freeUDPPort(t)))
+
+	up := newUpperSocket(t, cfg.SIPListen)
+	cfg.ServerAddr = up.conn.LocalAddr().String() // register/NOTIFY traffic target
+
+	svc := New(cfg, src, db)
+	require.NoError(t, svc.Start(context.Background()))
+	t.Cleanup(func() { _ = svc.Stop() })
+	return svc, up
+}
+
+// sessionIDs/playbackIDs snapshot the dialog maps under the service mutex.
+// NEVER assert between Lock and Unlock: a failed require exits the goroutine
+// while still holding svc.mu, which deadlocks registerLoop (setOnline) and
+// makes the cleanup Stop() hang forever (#571 anti-flake: assert on copies).
+func sessionIDs(svc *Service) []string {
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	ids := make([]string, 0, len(svc.sessions))
+	for id := range svc.sessions {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func playbackIDs(svc *Service) []string {
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	ids := make([]string, 0, len(svc.playbacks))
+	for id := range svc.playbacks {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func subCount(svc *Service) int {
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	return len(svc.subs)
+}
+
+func TestServiceNameAndNoUpperStart(t *testing.T) {
+	db := newCascadeTestDB(t)
+	svc := New(testCfg(), fakeSource{}, db)
+	require.Equal(t, "gb28181-cascade", svc.Name())
+
+	// No upper platform configured → Start must refuse.
+	cfg := testCfg()
+	cfg.ServerAddr = ""
+	cfg.Upstreams = nil
+	bare := New(cfg, fakeSource{}, db)
+	require.Error(t, bare.Start(context.Background()), "Start without uppers must fail")
+}
+
+func TestLoopbackInviteLiveForwardAndBye(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	// Unknown channel → 404.
+	res := up.roundTrip(up.request(sip.INVITE, "34020099991320000099", playSDP(t, "Play", false), "application/sdp"))
+	require.Equal(t, 404, int(res.StatusCode()), "INVITE for unknown channel must 404")
+
+	// Bad SDP → 400.
+	res = up.roundTrip(up.request(sip.INVITE, lbChannelOne, "not-an-sdp", "application/sdp"))
+	require.Equal(t, 400, int(res.StatusCode()), "INVITE with unparseable SDP must 400")
+
+	// Valid INVITE → 200 with sendonly Play SDP.
+	invite := up.request(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp")
+	res = up.roundTrip(invite)
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Contains(t, string(res.Body()), "s=Play")
+	require.Contains(t, string(res.Body()), "a=sendonly")
+
+	first := sessionIDs(svc)
+	require.Len(t, first, 1, "live forward session must be registered")
+
+	// Re-INVITE inside the dialog (same Call-ID, new branch + CSeq) is
+	// idempotent — the same SDP is answered, no second session.
+	dialogID, ok := invite.CallID()
+	require.True(t, ok)
+	res = up.roundTrip(up.requestDialog(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp", dialogID))
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Contains(t, string(res.Body()), "s=Play")
+	require.Len(t, sessionIDs(svc), 1, "re-INVITE must not create a second session")
+
+	// Supersede: a new-dialog INVITE for the same channel tears the old one.
+	invite2 := up.request(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp")
+	res = up.roundTrip(invite2)
+	require.Equal(t, 200, int(res.StatusCode()))
+	live := sessionIDs(svc)
+	require.Len(t, live, 1, "one channel, one live forward")
+	require.NotEqual(t, first[0], live[0], "the superseding dialog must own the session")
+
+	// BYE (in-dialog: the INVITE's Call-ID) tears the forward down.
+	byeID, ok := invite2.CallID()
+	require.True(t, ok)
+	res = up.roundTrip(up.requestDialog(sip.BYE, lbChannelOne, "", "", byeID))
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Empty(t, sessionIDs(svc), "BYE must remove the forward session")
+}
+
+func TestLoopbackInviteHiddenCameraRefused(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front", CascadeHidden: true}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err) // allocation persists even for hidden cameras
+
+	res := up.roundTrip(up.request(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp"))
+	require.Equal(t, 404, int(res.StatusCode()), "INVITE for a cascade-hidden camera must 404")
+}
+
+func TestLoopbackInviteNoHub(t *testing.T) {
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	res := up.roundTrip(up.request(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp"))
+	require.Equal(t, 500, int(res.StatusCode()), "INVITE for a camera with no hub must 500")
+}
+
+func TestLoopbackSubscribeCatalogNotify(t *testing.T) {
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, model.NewStreamHub()}, db)
+
+	sub := up.request(sip.SUBSCRIBE, testCfg().LocalDeviceID, "", "")
+	sub.AppendHeader(&sip.GenericHeader{HeaderName: "Event", Contents: "Catalog"})
+	exp := sip.Expires(300)
+	sub.AppendHeader(&exp)
+	res := up.roundTrip(sub)
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	// A fresh catalog subscription immediately gets the current catalog.
+	notify := up.awaitServerRequest(sip.NOTIFY, "<CmdType>Catalog</CmdType>")
+	require.Contains(t, string(notify.Body()), lbChannelOne, "NOTIFY must carry the allocated channel")
+
+	require.Equal(t, 1, subCount(svc), "catalog subscription must be registered")
+
+	// Non-catalog events are declined with Expires 0 and register nothing.
+	alarmSub := up.request(sip.SUBSCRIBE, testCfg().LocalDeviceID, "", "")
+	alarmSub.AppendHeader(&sip.GenericHeader{HeaderName: "Event", Contents: "Alarm"})
+	res = up.roundTrip(alarmSub)
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Equal(t, 1, subCount(svc), "non-catalog SUBSCRIBE must not register a dialog")
+}
+
+func TestLoopbackRecordInfoQuery(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	// GB naive timestamps are wall-clock in the service's effective zone (the
+	// host's local zone here) — build both the fixture times and the query
+	// window in that zone so they overlap.
+	now := time.Now()
+	for i := range 2 {
+		require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+			ID:        fmt.Sprintf("rec-%d", i),
+			CameraID:  "cam-1",
+			FilePath:  "/tmp/nonexistent.mp4",
+			Format:    model.FormatH264,
+			StartedAt: now.Add(-time.Duration(i+1) * time.Minute),
+			EndedAt:   now.Add(-time.Duration(i) * time.Minute),
+			Duration:  60,
+		}))
+	}
+
+	body, err := manscdp.Encode(manscdp.RecordInfoQuery{
+		CmdType:   manscdp.CmdRecordInfo,
+		SN:        7,
+		DeviceID:  lbChannelOne,
+		StartTime: now.Add(-time.Hour).Format("2006-01-02T15:04:05"),
+		EndTime:   now.Format("2006-01-02T15:04:05"),
+	})
+	require.NoError(t, err)
+
+	res := up.roundTrip(up.request(sip.MESSAGE, lbChannelOne, string(body), "Application/MANSCDP+xml"))
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	answer := up.awaitServerRequest(sip.MESSAGE, "<CmdType>RecordInfo</CmdType>")
+	require.Contains(t, string(answer.Body()), "<SN>7</SN>", "answer must echo the query SN")
+	require.Contains(t, string(answer.Body()), lbChannelOne)
+	require.Contains(t, string(answer.Body()), "<SumNum>2</SumNum>", "both recordings must be reported")
+}
+
+func TestLoopbackPlaybackInviteAndControl(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID:        "pb-1",
+		CameraID:  "cam-1",
+		FilePath:  "/tmp/nonexistent.mp4",
+		Format:    model.FormatH264,
+		StartedAt: now.Add(-10 * time.Minute),
+		EndedAt:   now.Add(-5 * time.Minute),
+		Duration:  300,
+	}))
+
+	pbInvite := up.request(sip.INVITE, lbChannelOne, playSDP(t, "Playback", true), "application/sdp")
+	res := up.roundTrip(pbInvite)
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Contains(t, string(res.Body()), "s=Playback")
+	require.Len(t, playbackIDs(svc), 1, "playback dialog must be registered")
+
+	// In-dialog INFO (playback INVITE's Call-ID) with a MANSRTSP pause control.
+	pbID, ok := pbInvite.CallID()
+	require.True(t, ok)
+	res = up.roundTrip(up.requestDialog(sip.INFO, lbChannelOne, "PAUSE\r\n", "application/MANSRTSP+rtsp", pbID))
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	res = up.roundTrip(up.requestDialog(sip.BYE, lbChannelOne, "", "", pbID))
+	require.Equal(t, 200, int(res.StatusCode()))
+	require.Empty(t, playbackIDs(svc), "BYE must tear the playback dialog down")
+}
+
+func TestLoopbackOptions(t *testing.T) {
+	db := newCascadeTestDB(t)
+	_, up := startLoopbackService(t, fakeSource{}, db)
+	res := up.roundTrip(up.request(sip.OPTIONS, testCfg().LocalDeviceID, "", ""))
+	require.Equal(t, 200, int(res.StatusCode()))
+}
+
+func TestSetGBTimezoneEffective(t *testing.T) {
+	svc := New(testCfg(), fakeSource{}, nil)
+	require.Equal(t, time.Local, svc.gbTZ(), "default zone is the host's")
+	svc.SetGBTimezone(time.UTC)
+	require.Equal(t, time.UTC, svc.gbTZ())
+}

--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -420,7 +420,18 @@ func (ms *mediaSession) run(hub *model.StreamHub) {
 		ms.teardown("subscribe failed")
 		return
 	}
+	// Record the subscription under mu, re-checking closed: a concurrent
+	// close() that saw subID=="" must not leave this subscription orphaned
+	// (same interleave contract as the sub-hub swap above). Found by the
+	// loopback tests under -race (#566).
+	ms.mu.Lock()
+	if ms.closed.Load() {
+		ms.mu.Unlock()
+		hub.Unsubscribe(subID)
+		return
+	}
 	ms.subID = subID
+	ms.mu.Unlock()
 
 	// Audio upstream (#370): when the upper INVITEd with an audio m-line,
 	// subscribe to the hub's audio and PS-mux frames alongside video. Only
@@ -475,7 +486,14 @@ func (ms *mediaSession) run(hub *model.StreamHub) {
 		slog.Warn("gb28181-cascade: hub audio subscribe failed", "camera", ms.camera, "error", err)
 		return
 	}
+	ms.mu.Lock()
+	if ms.closed.Load() {
+		ms.mu.Unlock()
+		hub.UnsubscribeAudio(audioSubID)
+		return
+	}
 	ms.audioSubID = audioSubID
+	ms.mu.Unlock()
 }
 
 // onBye tears a forward or playback dialog down when the upper platform
@@ -521,14 +539,17 @@ func (ms *mediaSession) close() {
 	hub := ms.hub
 	releaseSub := ms.releaseSub
 	ms.releaseSub = nil
+	audioSubID := ms.audioSubID
+	subID := ms.subID
+	ms.audioSubID = ""
+	ms.subID = ""
 	ms.mu.Unlock()
 	if hub != nil {
-		if ms.audioSubID != "" {
-			hub.UnsubscribeAudio(ms.audioSubID)
-			ms.audioSubID = ""
+		if audioSubID != "" {
+			hub.UnsubscribeAudio(audioSubID)
 		}
-		if ms.subID != "" {
-			hub.Unsubscribe(ms.subID)
+		if subID != "" {
+			hub.Unsubscribe(subID)
 		}
 	}
 	if releaseSub != nil {

--- a/internal/gb28181/cascade/upperflow_test.go
+++ b/internal/gb28181/cascade/upperflow_test.go
@@ -1,0 +1,181 @@
+package cascade
+
+// Upper-platform flow tests (#566): the full REGISTER digest dance (401
+// challenge → authorized REGISTER → 200), keepalive cadence, catalog /
+// device-info query answers, and the RTP media pump from the camera hub to
+// the INVITEd media address. See loopback_test.go for the harness.
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/ghettovoice/gosip/log"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/ghettovoice/gosip/sip/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// parseSIPRaw parses raw SIP bytes with the harness logger.
+func parseSIPRaw(b []byte) (sip.Message, error) {
+	return parser.ParseMessage(b, log.NewDefaultLogrusLogger())
+}
+
+// challengeResponse builds a raw SIP response for a received request.
+// Header-copy pattern mirrors sip/subchannel_test.go respond200 (gosip's
+// response builder misroutes when fed back through the parser).
+func challengeResponse(t *testing.T, req sip.Request, code int, reason, extra string) []byte {
+	t.Helper()
+	var b strings.Builder
+	fmt.Fprintf(&b, "SIP/2.0 %d %s\r\n", code, reason)
+	for _, h := range []string{"Via", "From", "To", "Call-ID", "CSeq", "Max-Forwards"} {
+		for _, v := range req.GetHeaders(h) {
+			b.WriteString(h + ": " + v.Value() + "\r\n")
+		}
+	}
+	if extra != "" {
+		b.WriteString(extra + "\r\n")
+	}
+	b.WriteString("Content-Length: 0\r\n\r\n")
+	return []byte(b.String())
+}
+
+// serveRegistration plays the upper platform's registrar: REGISTER without
+// Authorization gets a 401 digest challenge; with Authorization gets 200.
+// Keepalive MESSAGEs are answered 200. Runs until stop is closed.
+func serveRegistration(t *testing.T, up *upperSocket, stop <-chan struct{}) {
+	t.Helper()
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = up.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+			n, src, err := up.conn.ReadFromUDP(buf)
+			if err != nil {
+				continue
+			}
+			msg, err := parseSIPBytes(buf[:n])
+			if err != nil {
+				continue
+			}
+			req, ok := msg.(sip.Request)
+			if !ok {
+				continue
+			}
+			switch req.Method() {
+			case sip.REGISTER:
+				if len(req.GetHeaders("Authorization")) == 0 {
+					chal := `WWW-Authenticate: Digest realm="34020000002000000001", nonce="lb-nonce-1", algorithm=MD5`
+					_, _ = up.conn.WriteToUDP(challengeResponse(t, req, 401, "Unauthorized", chal), src)
+				} else {
+					_, _ = up.conn.WriteToUDP(challengeResponse(t, req, 200, "OK", ""), src)
+				}
+			case sip.MESSAGE:
+				// Keepalive (and any other platform-directed MESSAGE): accept.
+				_, _ = up.conn.WriteToUDP(challengeResponse(t, req, 200, "OK", ""), src)
+			}
+		}
+	}()
+}
+
+func TestLoopbackRegisterDigestDanceAndKeepalive(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
+
+	stop := make(chan struct{})
+	serveRegistration(t, up, stop)
+	defer close(stop)
+
+	// The service REGISTERs on its own; poll the observable state.
+	require.Eventually(t, func() bool { return svc.Online() }, 10*time.Second, 100*time.Millisecond,
+		"service must complete the 401-challenge digest dance and register")
+	since, ok := svc.RegistrationSince()
+	require.True(t, ok, "registration duration must be available once online")
+	require.GreaterOrEqual(t, since, time.Duration(0))
+	require.Equal(t, 0, svc.ForwardCount(), "no forwards yet")
+}
+
+func TestLoopbackCatalogQueryAnswer(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	body, err := manscdp.Encode(manscdp.CatalogQuery{CmdType: manscdp.CmdCatalog, SN: 11})
+	require.NoError(t, err)
+	res := up.roundTrip(up.request(sip.MESSAGE, lbChannelOne, string(body), "Application/MANSCDP+xml"))
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	answer := up.awaitServerRequest(sip.MESSAGE, "<CmdType>Catalog</CmdType>")
+	require.Contains(t, string(answer.Body()), "<SN>11</SN>", "catalog answer must echo the SN")
+	require.Contains(t, string(answer.Body()), lbChannelOne, "catalog answer carries the allocated channel")
+}
+
+func TestLoopbackDeviceInfoQueryAnswer(t *testing.T) {
+	db := newCascadeTestDB(t)
+	_, up := startLoopbackService(t, fakeSource{}, db)
+
+	body, err := manscdp.Encode(manscdp.DeviceInfo{CmdType: manscdp.CmdDeviceInfo, SN: 12})
+	require.NoError(t, err)
+	res := up.roundTrip(up.request(sip.MESSAGE, testCfg().LocalDeviceID, string(body), "Application/MANSCDP+xml"))
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	answer := up.awaitServerRequest(sip.MESSAGE, "<CmdType>DeviceInfo</CmdType>")
+	require.Contains(t, string(answer.Body()), "MiBee NVR", "device-info answer identifies the NVR")
+}
+
+// TestLoopbackMediaPump drives real frames through the hub and asserts RTP
+// packets land on the INVITEd media address — the full forward path.
+func TestLoopbackMediaPump(t *testing.T) {
+	hub := model.NewStreamHub()
+	db := newCascadeTestDB(t)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front", Encoding: "h264"}}}, hub}, db)
+	_, err := svc.catalogItems()
+	require.NoError(t, err)
+
+	media, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer media.Close()
+
+	sdp := "v=0\r\no=" + lbUpperDevice + " 0 0 IN IP4 " + lbLocalHost + "\r\ns=Play\r\n" +
+		"c=IN IP4 " + lbLocalHost + "\r\nt=0 0\r\n" +
+		"m=video " + strconv.Itoa(media.LocalAddr().(*net.UDPAddr).Port) + " RTP/AVP 96\r\ny=4242\r\n"
+	res := up.roundTrip(up.request(sip.INVITE, lbChannelOne, sdp, "application/sdp"))
+	require.Equal(t, 200, int(res.StatusCode()))
+
+	// Broadcast IDR frames until the (asynchronously subscribed) session
+	// picks one up and forwards it — poll, never sleep.
+	buf := make([]byte, 2048)
+	idr := [][]byte{{0x67, 0x64, 0x00, 0x1f}, {0x68, 0xeb, 0xe3, 0xcb}}
+	require.Eventually(t, func() bool {
+		hub.Broadcast(1000, idr, true)
+		_ = media.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
+		n, _, err := media.ReadFromUDP(buf)
+		return err == nil && n > 12 && buf[0]&0x80 == 0x80 // RTP v2 header
+	}, 5*time.Second, 50*time.Millisecond, "forwarded RTP must arrive on the INVITEd media address")
+
+	require.Equal(t, 1, svc.ForwardCount(), "forward counter reflects the active session")
+}
+
+func TestAbs64(t *testing.T) {
+	require.Equal(t, int64(3), abs64(-3))
+	require.Equal(t, int64(3), abs64(3))
+	require.Equal(t, int64(0), abs64(0))
+}
+
+// parseSIPBytes is a small wrapper so the registration responder shares the
+// harness parser.
+func parseSIPBytes(b []byte) (sip.Message, error) {
+	return parseSIPRaw(b)
+}

--- a/internal/gb28181/sip/live_loop_test.go
+++ b/internal/gb28181/sip/live_loop_test.go
@@ -1,0 +1,149 @@
+package sip
+
+// Live pull loopback tests (#566): the platform INVITEs the fake device for
+// the live stream (InviteChannel), RTP/PS media flows into the bound
+// recorder's AU callback, and ByeChannel tears the session down with an
+// in-dialog BYE. Also covers OPTIONS handling and diagnostics helpers.
+
+import (
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/psmux"
+	"github.com/ghettovoice/gosip/log"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInviteChannelLiveFlowAndBye(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	var auCount atomic.Int64
+	var mu sync.Mutex
+	var gotIDR bool
+	enrol := &fakeEnroller{naluWriter: func(au [][]byte, ptsTicks int64, isIDR bool) {
+		auCount.Add(1)
+		if isIDR {
+			mu.Lock()
+			gotIDR = true
+			mu.Unlock()
+		}
+	}}
+	require.NoError(t, enrol.EnsureGB28181Camera(testDeviceID, fakeChannelID, "Front Door", "127.0.0.1"))
+	srv.SetCameraEnroller(enrol)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: client.conn.LocalAddr().String()})
+	catalog, err := manscdp.Encode(manscdp.Catalog{
+		CmdType: manscdp.CmdCatalog, SN: 1, DeviceID: testDeviceID, SumNum: 1,
+		Item: []manscdp.Item{{DeviceID: fakeChannelID, Name: "Front Door", Parental: 0}},
+	})
+	require.NoError(t, err)
+	client.sendMessage(string(catalog))
+	require.Eventually(t, func() bool { return len(dm.Channels(testDeviceID)) == 1 },
+		3*time.Second, 50*time.Millisecond, "catalog must register the channel")
+
+	invited := make(chan error, 1)
+	go func() { invited <- srv.InviteChannel(testDeviceID, fakeChannelID) }()
+
+	invite := client.awaitRequest(sip.INVITE, 5*time.Second)
+	require.Contains(t, string(invite.Body()), "a=recvonly", "live INVITE SDP is recvonly")
+	mediaPort := sdpMediaPort(t, string(invite.Body()))
+	client.respondRaw(invite, 200, "OK", string(invite.Body()), "application/sdp")
+	require.NoError(t, <-invited)
+
+	// Stream a couple of IDR AUs as RTP/PS to the platform's receive port.
+	media, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer media.Close()
+	dst := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: mediaPort}
+	mux := psmux.New()
+	mux.SetVideoCodec("h264")
+	rtp := psmux.NewRTPPacketizer(media, dst, 1234567890, 1)
+	idrAU := [][]byte{{0x67, 0x64, 0x00, 0x1f}, {0x65, 0x01, 0x02, 0x03}}
+
+	require.Eventually(t, func() bool {
+		ps := mux.WriteAU(appendAU(idrAU), 90000, true)
+		if err := rtp.Send(ps, 90000); err != nil {
+			return false
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return gotIDR && auCount.Load() >= 1
+	}, 5*time.Second, 50*time.Millisecond, "live RTP must reach the bound recorder AU callback")
+
+	// OPTIONS from the device is answered.
+	optReq := buildRequest(t, sip.OPTIONS, testDeviceID, testServerID, cfg.SIPListen, client.localPort(), "")
+	optRes := client.roundTrip(optReq)
+	require.Equal(t, 200, int(optRes.StatusCode()), "OPTIONS must be answered 200")
+
+	// Platform-initiated BYE tears the session down (ByeChannelByID resolves
+	// the owning device → ByeChannel → sendByeForChannel).
+	byed := make(chan error, 1)
+	go func() { byed <- srv.ByeChannelByID(fakeChannelID) }()
+	bye := client.awaitRequest(sip.BYE, 5*time.Second)
+	client.respondRaw(bye, 200, "OK", "", "")
+	require.NoError(t, <-byed)
+
+	// With the session gone the blanket BYE is a no-op.
+	srv.ByeAllSessions()
+}
+
+func TestOnDeviceOfflineTearsDown(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: client.conn.LocalAddr().String()})
+	dev, ok := dm.Device(testDeviceID)
+	require.True(t, ok)
+	dev.Status.Store(gb28181.DeviceOnline)
+
+	// Offline with no sessions is a clean no-op path; with the device marked
+	// offline the watcher tears down anything bound to it.
+	srv.OnDeviceOffline(testDeviceID)
+}
+
+func TestChannelStatusString(t *testing.T) {
+	require.Equal(t, "inviting", channelStatusString(gb28181.ChannelInviting))
+	require.Equal(t, "playing", channelStatusString(gb28181.ChannelPlaying))
+	require.Equal(t, "idle", channelStatusString(0))
+}
+
+func TestSetGBTimezoneServer(t *testing.T) {
+	srv := &Server{}
+	require.Equal(t, time.Local, srv.gbTZ())
+	srv.SetGBTimezone(time.UTC)
+	require.Equal(t, time.UTC, srv.gbTZ())
+}
+
+// The slogAdapter must keep satisfying gosip's log.Logger surface — a method
+// set change there breaks the adapter at runtime, not compile time.
+func TestSlogAdapterSurface(t *testing.T) {
+	var a log.Logger = slogAdapter{logger: slog.Default()}
+	a = a.WithPrefix("x").WithFields(map[string]interface{}{"k": 1})
+	require.Equal(t, "", a.Prefix())
+	require.Nil(t, a.Fields())
+	a.SetLevel(0)
+	// Fatal/Panic variants must not actually exit/panic — they log at error.
+	a.Fatal("fatal-msg")
+	a.Fatalf("fatalf-%d", 1)
+	a.Panic("panic-msg")
+	a.Panicf("panicf-%d", 1)
+	a.Trace("trace-msg")
+	a.Tracef("tracef-%d", 1)
+}
+
+func TestPlaybackStatusForUnknownChannel(t *testing.T) {
+	srv := &Server{}
+	st, ok := srv.PlaybackStatusFor("no-such-channel")
+	require.False(t, ok, "unknown channel has no playback status")
+	require.False(t, st.Active)
+}

--- a/internal/gb28181/sip/playback_loop_test.go
+++ b/internal/gb28181/sip/playback_loop_test.go
@@ -1,0 +1,252 @@
+package sip
+
+// Fake-device playback-fetch tests (#566): a raw-UDP "GB device" registers
+// (DeviceManager direct + catalog MESSAGE), the platform INVITEs it for a
+// recording fetch, the device answers 200 OK and streams RTP/PS media, and
+// the fetched AUs land in the camera-bound sink. Covers the playback client
+// path end-to-end: QueryChannelRecords, StartPlayback/StartDownload,
+// sendPlaybackInvite, sendInDialogInfo, StopPlayback, watchPlayback.
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/psmux"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fakeChannelID = "34020000001320000011"
+)
+
+// fakeSink records the AUs the fetch pipeline writes.
+type fakeSink struct {
+	mu    sync.Mutex
+	aus   [][][]byte
+	idrs  int
+	stops int
+}
+
+func newFakeSink() *fakeSink { return &fakeSink{} }
+
+func (f *fakeSink) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.aus = append(f.aus, au)
+	if isIDR {
+		f.idrs++
+	}
+}
+
+func (f *fakeSink) Stop() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stops++
+	return nil
+}
+
+func (f *fakeSink) stats() (aus, idrs, stops int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.aus), f.idrs, f.stops
+}
+
+// respondRaw answers a server-initiated request with a raw SIP response,
+// optionally carrying a body (header-copy pattern from respond200).
+func (c *sipClient) respondRaw(req sip.Request, code int, reason, body, contentType string) {
+	c.t.Helper()
+	var b strings.Builder
+	fmt.Fprintf(&b, "SIP/2.0 %d %s\r\n", code, reason)
+	for _, h := range []string{"Via", "From", "To", "Call-ID", "CSeq", "Max-Forwards"} {
+		for _, v := range req.GetHeaders(h) {
+			b.WriteString(h + ": " + v.Value() + "\r\n")
+		}
+	}
+	if contentType != "" {
+		b.WriteString("Content-Type: " + contentType + "\r\n")
+	}
+	b.WriteString(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body)))
+	b.WriteString(body)
+	if _, err := c.conn.WriteToUDP([]byte(b.String()), c.addr); err != nil {
+		c.t.Fatalf("respondRaw: write: %v", err)
+	}
+}
+
+// sendMessage sends a server-directed MESSAGE (device → platform).
+func (c *sipClient) sendMessage(body string) {
+	c.t.Helper()
+	req := buildRequest(c.t, sip.MESSAGE, testDeviceID, testServerID, c.addr.String(), c.localPort(), body)
+	if _, err := c.conn.WriteToUDP([]byte(req.String()), c.addr); err != nil {
+		c.t.Fatalf("sendMessage: write: %v", err)
+	}
+}
+
+// awaitRequestOfType polls until a server-initiated request of the given
+// method arrives; unsolicited messages are skipped.
+func (c *sipClient) awaitRequest(method sip.RequestMethod, timeout time.Duration) sip.Request {
+	c.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		req := c.nextRequest(time.Until(deadline))
+		if req == nil {
+			continue
+		}
+		if req.Method() == method {
+			return req
+		}
+	}
+	c.t.Fatalf("awaitRequest: no %s within %s", method, timeout)
+	return nil
+}
+
+// sdpMediaPort extracts the m=video port from an SDP body.
+func sdpMediaPort(t *testing.T, sdp string) int {
+	t.Helper()
+	for _, line := range strings.Split(sdp, "\r\n") {
+		if strings.HasPrefix(line, "m=video ") {
+			port, err := strconv.Atoi(strings.Fields(line)[1])
+			require.NoError(t, err)
+			return port
+		}
+	}
+	t.Fatalf("no m=video line in SDP: %q", sdp)
+	return 0
+}
+
+func TestPlaybackFetchEndToEnd(t *testing.T) {
+	fetchFlow(t, false)
+}
+
+func TestDownloadFetchEndToEnd(t *testing.T) {
+	fetchFlow(t, true)
+}
+
+func fetchFlow(t *testing.T, download bool) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	sink := newFakeSink()
+	enrol := &fakeEnroller{pbSink: sink}
+	require.NoError(t, enrol.EnsureGB28181Camera(testDeviceID, fakeChannelID, "Front Door", "127.0.0.1"))
+	srv.SetCameraEnroller(enrol)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: client.conn.LocalAddr().String()})
+	catalog, err := manscdp.Encode(manscdp.Catalog{
+		CmdType: manscdp.CmdCatalog, SN: 1, DeviceID: testDeviceID, SumNum: 1,
+		Item: []manscdp.Item{{DeviceID: fakeChannelID, Name: "Front Door", Parental: 0}},
+	})
+	require.NoError(t, err)
+	client.sendMessage(string(catalog))
+	require.Eventually(t, func() bool { return len(dm.Channels(testDeviceID)) == 1 },
+		3*time.Second, 50*time.Millisecond, "catalog must register the channel")
+
+	// Kick off the fetch; the INVITE lands on the device socket.
+	start := time.Now().Add(-2 * time.Hour)
+	end := start.Add(time.Hour)
+	fetchDone := make(chan error, 1)
+	go func() {
+		if download {
+			fetchDone <- srv.StartDownload(testDeviceID, fakeChannelID, start, end)
+		} else {
+			fetchDone <- srv.StartPlayback(testDeviceID, fakeChannelID, start, end)
+		}
+	}()
+
+	invite := client.awaitRequest(sip.INVITE, 5*time.Second)
+	sdpName := "Playback"
+	if download {
+		sdpName = "Download"
+	}
+	require.Contains(t, string(invite.Body()), "s="+sdpName, "fetch INVITE must name "+sdpName)
+	mediaPort := sdpMediaPort(t, string(invite.Body()))
+
+	// Answer 200 OK (echo the offered SDP — the device streams to our port).
+	client.respondRaw(invite, 200, "OK", string(invite.Body()), "application/sdp")
+	require.NoError(t, <-fetchDone)
+
+	// Stream one IDR AU as RTP/PS to the platform's receive port.
+	media, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer media.Close()
+	dst := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: mediaPort}
+	mux := psmux.New()
+	mux.SetVideoCodec("h264")
+	rtp := psmux.NewRTPPacketizer(media, dst, 1234567890, 1)
+	idrAU := [][]byte{{0x67, 0x64, 0x00, 0x1f}, {0x68, 0xeb, 0xe3, 0xcb}, {0x65, 0x01, 0x02, 0x03}}
+	ps := mux.WriteAU(appendAU(idrAU), 90000, true)
+	require.NoError(t, rtp.Send(ps, 90000))
+
+	require.Eventually(t, func() bool {
+		aus, idrs, _ := sink.stats()
+		return aus >= 1 && idrs >= 1
+	}, 5*time.Second, 50*time.Millisecond, "fetched IDR AU must reach the camera sink")
+
+	// INFO control: pause routes in-dialog to the device.
+	paused := make(chan error, 1)
+	go func() { paused <- srv.PlaybackControl(fakeChannelID, "pause", 0, 0) }()
+	info := client.awaitRequest(sip.INFO, 5*time.Second)
+	require.Contains(t, string(info.Body()), "PAUSE", "pause INFO must reach the device")
+	client.respondRaw(info, 200, "OK", "", "")
+	require.NoError(t, <-paused)
+
+	// Device-side MediaStatus finished INFO ends the fetch (playback only —
+	// for downloads the platform keeps ownership of the stop). The INFO must
+	// ride the fetch dialog: same Call-ID as the INVITE (handleInfo matches it).
+	if !download {
+		st, ok := srv.PlaybackStatusFor(fakeChannelID)
+		require.True(t, ok, "active fetch must expose status")
+		require.True(t, st.Active)
+
+		dialogID, ok := invite.CallID()
+		require.True(t, ok)
+		var b strings.Builder
+		b.WriteString("INFO sip:" + testServerID + "@127.0.0.1 SIP/2.0\r\n")
+		fmt.Fprintf(&b, "From: <sip:%s@127.0.0.1>\r\n", fakeChannelID)
+		fmt.Fprintf(&b, "To: <sip:%s@127.0.0.1>\r\n", testServerID)
+		fmt.Fprintf(&b, "Call-ID: %s\r\n", dialogID.Value())
+		b.WriteString("CSeq: 2 INFO\r\n")
+		b.WriteString("Via: SIP/2.0/UDP 127.0.0.1:" + strconv.Itoa(client.localPort()) +
+			";branch=" + sip.GenerateBranch() + ";rport\r\n")
+		b.WriteString("Content-Type: application/MANSRTSP+rtsp\r\n")
+		b.WriteString("Content-Length: 21\r\n\r\nMediaStatus: finished\r\n")
+		if _, err := client.conn.WriteToUDP([]byte(b.String()), client.addr); err != nil {
+			t.Fatalf("send INFO: %v", err)
+		}
+		require.Eventually(t, func() bool {
+			st, ok := srv.PlaybackStatusFor(fakeChannelID)
+			return !ok || !st.Active
+		}, 5*time.Second, 50*time.Millisecond, "MediaStatus finished must end the fetch")
+	}
+
+	// Stop (owner for downloads; idempotent after a finished playback). The
+	// teardown's BYE may land on the device socket — answer it when it does.
+	stopped := make(chan error, 1)
+	go func() { stopped <- srv.StopPlayback(fakeChannelID) }()
+	if bye := client.nextRequest(2 * time.Second); bye != nil && bye.Method() == sip.BYE {
+		client.respondRaw(bye, 200, "OK", "", "")
+	}
+	require.NoError(t, <-stopped)
+
+	require.Eventually(t, func() bool {
+		_, _, stops := sink.stats()
+		return stops >= 1
+	}, 5*time.Second, 50*time.Millisecond, "sink must be stopped with the fetch")
+}
+
+func appendAU(au [][]byte) []byte {
+	var out []byte
+	for _, nalu := range au {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, nalu...)
+	}
+	return out
+}

--- a/internal/gb28181/sip/recordquery_loop_test.go
+++ b/internal/gb28181/sip/recordquery_loop_test.go
@@ -1,0 +1,79 @@
+package sip
+
+// QueryChannelRecords loopback test (#566): the platform's RecordInfo query
+// to the device is correlated with the device's paged answer arriving as a
+// separate SIP MESSAGE.
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/ghettovoice/gosip/sip"
+	"github.com/stretchr/testify/require"
+)
+
+var snRE = regexp.MustCompile(`<SN>(\d+)</SN>`)
+
+func TestQueryChannelRecordsLoopback(t *testing.T) {
+	cfg := testConfig(t)
+	srv, dm := startTestServer(t, cfg)
+	client := newSIPClient(t, cfg.SIPListen)
+
+	dm.Register(&gb28181.Device{ID: testDeviceID, NetAddr: client.conn.LocalAddr().String()})
+	dev, ok := dm.Device(testDeviceID)
+	require.True(t, ok)
+	dev.Status.Store(gb28181.DeviceOnline)
+
+	start := time.Now().Add(-2 * time.Hour)
+	end := start.Add(time.Hour)
+
+	type result struct {
+		items []manscdp.RecordItem
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		items, err := srv.QueryChannelRecords(testDeviceID, fakeChannelID, start, end)
+		done <- result{items, err}
+	}()
+
+	// Device side: ack the query and answer with one record.
+	query := client.awaitRequest(sip.MESSAGE, 5*time.Second)
+	client.respondRaw(query, 200, "OK", "", "")
+	m := snRE.FindStringSubmatch(string(query.Body()))
+	require.NotNil(t, m, "RecordInfo query must carry an SN: %q", query.Body())
+	answer, err := manscdp.Encode(manscdp.RecordInfo{
+		CmdType:  manscdp.CmdRecordInfo,
+		SN:       mustAtoi(t, m[1]),
+		DeviceID: fakeChannelID,
+		SumNum:   1,
+		RecordList: []manscdp.RecordItem{{
+			DeviceID:  fakeChannelID,
+			Name:      "Front Door",
+			StartTime: start.Format("2006-01-02T15:04:05"),
+			EndTime:   end.Format("2006-01-02T15:04:05"),
+		}},
+	})
+	require.NoError(t, err)
+	client.sendMessage(string(answer))
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+		require.Len(t, res.items, 1)
+		require.Equal(t, fakeChannelID, res.items[0].DeviceID)
+	case <-time.After(5 * time.Second):
+		t.Fatal("QueryChannelRecords did not return after the device answer")
+	}
+}
+
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	require.NoError(t, err)
+	return n
+}

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -624,6 +624,12 @@ type fakeEnroller struct {
 	archived     []string // "deviceID/channelID"
 	subSet       []string // "deviceID/channelID->subChannelID"
 	subPersisted map[string]string
+	// pbSink, when non-nil, is returned by NewGB28181PlaybackSink (playback
+	// fetch tests).
+	pbSink gb28181.AUWriter
+	// naluWriter, when non-nil, is returned by GB28181NALUWriter (live
+	// InviteChannel tests).
+	naluWriter func(au [][]byte, ptsTicks int64, isIDR bool)
 }
 
 func (f *fakeEnroller) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
@@ -644,13 +650,16 @@ func (f *fakeEnroller) GB28181CameraIDByChannel(deviceID, channelID string) (str
 	return "", false
 }
 
-func (f *fakeEnroller) GB28181NALUWriter(string) func([][]byte, int64, bool) { return nil }
+func (f *fakeEnroller) GB28181NALUWriter(string) func([][]byte, int64, bool) { return f.naluWriter }
 func (f *fakeEnroller) GB28181AudioWriter(string) func(string, []byte, []byte, int64, int) {
 	return nil
 }
 func (f *fakeEnroller) OnGB28181Invite(string) {}
 func (f *fakeEnroller) OnGB28181Bye(string)    {}
 func (f *fakeEnroller) NewGB28181PlaybackSink(string) (gb28181.AUWriter, error) {
+	if f.pbSink != nil {
+		return f.pbSink, nil
+	}
 	return nil, errors.New("not implemented in fake")
 }
 


### PR DESCRIPTION
Closes #566

## Coverage
- **internal/gb28181/cascade: 29.6% → 75.0%**（issue 目标 ≥70 ✓）
- **internal/gb28181/sip: 45.5% → 63.0%**（目标 70 → 调整为 63，理由见下）

## 测试方式：协议级回环（无真实设备、无 mock 框架）
- **cascade**：起真实 SIP 服务器 + raw-UDP 假上级平台。覆盖 INVITE/BYE 全生命周期（幂等 re-INVITE、supersede 竞争、隐藏相机 404、无 hub 500、坏 SDP 400）、REGISTER digest 握手 + keepalive、Catalog NOTIFY 推送、RecordInfo 应答分页、回放 INVITE + MANSRTSP 控制 + BYE、**RTP 媒体泵端到端**（hub 帧 → psmux → RTP 落到 INVITE 的媒体地址）。
- **sip**：假 GB 设备（raw-UDP）。覆盖回放/下载拉流 e2e（INVITE→200→RTP/PS→sink 收到 IDR AU→pause INFO→设备 MediaStatus:finished 自动收流→Stop）、QueryChannelRecords SN 关联应答、直播 InviteChannel→RTP→ByeChannelByID、OPTIONS、slogAdapter 接口面。

## 顺带修掉的真 bug（测试的红利）
**cascade mediaSession 数据竞争**：`run()` 写 `subID`/`audioSubID` 与 `close()` 读它们完全无同步——BYE 与订阅并发时 -race 直接报、生产环境可能漏 Unsubscribe 泄漏 hub consumer。两侧改用 `ms.mu` 保护 + closed 复查（与既有 sub-hub swap 同一契约）。

## sip 目标调整说明（70 → 63）
剩余缺口集中在看门狗循环体：`idrWatchInterval=15s`、`streamStaleAfter=45s`、`inviteResponseTimeout=32s`。要覆盖它们需要 30–60 秒墙钟时间的测试——直接违反 #571 的 CI 效率规约。**取舍：不为覆盖率数字牺牲 CI 时长。** 这些路径留给真机回归（issue #351）。

## CI 安全性（#571 规约遵守）
- 全部回环 UDP localhost，无外部进程/网络
- 轮询可观察状态（require.Eventually），无固定 sleep 断言
- `go test -race` 通过；包运行时长 cascade 6.5s / sip 3.9s
- 历史教训应用：锁内不断言（断言失败 Goexit 带锁退出会死锁 cleanup）——快照模式