### PR TITLE
test(relay): coverage 30.1%→55.5% — manager lifecycle, RTMP publish loopback, ffmpeg stubs (#567)

### DIFF
--- a/internal/relay/ffmpeg_harness_test.go
+++ b/internal/relay/ffmpeg_harness_test.go
@@ -1,0 +1,130 @@
+package relay
+
+// FFmpeg-subprocess relay tests (#567): the ffmpeg/ffprobe coupling is
+// exercised with hermetic stub scripts (echo fixtures — no real binaries),
+// plus the remaining pure helpers (splitRTMPPath, avsync.round1) and
+// CameraStatusJSON. See #571: fake scripts keep CI dependency-free.
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeSourceVideoFPS_ParsesFrameRate(t *testing.T) {
+	// ffprobe lives next to the "ffmpeg" binary — provide both.
+	dir := t.TempDir()
+	ffmpeg := filepath.Join(dir, "ffmpeg")
+	ffprobe := filepath.Join(dir, "ffprobe")
+	require.NoError(t, os.WriteFile(ffmpeg, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(t, os.WriteFile(ffprobe, []byte("#!/bin/sh\nprintf '15/1\\n'\n"), 0o755))
+
+	require.Equal(t, 15, probeSourceVideoFPS(ffmpeg, "rtsp://127.0.0.1:1/x"))
+}
+
+func TestProbeSourceVideoFPS_GarbageYieldsZero(t *testing.T) {
+	dir := t.TempDir()
+	ffmpeg := filepath.Join(dir, "ffmpeg")
+	require.NoError(t, os.WriteFile(ffmpeg, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(t, os.WriteFile(ffprobePath(t, dir), []byte("#!/bin/sh\nprintf 'not-a-rate\\n'\n"), 0o755))
+
+	require.Equal(t, 0, probeSourceVideoFPS(ffmpeg, "rtsp://127.0.0.1:1/x"))
+	require.Equal(t, 0, probeSourceVideoFPS("/nonexistent/ffmpeg", "rtsp://127.0.0.1:1/x"),
+		"missing binary path must degrade to 0, never error")
+}
+
+func ffprobePath(t *testing.T, dir string) string {
+	t.Helper()
+	return filepath.Join(dir, "ffprobe")
+}
+
+// connectViaFFmpeg with stub ffmpeg binaries: a clean exit 0 ends the relay
+// normally (nil error); a non-zero exit surfaces as an error.
+func TestConnectViaFFmpeg_StubProcess(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		script  string
+		wantErr bool
+	}{
+		{"clean exit", "#!/bin/sh\nexit 0\n", false},
+		{"failed exit", "#!/bin/sh\nexit 1\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ffmpeg := filepath.Join(dir, "ffmpeg")
+			require.NoError(t, os.WriteFile(ffmpeg, []byte(tc.script), 0o755))
+
+			target := NewPushTarget("cam1", PushTargetConfig{
+				ID: "ff", Protocol: "rtmp", URL: "rtmp://127.0.0.1:1/live/key",
+				SourceURL: "rtsp://127.0.0.1:1/src", UseFFmpeg: true,
+			}, newHubForRelay(), nil)
+			target.SetFFmpegPath(ffmpeg)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			err := target.connectAndStream(ctx)
+			if tc.wantErr {
+				require.Error(t, err, "non-zero ffmpeg exit must surface as an error")
+			} else {
+				require.NoError(t, err, "clean exit ends the relay without error")
+			}
+		})
+	}
+}
+
+func TestConnectViaFFmpeg_NoBinaryNoSource(t *testing.T) {
+	target := NewPushTarget("cam1", PushTargetConfig{
+		ID: "ff", Protocol: "rtmp", URL: "rtmp://127.0.0.1:1/live/key", UseFFmpeg: true,
+	}, newHubForRelay(), nil)
+	target.SetFFmpegPath("/nonexistent/ffmpeg")
+
+	err := target.connectAndStream(context.Background())
+	require.ErrorIs(t, err, errPermanent, "missing ffmpeg must fail permanently")
+	require.Contains(t, target.Status().Error, "cannot resolve source URL",
+		"source-URL resolution fails before the binary lookup")
+}
+
+func TestSplitRTMPPath(t *testing.T) {
+	u := mustParseURL(t, "rtmp://host/live/key?wsSecret=x")
+	app, key := splitRTMPPath(u)
+	require.Equal(t, "live", app)
+	require.Equal(t, "key?wsSecret=x", key, "query must stay attached to the stream key")
+
+	u2 := mustParseURL(t, "rtmp://host/live")
+	app2, key2 := splitRTMPPath(u2)
+	require.Equal(t, "live", app2)
+	require.Empty(t, key2)
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestRound1(t *testing.T) {
+	// round1 truncates to one decimal (avsync drift bucketing).
+	require.Equal(t, 1.4, round1(1.44))
+	require.Equal(t, 1.9, round1(1.99))
+	require.Equal(t, 0.0, round1(0))
+}
+
+func TestCameraStatusJSON(t *testing.T) {
+	m := newTestManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	m.SetCameraTargets("cam1", []config.PushTargetConfig{
+		{ID: "t1", Protocol: "bogus", URL: "x://nope", Enabled: true},
+	})
+	require.Eventually(t, func() bool { return len(m.CameraStatusJSON("cam1")) == 1 },
+		5*time.Second, 50*time.Millisecond)
+	m.Stop()
+}

--- a/internal/relay/manager_loop_test.go
+++ b/internal/relay/manager_loop_test.go
@@ -1,0 +1,134 @@
+package relay
+
+// Manager lifecycle tests (#567): setter wiring, FFmpegAvailable, the
+// SetCameraTargets reconcile loop (start / restart-on-change / stop-on-remove
+// / disabled-skipped), and Stop joining target goroutines. Deterministic by
+// construction: an unsupported protocol fails permanently (no live network),
+// and states are observed via CameraStatus polling — never sleeps.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestManager() *Manager {
+	return NewManager(
+		func(string) *model.StreamHub { return model.NewStreamHub() },
+		func(string) ([]byte, []byte, bool) { return []byte{0x67}, []byte{0x68}, true },
+	)
+}
+
+func TestManager_FFmpegAvailable(t *testing.T) {
+	m := newTestManager()
+	require.False(t, m.FFmpegAvailable(), "nothing wired → unavailable")
+
+	m.SetFFmpegPath("/usr/local/bin/ffmpeg")
+	require.True(t, m.FFmpegAvailable(), "explicit path → available")
+
+	m.SetHardwareCap(&transcoding.HardwareCapabilities{FFmpegAvailable: false})
+	require.False(t, m.FFmpegAvailable(), "hardware capability report wins over raw path")
+}
+
+func TestManager_SettersAndStart(t *testing.T) {
+	m := newTestManager()
+	m.SetCodecInfoProvider(func(string) model.CodecInfo { return model.CodecInfo{} })
+	m.SetSourceCodecProvider(func(string) string { return "h264" })
+	m.SetPresetRegistry(NewPresetRegistry())
+	m.SetHardwareCap(&transcoding.HardwareCapabilities{})
+	m.SetFFmpegPath("")
+	m.SetStreamURLProvider(func(string) string { return "" })
+	m.Start(context.Background())
+	m.Stop() // no targets — returns immediately
+}
+
+func TestManager_ReconcileLifecycle(t *testing.T) {
+	m := newTestManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+
+	target := config.PushTargetConfig{
+		ID: "t1", Name: "Test", Protocol: "bogus", URL: "x://nope", Enabled: true,
+	}
+
+	// Start: the target runs, hits the permanent protocol error, and lands in
+	// reconnecting with the cause attached (the watched wrapper reports the
+	// permanent error; Run retries with backoff).
+	m.SetCameraTargets("cam1", []config.PushTargetConfig{target})
+	require.Eventually(t, func() bool {
+		for _, st := range m.CameraStatus("cam1") {
+			if st.ID == "t1" && st.Status == StatusReconnecting &&
+				strings.Contains(st.Error, "permanent relay error") {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "permanent protocol error must surface in status")
+
+	// Idempotent re-apply: unchanged config does not churn the target.
+	m.SetCameraTargets("cam1", []config.PushTargetConfig{target})
+	require.Len(t, m.CameraStatus("cam1"), 1)
+
+	// Change the URL → restart (new target instance, same ID).
+	changed := target
+	changed.URL = "x://other"
+	m.SetCameraTargets("cam1", []config.PushTargetConfig{changed})
+	require.Len(t, m.CameraStatus("cam1"), 1)
+
+	// Empty list → target removed.
+	m.SetCameraTargets("cam1", nil)
+	require.Empty(t, m.CameraStatus("cam1"), "removal must stop the target")
+
+	m.Stop()
+}
+
+func TestManager_DisabledTargetNotStarted(t *testing.T) {
+	m := newTestManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+
+	m.SetCameraTargets("cam1", []config.PushTargetConfig{
+		{ID: "off", Protocol: "rtsp", URL: "rtsp://127.0.0.1:1/x", Enabled: false},
+	})
+	require.Empty(t, m.CameraStatus("cam1"), "disabled targets must not start")
+	m.Stop()
+}
+
+func TestPushTarget_RunNilHub(t *testing.T) {
+	target := NewPushTarget("cam1", PushTargetConfig{ID: "t1", Protocol: "rtsp"}, nil, nil)
+	target.Run(context.Background()) // returns without connecting
+	st := target.Status()
+	require.Equal(t, StatusError, st.Status)
+	require.Contains(t, st.Error, "no stream hub")
+}
+
+func TestConnectAndStream_UnsupportedProtocol(t *testing.T) {
+	target := NewPushTarget("cam1", PushTargetConfig{ID: "t1", Protocol: "carrier-pigeon"},
+		model.NewStreamHub(), func() ([]byte, []byte, bool) { return nil, nil, true })
+	err := target.connectAndStream(context.Background())
+	require.ErrorIs(t, err, errPermanent)
+	st := target.Status()
+	require.Equal(t, StatusError, st.Status)
+	require.Contains(t, st.Error, "unsupported protocol")
+}
+
+// RTSP dial to a refused port fails fast — the error path of connectRTSP
+// without any live server.
+func TestConnectRTSP_ConnectionRefused(t *testing.T) {
+	target := NewPushTarget("cam1", PushTargetConfig{ID: "t1", Protocol: "rtsp", URL: "rtsp://127.0.0.1:1/x"},
+		model.NewStreamHub(), func() ([]byte, []byte, bool) { return []byte{0x67}, []byte{0x68}, true })
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := target.connectAndStream(ctx)
+	require.Error(t, err, "dial to a closed port must fail")
+	st := target.Status()
+	require.NotEqual(t, StatusStreaming, st.Status)
+}

--- a/internal/relay/rtmp_loop_test.go
+++ b/internal/relay/rtmp_loop_test.go
@@ -1,0 +1,211 @@
+package relay
+
+// RTMP publish loopback tests (#567): a scripted fake RTMP server exercises
+// the custom handshake + FMLE publish sequence (dialRTMPPublish) and the full
+// engine path (connectRTMP → hub frames → RTMP video messages on the wire).
+// Hermetic: everything on 127.0.0.1, no real platform involved.
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/bluenviron/gortmplib/pkg/amf0"
+	"github.com/bluenviron/gortmplib/pkg/bytecounter"
+	"github.com/bluenviron/gortmplib/pkg/message"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	rlSPS = []byte{
+		0x67, 0x64, 0x00, 0x1f, 0xac, 0xd9, 0x40, 0x50, 0x05, 0xbb, 0x01,
+		0x10, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00,
+		0x00, 0x03, 0x00, 0x7b, 0xac, 0x09,
+	}
+	rlPPS = []byte{0x68, 0xee, 0x3c, 0x80}
+	rlIDR = []byte{0x65, 0x88, 0x84, 0x00, 0x40, 0xff, 0xfe, 0xf8, 0xc0}
+)
+
+// fakeRTMPServer is a minimal scripted RTMP publish receiver: plain
+// handshake, _result answers for connect/createStream, NetStream.Publish.Start
+// for publish, and counting of subsequent video messages.
+type fakeRTMPServer struct {
+	listener    net.Listener
+	published   chan string // stream key from the publish command
+	videoMsgs   atomic.Int64
+	metaData    atomic.Bool
+	gotSetChunk atomic.Bool
+}
+
+func startFakeRTMPServer(t *testing.T) *fakeRTMPServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := &fakeRTMPServer{listener: ln, published: make(chan string, 1)}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *fakeRTMPServer) addr() string { return s.listener.Addr().String() }
+
+func (s *fakeRTMPServer) serve() {
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+
+	// Plain handshake: C0+C1 in, S0+S1+S2 out (S1 without digest), C2 in.
+	head := make([]byte, 1+1536)
+	if _, err := io.ReadFull(conn, head); err != nil {
+		return
+	}
+	s1 := make([]byte, 1536)
+	_, _ = rand.Read(s1)
+	resp := make([]byte, 0, 1+1536+1536)
+	resp = append(resp, 0x03)
+	resp = append(resp, s1...)
+	resp = append(resp, head[1:]...) // S2 = echo of C1
+	if _, err := conn.Write(resp); err != nil {
+		return
+	}
+	if _, err := io.ReadFull(conn, make([]byte, 1536)); err != nil { // C2
+		return
+	}
+
+	bc := bytecounter.NewReadWriter(conn)
+	mrw := message.NewReadWriter(bc, bc, false)
+	for {
+		msg, err := mrw.Read()
+		if err != nil {
+			return
+		}
+		switch m := msg.(type) {
+		case *message.SetChunkSize:
+			s.gotSetChunk.Store(true)
+		case *message.DataAMF0:
+			s.metaData.Store(true)
+		case *message.Video:
+			s.videoMsgs.Add(1)
+		case *message.CommandAMF0:
+			switch m.Name {
+			case "connect":
+				_ = mrw.Write(&message.SetWindowAckSize{Value: 2500000})
+				_ = mrw.Write(&message.CommandAMF0{
+					ChunkStreamID: 3,
+					Name:          "_result",
+					CommandID:     1,
+					Arguments: []any{
+						amf0.Object{{Key: "fmsVer", Value: "FMS/3,5,3,824"}},
+						amf0.Object{{Key: "level", Value: "status"}},
+					},
+				})
+			case "createStream":
+				_ = mrw.Write(&message.CommandAMF0{
+					ChunkStreamID: 3,
+					Name:          "_result",
+					CommandID:     4,
+					Arguments:     []any{nil, float64(1)},
+				})
+			case "publish":
+				key := ""
+				if len(m.Arguments) > 1 {
+					if ks, ok := m.Arguments[1].(string); ok {
+						key = ks
+					}
+				}
+				select {
+				case s.published <- key:
+				default:
+				}
+				_ = mrw.Write(&message.CommandAMF0{
+					ChunkStreamID:   5,
+					MessageStreamID: 0x1000000,
+					Name:            "onStatus",
+					CommandID:       0,
+					Arguments: []any{nil, amf0.Object{
+						{Key: "level", Value: "status"},
+						{Key: "code", Value: "NetStream.Publish.Start"},
+					}},
+				})
+			}
+		}
+	}
+}
+
+func TestDialRTMPPublishLoopback(t *testing.T) {
+	srv := startFakeRTMPServer(t)
+
+	conn, cleanup, err := dialRTMPPublish(context.Background(),
+		"rtmp://"+srv.addr()+"/live/stream-key", 640, 360, 25)
+	require.NoError(t, err)
+	defer cleanup()
+
+	select {
+	case key := <-srv.published:
+		require.Equal(t, "stream-key", key)
+	case <-time.After(5 * time.Second):
+		t.Fatal("fake server never saw the publish command")
+	}
+	require.True(t, srv.gotSetChunk.Load(), "client must send SetChunkSize=4096 before connect")
+	require.Greater(t, conn.BytesSent(), uint64(0))
+	// Note: do NOT call conn.Read() here — dialRTMPPublish already runs its
+	// own background reader; a second reader would race on the bufio state.
+	cleanup()
+}
+
+// The full engine path: connectRTMP subscribes the hub and forwards hub AUs
+// as RTMP video messages the fake server can count.
+func TestConnectRTMPFullFlow(t *testing.T) {
+	srv := startFakeRTMPServer(t)
+	hub := newHubForRelay()
+
+	target := NewPushTarget("cam1", PushTargetConfig{
+		ID: "rtmp-e2e", Protocol: "rtmp",
+		URL:             "rtmp://" + srv.addr() + "/live/key",
+		TranscodePolicy: "off",
+	}, hub, func() ([]byte, []byte, bool) {
+		return append([]byte(nil), rlSPS...), append([]byte(nil), rlPPS...), true
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- target.connectAndStream(ctx) }()
+
+	select {
+	case key := <-srv.published:
+		require.Equal(t, "key", key)
+	case <-time.After(5 * time.Second):
+		t.Fatal("publish never reached the server")
+	}
+
+	// Push frames until the (asynchronously subscribed) target forwards one.
+	au := [][]byte{append([]byte(nil), rlSPS...), append([]byte(nil), rlPPS...), append([]byte(nil), rlIDR...)}
+	require.Eventually(t, func() bool {
+		hub.Broadcast(time.Now().UnixNano()/1e6, au, true)
+		return srv.videoMsgs.Load() >= 1 && srv.metaData.Load()
+	}, 5*time.Second, 50*time.Millisecond, "hub AUs must arrive as RTMP video messages")
+
+	require.Eventually(t, func() bool {
+		return target.Status().Status == StatusStreaming
+	}, 5*time.Second, 50*time.Millisecond, "target must report streaming")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("connectAndStream did not return after cancel")
+	}
+}
+
+func newHubForRelay() *model.StreamHub {
+	return model.NewStreamHub()
+}


### PR DESCRIPTION
Closes #567

## 覆盖率
`internal/relay`: **30.1% → 55.5%**（目标 65 → 55.5，理由见下）

## 测试内容
### Manager 生命周期（manager_loop_test.go）
全部 setter 注入面、`FFmpegAvailable` 优先级（hardwareCap > 显式路径）、`SetCameraTargets` 完整 reconcile（启动 / 幂等重放 / 变更重启 / 删除停止 / disabled 跳过）、`Stop` 等待 goroutine 退出、`CameraStatusJSON`。

### 自定义 RTMP 客户端 vs 假 RTMP 服务器（rtmp_loop_test.go）🔥
`rtmp_client.go` 是 Douyu/B 站兼容的关键层（复杂握手 digest、SetChunkSize=4096 前置、Type-0 chunk、FMLE publish 序列）。用脚本化假服务器（127.0.0.1 TCP，纯 handshake + _result/onStatus 应答）真测：
- 握手 → connect → createStream → publish → `NetStream.Publish.Start`
- 断言 SetChunkSize 在 connect **之前**发送（严格接收方依赖）
- **完整引擎路径**：`connectRTMP` → hub Broadcast 帧 → gortmplib Writer → 服务器在网络上收到 onMetaData + 视频消息 → 目标状态 streaming → cancel 干净退出

### FFmpeg 子进程路径（ffmpeg_harness_test.go）
`connectViaFFmpeg`（干净退出=正常结束 / 非零退出=错误）、`probeSourceVideoFPS`（解析 "15/1"、垃圾输出降级 0、路径缺失降级 0）——全部用 hermetic stub 脚本，CI 零依赖。

### 其它
`connectRTSP` 拨号拒绝快速失败、不支持协议永久错误、nil-hub Run、`splitRTMPPath` query 附着、`round1` 截断语义。

## 目标调整说明（65 → 55.5）
剩余缺口集中在 `connect_transcode.go`（H.265→H.264 转码胶水，~500 行）——需要真实 FFmpeg 转码器进程。转码器本身在 `internal/livetranscode` 已有 86% 覆盖。遵循 #571 规约：不为覆盖率数字引入慢速/硬件依赖测试（#566 同样的取舍先例）。

## CI 安全性
- 全部 127.0.0.1 回环 / stub 脚本，无外部依赖
- 轮询可观察状态；`go test -race` 通过（还修了一个测试自身与后台 reader 的读竞争）
- 新增测试运行 < 0.2s（套件总时长不变，来自既有 watchdog 测试）