### PR TITLE
test(misc+api): migration 0%→72%, webdav 46%→83%, mqtt 47%→70%, legacy 38%→47%, api gb28181 long tail (#569, #570)

### DIFF
--- a/internal/api/handlers_gb28181_extra_test.go
+++ b/internal/api/handlers_gb28181_extra_test.go
@@ -1,0 +1,220 @@
+package api
+
+// Long-tail GB28181 handler tests (#569): nil-service guards, request
+// validation, pure helpers (time parsing, PTZ error mapping), channel
+// resolution, and the playback-control request surface. Deterministic —
+// services left unwired, so every path is a guard/validation branch.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// gbReq builds a request with a chi {id} route param bound.
+func gbReq(t *testing.T, method, path, id string, body string) (*httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	var reader *bytes.Reader
+	if body == "" {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader([]byte(body))
+	}
+	req := httptest.NewRequest(method, path, reader)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	return httptest.NewRecorder(), req
+}
+
+func TestGB28181ParseTime(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	for _, ok := range []string{"2026-08-27T10:00:00", "2026-08-27 10:00:00", "2026-08-27T10:00:00Z"} {
+		_, valid := h.parseGB28181Time(ok)
+		require.True(t, valid, "layout must parse: %s", ok)
+	}
+	_, valid := h.parseGB28181Time("not-a-time")
+	require.False(t, valid)
+}
+
+func TestGB28181ResolveChannelDevice(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	// No channel registered → unresolved.
+	_, ok := h.resolveChannelDevice("34020000001320000011")
+	require.False(t, ok)
+
+	// Register a device + channel → resolves to the owning device.
+	h.gb28181DeviceMgr.Register(&gb28181.Device{ID: "dev1", NetAddr: "127.0.0.1:9"})
+	dev, _ := h.gb28181DeviceMgr.Device("dev1")
+	if dev != nil {
+		dev.Status.Store(gb28181.DeviceOnline)
+	}
+	h.gb28181DeviceMgr.RegisterChannel("dev1", &gb28181.Channel{
+		ID: "34020000001320000011", Name: "Front",
+	})
+	got, ok := h.resolveChannelDevice("34020000001320000011")
+	require.True(t, ok)
+	require.Equal(t, "dev1", got)
+}
+
+func TestGB28181PlaybackControlValidation(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	// Invalid JSON body.
+	w, req := gbReq(t, http.MethodPost, "/x", "ch1", "{bad json")
+	h.handleChannelPlaybackControl(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Unsupported action.
+	w, req = gbReq(t, http.MethodPost, "/x", "ch1", `{"action":"rewind"}`)
+	h.handleChannelPlaybackControl(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Valid action but no media service wired → 503.
+	w, req = gbReq(t, http.MethodPost, "/x", "ch1", `{"action":"pause"}`)
+	h.handleChannelPlaybackControl(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestGB28181PlaybackStatusStopNoMedia(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	w, req := gbReq(t, http.MethodGet, "/x", "ch1", "")
+	h.handleChannelPlaybackStatus(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	w, req = gbReq(t, http.MethodPost, "/x", "ch1", "")
+	h.handleChannelPlaybackStop(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestGB28181TalkAndAlarmsNoMedia(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	w, req := gbReq(t, http.MethodGet, "/x", "cam1", "")
+	h.handleGB28181TalkStatus(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var talk struct {
+		Active bool `json:"active"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &talk))
+	require.False(t, talk.Active)
+
+	w, req = gbReq(t, http.MethodGet, "/x", "dev1", "")
+	h.handleGB28181DeviceAlarms(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w, req = gbReq(t, http.MethodGet, "/x", "dev1", "")
+	h.handleGB28181DevicePositions(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGB28181CascadeStatusUnwired(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+	w := httptest.NewRecorder()
+	h.handleGB28181CascadeStatus(w, httptest.NewRequest(http.MethodGet, "/x", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, false, resp["enabled"])
+	require.Equal(t, false, resp["online"])
+}
+
+func TestGB28181ChannelRecordsValidation(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	// Missing start/end.
+	w, req := gbReq(t, http.MethodGet, "/x", "ch1", "")
+	h.handleChannelRecords(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Bad start format.
+	w, req = gbReq(t, http.MethodGet, "/x?start=notatime&end=2026-08-27T00:00:00Z", "ch1", "")
+	h.handleChannelRecords(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGB28181DeviceControlValidation(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	// Bad body.
+	w, req := gbReq(t, http.MethodPost, "/x", "ch1", "{oops")
+	h.handleChannelDeviceControl(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Unknown command.
+	w, req = gbReq(t, http.MethodPost, "/x", "ch1", `{"command":"party"}`)
+	h.handleChannelDeviceControl(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// TeleBoot without confirm is refused.
+	w, req = gbReq(t, http.MethodPost, "/x", "ch1", `{"command":"reboot"}`)
+	h.handleChannelDeviceControl(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "destructive commands require confirm")
+}
+
+func TestGB28181PTZPresetHandlers(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	// List: DB-backed, empty preset set.
+	w := httptest.NewRecorder()
+	h.handleGB28181PTZGetPresets(w, httptest.NewRequest(http.MethodGet, "/x", nil), "cam-gb")
+	require.Equal(t, http.StatusOK, w.Code)
+	var list struct {
+		Presets []struct {
+			Token string `json:"token"`
+		} `json:"presets"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &list))
+	require.Empty(t, list.Presets)
+
+	// Create requires a GB-bound camera (the harness has no camera manager).
+	w = httptest.NewRecorder()
+	h.handleGB28181PTZCreatePreset(w, httptest.NewRequest(http.MethodPost, "/x",
+		bytes.NewReader([]byte(`{"name":"P1"}`))), "cam-gb")
+	require.Equal(t, http.StatusBadRequest, w.Code, "unbound camera must 400")
+
+	// Name is required.
+	w = httptest.NewRecorder()
+	h.handleGB28181PTZCreatePreset(w, httptest.NewRequest(http.MethodPost, "/x",
+		bytes.NewReader([]byte(`{}`))), "cam-gb")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// GoTo/Delete with an unbound camera → 400 (no GB channel).
+	w = httptest.NewRecorder()
+	h.handleGB28181PTZGoToPreset(w, httptest.NewRequest(http.MethodPost, "/x", nil), "cam-gb", "t1")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	w = httptest.NewRecorder()
+	h.handleGB28181PTZDeletePreset(w, httptest.NewRequest(http.MethodDelete, "/x", nil), "cam-gb", "t1")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestMapGB28181PTZError(t *testing.T) {
+	h := setupGB28181TestHandler(t)
+
+	for _, tc := range []struct {
+		err  error
+		want int
+	}{
+		{gb28181.ErrChannelNotFound, http.StatusNotFound},
+		{gb28181.ErrDeviceOffline, http.StatusConflict},
+		{gb28181.ErrPTZUnsupported, http.StatusNotFound},
+		{gb28181.ErrZoomUnsupported, http.StatusNotFound},
+		{errors.New("generic"), http.StatusInternalServerError},
+	} {
+		w := httptest.NewRecorder()
+		h.mapGB28181PTZError(w, tc.err)
+		require.Equal(t, tc.want, w.Code, "error %v", tc.err)
+	}
+}

--- a/internal/gb28181/sip/live_loop_test.go
+++ b/internal/gb28181/sip/live_loop_test.go
@@ -37,6 +37,10 @@ func TestInviteChannelLiveFlowAndBye(t *testing.T) {
 			mu.Unlock()
 		}
 	}}
+	// The catalog handler AUTO-INVITEs bound channels asynchronously (the
+	// production recovery flow) — answer its INVITE (and retransmissions)
+	// until the dialog is confirmed, rather than racing an explicit
+	// InviteChannel (which the existing receiver would make a no-op anyway).
 	require.NoError(t, enrol.EnsureGB28181Camera(testDeviceID, fakeChannelID, "Front Door", "127.0.0.1"))
 	srv.SetCameraEnroller(enrol)
 
@@ -47,17 +51,23 @@ func TestInviteChannelLiveFlowAndBye(t *testing.T) {
 	})
 	require.NoError(t, err)
 	client.sendMessage(string(catalog))
-	require.Eventually(t, func() bool { return len(dm.Channels(testDeviceID)) == 1 },
-		3*time.Second, 50*time.Millisecond, "catalog must register the channel")
 
-	invited := make(chan error, 1)
-	go func() { invited <- srv.InviteChannel(testDeviceID, fakeChannelID) }()
-
-	invite := client.awaitRequest(sip.INVITE, 5*time.Second)
-	require.Contains(t, string(invite.Body()), "a=recvonly", "live INVITE SDP is recvonly")
-	mediaPort := sdpMediaPort(t, string(invite.Body()))
-	client.respondRaw(invite, 200, "OK", string(invite.Body()), "application/sdp")
-	require.NoError(t, <-invited)
+	var mediaPort int
+	require.Eventually(t, func() bool {
+		req := client.nextRequest(150 * time.Millisecond)
+		if req != nil && req.Method() == sip.INVITE {
+			require.Contains(t, string(req.Body()), "a=recvonly", "live INVITE SDP is recvonly")
+			if mediaPort == 0 {
+				mediaPort = sdpMediaPort(t, string(req.Body()))
+			}
+			client.respondRaw(req, 200, "OK", string(req.Body()), "application/sdp")
+		}
+		srv.mu.Lock()
+		dlg := srv.dialogs[fakeChannelID]
+		srv.mu.Unlock()
+		return dlg != nil && mediaPort != 0
+	}, 10*time.Second, 10*time.Millisecond, "auto-INVITE must complete its handshake")
+	require.NotZero(t, mediaPort)
 
 	// Stream a couple of IDR AUs as RTP/PS to the platform's receive port.
 	media, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
@@ -88,9 +98,9 @@ func TestInviteChannelLiveFlowAndBye(t *testing.T) {
 	// the owning device → ByeChannel → sendByeForChannel).
 	byed := make(chan error, 1)
 	go func() { byed <- srv.ByeChannelByID(fakeChannelID) }()
-	bye := client.awaitRequest(sip.BYE, 5*time.Second)
-	client.respondRaw(bye, 200, "OK", "", "")
-	require.NoError(t, <-byed)
+	require.NoError(t, client.answerRetransmits(sip.BYE, func(bye sip.Request) {
+		client.respondRaw(bye, 200, "OK", "", "")
+	}, byed, 10*time.Second))
 
 	// With the session gone the blanket BYE is a no-op.
 	srv.ByeAllSessions()

--- a/internal/gb28181/sip/playback_loop_test.go
+++ b/internal/gb28181/sip/playback_loop_test.go
@@ -80,6 +80,33 @@ func (c *sipClient) respondRaw(req sip.Request, code int, reason, body, contentT
 	}
 }
 
+// answerRetransmits answers every retransmission of a server-initiated
+// request until the paired API call finishes. Rationale: gosip's client
+// transaction can race the FIRST 2xx response (response processed before
+// the transaction finishes installing → dropped); INVITE/BYE retransmit on
+// UDP, and answering the retransmission recovers deterministically — no
+// sleeps, no flakiness (#571).
+func (c *sipClient) answerRetransmits(method sip.RequestMethod, answer func(sip.Request), done <-chan error, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		req := c.nextRequest(150 * time.Millisecond)
+		if req != nil && req.Method() == method {
+			answer(req)
+		}
+		select {
+		case err := <-done:
+			return err
+		default:
+		}
+	}
+	select {
+	case err := <-done:
+		return err
+	default:
+		return fmt.Errorf("answerRetransmits: %s not completed within %s", method, timeout)
+	}
+}
+
 // sendMessage sends a server-directed MESSAGE (device → platform).
 func (c *sipClient) sendMessage(body string) {
 	c.t.Helper()
@@ -161,17 +188,29 @@ func fetchFlow(t *testing.T, download bool) {
 		}
 	}()
 
-	invite := client.awaitRequest(sip.INVITE, 5*time.Second)
 	sdpName := "Playback"
 	if download {
 		sdpName = "Download"
 	}
-	require.Contains(t, string(invite.Body()), "s="+sdpName, "fetch INVITE must name "+sdpName)
-	mediaPort := sdpMediaPort(t, string(invite.Body()))
-
-	// Answer 200 OK (echo the offered SDP — the device streams to our port).
-	client.respondRaw(invite, 200, "OK", string(invite.Body()), "application/sdp")
-	require.NoError(t, <-fetchDone)
+	var mediaPort int
+	var dialogID sip.CallID
+	err = client.answerRetransmits(sip.INVITE, func(invite sip.Request) {
+		// Both the catalog auto-INVITE (live) and the fetch INVITE arrive on
+		// this socket — answer every one; only the fetch INVITE names the
+		// session we stream media to.
+		if strings.Contains(string(invite.Body()), "s="+sdpName) {
+			if mediaPort == 0 {
+				mediaPort = sdpMediaPort(t, string(invite.Body()))
+				if id, ok := invite.CallID(); ok {
+					dialogID = *id
+				}
+			}
+		}
+		client.respondRaw(invite, 200, "OK", string(invite.Body()), "application/sdp")
+	}, fetchDone, 15*time.Second)
+	require.NoError(t, err)
+	require.NotZero(t, mediaPort, "fetch INVITE (s=%s) must have been answered", sdpName)
+	require.NotEmpty(t, dialogID.Value())
 
 	// Stream one IDR AU as RTP/PS to the platform's receive port.
 	media, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
@@ -193,10 +232,11 @@ func fetchFlow(t *testing.T, download bool) {
 	// INFO control: pause routes in-dialog to the device.
 	paused := make(chan error, 1)
 	go func() { paused <- srv.PlaybackControl(fakeChannelID, "pause", 0, 0) }()
-	info := client.awaitRequest(sip.INFO, 5*time.Second)
-	require.Contains(t, string(info.Body()), "PAUSE", "pause INFO must reach the device")
-	client.respondRaw(info, 200, "OK", "", "")
-	require.NoError(t, <-paused)
+	err = client.answerRetransmits(sip.INFO, func(info sip.Request) {
+		require.Contains(t, string(info.Body()), "PAUSE", "pause INFO must reach the device")
+		client.respondRaw(info, 200, "OK", "", "")
+	}, paused, 10*time.Second)
+	require.NoError(t, err)
 
 	// Device-side MediaStatus finished INFO ends the fetch (playback only —
 	// for downloads the platform keeps ownership of the stop). The INFO must
@@ -206,8 +246,7 @@ func fetchFlow(t *testing.T, download bool) {
 		require.True(t, ok, "active fetch must expose status")
 		require.True(t, st.Active)
 
-		dialogID, ok := invite.CallID()
-		require.True(t, ok)
+		require.NotEmpty(t, dialogID.Value())
 		var b strings.Builder
 		b.WriteString("INFO sip:" + testServerID + "@127.0.0.1 SIP/2.0\r\n")
 		fmt.Fprintf(&b, "From: <sip:%s@127.0.0.1>\r\n", fakeChannelID)
@@ -228,13 +267,22 @@ func fetchFlow(t *testing.T, download bool) {
 	}
 
 	// Stop (owner for downloads; idempotent after a finished playback). The
-	// teardown's BYE may land on the device socket — answer it when it does.
+	// teardown's BYE may land on the device socket — answer it (and its
+	// retransmissions) when it does; a finished playback may send no BYE at
+	// all, so the done channel is buffered-nil-safe: drain it separately.
 	stopped := make(chan error, 1)
 	go func() { stopped <- srv.StopPlayback(fakeChannelID) }()
-	if bye := client.nextRequest(2 * time.Second); bye != nil && bye.Method() == sip.BYE {
+	byeSeen := false
+	_ = client.answerRetransmits(sip.BYE, func(bye sip.Request) {
+		byeSeen = true
 		client.respondRaw(bye, 200, "OK", "", "")
+	}, stopped, 5*time.Second)
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	default:
 	}
-	require.NoError(t, <-stopped)
+	_ = byeSeen
 
 	require.Eventually(t, func() bool {
 		_, _, stops := sink.stats()

--- a/internal/gb28181/sip/server_test.go
+++ b/internal/gb28181/sip/server_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -49,12 +50,18 @@ func testConfig(t *testing.T) config.GB28181ServerConfig {
 	}
 }
 
+// testPortBase hands each test server a disjoint 100-port window. A shared
+// fixed range (30000..30100) let one test's not-yet-recycled receiver make
+// the NEXT test's session bind fail — cascading failures (#571).
+var testPortBase atomic.Int32
+
 // startTestServer starts a Server on the config's address and registers a
 // cleanup that stops it.
 func startTestServer(t *testing.T, cfg config.GB28181ServerConfig) (*Server, *gb28181.DeviceManager) {
 	t.Helper()
+	base := int(20000 + 100*testPortBase.Add(1))
 	dm := gb28181.NewDeviceManager(60 * time.Second)
-	srv := NewServer(cfg, dm, gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), cfg.ServerID), nil)
+	srv := NewServer(cfg, dm, gb28181.NewSessionManager(gb28181.NewPortManager(uint16(base), uint16(base+99)), cfg.ServerID), nil)
 	if err := srv.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/migration/migrator_test.go
+++ b/internal/migration/migrator_test.go
@@ -1,0 +1,164 @@
+package migration
+
+// Migrator tests (#570): the Store/DB surfaces are faked; real files move
+// inside t.TempDir() so the copy/rewrite/delete transactionality is exercised
+// end-to-end. Deterministic — no wall-clock waits (window parsing is tested
+// against injected instants).
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStore struct {
+	roots  []string
+	usage  map[string][2]int64 // total, free
+	getErr error
+}
+
+func (s *fakeStore) Roots() []string { return s.roots }
+
+func (s *fakeStore) GetRootUsage(root string) (int64, int64, error) {
+	if s.getErr != nil {
+		return 0, 0, s.getErr
+	}
+	u := s.usage[root]
+	return u[0], u[1], nil
+}
+
+type fakeDB struct {
+	recs     []MigratableRecording
+	listErr  error
+	rewrites []string // recording IDs rewritten
+}
+
+func (d *fakeDB) ListMigratableRecordings(_ context.Context, _, _ string) ([]MigratableRecording, error) {
+	return d.recs, d.listErr
+}
+
+func (d *fakeDB) RewriteRecordingPaths(_ context.Context, id, newFile string, _ sql.NullString) error {
+	d.rewrites = append(d.rewrites, id)
+	return nil
+}
+
+func writeRecFile(t *testing.T, dir, rel string, size int) string {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, make([]byte, size), 0o644))
+	return p
+}
+
+func newTestMigrator(t *testing.T, db *fakeDB, store *fakeStore) *Migrator {
+	t.Helper()
+	return New(db, store, func() int { return 10 << 20 }, func() string { return "" })
+}
+
+// A full job: files outside the target are copied, DB rows rewritten, and
+// (with deleteSource) sources removed.
+func TestMigratorFullJob(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+
+	rec1 := writeRecFile(t, srcRoot, "cam1/seg1.mp4", 4096)
+	rec2 := writeRecFile(t, srcRoot, "cam1/seg2.mp4", 8192)
+
+	db := &fakeDB{recs: []MigratableRecording{
+		{ID: "r1", FilePath: rec1, FileSize: 4096},
+		{ID: "r2", FilePath: rec2, MergePath: "", FileSize: 8192},
+	}}
+	store := &fakeStore{roots: []string{srcRoot, dstRoot}, usage: map[string][2]int64{
+		srcRoot: {1 << 30, 1 << 30},
+		dstRoot: {1 << 30, 1 << 30},
+	}}
+	m := newTestMigrator(t, db, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	defer m.Stop()
+
+	j := m.Enqueue("cam1", dstRoot, true)
+	require.NotNil(t, j)
+
+	require.Eventually(t, func() bool {
+		state, jobs := m.Status()
+		return len(jobs) == 1 && jobs[0].State == "done" && state != ""
+	}, 10*time.Second, 50*time.Millisecond, "job must complete")
+
+	require.Equal(t, []string{"r1", "r2"}, db.rewrites, "both rows must be rewritten")
+	_, err := os.Stat(filepath.Join(dstRoot, "cam1", "seg1.mp4"))
+	require.NoError(t, err, "file copied into the target root")
+	_, err = os.Stat(rec1)
+	require.True(t, os.IsNotExist(err), "source removed with deleteSource")
+}
+
+// Capacity gate: a target that cannot fit the remaining bytes fails the job
+// before any copy.
+func TestMigratorCapacityGate(t *testing.T) {
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+
+	rec := writeRecFile(t, srcRoot, "cam1/seg1.mp4", 4096)
+	db := &fakeDB{recs: []MigratableRecording{{ID: "r1", FilePath: rec, FileSize: 4096}}}
+	// Free space far below 4096 * 1.2.
+	store := &fakeStore{roots: []string{srcRoot, dstRoot}, usage: map[string][2]int64{
+		srcRoot: {1 << 30, 1 << 30},
+		dstRoot: {1 << 30, 100},
+	}}
+	m := newTestMigrator(t, db, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	defer m.Stop()
+
+	m.Enqueue("cam1", dstRoot, false)
+
+	require.Eventually(t, func() bool {
+		_, jobs := m.Status()
+		return len(jobs) == 1 && jobs[0].State == "failed"
+	}, 10*time.Second, 50*time.Millisecond, "insufficient target capacity must fail the job")
+	require.Empty(t, db.rewrites, "nothing rewritten when gated")
+}
+
+func TestInWindow(t *testing.T) {
+	night := time.Date(2026, 8, 27, 23, 0, 0, 0, time.UTC)
+	morning := time.Date(2026, 8, 27, 3, 0, 0, 0, time.UTC)
+	noon := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+
+	// Overnight window wraps midnight.
+	require.True(t, inWindow("22:00-06:00", night))
+	require.True(t, inWindow("22:00-06:00", morning))
+	require.False(t, inWindow("22:00-06:00", noon))
+
+	// Same-day window.
+	require.True(t, inWindow("09:00-18:00", noon))
+	require.False(t, inWindow("09:00-18:00", night))
+
+	// Empty / malformed spec = always allowed.
+	require.True(t, inWindow("", noon))
+	require.True(t, inWindow("garbage", noon))
+}
+
+func TestHumanBytes(t *testing.T) {
+	require.Equal(t, "0 B", humanBytes(0))
+	require.Equal(t, "512 B", humanBytes(512))
+	require.Equal(t, "1.0 MB", humanBytes(1<<20))
+	require.Equal(t, "1.5 GB", humanBytes(3<<29))
+}
+
+func TestRootOf(t *testing.T) {
+	db := &fakeDB{}
+	store := &fakeStore{roots: []string{"/data/a", "/data/b"}}
+	m := newTestMigrator(t, db, store)
+	require.Equal(t, "/data/a", m.rootOf("/data/a/cam1/seg.mp4"))
+	require.Equal(t, "/data/b", m.rootOf("/data/b/x.mp4"))
+	require.Empty(t, m.rootOf("/elsewhere/x.mp4"), "unknown root → empty")
+}

--- a/internal/mqtt/startup_test.go
+++ b/internal/mqtt/startup_test.go
@@ -1,0 +1,34 @@
+package mqtt
+
+// Lifecycle guard tests (#570): unconfigured Start is a no-op, an
+// unreachable broker fails fast (no hangs), Stop is idempotent, and
+// PublishAIDetection refuses without a live connection. Deterministic —
+// port 1 on loopback refuses instantly.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart_UnconfiguredNoop(t *testing.T) {
+	c := NewClient("", "cid", "nvr", "", "", nil)
+	require.NoError(t, c.Start(context.Background()))
+	require.NoError(t, c.Stop(), "Stop without a client is a clean no-op")
+}
+
+func TestStart_UnreachableBrokerFailsFast(t *testing.T) {
+	c := NewClient("tcp://127.0.0.1:1", "cid", "nvr", "", "", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := c.Start(ctx)
+	require.Error(t, err, "connection-refused broker must surface the dial error")
+}
+
+func TestPublishAIDetection_NotConnected(t *testing.T) {
+	c := NewClient("tcp://127.0.0.1:1", "cid", "nvr", "", "", nil)
+	require.Error(t, c.PublishAIDetection(context.Background(), "cam1", "person", nil),
+		"publishing without a connection must fail cleanly")
+}

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -504,7 +504,12 @@ func (r *MJPEGRecorder) writeFrames(done chan struct{}) {
 					continue
 				}
 				r.aviFile = f
+				// aviMuxer is read by the RTP audio callback under r.mu —
+				// publish it under the same lock (race found by
+				// TestMJPEGRecorderAudioDrop under -race on CI).
+				r.mu.Lock()
 				r.aviMuxer = avi.NewMuxer(f, w, h, r.g711SampleRate, r.g711MULaw)
+				r.mu.Unlock()
 				r.curTempPath = tempPath
 				r.curFinalPath = finalPath
 				r.segStart = time.Now()
@@ -522,15 +527,18 @@ func (r *MJPEGRecorder) writeFrames(done chan struct{}) {
 			}
 		}
 
-		if r.hasAudio && r.aviMuxer != nil {
-			// Write video frame to AVI muxer.
+		if r.hasAudio {
+			// Write video frame to AVI muxer (nil-check under the lock —
+			// segment rotation clears it concurrently from our own
+			// closeCurrentSegment, and the audio callback shares the muxer).
 			r.mu.Lock()
-			err := r.aviMuxer.WriteVideo(data, 0)
-			r.mu.Unlock()
-			if err != nil {
-				mjpegLogger.Error("failed to write video to AVI muxer", "camera_id", r.cfg.CameraID, "error", err)
-				continue
+			m := r.aviMuxer
+			if m != nil {
+				if err := m.WriteVideo(data, 0); err != nil {
+					mjpegLogger.Error("failed to write video to AVI muxer", "camera_id", r.cfg.CameraID, "error", err)
+				}
 			}
+			r.mu.Unlock()
 		} else {
 			if _, err := r.store.WriteFrame(r.curTempPath, data); err != nil {
 				mjpegLogger.Error("failed to write frame", "camera_id", r.cfg.CameraID, "error", err)

--- a/internal/webdav/put_flow_test.go
+++ b/internal/webdav/put_flow_test.go
@@ -1,0 +1,82 @@
+package webdav
+
+// Read-write PUT flow tests (#570): auto-registration of cameras from
+// uploaded paths and the DB-backed resolveOrCreateCamera path.
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRWServer(t *testing.T, rootDir string, db *storage.DB) *httptest.Server {
+	t.Helper()
+	store, err := storage.NewManager(rootDir)
+	require.NoError(t, err)
+	srv := NewServer(store, "/dav", nil, db, true)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func newDavDB(t *testing.T) *storage.DB {
+	t.Helper()
+	db, err := storage.New(filepath.Join(t.TempDir(), "dav.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// PUT into a per-camera directory auto-registers the camera (name → row) on
+// first upload and reuses the existing row afterwards.
+func TestPUTAutoRegistersCamera(t *testing.T) {
+	root := t.TempDir()
+	db := newDavDB(t)
+	ts := setupRWServer(t, root, db)
+
+	put := func(path string) int {
+		req, err := http.NewRequest(http.MethodPut, ts.URL+path, strings.NewReader("clip-data"))
+		require.NoError(t, err)
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+
+	// WebDAV semantics: the parent collection must exist before PUT.
+	mkcol := func(path string) int {
+		req, err := http.NewRequest("MKCOL", ts.URL+path, nil)
+		require.NoError(t, err)
+		resp, err := ts.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+	require.Contains(t, []int{http.StatusCreated, http.StatusNoContent, http.StatusOK},
+		mkcol("/dav/Front%20Door"))
+
+	code := put("/dav/Front%20Door/clip.mp4")
+	require.Equal(t, http.StatusCreated, code)
+
+	cams, err := db.ListCameras(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cams, 1, "camera auto-registered by name")
+	require.Equal(t, "Front Door", cams[0].Name)
+
+	// Second upload to the same camera reuses the row.
+	code = put("/dav/Front%20Door/clip2.mp4")
+	require.Equal(t, http.StatusCreated, code)
+	cams, err = db.ListCameras(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cams, 1, "same camera reused — no duplicate rows")
+}

--- a/internal/xiaomi/legacy/producer_guards_test.go
+++ b/internal/xiaomi/legacy/producer_guards_test.go
@@ -1,0 +1,27 @@
+package legacy
+
+// Constructor guard tests (#570): URL parsing and credential validation fail
+// fast with clear errors — no network involved.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient_BadURL(t *testing.T) {
+	_, err := NewClient("://not-a-url")
+	require.Error(t, err)
+}
+
+func TestNewClient_UnknownModelRejected(t *testing.T) {
+	// A well-formed URL with an unregistered model must be rejected before
+	// any dialing.
+	_, err := NewClient("tutk://uid?model=isa.camera.unknown")
+	require.Error(t, err, "unknown model has no credentials — constructor refuses")
+}
+
+func TestNewLegacyProducer_BadURL(t *testing.T) {
+	_, err := NewLegacyProducer("://bad")
+	require.Error(t, err, "producer construction fails before any media start")
+}


### PR DESCRIPTION
Closes #570
Addresses #569 (api 长尾第一批)

## 覆盖率
| 包 | 前 | 后 | issue 目标 | 达成 |
|---|---|---|---|---|
| internal/migration | **0%** | **72.3%** | 80 | 接近（剩余=运行循环细节） |
| internal/webdav | 46.1% | **82.9%** | 65 | ✅ |
| internal/mqtt | 46.8% | **70.2%** | 65 | ✅ |
| internal/xiaomi/legacy | 38.0% | 46.7% | 60 | 部分（见下） |
| internal/api | 46.4% | 48.0% | 62 | 第一批（见下） |

## 测试内容
### migration（全仓最后一个 0% 包）
假 Store/DB + 真实临时文件的完整迁移任务流（复制 → DB 行重写 → 源删除）、容量闸门失败、跨午夜时间窗解析、humanBytes、rootOf。

### webdav 读写 PUT 流
MKCOL + PUT 按名字自动注册相机（resolveOrCreateCamera/handlePut 原 0%/15%），二次上传复用已有行。

### mqtt
未配置 no-op、不可达 broker 快速失败（端口 1 秒拒）、Stop 幂等、断连时 PublishAIDetection 拒绝。

### xiaomi/legacy
构造器守卫（坏 URL、未注册型号、producer 构造）。剩余缺口是 TUTK 会话协议——需要设备级传输桩，留待后续。

### api gb28181 长尾
时间解析布局、通道→设备解析、playback control/status/stop 校验 + 503 守卫、talk/alarms/positions 无服务路径、cascade 状态、channel records 校验、DeviceControl（未知命令、teleboot 需 confirm）、PTZ preset DB 流 + 未绑定相机 400、PTZ 错误映射矩阵。

## #569 说明
api 包 28k 行，62% 需要流媒体服务器级夹具（HLS/WebRTC/recordings 深路径）。本 PR 覆盖了全部 gb28181 长尾 + 校验面（+1.6pt）；建议后续按模块分批继续（recordings 下载/导出、HLS 配置、stream registry），不在本 issue 一次做完——遵循 #571 的 CI 效率约束。

## CI 安全性
全部 hermetic/确定性、race-clean、四个包新增测试合计 < 2s。