### PR TITLE
test(api): coverage 47.9%→60.3% — hermetic handler long tail (#578)

### DIFF
--- a/internal/api/ai_handler_test.go
+++ b/internal/api/ai_handler_test.go
@@ -1,0 +1,157 @@
+package api
+
+// Tests for ai_handler.go — AI config management + ROI zone CRUD (#578).
+// Fully hermetic: ai.Manager is an in-memory config store and config.Save
+// writes to a t.TempDir yaml. No inference, no network (AI is browser-side
+// by design — see AGENTS.md).
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/ai"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// aiHandlerEnv wires a Handler whose AI routes are live, with a real temp
+// config file so syncAndSaveConfig persistence can be asserted.
+func aiHandlerEnv(t *testing.T) (*Handler, http.Handler, string) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	cfg := &config.Config{Storage: config.StorageConfig{RootDir: store.RootDir()}}
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	h := NewHandler(db, store, noopAuthMW(), cfg, nil, nil, cfgPath, nil, nil, nil, nil, nil)
+	h.SetAIHandler(NewAIHandler(ai.NewManager(ai.Config{}, nil), cfg, cfgPath))
+	return h, h.Routes(), cfgPath
+}
+
+func TestAIHandler_StatusReflectsConfig(t *testing.T) {
+	t.Parallel()
+	_, routes, _ := aiHandlerEnv(t)
+
+	rr := doRequest(t, routes, http.MethodGet, "/api/ai/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"enabled":false`)
+
+	// Flip the flag through the config endpoint, then re-read status.
+	body := strings.NewReader(`{"enabled":true,"confidence_threshold":0.7}`)
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/config", body, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/ai/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"enabled":true`)
+	require.Contains(t, rr.Body.String(), `"confidence_threshold":0.7`)
+}
+
+func TestAIHandler_UpdateConfigValidationAndPersist(t *testing.T) {
+	t.Parallel()
+	_, routes, cfgPath := aiHandlerEnv(t)
+
+	rr := doRequest(t, routes, http.MethodPut, "/api/ai/config", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// enabled_classes: explicit empty array clears the filter.
+	body := strings.NewReader(`{"enabled_classes":[]}`)
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/config", body, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// The update must have persisted to the yaml on disk.
+	raw, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "ai:")
+}
+
+func TestAIHandler_ZoneCRUD(t *testing.T) {
+	t.Parallel()
+	_, routes, _ := aiHandlerEnv(t)
+
+	// Empty list starts as [].
+	rr := doRequest(t, routes, http.MethodGet, "/api/ai/zones", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"zones":[]`)
+
+	// Create requires camera_id + zone.name.
+	rr = doRequest(t, routes, http.MethodPost, "/api/ai/zones", strings.NewReader(`{"camera_id":""}`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPost, "/api/ai/zones", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Create one zone.
+	zone := `{"camera_id":"front-door","zone":{"name":"porch","points":[[0,0],[1,0],[1,1]]},"enabled":true}`
+	rr = doRequest(t, routes, http.MethodPost, "/api/ai/zones", strings.NewReader(zone), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.Contains(t, rr.Body.String(), "porch")
+
+	// Duplicate name across ANY camera → 409.
+	dup := `{"camera_id":"other-cam","zone":{"name":"porch"}}`
+	rr = doRequest(t, routes, http.MethodPost, "/api/ai/zones", strings.NewReader(dup), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	// List shows it.
+	rr = doRequest(t, routes, http.MethodGet, "/api/ai/zones", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "front-door")
+	require.Contains(t, rr.Body.String(), "porch")
+
+	// Update: rename + move points.
+	upd := `{"camera_id":"front-door","zone":{"name":"driveway","points":[[2,2],[3,3]]}}`
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/zones/porch", strings.NewReader(upd), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Rename onto an existing name → 409 (create a second zone first).
+	rr = doRequest(t, routes, http.MethodPost, "/api/ai/zones",
+		strings.NewReader(`{"camera_id":"front-door","zone":{"name":"yard"}}`), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code)
+	upd = `{"zone":{"name":"yard"}}`
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/zones/driveway", strings.NewReader(upd), "", "")
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	// Update unknown → 404; bad body → 400.
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/zones/nope", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPut, "/api/ai/zones/nope", strings.NewReader(`{}`), "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// Delete: unknown → 404, known → 200, then gone from list.
+	rr = doRequest(t, routes, http.MethodDelete, "/api/ai/zones/nope", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	rr = doRequest(t, routes, http.MethodDelete, "/api/ai/zones/yard", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	rr = doRequest(t, routes, http.MethodGet, "/api/ai/zones", nil, "", "")
+	require.NotContains(t, rr.Body.String(), "yard")
+}
+
+func TestAIHandler_ModelsListsOnnx(t *testing.T) {
+	t.Parallel()
+	h, routes, _ := aiHandlerEnv(t)
+
+	// Missing models dir → empty list, not 500.
+	rr := doRequest(t, routes, http.MethodGet, "/api/ai/models", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"models":[]`)
+
+	// Populate the models dir with one .onnx + noise files.
+	modelDir := h.config.Storage.ModelsDir()
+	require.NoError(t, os.MkdirAll(modelDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(modelDir, "yolo11n.onnx"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(modelDir, "readme.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(modelDir, "nested"), 0o755))
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/ai/models", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "yolo11n.onnx")
+	require.Contains(t, rr.Body.String(), "/models/yolo11n.onnx")
+	require.NotContains(t, rr.Body.String(), "readme.txt")
+}

--- a/internal/api/events_handler_extra_test.go
+++ b/internal/api/events_handler_extra_test.go
@@ -1,0 +1,112 @@
+package api
+
+// Tests for events_handler.go camera-specific SSE + cameraIDFromEventData
+// (#578). Uses a real httptest.Server + cancellable request context: the
+// SSE loop only ends on ctx cancellation, which the test drives explicitly
+// (never a sleep-then-assert).
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCameraEvents_NilBusIs503(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/events", nil, "", "")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+func TestCameraEvents_SSEFiltersByCamera(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	bus := event.NewEventBus(16)
+	h.SetEventBus(bus)
+
+	srv := httptest.NewServer(h.Routes())
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/api/cameras/cam-1/events", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// Events for other cameras are filtered out; ours arrive as SSE frames.
+	lines := make(chan string, 64)
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		for sc.Scan() {
+			lines <- sc.Text()
+		}
+		close(lines)
+	}()
+
+	// Alternate foreign-camera and our-camera events: only ours may be
+	// written to the stream. Success = a data frame carrying our recording.
+	var sawForeign bool
+	require.Eventually(t, func() bool {
+		bus.Publish(context.Background(), event.TopicSegmentCompleted,
+			event.SegmentCompleted{CameraID: "cam-2", RecordingID: "foreign"})
+		bus.Publish(context.Background(), event.TopicSegmentCompleted,
+			event.SegmentCompleted{CameraID: "cam-1", RecordingID: "rec-9"})
+		for {
+			select {
+			case line, ok := <-lines:
+				if !ok {
+					return false
+				}
+				if strings.Contains(line, "foreign") {
+					sawForeign = true
+				}
+				if strings.Contains(line, "rec-9") {
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 10*time.Second, 100*time.Millisecond, "camera-1 event never streamed")
+	require.False(t, sawForeign, "foreign-camera event leaked through the filter")
+
+	cancel()
+}
+
+func TestCameraIDFromEventData(t *testing.T) {
+	t.Parallel()
+	// Fast type-assertion paths.
+	require.Equal(t, "c1", cameraIDFromEventData(event.SegmentCompleted{CameraID: "c1"}))
+	require.Equal(t, "c2", cameraIDFromEventData(event.SegmentDeleted{CameraID: "c2"}))
+	require.Equal(t, "c3", cameraIDFromEventData(event.StorageHealthChanged{CameraID: "c3"}))
+	require.Equal(t, "c4", cameraIDFromEventData(event.AIDetectionEvent{CameraID: "c4"}))
+
+	// Map fast path with several key spellings.
+	require.Equal(t, "m1", cameraIDFromEventData(map[string]interface{}{"camera_id": "m1"}))
+	require.Equal(t, "m2", cameraIDFromEventData(map[string]interface{}{"CameraID": "m2"}))
+	require.Equal(t, "m3", cameraIDFromEventData(map[string]interface{}{"camera": "m3"}))
+	require.Equal(t, "", cameraIDFromEventData(map[string]interface{}{"camera_id": 42}))
+	require.Equal(t, "", cameraIDFromEventData(map[string]interface{}{}))
+
+	// JSON fallback for ad-hoc struct types.
+	type adhoc struct {
+		Camera string `json:"camera"`
+	}
+	require.Equal(t, "j1", cameraIDFromEventData(adhoc{Camera: "j1"}))
+	require.Equal(t, "", cameraIDFromEventData(42)) // not marshalable to a map with a key
+}

--- a/internal/api/handlers_mjpeg_extra_test.go
+++ b/internal/api/handlers_mjpeg_extra_test.go
@@ -1,0 +1,125 @@
+package api
+
+// Tests for handlers_mjpeg.go (#578): stream-URL resolution + latest-frame
+// polling with ETag. Hermetic via stub recorders and a constructed (never
+// started) HTTPJPEGRecorder.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/stretchr/testify/require"
+)
+
+// frameStub serves a fixed latest frame.
+type frameStub struct {
+	stubRecorder
+	frame []byte
+}
+
+func (f *frameStub) LatestFrame() []byte { return f.frame }
+
+func mjpegEnv(t *testing.T, rec model.Recorder, cams []config.CameraConfig) http.Handler {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	cfg := &config.Config{Storage: config.StorageConfig{RootDir: store.RootDir()}, Cameras: cams}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	if rec != nil {
+		camMgr.SetTestRecorder("cam-1", rec)
+	}
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, nil, nil)
+	return h.Routes()
+}
+
+func TestMjpegStreamURL(t *testing.T) {
+	t.Parallel()
+
+	// No camera manager at all → 404.
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	rr := doRequest(t, TestHandler(db, store).Routes(), http.MethodGet, "/api/cameras/cam-1/stream.mjpeg", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// Unknown camera (no recorder, no http config) → 404.
+	rr = doRequest(t, mjpegEnv(t, nil, nil), http.MethodGet, "/api/cameras/cam-1/stream.mjpeg", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// HTTPJPEG recorder supplies its URL directly.
+	jpegRec := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{
+		CameraID: "cam-1", URL: "http://192.168.63.225:81/stream",
+	}, nil)
+	rr = doRequest(t, mjpegEnv(t, jpegRec, nil), http.MethodGet, "/api/cameras/cam-1/stream.mjpeg", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "http://192.168.63.225:81/stream")
+
+	// Fallback: http-protocol camera config URL.
+	cams := []config.CameraConfig{{ID: "cam-1", Protocol: "http", URL: "http://10.0.0.5/mjpeg"}}
+	rr = doRequest(t, mjpegEnv(t, nil, cams), http.MethodGet, "/api/cameras/cam-1/stream.mjpeg", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "http://10.0.0.5/mjpeg")
+}
+
+func TestGetMjpegURLFromRecorder(t *testing.T) {
+	t.Parallel()
+
+	jpegRec := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{URL: "http://x:81/stream"}, nil)
+	require.Equal(t, "http://x:81/stream", getMjpegURLFromRecorder(jpegRec))
+
+	// Delegate layers are unwrapped before the type check.
+	wrapped := &delegatingStub{inner: jpegRec}
+	require.Equal(t, "http://x:81/stream", getMjpegURLFromRecorder(wrapped))
+
+	// RTSP MJPEG recorders have no HTTP URL.
+	require.Empty(t, getMjpegURLFromRecorder(stubRecorder{}))
+}
+
+func TestLatestFrame_ETagFlow(t *testing.T) {
+	t.Parallel()
+	frame := []byte("fake-jpeg-bytes")
+	routes := mjpegEnv(t, &frameStub{frame: frame}, nil)
+
+	rr := doRequest(t, routes, http.MethodGet, "/api/cameras/cam-1/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "image/jpeg", rr.Header().Get("Content-Type"))
+	require.Equal(t, frame, rr.Body.Bytes())
+	etag := rr.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// Conditional request with the matching ETag → 304, no body.
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/cameras/cam-1/latest-frame", nil)
+	req.Header.Set("If-None-Match", etag)
+	w := httptest.NewRecorder()
+	routes.ServeHTTP(w, req)
+	require.Equal(t, http.StatusNotModified, w.Code)
+	require.Empty(t, w.Body.Bytes())
+
+	// Delegating recorder unwraps to the frame provider.
+	routes = mjpegEnv(t, &delegatingStub{inner: &frameStub{frame: frame}}, nil)
+	rr = doRequest(t, routes, http.MethodGet, "/api/cameras/cam-1/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, frame, rr.Body.Bytes())
+}
+
+func TestLatestFrame_Guards(t *testing.T) {
+	t.Parallel()
+
+	// Unknown camera → 404.
+	rr := doRequest(t, mjpegEnv(t, nil, nil), http.MethodGet, "/api/cameras/cam-1/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// Recorder without latest-frame support → 404.
+	rr = doRequest(t, mjpegEnv(t, stubRecorder{}, nil), http.MethodGet, "/api/cameras/cam-1/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// Recorder present but no frame captured yet → 404.
+	jpegRec := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{CameraID: "cam-1"}, nil)
+	rr = doRequest(t, mjpegEnv(t, jpegRec, nil), http.MethodGet, "/api/cameras/cam-1/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/internal/api/handlers_recording_extra_test.go
+++ b/internal/api/handlers_recording_extra_test.go
@@ -1,0 +1,334 @@
+package api
+
+// Tests for the uncovered long tail of handlers_recording.go (#578):
+// timeline segments / daily summary, MiBeeVision recording CRUD, timeline
+// seek, timeline gaps, and timelapse/AVI frame serving. All hermetic
+// (temp DB + temp files; AVI built with the internal avi muxer).
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTimelapseFrame(t *testing.T) {
+	t.Parallel()
+	for name, want := range map[string]bool{
+		"frame_1.jpg": true, "f2.jpeg": true, "seg.h264": true, "seg.h265": true,
+		"notes.txt": false, "plan.mp4": false, "frame.PNG": false,
+	} {
+		require.Equal(t, want, isTimelapseFrame(name), name)
+	}
+}
+
+func TestParseDateParts(t *testing.T) {
+	t.Parallel()
+	y, m, d, err := parseDateParts("2026-08-20")
+	require.NoError(t, err)
+	require.Equal(t, 2026, y)
+	require.Equal(t, 8, m)
+	require.Equal(t, 20, d)
+
+	for _, bad := range []string{"2026-08", "2026/08/20", "aaaa-bb-cc", ""} {
+		_, _, _, err := parseDateParts(bad)
+		require.Error(t, err, bad)
+	}
+}
+
+func TestTimelineSegments(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	day := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	seedRecording(t, db, makeRecording("seg-1", "cam-1", "h264", day, false))
+	seedRecording(t, db, makeRecording("seg-2", "cam-1", "h264", day.Add(time.Hour), true))
+
+	rr := doRequest(t, h.Routes(), http.MethodGet,
+		"/api/recordings/timeline?camera_id=cam-1&start=2026-08-20T00:00:00Z&end=2026-08-21T00:00:00Z", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Segments  []model.TimelineSegment `json:"segments"`
+		Total     int                     `json:"total"`
+		Truncated bool                    `json:"truncated"`
+	}
+	parseJSON(t, rr, &resp)
+	require.Len(t, resp.Segments, 2)
+	require.Equal(t, 2, resp.Total)
+	require.False(t, resp.Truncated)
+
+	// Empty range → non-nil empty array.
+	rr = doRequest(t, h.Routes(), http.MethodGet,
+		"/api/recordings/timeline?camera_id=ghost&start=2026-08-20T00:00:00Z&end=2026-08-21T00:00:00Z", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"segments":[]`)
+}
+
+func TestDailyRecordingSummary(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	day := time.Date(2026, 8, 20, 8, 0, 0, 0, time.UTC)
+	seedRecording(t, db, makeRecording("sum-1", "cam-1", "h264", day, false))
+	seedRecording(t, db, makeRecording("sum-2", "cam-1", "mjpeg", day.Add(2*time.Hour), false))
+
+	rr := doRequest(t, h.Routes(), http.MethodGet,
+		"/api/recordings/daily-summary?start=2026-08-20T00:00:00Z&end=2026-08-21T00:00:00Z&formats=h264,mjpeg&tz_offset=480", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"days":`)
+	require.Contains(t, rr.Body.String(), "2026-08-20")
+
+	// No data → empty array, not null.
+	rr = doRequest(t, h.Routes(), http.MethodGet,
+		"/api/recordings/daily-summary?start=2027-01-01T00:00:00Z&end=2027-01-02T00:00:00Z", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"days":[]`)
+}
+
+func TestRecordingCRUD_VisionPaths(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := withAPIKey("vision", h.Routes())
+
+	// Without API-key context → 401.
+	rr := doRequest(t, h.Routes(), http.MethodPost, "/api/recordings", strings.NewReader(`{}`), "", "")
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	// Bad body / missing fields.
+	rr = doRequest(t, routes, http.MethodPost, "/api/recordings", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPost, "/api/recordings", strings.NewReader(`{"camera_id":"c"}`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Create happy path.
+	body := `{"id":"vis-1","camera_id":"cam-1","file_path":"/x/a.mp4","format":"h264",
+		"started_at":"2026-08-20T10:00:00Z","ended_at":"2026-08-20T10:05:00Z","duration":300}`
+	rr = doRequest(t, routes, http.MethodPost, "/api/recordings", strings.NewReader(body), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code)
+	require.Contains(t, rr.Body.String(), "vis-1")
+
+	// PATCH: unknown → 404, known → update applied.
+	rr = doRequest(t, routes, http.MethodPatch, "/api/recordings/nope", strings.NewReader(`{}`), "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	rr = doRequest(t, routes, http.MethodPatch, "/api/recordings/vis-1",
+		strings.NewReader(`{"duration":42,"frame_count":7,"file_size":100}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	rec, err := db.GetRecording(context.Background(), "vis-1")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.Equal(t, 42.0, rec.Duration)
+	require.Equal(t, 7, rec.FrameCount)
+	require.Equal(t, int64(100), rec.FileSize)
+
+	// AI status: invalid value / unknown recording / happy path.
+	rr = doRequest(t, routes, http.MethodPatch, "/api/recordings/vis-1/ai-status",
+		strings.NewReader(`{"ai_status":"weird"}`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPatch, "/api/recordings/nope/ai-status",
+		strings.NewReader(`{"ai_status":"completed"}`), "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	rr = doRequest(t, routes, http.MethodPatch, "/api/recordings/vis-1/ai-status",
+		strings.NewReader(`{"ai_status":"completed"}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	rec, err = db.GetRecording(context.Background(), "vis-1")
+	require.NoError(t, err)
+	require.Equal(t, "completed", rec.AIStatus)
+}
+
+func TestTimelineSeekEvent(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	rr := doRequest(t, h.Routes(), http.MethodPost, "/api/recordings/timeline/seek-event",
+		strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	rr = doRequest(t, h.Routes(), http.MethodPost, "/api/recordings/timeline/seek-event",
+		strings.NewReader(`{"camera_id":"cam-1","type":"intra"}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "recorded")
+
+	// Missing camera/type default to "unknown"/"segment" — still 200.
+	rr = doRequest(t, h.Routes(), http.MethodPost, "/api/recordings/timeline/seek-event",
+		strings.NewReader(`{}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestTimelineGaps(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	// Missing date → 400; malformed date → 400.
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/timeline/gaps", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/timeline/gaps?date=2026/08/20", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	day := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	r1 := makeRecording("g1", "cam-1", "h264", day.Add(1*time.Hour), false)
+	r1.EndedAt = r1.StartedAt.Add(10 * time.Minute)
+	r2 := makeRecording("g2", "cam-1", "h264", day.Add(2*time.Hour), false)
+	r2.EndedAt = r2.StartedAt.Add(10 * time.Minute)
+	seedRecording(t, db, r1)
+	seedRecording(t, db, r2)
+
+	// Default min_gap=30s → the 50-minute hole between r1.end and r2.start.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/timeline/gaps?date=2026-08-20", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Gaps []struct {
+			Start    string  `json:"start"`
+			End      string  `json:"end"`
+			Duration float64 `json:"duration"`
+		} `json:"gaps"`
+		TotalGaps int `json:"total_gaps"`
+	}
+	parseJSON(t, rr, &resp)
+	require.Equal(t, 1, resp.TotalGaps)
+	require.InDelta(t, 3000.0, resp.Gaps[0].Duration, 0.1)
+
+	// min_gap larger than the hole → no gaps.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/timeline/gaps?date=2026-08-20&min_gap=2h", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"total_gaps":0`)
+
+	// Garbage min_gap falls back to 30s without error.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/timeline/gaps?date=2026-08-20&min_gap=nonsense", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestTimelapseFrames_ListAndServe(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	framesDir := t.TempDir()
+	for _, n := range []string{"frame_20260820_100001.jpg", "frame_20260820_100002.jpg", "notes.txt"} {
+		require.NoError(t, os.WriteFile(filepath.Join(framesDir, n), []byte("jpeg-bytes-"+n), 0o644))
+	}
+
+	rec := makeRecording("tl-1", "cam-1", "timelapse", time.Now(), false)
+	rec.FilePath = framesDir
+	seedRecording(t, db, rec)
+	seedRecording(t, db, makeRecording("h264-1", "cam-1", "h264", time.Now(), false))
+
+	// Listing: only frame files, sorted.
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-1/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var frames []struct {
+		Filename string `json:"filename"`
+		URL      string `json:"url"`
+	}
+	parseJSON(t, rr, &frames)
+	require.Len(t, frames, 2)
+	require.Equal(t, "frame_20260820_100001.jpg", frames[0].Filename)
+	require.Contains(t, frames[0].URL, "/api/recordings/tl-1/timelapse-frames/")
+
+	// Serving one frame returns its bytes.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-1/timelapse-frames/frame_20260820_100001.jpg", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "jpeg-bytes-frame_20260820_100001.jpg", rr.Body.String())
+
+	// Guards: bad filename chars → 400; dot/dotdot → 400; unknown recording → 404;
+	// non-timelapse format → 404.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-1/timelapse-frames/bad%2Fname.jpg", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-1/timelapse-frames/..", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/nope/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/h264-1/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	require.Contains(t, rr.Body.String(), "not a timelapse")
+
+	// Recording whose directory vanished → 404.
+	gone := makeRecording("tl-gone", "cam-1", "timelapse", time.Now(), false)
+	gone.FilePath = filepath.Join(t.TempDir(), "does-not-exist")
+	seedRecording(t, db, gone)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-gone/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// FilePath pointing at a regular file (not a dir) → 404.
+	notDir := makeRecording("tl-file", "cam-1", "timelapse", time.Now(), false)
+	notDir.FilePath = filepath.Join(t.TempDir(), "plain.jpg")
+	require.NoError(t, os.WriteFile(notDir.FilePath, []byte("x"), 0o644))
+	seedRecording(t, db, notDir)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/tl-file/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// buildTestAVI writes a small AVI with n video frames (synthetic JPEG
+// payloads) and returns its path.
+func buildTestAVI(t *testing.T, n int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "seg.avi")
+	f, err := os.Create(p)
+	require.NoError(t, err)
+	defer f.Close()
+	mux := avi.NewMuxer(f, 64, 48, 8000, true)
+	for i := range n {
+		frame := []byte(fmt.Sprintf("jpeg-frame-%02d-", i) + strings.Repeat("x", 32))
+		require.NoError(t, mux.WriteVideo(frame, int64(i)*1_000_000))
+	}
+	require.NoError(t, mux.Close())
+	return p
+}
+
+func TestAVIFrames_ListAndServe(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	rec := makeRecording("avi-1", "cam-1", "avi", time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC), false)
+	rec.FilePath = buildTestAVI(t, 3)
+	seedRecording(t, db, rec)
+
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/avi-1/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var frames []struct {
+		Filename string `json:"filename"`
+		Size     int64  `json:"size"`
+	}
+	parseJSON(t, rr, &frames)
+	require.Len(t, frames, 3)
+	require.Equal(t, "f000000.jpg", frames[0].Filename)
+	require.Positive(t, frames[0].Size)
+
+	// Serve frame 1: content matches the muxed payload prefix.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/avi-1/timelapse-frames/f000001.jpg", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "jpeg-frame-01")
+
+	// Out-of-range and malformed names.
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/avi-1/timelapse-frames/f000099.jpg", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/avi-1/timelapse-frames/notafnumber.jpg", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Missing file on disk → 404.
+	gone := makeRecording("avi-gone", "cam-1", "avi", time.Now(), false)
+	gone.FilePath = filepath.Join(t.TempDir(), "missing.avi")
+	seedRecording(t, db, gone)
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/recordings/avi-gone/timelapse-frames", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}

--- a/internal/api/handlers_storage_migrate_extra_test.go
+++ b/internal/api/handlers_storage_migrate_extra_test.go
@@ -1,0 +1,141 @@
+package api
+
+// Tests for the uncovered batch-migrate endpoints of
+// handlers_storage_migrate.go (#578): POST /api/storage/migrate and
+// GET /api/storage/migrate/status, plus humanBytes. Mirrors the
+// setupMigrationHandler pattern from handlers_storage_migrate_test.go
+// (per-test SQLite + temp roots; the migrator is the real one but never
+// started — only its Enqueue/Status surface is exercised).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/migration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageMigrateStatus_NilAndLive(t *testing.T) {
+	t.Parallel()
+
+	// Nil migrator → idle with an empty job list.
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/storage/migrate/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"state":"idle"`)
+
+	// Real migrator (not started) → state string + jobs array.
+	h2, _, _ := setupMigrationHandler(t)
+	h2.authMW = noopAuthMW()
+	rr = doRequest(t, h2.Routes(), http.MethodGet, "/api/storage/migrate/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"state"`)
+	require.Contains(t, rr.Body.String(), `"jobs"`)
+}
+
+func TestStartStorageMigrate_Validation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad json", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupMigrationHandler(t)
+		h.authMW = noopAuthMW()
+		req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate", strings.NewReader(`{bad`))
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("relative target", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupMigrationHandler(t)
+		h.authMW = noopAuthMW()
+		req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate",
+			strings.NewReader(`{"target":"data/recordings"}`))
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("same as current root", func(t *testing.T) {
+		t.Parallel()
+		h, _, old := setupMigrationHandler(t)
+		h.authMW = noopAuthMW()
+		req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate",
+			strings.NewReader(`{"target":"`+old+`"}`))
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("inside current root", func(t *testing.T) {
+		t.Parallel()
+		h, _, old := setupMigrationHandler(t)
+		h.authMW = noopAuthMW()
+		req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate",
+			strings.NewReader(`{"target":"`+old+"/sub"+`"}`))
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("unusable target", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupMigrationHandler(t)
+		h.authMW = noopAuthMW()
+		req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate",
+			strings.NewReader(`{"target":"/definitely/not/a/real/path"}`))
+		w := httptest.NewRecorder()
+		h.Routes().ServeHTTP(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestStartStorageMigrate_AcceptsAndEnqueues(t *testing.T) {
+	t.Parallel()
+	h, mig, _ := setupMigrationHandler(t)
+	h.authMW = noopAuthMW()
+	target := t.TempDir()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/storage/migrate",
+		strings.NewReader(`{"target":"`+target+`","delete_source":true}`))
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), `"jobs_enqueued":1`)
+
+	// Default switched hot + config updated.
+	require.Equal(t, target, h.store.RootDir())
+	require.Equal(t, target, h.config.Storage.RootDir)
+	require.Empty(t, h.config.Storage.CameraRoots)
+
+	// The camera with recordings outside the new default got one job.
+	// (Enqueue auto-starts the worker, so the state may be "running" or
+	// already back to "idle" — the job row is the durable fact.)
+	t.Cleanup(mig.Stop)
+	var job *migration.Job
+	require.Eventually(t, func() bool {
+		_, jobs := mig.Status()
+		for i := range jobs {
+			if jobs[i].CameraID == "cam-one" {
+				job = jobs[i]
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "migration job for cam-one never appeared")
+	require.True(t, job.DeleteSource)
+}
+
+func TestHumanBytes(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "512 B", humanBytes(512))
+	require.Equal(t, "1.5 MB", humanBytes(1536*1024))
+	require.Equal(t, "2.0 GB", humanBytes(2*1024*1024*1024))
+	require.Equal(t, "0 B", humanBytes(0))
+}

--- a/internal/api/handlers_stream_adapters_test.go
+++ b/internal/api/handlers_stream_adapters_test.go
@@ -1,0 +1,272 @@
+package api
+
+// Tests for the StreamHandler adapters + StreamRegistry + codec/hub
+// extractors in handlers_stream.go / handlers_hls.go (#578). Fully
+// hermetic: real hls.Manager pointed at a temp dir, stub recorders
+// implementing model.Recorder + model.HLSProvider. No media pump, no
+// network — the managers' start/stop bookkeeping is exercised with
+// synthetic SPS/PPS bytes.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/stretchr/testify/require"
+)
+
+// providerStub is a recorder that reports fixed codec parameters.
+type providerStub struct {
+	stubRecorder
+	codec model.Format
+	sps   []byte
+	pps   []byte
+	vps   []byte
+	hub   *model.StreamHub
+}
+
+func (p *providerStub) CodecParams() (model.Format, []byte, []byte, []byte) {
+	return p.codec, p.sps, p.pps, p.vps
+}
+
+func (p *providerStub) GetHub() *model.StreamHub { return p.hub }
+
+// delegatingStub unwraps to an inner recorder (ONVIF-style).
+type delegatingStub struct {
+	stubRecorder
+	inner model.Recorder
+}
+
+func (d *delegatingStub) Delegate() model.Recorder { return d.inner }
+
+func newTestHLSHandler(t *testing.T) *HLSStreamHandler {
+	t.Helper()
+	mgr := hls.NewManagerWithOpts(t.Context(), t.TempDir(), 0, 0, 0)
+	t.Cleanup(func() { mgr.StopAll() })
+	return &HLSStreamHandler{Mgr: mgr}
+}
+
+func TestStreamRegistry_Dispatch(t *testing.T) {
+	t.Parallel()
+	reg := NewStreamRegistry()
+	reg.Register(&HLSStreamHandler{})
+	reg.Register(&WebRTCStreamHandler{})
+	reg.Register(&MJPEGStreamHandler{})
+
+	require.Equal(t, []string{"hls"}, reg.protocolsForCodec(model.FormatH265))
+	require.Equal(t, []string{"hls", "webrtc"}, reg.protocolsForCodec(model.FormatH264))
+	require.Equal(t, []string{"mjpeg"}, reg.protocolsForCodec(model.FormatMJPEG))
+	require.Empty(t, reg.protocolsForCodec("rtsp"))
+
+	detail := reg.ProtocolsDetailForCodec(model.FormatH264)
+	require.Len(t, detail, 2)
+	require.True(t, detail[0].Available)
+	require.Equal(t, "hls", detail[0].Protocol)
+}
+
+// conditionalStub reports a supported-but-unavailable protocol.
+type conditionalStub struct {
+	stubRecorder
+}
+
+func (c *conditionalStub) Name() string                { return "cond" }
+func (c *conditionalStub) CanHandle(model.Format) bool { return false }
+func (c *conditionalStub) StartStream(string, model.Recorder, StreamStartOptions) error {
+	return nil
+}
+func (c *conditionalStub) StopStream(string) error { return nil }
+func (c *conditionalStub) SupportedCodec(codec model.Format) bool {
+	return codec == model.FormatH265
+}
+
+func (c *conditionalStub) UnavailabilityReason(model.Format) string {
+	return "disabled in settings"
+}
+
+func TestStreamRegistry_ConditionalHandler(t *testing.T) {
+	t.Parallel()
+	reg := NewStreamRegistry()
+	reg.Register(&conditionalStub{})
+
+	detail := reg.ProtocolsDetailForCodec(model.FormatH265)
+	require.Len(t, detail, 1)
+	require.False(t, detail[0].Available)
+	require.Equal(t, "disabled in settings", detail[0].Reason)
+
+	// For codecs it doesn't even nominally support, it is omitted entirely.
+	require.Empty(t, reg.ProtocolsDetailForCodec(model.FormatMJPEG))
+}
+
+func TestHLSAdapter_StartStop(t *testing.T) {
+	t.Parallel()
+	adapter := newTestHLSHandler(t)
+
+	// Happy path via HLSProvider with synthetic parameter sets.
+	rec := &providerStub{codec: model.FormatH264, sps: []byte{0x67, 0x64}, pps: []byte{0x68}}
+	require.NoError(t, adapter.StartStream("cam-1", rec, StreamStartOptions{}))
+	require.True(t, adapter.Mgr.IsActive("cam-1"))
+
+	// Stop with the recorder (hub path) and without.
+	require.NoError(t, adapter.StopStreamWithRecorder("cam-1", rec))
+	require.False(t, adapter.Mgr.IsActive("cam-1"))
+	require.NoError(t, adapter.StopStream("cam-1"))
+
+	// H.265 happy path.
+	h265 := &providerStub{codec: model.FormatH265, sps: []byte{0x42}, pps: []byte{0x44}, vps: []byte{0x40}}
+	require.NoError(t, adapter.StartStream("cam-2", h265, StreamStartOptions{}))
+	require.True(t, adapter.Mgr.IsActive("cam-2"))
+	require.NoError(t, adapter.StopStream("cam-2"))
+}
+
+func TestHLSAdapter_StartErrors(t *testing.T) {
+	t.Parallel()
+
+	// Nil manager.
+	nilMgr := &HLSStreamHandler{}
+	require.ErrorContains(t, nilMgr.StartStream("cam", &providerStub{codec: model.FormatH264}, StreamStartOptions{}), "not available")
+
+	adapter := newTestHLSHandler(t)
+
+	// Params not ready yet.
+	require.ErrorContains(t, adapter.StartStream("cam", &providerStub{codec: model.FormatH264}, StreamStartOptions{}), "not ready")
+	require.ErrorContains(t, adapter.StartStream("cam", &providerStub{codec: model.FormatH265}, StreamStartOptions{}), "not ready")
+
+	// Provider reporting a codec HLS cannot mux → HLSSupportedCodecError.
+	err := adapter.StartStream("cam", &providerStub{codec: model.FormatMJPEG}, StreamStartOptions{})
+	var codecErr *model.HLSSupportedCodecError
+	require.ErrorAs(t, err, &codecErr)
+
+	// Non-provider recorder of an unrecognized type → same error.
+	err = adapter.StartStream("cam", stubRecorder{}, StreamStartOptions{})
+	require.ErrorAs(t, err, &codecErr)
+}
+
+func TestHLSAdapter_SubStreamFallback(t *testing.T) {
+	t.Parallel()
+	adapter := newTestHLSHandler(t)
+	rec := &providerStub{codec: model.FormatH264, sps: []byte{0x67}, pps: []byte{0x68}}
+
+	// A sub-stream URL that cannot be pulled falls back to hub subscription
+	// (nil hub here) — the stream still starts.
+	opts := StreamStartOptions{SubStreamURL: "rtsp://127.0.0.1:9/none"}
+	require.NoError(t, adapter.StartStream("cam-sub", rec, opts))
+	require.True(t, adapter.Mgr.IsActive("cam-sub"))
+}
+
+func TestStreamAdapters_NoOpRegistrations(t *testing.T) {
+	t.Parallel()
+	reg := NewStreamRegistry()
+	reg.Register(&WebRTCStreamHandler{})
+	reg.Register(&FLVStreamHandler{})
+	reg.Register(&WSStreamHandler{})
+	reg.Register(&MJPEGStreamHandler{})
+
+	for _, codec := range []model.Format{model.FormatH264, model.FormatH265, model.FormatMJPEG, model.EncJPEG} {
+		detail := reg.ProtocolsDetailForCodec(codec)
+		require.NotEmpty(t, detail, string(codec))
+		for _, d := range detail {
+			require.True(t, d.Available, d.Protocol)
+		}
+	}
+
+	// The no-op start/stop contracts hold for every adapter.
+	for _, h := range []StreamHandler{
+		&WebRTCStreamHandler{}, &FLVStreamHandler{}, &WSStreamHandler{}, &MJPEGStreamHandler{},
+	} {
+		require.NoError(t, h.StartStream("cam", stubRecorder{}, StreamStartOptions{}))
+		require.NoError(t, h.StopStream("cam"))
+	}
+
+	// Naming contract the frontend depends on.
+	require.Equal(t, "webrtc", (&WebRTCStreamHandler{}).Name())
+	require.Equal(t, "flv", (&FLVStreamHandler{}).Name())
+	require.Equal(t, "wasm", (&WSStreamHandler{}).Name())
+	require.Equal(t, "mjpeg", (&MJPEGStreamHandler{}).Name())
+}
+
+func TestUnwrapDelegate(t *testing.T) {
+	t.Parallel()
+	inner := &providerStub{codec: model.FormatH264}
+	outer := &delegatingStub{inner: inner}
+	require.Equal(t, inner, unwrapDelegate(outer))
+
+	// Delegation chain terminates at nil-safe innermost recorder.
+	chain := &delegatingStub{inner: &delegatingStub{inner: stubRecorder{}}}
+	_, ok := unwrapDelegate(chain).(stubRecorder)
+	require.True(t, ok)
+
+	// Plain recorder is returned unchanged.
+	plain := stubRecorder{}
+	require.Equal(t, plain, unwrapDelegate(plain))
+}
+
+func TestGetCodecParams(t *testing.T) {
+	t.Parallel()
+
+	// Provider path (through a delegation layer).
+	deep := &delegatingStub{inner: &providerStub{codec: model.FormatH265, vps: []byte{1}}}
+	codec, sps, _, vps := getCodecParams(deep)
+	require.Equal(t, model.FormatH265, codec)
+	require.Nil(t, sps)
+	require.NotNil(t, vps)
+
+	// JPEG/MJPEG concrete fallbacks.
+	codec, _, _, _ = getCodecParams(&recorder.HTTPJPEGRecorder{})
+	require.Equal(t, model.EncJPEG, codec)
+	codec, _, _, _ = getCodecParams(&recorder.MJPEGRecorder{})
+	require.Equal(t, model.FormatMJPEG, codec)
+
+	// Unknown type → empty codec.
+	codec, _, _, _ = getCodecParams(stubRecorder{})
+	require.Empty(t, codec)
+}
+
+func TestGetStreamHubs(t *testing.T) {
+	t.Parallel()
+
+	// GetHub interface path.
+	hub := &model.StreamHub{}
+	require.Equal(t, hub, getStreamHub(&providerStub{hub: hub}))
+
+	// Recorders without a hub surface fall through to nil. (Concrete
+	// recorder types embed *baseRecorder — a zero value panics on promoted
+	// field reads, so they are exercised via their constructors in the
+	// recorder package's own tests instead.)
+	require.Nil(t, getStreamHub(stubRecorder{}))
+	require.Nil(t, getRecorderHub(stubRecorder{}))
+}
+
+func TestParseQualityValues(t *testing.T) {
+	t.Parallel()
+	for q, want := range map[string]string{"": "main", "main": "main", "sub": "sub"} {
+		got, err := parseQuality(httptest.NewRequest(http.MethodGet, "/x?quality="+q, nil))
+		require.NoError(t, err, q)
+		require.Equal(t, want, got)
+	}
+	_, err := parseQuality(httptest.NewRequest(http.MethodGet, "/x?quality=ultra", nil))
+	require.ErrorContains(t, err, "invalid quality")
+}
+
+func TestAcquireSub(t *testing.T) {
+	t.Parallel()
+
+	// No camera manager → main-stream header, nil source.
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	w := httptest.NewRecorder()
+	require.Nil(t, h.acquireSub(w, httptest.NewRequest(http.MethodGet, "/x", nil), "cam-1"))
+	require.Equal(t, "main", w.Header().Get("X-Stream-Quality"))
+
+	// Real manager, unknown camera → AcquireSubStream errors → main fallback.
+	cfg := &config.Config{Storage: config.StorageConfig{RootDir: store.RootDir()}, Cameras: []config.CameraConfig{}}
+	h2 := NewHandler(db, store, noopAuthMW(), cfg, camera.NewCameraManager(cfg, store, db, ""), nil, "", nil, nil, nil, nil, nil)
+	w2 := httptest.NewRecorder()
+	require.Nil(t, h2.acquireSub(w2, httptest.NewRequest(http.MethodGet, "/x", nil), "ghost"))
+	require.Equal(t, "main", w2.Header().Get("X-Stream-Quality"))
+}

--- a/internal/api/handlers_system_extra_test.go
+++ b/internal/api/handlers_system_extra_test.go
@@ -1,0 +1,198 @@
+package api
+
+// Tests for the uncovered long tail of handlers_system.go (#578):
+// transcoding + auto-discover settings, system stats, feature toggles,
+// backup listing/creation, and the /proc readers. The /proc readers run
+// only where /proc exists (Linux — CI and the RPi target are Linux).
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// systemEnv builds a Handler with a live config + config file in a temp dir.
+func systemEnv(t *testing.T) (*Handler, http.Handler) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	cfg := &config.Config{
+		Storage:      config.StorageConfig{RootDir: store.RootDir()},
+		AutoDiscover: config.AutoDiscoverConfig{ScanIntervalSeconds: 60},
+		Transcoding:  config.TranscodingConfig{Enabled: false, MaxWorkers: 2},
+	}
+	require.NoError(t, config.Save(cfgPath, cfg))
+	h := NewHandler(db, store, noopAuthMW(), cfg, nil, nil, cfgPath, nil, nil, nil, nil, nil)
+	return h, h.Routes()
+}
+
+func TestTranscodingSettings(t *testing.T) {
+	t.Parallel()
+	_, routes := systemEnv(t)
+
+	rr := doRequest(t, routes, http.MethodGet, "/api/settings/transcoding", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"max_workers":2`)
+
+	// Update within bounds persists.
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/transcoding",
+		strings.NewReader(`{"enabled":true,"max_workers":3}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	rr = doRequest(t, routes, http.MethodGet, "/api/settings/transcoding", nil, "", "")
+	require.Contains(t, rr.Body.String(), `"enabled":true`)
+	require.Contains(t, rr.Body.String(), `"max_workers":3`)
+
+	// Out-of-bounds workers → 400; bad JSON → 400.
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/transcoding",
+		strings.NewReader(`{"max_workers":9}`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/transcoding",
+		strings.NewReader(`{"max_workers":0}`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/transcoding",
+		strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Nil-config handler degrades to 500.
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	nilCfg := TestHandler(db, store)
+	rr = doRequest(t, nilCfg.Routes(), http.MethodGet, "/api/settings/transcoding", nil, "", "")
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestAutoDiscoverSettings(t *testing.T) {
+	t.Parallel()
+	h, routes := systemEnv(t)
+
+	// GET never leaks the password, only the has_default_password flag.
+	h.config.AutoDiscover.DefaultPassword = "secret"
+	rr := doRequest(t, routes, http.MethodGet, "/api/settings/auto-discover", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotContains(t, rr.Body.String(), "secret")
+	require.Contains(t, rr.Body.String(), `"has_default_password":true`)
+
+	// PUT: floor scan interval to 30, set fields, empty password = unchanged.
+	body := `{"enabled":true,"scan_interval":5,"listen_for_hello":false,
+		"network_interface":"eth0","default_username":"admin","default_password":"","ignore_scopes":["lan"]}`
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/auto-discover", strings.NewReader(body), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, 30, h.config.AutoDiscover.ScanIntervalSeconds)
+	require.Equal(t, "admin", h.config.AutoDiscover.DefaultUsername)
+	require.Equal(t, "secret", h.config.AutoDiscover.DefaultPassword, "empty password must not wipe")
+
+	// Non-empty password updates it.
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/auto-discover",
+		strings.NewReader(`{"default_password":"new"}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "new", h.config.AutoDiscover.DefaultPassword)
+
+	// Bad JSON → 400; nil config → 500.
+	rr = doRequest(t, routes, http.MethodPut, "/api/settings/auto-discover",
+		strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	nilCfg := TestHandler(db, store)
+	rr = doRequest(t, nilCfg.Routes(), http.MethodGet, "/api/settings/auto-discover", nil, "", "")
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	rr = doRequest(t, nilCfg.Routes(), http.MethodPut, "/api/settings/auto-discover",
+		strings.NewReader(`{}`), "", "")
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestSystemStats(t *testing.T) {
+	t.Parallel()
+	_, routes := systemEnv(t)
+	rr := doRequest(t, routes, http.MethodGet, "/api/stats/system", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"cpu"`)
+	require.Contains(t, rr.Body.String(), `"memory"`)
+	require.Contains(t, rr.Body.String(), `"uptime"`)
+}
+
+func TestProcReaders(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS != "linux" {
+		t.Skip("/proc readers are Linux-only")
+	}
+	total, idle, err := readCPURaw()
+	require.NoError(t, err)
+	require.Positive(t, total)
+	require.GreaterOrEqual(t, total, idle)
+
+	memTotal, memAvail, err := readMemoryInfo()
+	require.NoError(t, err)
+	require.Positive(t, memTotal)
+	require.Positive(t, memAvail)
+
+	sent, recv, err := readNetworkInfo()
+	require.NoError(t, err)
+	// Loopback always has some traffic on a live host.
+	require.GreaterOrEqual(t, sent+recv, uint64(0))
+	require.Positive(t, readProcessRSS())
+}
+
+func TestFeatureToggles(t *testing.T) {
+	t.Parallel()
+	_, routes := systemEnv(t)
+
+	rr := doRequest(t, routes, http.MethodPut, "/api/features",
+		strings.NewReader(`{"protocols":{"onvif":true,"rtsp":false}}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"onvif":true`)
+	require.Contains(t, rr.Body.String(), `"rtsp":false`)
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/features", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"onvif":true`)
+
+	// Bad JSON → 400.
+	rr = doRequest(t, routes, http.MethodPut, "/api/features", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestBackupCreateAndList(t *testing.T) {
+	t.Parallel()
+	h, routes := systemEnv(t)
+
+	// Empty listing first.
+	rr := doRequest(t, routes, http.MethodGet, "/api/backups", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "[]")
+
+	rr = doRequest(t, routes, http.MethodPost, "/api/backup", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "nvr-backup-")
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/backups", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), ".db")
+
+	// The backup file really exists next to the config.
+	entries, err := os.ReadDir(filepath.Join(filepath.Dir(h.configPath), "backups"))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}
+
+func TestFormatUptime(t *testing.T) {
+	t.Parallel()
+	cases := map[time.Duration]string{
+		90 * time.Second:             "1m 30s",
+		2*time.Hour + 15*time.Minute: "2h 15m 0s",
+		42 * time.Second:             "42s",
+		0:                            "0s",
+	}
+	for d, want := range cases {
+		require.Equal(t, want, formatUptime(d), d.String())
+	}
+}

--- a/internal/api/handlers_update_test.go
+++ b/internal/api/handlers_update_test.go
@@ -1,0 +1,38 @@
+package api
+
+// Tests for handlers_update.go (#578). The nil-checker paths are the
+// hermetic surface: a live update.Checker would dial GitHub, which is not
+// CI-safe. updateChecker stays nil throughout (never mutated here — it is
+// a package var and tests run in parallel).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate_NoCheckerDegradesGracefully(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := h.Routes()
+
+	rr := doRequest(t, routes, http.MethodGet, "/api/version", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"current":""`)
+	require.Contains(t, rr.Body.String(), `"deployment"`)
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/update/check", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"update_available":false`)
+
+	// POST forces a refresh; with no checker it must still answer, not 5xx.
+	req := httptest.NewRequest(http.MethodPost, "/api/update/check", nil)
+	w := httptest.NewRecorder()
+	routes.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"deployment"`)
+}

--- a/internal/api/handlers_vision_test.go
+++ b/internal/api/handlers_vision_test.go
@@ -1,0 +1,71 @@
+package api
+
+// Tests for handlers_vision.go (#578): heartbeat + status with and without
+// a real vision.Coordinator (db/provider nil are supported constructor
+// values — only the health tracker matters here).
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVision_NilCoordinatorDegrades(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := h.Routes()
+
+	// Heartbeat without coordinator → 503 (public, unauthenticated route).
+	rr := doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat",
+		strings.NewReader(`{"status":"ok"}`), "", "")
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+
+	// Status without coordinator → {"enabled":false}, 200.
+	rr = doRequest(t, routes, http.MethodGet, "/api/vision/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"enabled":false`)
+}
+
+func TestVision_HeartbeatAndStatus(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	h.SetVisionCoordinator(vision.NewCoordinator(
+		func() config.VisionConfig { return config.VisionConfig{HeartbeatTimeoutSecs: 30} },
+		func() string { return store.RootDir() },
+		event.NewEventBus(4),
+		nil, nil,
+	))
+	routes := h.Routes()
+
+	// Status before any heartbeat: enabled, no last_seen (zero time omitted).
+	rr := doRequest(t, routes, http.MethodGet, "/api/vision/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"enabled":true`)
+	require.NotContains(t, rr.Body.String(), "last_seen")
+	require.NotContains(t, rr.Body.String(), "0001-01-01")
+
+	// Bad body → 400.
+	rr = doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat", strings.NewReader(`{bad`), "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Healthy heartbeat → ok + push_enabled true; status now carries fields.
+	body := `{"status":"healthy","device":"vision-1","queue_depth":2,"processed_count":9,"skip_cameras":["cam-x"]}`
+	rr = doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat", strings.NewReader(body), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"push_enabled":true`)
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/vision/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"device":"vision-1"`)
+	require.Contains(t, rr.Body.String(), `"last_seen"`)
+	require.Contains(t, rr.Body.String(), "cam-x")
+}

--- a/internal/api/handlers_vod_test.go
+++ b/internal/api/handlers_vod_test.go
@@ -1,0 +1,103 @@
+package api
+
+// Tests for handlers_vod.go — VOD HLS playback endpoints (#321, batch #578).
+// Error/validation paths only: the happy path needs a real parseable MP4
+// fixture (vod.Manager parses sample tables from disk), which is out of
+// scope for the hermetic batch per the #578 non-goals.
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const vodDay = "2026-08-20T10:00:00Z"
+
+func vodRange(extra string) string {
+	return "?start=" + vodDay + "&end=2026-08-20T12:00:00Z" + extra
+}
+
+func TestVODPlaylist_Validation(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := h.Routes()
+
+	cases := []struct {
+		name string
+		qs   string
+		code int
+	}{
+		{"missing start", "?end=2026-08-20T12:00:00Z", http.StatusBadRequest},
+		{"missing end", "?start=" + vodDay, http.StatusBadRequest},
+		{"bad start", "?start=nope&end=2026-08-20T12:00:00Z", http.StatusBadRequest},
+		{"bad end", "?start=" + vodDay + "&end=nope", http.StatusBadRequest},
+		{"end before start", "?start=" + vodDay + "&end=2026-08-20T09:00:00Z", http.StatusBadRequest},
+		{"range too wide", "?start=" + vodDay + "&end=2026-08-25T10:00:00Z", http.StatusBadRequest},
+		{"no recordings in range", vodRange(""), http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rr := doRequest(t, routes, http.MethodGet, "/api/cameras/cam-1/playback/playlist.m3u8"+tc.qs, nil, "", "")
+			require.Equal(t, tc.code, rr.Code)
+		})
+	}
+}
+
+func TestVODSegment_Guards(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := h.Routes()
+
+	seedRecording(t, db, makeRecording("vod-1", "cam-1", "h264", time.Now(), false))
+	// A recording of a different camera: URL camera mismatch → 404.
+	seedRecording(t, db, makeRecording("vod-other", "cam-2", "h264", time.Now(), false))
+	// Non-video format → 404 "not video-playable".
+	seedRecording(t, db, makeRecording("vod-mjpeg", "cam-1", "mjpeg", time.Now(), false))
+
+	cases := []struct {
+		name string
+		path string
+		code int
+	}{
+		{"unknown recording", "/api/cameras/cam-1/playback/nope/init.mp4", http.StatusNotFound},
+		{"camera mismatch", "/api/cameras/cam-1/playback/vod-other/init.mp4", http.StatusNotFound},
+		{"non-video format", "/api/cameras/cam-1/playback/vod-mjpeg/init.mp4", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rr := doRequest(t, routes, http.MethodGet, tc.path, nil, "", "")
+			require.Equal(t, tc.code, rr.Code)
+		})
+	}
+}
+
+func TestVODSegment_GarbageFileIs500(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	// A video recording whose file exists but is not an MP4: the fragment
+	// planner must fail with 500, not serve garbage.
+	p := filepath.Join(t.TempDir(), "seg.mp4")
+	require.NoError(t, os.WriteFile(p, []byte("definitely not an mp4"), 0o644))
+	rec := makeRecording("vod-garbage", "cam-1", "h264", time.Now(), false)
+	rec.FilePath = p
+	seedRecording(t, db, rec)
+
+	rr := doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/playback/vod-garbage/init.mp4", nil, "", "")
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	rr = doRequest(t, h.Routes(), http.MethodGet, "/api/cameras/cam-1/playback/vod-garbage/f0-1.m4s", nil, "", "")
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+}

--- a/internal/api/handlers_xiaomi_audio_test.go
+++ b/internal/api/handlers_xiaomi_audio_test.go
@@ -1,0 +1,200 @@
+package api
+
+// Tests for handlers_xiaomi_audio.go — two-way audio REST guards +
+// processAudioUpstreamMessage encode matrix (#578). Uses the same mock
+// MISS client pattern as handlers_xiaomi_ptz_test.go: no camera, no
+// network. The mock conn reports the CS2 protocol, which makes
+// StartSpeaker fail with "requires TUTK transport" — that exercises the
+// handler's error branch deterministically.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRecorder is any non-Xiaomi recorder: exercises the type-assert
+// guard (400 "does not support two-way audio").
+type stubRecorder struct{}
+
+func (stubRecorder) Start(ctx context.Context) error { return nil }
+func (stubRecorder) Stop() error                     { return nil }
+func (stubRecorder) Status() model.RecorderStatus    { return "" }
+
+func xiaomiAudioEnv(t *testing.T, rec model.Recorder, cameraID string) http.Handler {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, db.UpsertCamera(t.Context(), cameraID, "Cam", "xiaomi", "", "xiaomi://1", "", "", "", "", "", ""))
+
+	cfg := &config.Config{
+		Storage: config.StorageConfig{RootDir: store.RootDir(), SegmentDuration: "30s"},
+		Cameras: []config.CameraConfig{},
+	}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	if rec != nil {
+		camMgr.SetTestRecorder(cameraID, rec)
+	}
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, nil, nil)
+	return h.Routes()
+}
+
+func newXiaomiRecorderWithMock(t *testing.T) (*xiaomi.XiaomiRecorder, *testMISSConn) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	rec := xiaomi.NewXiaomiRecorder(xiaomi.XiaomiRecorderConfig{CameraID: "xiaomi-cam", DID: "12345"}, store)
+	conn := newTestMISSConn()
+	conn.protocol = "tutk" // CS2 transport refuses two-way audio writes
+	rec.SetMISSClientForTest(xiaomi.NewTestMISSClient(conn))
+	return rec, conn
+}
+
+func TestTwoWayAudio_Guards(t *testing.T) {
+	t.Parallel()
+
+	// Unknown camera → 404.
+	routes := xiaomiAudioEnv(t, nil, "ghost")
+	rr := doRequest(t, routes, http.MethodPost, "/api/cameras/ghost/xiaomi/two-way-audio/start", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	// Non-Xiaomi recorder → 400 on all three endpoints.
+	routes = xiaomiAudioEnv(t, stubRecorder{}, "plain-cam")
+	rr = doRequest(t, routes, http.MethodPost, "/api/cameras/plain-cam/xiaomi/two-way-audio/start", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	rr = doRequest(t, routes, http.MethodPost, "/api/cameras/plain-cam/xiaomi/two-way-audio/stop", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	req := httptest.NewRequest(http.MethodGet, "/api/ws/camera/plain-cam/audio-upstream", nil)
+	w := httptest.NewRecorder()
+	routes.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Xiaomi recorder over the CS2 mock: start fails (TUTK-only) → 400,
+	// and stop is a plain packet write → 200.
+	db2, store2 := setupTestDB(t)
+	t.Cleanup(func() { db2.Close() })
+	rec := xiaomi.NewXiaomiRecorder(xiaomi.XiaomiRecorderConfig{CameraID: "xiaomi-cam", DID: "1"}, store2)
+	rec.SetMISSClientForTest(xiaomi.NewTestMISSClient(newTestMISSConn())) // cs2
+	routes = xiaomiAudioEnv(t, rec, "xiaomi-cam")
+	rr = doRequest(t, routes, http.MethodPost, "/api/cameras/xiaomi-cam/xiaomi/two-way-audio/start", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "TUTK")
+
+	// Stop succeeds over the mock (plain packet write) → 200.
+	rr = doRequest(t, routes, http.MethodPost, "/api/cameras/xiaomi-cam/xiaomi/two-way-audio/stop", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "stopped")
+}
+
+func TestTwoWayAudio_StartWithoutClient(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, db.UpsertCamera(t.Context(), "xiaomi-cam", "Cam", "xiaomi", "", "xiaomi://1", "", "", "", "", "", ""))
+
+	cfg := &config.Config{Storage: config.StorageConfig{RootDir: store.RootDir()}, Cameras: []config.CameraConfig{}}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	// No SetMISSClientForTest → missClient nil → "not connected" → 400.
+	rec := xiaomi.NewXiaomiRecorder(xiaomi.XiaomiRecorderConfig{CameraID: "xiaomi-cam", DID: "1"}, store)
+	camMgr.SetTestRecorder("xiaomi-cam", rec)
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, nil, nil)
+
+	rr := doRequest(t, h.Routes(), http.MethodPost, "/api/cameras/xiaomi-cam/xiaomi/two-way-audio/start", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "not connected")
+
+	rr = doRequest(t, h.Routes(), http.MethodPost, "/api/cameras/xiaomi-cam/xiaomi/two-way-audio/stop", nil, "", "")
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestProcessAudioUpstreamMessage(t *testing.T) {
+	t.Parallel()
+
+	pcmMsg := make([]byte, 641) // reserved byte + 640 PCM bytes
+	for i := range pcmMsg {
+		pcmMsg[i] = byte(i % 251)
+	}
+
+	t.Run("undersized frame is skipped", func(t *testing.T) {
+		t.Parallel()
+		rec, _ := newXiaomiRecorderWithMock(t)
+		require.NoError(t, processAudioUpstreamMessage(rec, missCodecPCMU, pcmMsg[:100]))
+	})
+
+	t.Run("pcm passthrough", func(t *testing.T) {
+		t.Parallel()
+		rec, _ := newXiaomiRecorderWithMock(t)
+		require.NoError(t, processAudioUpstreamMessage(rec, missCodecPCM, pcmMsg))
+	})
+
+	t.Run("g711 encode", func(t *testing.T) {
+		t.Parallel()
+		rec, _ := newXiaomiRecorderWithMock(t)
+		require.NoError(t, processAudioUpstreamMessage(rec, missCodecPCMU, pcmMsg))
+		require.NoError(t, processAudioUpstreamMessage(rec, missCodecPCMA, pcmMsg))
+	})
+
+	t.Run("unsupported codec is skipped", func(t *testing.T) {
+		t.Parallel()
+		rec, _ := newXiaomiRecorderWithMock(t)
+		require.NoError(t, processAudioUpstreamMessage(rec, 9999, pcmMsg))
+	})
+
+	t.Run("nil client surfaces write error", func(t *testing.T) {
+		t.Parallel()
+		db, store := setupTestDB(t)
+		t.Cleanup(func() { db.Close() })
+		rec := xiaomi.NewXiaomiRecorder(xiaomi.XiaomiRecorderConfig{CameraID: "c", DID: "1"}, store)
+		require.Error(t, processAudioUpstreamMessage(rec, missCodecPCM, pcmMsg))
+	})
+}
+
+func TestAudioUpstreamWS_RoundTrip(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	require.NoError(t, db.UpsertCamera(t.Context(), "xiaomi-cam", "Cam", "xiaomi", "", "xiaomi://1", "", "", "", "", "", ""))
+
+	cfg := &config.Config{Storage: config.StorageConfig{RootDir: store.RootDir()}, Cameras: []config.CameraConfig{}}
+	camMgr := camera.NewCameraManager(cfg, store, db, "")
+	rec := xiaomi.NewXiaomiRecorder(xiaomi.XiaomiRecorderConfig{CameraID: "xiaomi-cam", DID: "1"}, store)
+	conn := newTestMISSConn()
+	conn.protocol = "tutk" // CS2 transport refuses two-way audio
+	rec.SetMISSClientForTest(xiaomi.NewTestMISSClient(conn))
+	camMgr.SetTestRecorder("xiaomi-cam", rec)
+
+	h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, nil, nil)
+	h.SetWSManager(wsstream.NewManager())
+
+	srv := httptest.NewServer(h.Routes())
+	defer srv.Close()
+	url := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/ws/camera/xiaomi-cam/audio-upstream"
+
+	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	require.NoError(t, err)
+
+	msg := make([]byte, 641)
+	for i := range msg {
+		msg[i] = byte(i % 251)
+	}
+	require.NoError(t, ws.WriteMessage(websocket.BinaryMessage, msg))
+	// The server loops on read until the client goes away — closing here
+	// ends that loop; no server→client message is ever expected.
+	require.NoError(t, ws.Close())
+
+	// The PCM message must have been written to the camera: SpeakerCodec
+	// defaults to 0 → handler substitutes PCM → WriteAudio → WritePacket.
+	require.Eventually(t, func() bool { return conn.packetWrites.Load() > 0 },
+		5*time.Second, 50*time.Millisecond, "audio packet never reached the mock camera")
+}

--- a/internal/api/handlers_xiaomi_ptz_test.go
+++ b/internal/api/handlers_xiaomi_ptz_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestXiaomiPTZMove(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	require.Equal(t, "ok", resp["status"])
-	require.True(t, mockConn.writeCalled, "WriteCommand should have been called")
+	require.True(t, mockConn.writeCalled.Load(), "WriteCommand should have been called")
 }
 
 func TestXiaomiPTZStop(t *testing.T) {
@@ -86,7 +87,7 @@ func TestXiaomiPTZStop(t *testing.T) {
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err)
 	require.Equal(t, "ok", resp["status"])
-	require.True(t, mockConn.writeCalled, "WriteCommand should have been called")
+	require.True(t, mockConn.writeCalled.Load(), "WriteCommand should have been called")
 }
 
 func TestXiaomiDeviceInfo(t *testing.T) {
@@ -234,28 +235,44 @@ func TestXiaomiPTZInvalidInput(t *testing.T) {
 
 // testMISSConn implements xiaomi.MISSConn for testing MotorControl and GetDeviceInfo.
 type testMISSConn struct {
-	writeCalled bool
+	// writeCalled / packetWrites are atomics: WriteCommand/WritePacket run
+	// on the recorder's goroutines while tests assert on them (#571
+	// race-clean rule).
+	writeCalled atomic.Bool
 	readCmdData []byte // data returned by ReadCommand for GetDeviceInfo
+	// protocol overrides the reported transport ("cs2" default); "tutk"
+	// unlocks the two-way-audio paths that CS2 refuses.
+	protocol string
+	// packetWrites counts WritePacket calls (media packets).
+	packetWrites atomic.Int32
 }
 
 func newTestMISSConn() *testMISSConn {
 	return &testMISSConn{}
 }
 
-func (m *testMISSConn) Protocol() string                     { return "cs2" }
+func (m *testMISSConn) Protocol() string {
+	if m.protocol != "" {
+		return m.protocol
+	}
+	return "cs2"
+}
 func (m *testMISSConn) Version() string                      { return "test" }
 func (m *testMISSConn) ReadCommand() (uint32, []byte, error) { return 0, m.readCmdData, nil }
 func (m *testMISSConn) WriteCommand(cmd uint32, data []byte) error {
-	m.writeCalled = true
+	m.writeCalled.Store(true)
 	_ = cmd
 	_ = data
 	return nil
 }
-func (m *testMISSConn) ReadPacket() ([]byte, []byte, error)   { return nil, nil, nil }
-func (m *testMISSConn) WritePacket(hdr, payload []byte) error { return nil }
-func (m *testMISSConn) RemoteAddr() net.Addr                  { return &testMISSAddr{} }
-func (m *testMISSConn) SetDeadline(t time.Time) error         { return nil }
-func (m *testMISSConn) Close() error                          { return nil }
+func (m *testMISSConn) ReadPacket() ([]byte, []byte, error) { return nil, nil, nil }
+func (m *testMISSConn) WritePacket(hdr, payload []byte) error {
+	m.packetWrites.Add(1)
+	return nil
+}
+func (m *testMISSConn) RemoteAddr() net.Addr          { return &testMISSAddr{} }
+func (m *testMISSConn) SetDeadline(t time.Time) error { return nil }
+func (m *testMISSConn) Close() error                  { return nil }
 
 // testMISSAddr implements net.Addr for the mock MISS conn.
 type testMISSAddr struct{}

--- a/internal/api/xiaomi_local_test.go
+++ b/internal/api/xiaomi_local_test.go
@@ -1,0 +1,79 @@
+package api
+
+// Tests for xiaomi_local.go (#578) — pure helper surface only: the cloud
+// sign-in/device-list paths dial the Xiaomi cloud and are not CI-hermetic.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXiaomiLocal_SessionToResult(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, sessionToResult(nil))
+	r := sessionToResult(&xiaomi.CloudSession{UserID: "u", PassToken: "p", Region: "cn"})
+	require.NotNil(t, r)
+	require.Equal(t, "u", r.UserID)
+	require.Equal(t, "p", r.PassToken)
+	require.Equal(t, "cn", r.Region)
+}
+
+func TestXiaomiLocal_VerificationMapping(t *testing.T) {
+	t.Parallel()
+	login := loginErrToVerification(&xiaomi.LoginError{Captcha: []byte("img"), VerifyPhone: "+86"}, "sess-1")
+	require.NotNil(t, login.Captcha)
+	require.Equal(t, "+86", login.VerifyPhone)
+	require.Equal(t, "", login.VerifyEmail)
+	require.Equal(t, "sess-1", login.CaptchaSessionID)
+
+	captcha := captchaErrToVerification(&xiaomi.CaptchaSessionError{
+		LoginError:       &xiaomi.LoginError{VerifyEmail: "a@b.c"},
+		CaptchaSessionID: "sess-2",
+	})
+	require.Equal(t, "a@b.c", captcha.VerifyEmail)
+	require.Equal(t, "sess-2", captcha.CaptchaSessionID)
+}
+
+func TestXiaomiLocal_ErrorClassification(t *testing.T) {
+	t.Parallel()
+	var loginErr *xiaomi.LoginError
+	require.False(t, isLoginErr(context.Canceled, &loginErr))
+	require.True(t, isLoginErr(&xiaomi.LoginError{Captcha: []byte("x")}, &loginErr))
+	require.NotEmpty(t, loginErr.Captcha)
+
+	var capErr *xiaomi.CaptchaSessionError
+	require.False(t, isCaptchaErr(context.Canceled, &capErr))
+	require.True(t, isCaptchaErr(&xiaomi.CaptchaSessionError{}, &capErr))
+}
+
+func TestXiaomiLocal_IsCameraModel(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"isa.camera.hlc8":  true,
+		"lumi.cateye.v1":   true,
+		"isa.feeder.cat1":  true,
+		"isa.airpurifier":  false,
+		"chuangmi.plug.v1": false,
+		"":                 false,
+	}
+	for model, want := range cases {
+		require.Equal(t, want, isXiaomiCameraModel(model), model)
+	}
+}
+
+func TestXiaomiLocal_CheckVendorGuards(t *testing.T) {
+	t.Parallel()
+	// nil-config guard (LocalXiaomiAuth constructed without cfg).
+	a := &LocalXiaomiAuth{}
+	_, err := a.CheckVendor(context.Background(), "123")
+	require.EqualError(t, err, "xiaomi config not available")
+
+	// Constructor + SetCloudConfig are side-effect-free wiring.
+	cfg := &config.Config{}
+	auth := NewLocalXiaomiAuth(cfg)
+	require.NoError(t, auth.SetCloudConfig(context.Background(), "u", "t", "de"))
+}

--- a/internal/gb28181/cascade/loopback_test.go
+++ b/internal/gb28181/cascade/loopback_test.go
@@ -279,19 +279,25 @@ func TestLoopbackInviteLiveForwardAndBye(t *testing.T) {
 	require.Len(t, sessionIDs(svc), 1, "re-INVITE must not create a second session")
 
 	// Supersede: a new-dialog INVITE for the same channel tears the old one.
+	// The old session's removal is asynchronous (the 200 for the new INVITE
+	// can arrive first), so poll the observable end state (#571 rule).
 	invite2 := up.request(sip.INVITE, lbChannelOne, playSDP(t, "Play", false), "application/sdp")
 	res = up.roundTrip(invite2)
 	require.Equal(t, 200, int(res.StatusCode()))
-	live := sessionIDs(svc)
-	require.Len(t, live, 1, "one channel, one live forward")
-	require.NotEqual(t, first[0], live[0], "the superseding dialog must own the session")
+	require.Eventually(t, func() bool {
+		live := sessionIDs(svc)
+		return len(live) == 1 && live[0] != first[0]
+	}, 5*time.Second, 20*time.Millisecond, "the superseding dialog must own the session")
 
-	// BYE (in-dialog: the INVITE's Call-ID) tears the forward down.
+	// BYE (in-dialog: the INVITE's Call-ID) tears the forward down. The map
+	// delete runs after the 200 is sent — poll instead of asserting instantly
+	// (CI-runner flake: "BYE must remove the forward session").
 	byeID, ok := invite2.CallID()
 	require.True(t, ok)
 	res = up.roundTrip(up.requestDialog(sip.BYE, lbChannelOne, "", "", byeID))
 	require.Equal(t, 200, int(res.StatusCode()))
-	require.Empty(t, sessionIDs(svc), "BYE must remove the forward session")
+	require.Eventually(t, func() bool { return len(sessionIDs(svc)) == 0 },
+		5*time.Second, 20*time.Millisecond, "BYE must remove the forward session")
 }
 
 func TestLoopbackInviteHiddenCameraRefused(t *testing.T) {
@@ -413,7 +419,8 @@ func TestLoopbackPlaybackInviteAndControl(t *testing.T) {
 
 	res = up.roundTrip(up.requestDialog(sip.BYE, lbChannelOne, "", "", pbID))
 	require.Equal(t, 200, int(res.StatusCode()))
-	require.Empty(t, playbackIDs(svc), "BYE must tear the playback dialog down")
+	require.Eventually(t, func() bool { return len(playbackIDs(svc)) == 0 },
+		5*time.Second, 20*time.Millisecond, "BYE must tear the playback dialog down")
 }
 
 func TestLoopbackOptions(t *testing.T) {


### PR DESCRIPTION
Closes #578.

**Scope** — the hermetic long tail identified in #578 (temp DB + temp files + existing test doubles only; no streaming servers, no network, no ffmpeg — #571 CI-efficiency rules):

| File | Before | Covered now |
|---|---|---|
| ai_handler.go | 0% | full AI config + ROI zone CRUD, model listing, yaml persistence |
| handlers_vod.go | 0% | playlist validation matrix, segment guards, garbage-file 500s |
| handlers_update.go | 0% | nil-checker degrade paths (GET/POST) |
| handlers_xiaomi_audio.go | 0% | two-way audio guards, CS2-refusal, real WS round-trip (gorilla client → PCM → mock camera packet), G.711 encode matrix |
| xiaomi_local.go | 0% | pure helpers: session/verification mapping, error classification, camera-model filter |
| handlers_recording.go | 43.3% | timeline segments, daily summary, MiBeeVision CRUD + AI-status (API-key gated), seek event, timeline gaps, timelapse + AVI frame serving (real AVI via internal muxer) |
| handlers_system.go | 53.1% | transcoding + auto-discover settings (password-never-leaked, interval floor), system stats, /proc readers, feature toggles, backup create/list |
| events_handler.go | 28.3% | camera-events SSE with foreign-camera filter proof, cameraIDFromEventData matrix |
| handlers_vision.go | 50% | heartbeat (nil + real coordinator), status with last_seen omission |
| handlers_storage_migrate.go | 52.9% | batch migrate validation + enqueue (real migrator, state-agnostic job assert), status, humanBytes |
| handlers_stream.go | 35.8% | StreamRegistry dispatch + ConditionalHandler, HLS adapter start/stop/errors/sub-fallback via real hls.Manager, codec/hub extractors, parseQuality, acquireSub |
| handlers_mjpeg.go | 39.2% | stream-URL resolution (recorder + http-config fallback), latest-frame ETag 200/304 flow, delegation unwrap |

**Result**: api 47.9% → **60.3%** (target ≥58, stretch 60 ✅).

**Race hygiene**: one race found locally (mock MISS conn counters written on the recorder goroutine) — fixed by making `writeCalled`/`packetWrites` atomics; full `-race` run green. `golangci-lint` 0 issues (gofumpt/intrange/predeclared fixed pre-push).

Non-goals per #578 unchanged: live streaming endpoints needing media pumps (flv/ws/webrtc/hls data paths), VOD happy-path playlist (needs real MP4 fixture), xiaomi cloud auth (network).