### PR TITLE
chore(onvif): bump onvif-go to v2.0.0-rc2 — client package moved to /v2/onvif

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc1
+	github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2
 	github.com/miekg/dns v1.1.41 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
@@ -87,5 +87,5 @@ require (
 )
 
 // onvif-go is our own maintained continuation of 0x524a/onvif-go
-// (github.com/mickeyzzc/onvif-go/v2, v2.0.0-rc1+): service-facade API, capability
+// (github.com/mickeyzzc/onvif-go/v2, client at /v2/onvif, v2.0.0-rc2+): service-facade API, capability
 // XAddr repair, clock-skew-aware WS-Security digest. No replace needed.

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc1 h1:hRq1hrTtqdDqcxLvH+Jj4muLYXpUgHdVTDGqr2Zzsg8=
-github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc1/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
+github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2 h1:mbHQKNzFOWrSamcEuMEvqgSEUa79nMUntCFaW8XamvE=
+github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/internal/onvif/client.go
+++ b/internal/onvif/client.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 var logger = slog.Default().With("component", "onvif-client")

--- a/internal/onvif/client_test.go
+++ b/internal/onvif/client_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 
 	"github.com/stretchr/testify/require"
 )

--- a/internal/onvif/device_mgmt.go
+++ b/internal/onvif/device_mgmt.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"sync"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 // ErrUnsupported indicates the operation is not supported.

--- a/internal/onvif/device_mgmt_test.go
+++ b/internal/onvif/device_mgmt_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 var eventLogger = slog.Default().With("component", "onvif-events")

--- a/internal/onvif/events_test.go
+++ b/internal/onvif/events_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/imaging.go
+++ b/internal/onvif/imaging.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 var imagingLogger = slog.Default().With("component", "onvif-imaging")

--- a/internal/onvif/ptz.go
+++ b/internal/onvif/ptz.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"sync"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 var ptzLogger = slog.Default().With("component", "onvif-ptz")

--- a/internal/onvif/ptz_test.go
+++ b/internal/onvif/ptz_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/onvif/snapshot.go
+++ b/internal/onvif/snapshot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	onvifgo "github.com/mickeyzzc/onvif-go/v2"
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
 // SnapshotProviderImpl implements SnapshotProvider by delegating to onvif-go's media service.


### PR DESCRIPTION
## What

onvif-go [PR #33](https://github.com/mickeyzzc/onvif-go/pull/33) (tag `v2.0.0-rc2`) moved the client package out of the module root into the `onvif/` subdirectory — the repository root now contains zero Go source. Package identifier stays `onvif`, all exported symbols unchanged.

## Changes here

- import-path swap in 10 files (`internal/onvif/*.go` incl. tests): `…/onvif-go/v2` → `…/onvif-go/v2/onvif` (aliased `onvifgo` unchanged)
- `go.mod`/`go.sum`: `v2.0.0-rc1` → `v2.0.0-rc2` (+ dependency comment)

**No code changes** — 12 files, +14/−14 lines, all mechanical.

## Verification

- `CGO_ENABLED=0 GOOS=linux go build ./…` clean (Windows host build of `internal/storage` is a known pre-existing `syscall.Statfs` limitation, unrelated)
- `go test ./internal/onvif/…` green (7.1s)
- CI runs the full suite with `-race`