### PR TITLE
test(storage+small pkgs): coverage batch — 96 个 0% 函数长尾 + 2 个 merge 时区生产修复 (#580)

### DIFF
--- a/internal/autodiscover/adder_extra_test.go
+++ b/internal/autodiscover/adder_extra_test.go
@@ -1,0 +1,171 @@
+package autodiscover
+
+// Coverage for the Adder end-to-end flow (#580): dedup, ignore scopes,
+// enrichment failure fallback, classification, and enrollment — using a
+// fake CameraEnroller and dead endpoints (EnrichDevice fails fast against
+// 127.0.0.1 ports that are closed; the device fields set BEFORE enrichment
+// survive, exercising both classification branches).
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingEnroller records enrollment calls (unlike the existing
+// fakeEnroller, whose AddCamera discards the config).
+type recordingEnroller struct {
+	mu       sync.Mutex
+	added    []config.CameraConfig
+	updated  []string
+	restarts int
+	addErr   error
+}
+
+func (f *recordingEnroller) AddCamera(ctx context.Context, cam config.CameraConfig) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.added = append(f.added, cam)
+	if f.addErr != nil {
+		return "", f.addErr
+	}
+	return "cam-" + cam.Name, nil
+}
+
+func (f *recordingEnroller) UpdateCamera(ctx context.Context, cameraID string, updates camera.CameraUpdate) (*config.CameraConfig, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updated = append(f.updated, cameraID)
+	return &config.CameraConfig{ID: cameraID}, nil
+}
+
+func (f *recordingEnroller) RestartRecorder(ctx context.Context, cameraID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restarts++
+	return nil
+}
+
+func (f *recordingEnroller) snapshot() []config.CameraConfig {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]config.CameraConfig(nil), f.added...)
+}
+
+// deadEndpoint points at a loopback port nothing listens on.
+const deadEndpoint = "http://127.0.0.1:1/onvif/device_service"
+
+func newExtraTestDB(t *testing.T) *storage.DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := storage.New(dir + "/test.db")
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestHandleDiscovered_GuardsAndDedup(t *testing.T) {
+	t.Parallel()
+	db := newExtraTestDB(t)
+	enroller := &recordingEnroller{}
+	cfg := &config.AutoDiscoverConfig{}
+	adder := NewAdder(cfg, enroller, db, nil)
+
+	// No endpoint at all → early return, nothing enrolled.
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{Name: "nowhere"})
+	require.Empty(t, enroller.snapshot())
+
+	// Ignore-scope match → skipped (own endpoint so the dedup window from
+	// the no-endpoint case cannot mask the check).
+	cfg.IgnoreScopes = []string{"legacyline"}
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint: "http://127.0.0.1:9/onvif/device_service",
+		Scopes:   []string{"onvif://www.onvif.org/hardware/LegacyLine"},
+	})
+	require.Empty(t, enroller.snapshot())
+	cfg.IgnoreScopes = nil
+
+	// Dead endpoint, no pre-filled identity, no default creds →
+	// pending_activation enrollment (enrich fails, classify falls back).
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint: deadEndpoint,
+		Name:     "Front Porch",
+	})
+	added := enroller.snapshot()
+	require.Len(t, added, 1)
+	require.Equal(t, "pending_activation", added[0].ActivationState)
+	require.Equal(t, "Front Porch", added[0].Name)
+	require.Equal(t, deadEndpoint, added[0].ONVIFEndpoint)
+	require.Equal(t, "onvif", added[0].Protocol)
+
+	// The in-memory dedup window suppresses a chatty re-announcement.
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint: deadEndpoint,
+		Name:     "Front Porch",
+	})
+	require.Len(t, enroller.snapshot(), 1)
+}
+
+func TestHandleDiscovered_EnrichedDeviceActivates(t *testing.T) {
+	t.Parallel()
+	db := newExtraTestDB(t)
+	enroller := &recordingEnroller{}
+	cfg := &config.AutoDiscoverConfig{}
+	adder := NewAdder(cfg, enroller, db, nil)
+
+	// Identity fields survive the (failing) enrichment → open-device
+	// classification: active without credentials.
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint:     deadEndpoint,
+		Name:         "MiBeeCam",
+		Manufacturer: "MiBee",
+		Serial:       "SER-42",
+	})
+	added := enroller.snapshot()
+	require.Len(t, added, 1)
+	require.Equal(t, "active", added[0].ActivationState)
+	require.Equal(t, "SER-42", added[0].StableID)
+	require.Empty(t, added[0].Username, "open device must not carry credentials")
+
+	// Persisted dedup: the same serial arriving at a NEW endpoint must not
+	// create a second camera (the DB row from the first enrollment matches by
+	// stable_id once flushed via the storage layer).
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint: "http://127.0.0.1:2/onvif/device_service",
+		Serial:   "SER-42",
+	})
+	require.Len(t, enroller.snapshot(), 1)
+}
+
+func TestHandleDiscovered_DefaultCredsProbeFails(t *testing.T) {
+	t.Parallel()
+	db := newExtraTestDB(t)
+	enroller := &recordingEnroller{}
+	cfg := &config.AutoDiscoverConfig{DefaultUsername: "admin", DefaultPassword: "secret"}
+	adder := NewAdder(cfg, enroller, db, nil)
+
+	adder.HandleDiscovered(context.Background(), onvif.DiscoveredDevice{
+		Endpoint: deadEndpoint,
+		Serial:   "SER-7",
+	})
+	added := enroller.snapshot()
+	require.Len(t, added, 1)
+	// Creds configured but the probe against a dead endpoint fails → pending.
+	require.Equal(t, "pending_activation", added[0].ActivationState)
+	require.Empty(t, added[0].Password, "pending camera must not persist the password")
+}
+
+func TestServiceAdderForTestAccessor(t *testing.T) {
+	t.Parallel()
+	db := newExtraTestDB(t)
+	svc := New(&config.AutoDiscoverConfig{}, &recordingEnroller{}, db, nil)
+	require.Equal(t, "autodiscover", svc.Name())
+	require.NotNil(t, svc.AdderForTest())
+}

--- a/internal/mediaprobe/probe_extra_test.go
+++ b/internal/mediaprobe/probe_extra_test.go
@@ -1,0 +1,55 @@
+package mediaprobe
+
+// Coverage for FastProbeDuration + MediaInfo.FormatDuration (#580). The MP4
+// fixture is built with the real internal muxer — same pattern as the merge
+// package's tests.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fastProbeSPS = []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	fastProbePPS = []byte{0x68, 0xce, 0x38, 0x80}
+)
+
+func buildProbeMP4(t *testing.T, samples int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seg.mp4")
+	m := muxer.NewMP4Muxer(path)
+	trackID, err := m.AddH264Track(fastProbeSPS, fastProbePPS)
+	require.NoError(t, err)
+	for i := range samples {
+		nalu := []byte{0x41, 0x10, 0x00, byte(i)}
+		require.NoError(t, m.WriteSample(trackID, nalu, time.Duration(i)*33*time.Millisecond, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close())
+	return path
+}
+
+func TestFastProbeDuration(t *testing.T) {
+	t.Parallel()
+	p := buildProbeMP4(t, 30)
+	d, err := FastProbeDuration(p)
+	require.NoError(t, err)
+	require.InDelta(t, 0.99, d, 0.1) // 30 samples × 33ms
+
+	// Missing / non-MP4 files error, never panic.
+	_, err = FastProbeDuration(filepath.Join(t.TempDir(), "missing.mp4"))
+	require.Error(t, err)
+	_, err = FastProbeDuration("/etc/hostname")
+	require.Error(t, err)
+}
+
+func TestFormatDuration(t *testing.T) {
+	t.Parallel()
+	m := &MediaInfo{}
+	require.Equal(t, "0s", m.FormatDuration())
+	m2 := &MediaInfo{Duration: 90}
+	require.Contains(t, m2.FormatDuration(), "1m30s")
+}

--- a/internal/metrics/recorders_test.go
+++ b/internal/metrics/recorders_test.go
@@ -1,0 +1,68 @@
+package metrics
+
+// Coverage for the observability recorder methods (#580) — every one is a
+// thin Prometheus gauge/counter/histogram write; calling each with both a
+// fresh and repeated label set pins the no-panic contract and the
+// nil-metrics tolerance.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRecorderMethodsNoPanic(t *testing.T) {
+	m := NewMetrics()
+
+	// Query + SQLite health.
+	m.ObserveQueryDuration("ListRecordings", 0.25)
+	m.ObserveQueryDuration("ListRecordings", 1.25)
+	m.IncSQLiteBusyErrors()
+	m.IncStorageWriteErrors()
+
+	// Merge telemetry.
+	m.RecordMergeSuccess(2*time.Second, 4096)
+	m.RecordMergeFailure("incompatible")
+	m.UpdateMergePending("cam-1", 3)
+	m.RecordRollingMergeLatency("cam-1", 150*time.Millisecond)
+	m.UpdateRollingMergeBucketSegments("cam-1", 12)
+
+	// Playback telemetry.
+	m.SetPlaybackLiveLatency("cam-1", "hls", 850.5)
+	m.IncPlaybackStall("cam-1", "flv")
+
+	// Segment write + audit paths.
+	m.ObserveSegmentWrite("cam-1", 30*time.Millisecond)
+	m.IncRecordingAudit("cam-1", "ok")
+	m.IncRecordingAudit("cam-1", "missing")
+	m.IncRecordingDeepCheck("cam-1", "ok")
+	m.IncRecordingDeepCheck("cam-1", "corrupt")
+}
+
+func TestNilMetricsRecordersAreNoOps(t *testing.T) {
+	var m *Metrics
+	requireNoPanic(t, func() {
+		m.ObserveQueryDuration("q", 1)
+		m.IncSQLiteBusyErrors()
+		m.IncStorageWriteErrors()
+		m.RecordMergeSuccess(time.Second, 1)
+		m.RecordMergeFailure("x")
+		m.UpdateMergePending("c", 1)
+		m.RecordRollingMergeLatency("c", time.Second)
+		m.UpdateRollingMergeBucketSegments("c", 1)
+		m.SetPlaybackLiveLatency("c", "hls", 1)
+		m.IncPlaybackStall("c", "hls")
+		m.ObserveSegmentWrite("c", time.Second)
+		m.IncRecordingAudit("c", "ok")
+		m.IncRecordingDeepCheck("c", "ok")
+	})
+}
+
+func requireNoPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("recorder panicked on nil metrics: %v", r)
+		}
+	}()
+	fn()
+}

--- a/internal/storage/db_longtail_test.go
+++ b/internal/storage/db_longtail_test.go
@@ -1,0 +1,359 @@
+package storage
+
+// Long-tail coverage for the storage DB layer (#580): AI stats/deletes,
+// archive group stats, camera ingest/activation/stable-id/endpoint ops,
+// cascade channels, per-camera stats, dark recordings, transcode task
+// listing/recovery, and the db.go maintenance surface. All hermetic
+// (per-test SQLite via newTestDB).
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// recSeed is a minimal recording fixture for the long-tail tests.
+type recSeed struct {
+	id      string
+	camera  string
+	format  string
+	started time.Time
+	size    int64
+	merge   string
+	ended   time.Time
+}
+
+func seedRec(t *testing.T, db *DB, s *recSeed) {
+	t.Helper()
+	ended := s.ended
+	if ended.IsZero() {
+		ended = s.started.Add(time.Minute)
+	}
+	merge := s.merge
+	if merge == "" {
+		merge = model.MergeStatusPending
+	}
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID:          s.id,
+		CameraID:    s.camera,
+		FilePath:    "/tmp/" + s.id + ".mp4",
+		Format:      model.Format(s.format),
+		StartedAt:   s.started,
+		EndedAt:     ended,
+		Duration:    60,
+		FileSize:    s.size,
+		MergeStatus: merge,
+	}))
+}
+
+func TestAIEventStatsAndDeleteByRecording(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Two events for one recording, one for another camera.
+	for _, e := range []*AIEvent{
+		{CameraID: "cam-1", RecordingID: "rec-1", EventType: "zone_intrusion", Severity: "warn"},
+		{CameraID: "cam-1", RecordingID: "rec-1", EventType: "zone_intrusion", Severity: "warn"},
+		{CameraID: "cam-1", RecordingID: "rec-2", EventType: "loitering", Severity: "info"},
+		{CameraID: "cam-2", RecordingID: "rec-3", EventType: "person", Severity: "info"},
+	} {
+		_, err := db.InsertAIEvent(ctx, e)
+		require.NoError(t, err)
+	}
+
+	stats, err := db.GetAIEventStats(ctx, "cam-1", time.Now().UTC().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, stats, 2)
+	total := 0
+	for _, s := range stats {
+		total += s.Count
+	}
+	require.Equal(t, 3, total)
+
+	// Global view: empty cameraID aggregates across cameras.
+	stats, err = db.GetAIEventStats(ctx, "", time.Now().UTC().Add(-time.Hour))
+	require.NoError(t, err)
+	gtotal := 0
+	for _, s := range stats {
+		gtotal += s.Count
+	}
+	require.Equal(t, 4, gtotal)
+
+	// Since in the future filters everything out.
+	stats, err = db.GetAIEventStats(ctx, "cam-1", time.Now().UTC().Add(time.Hour))
+	require.NoError(t, err)
+	require.Empty(t, stats)
+
+	// Delete-by-recording removes exactly that recording's rows.
+	n, err := db.DeleteAIEventsByRecording(ctx, "rec-1")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+	stats, err = db.GetAIEventStats(ctx, "cam-1", time.Now().UTC().Add(-time.Hour))
+	require.NoError(t, err)
+	for _, s := range stats {
+		require.NotEqual(t, "zone_intrusion", s.EventType)
+	}
+}
+
+func TestMarshalBBox(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "[0.1,0.2,0.3,0.4]", MarshalBBox([4]float64{0.1, 0.2, 0.3, 0.4}))
+}
+
+func TestRecordingAIStatusReaders(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedRec(t, db, &recSeed{id: "ai-1", camera: "cam-1", format: "h264", started: now})
+	seedRec(t, db, &recSeed{id: "ai-2", camera: "cam-1", format: "h264", started: now})
+
+	require.NoError(t, db.UpdateRecordingAIStatus(ctx, "ai-1", "processing", ""))
+	st, err := db.GetRecordingAIStatus(ctx, "ai-1")
+	require.NoError(t, err)
+	require.Equal(t, "processing", st)
+
+	_, err = db.GetRecordingAIStatus(ctx, "nope")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	batch, err := db.BatchGetRecordingAIStatus(ctx, []string{"ai-1", "ai-2", "nope"})
+	require.NoError(t, err)
+	require.Equal(t, "processing", batch["ai-1"])
+	require.Equal(t, "", batch["ai-2"])
+	_, ok := batch["nope"]
+	require.False(t, ok, "unknown ids are omitted")
+}
+
+func TestArchiveGroupStatsAndRetention(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, db.UpsertCamera(ctx, "cam-1", "Cam", "onvif", "", "", "", "", "", "", "", ""))
+	seedRec(t, db, &recSeed{id: "ar-1", camera: "cam-1", format: "h264", started: now, size: 100})
+	seedRec(t, db, &recSeed{id: "ar-2", camera: "cam-1", format: "h264", started: now, size: 50})
+
+	// Nothing archived yet.
+	cnt, _, err := db.GetArchiveGroupStats(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, 0, cnt)
+
+	n, err := db.ArchiveAllRecordings(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), n)
+
+	cnt, size, err := db.GetArchiveGroupStats(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, 2, cnt)
+	require.Equal(t, int64(150), size)
+
+	// Non-archive stats exclude archived rows.
+	cnt, _, err = db.GetCameraRecordingStats(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, 0, cnt)
+
+	// Retention applies only to archived cameras — archive it first.
+	require.NoError(t, db.ArchiveCameraDB(ctx, "cam-1"))
+	require.NoError(t, db.SetArchiveRetention(ctx, "cam-1", 90))
+	require.NoError(t, db.UpsertCamera(ctx, "cam-2", "Cam 2", "onvif", "", "", "", "", "", "", "", ""))
+	require.ErrorIs(t, db.SetArchiveRetention(ctx, "cam-2", 90), sql.ErrNoRows, "non-archived camera has no archive retention row")
+
+	// No cleanup task exists until one is enqueued.
+	has, err := db.HasArchiveCleanupTaskForCamera(ctx, "cam-1")
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestCameraIngestActivationStableID(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.UpsertCamera(ctx, "cam-1", "Cam", "srt", "", "srt://x", "", "", "", "", "", ""))
+
+	// Ingest credentials round-trip.
+	require.NoError(t, db.UpsertCameraIngest(ctx, "cam-1", "key-1", "pass-1", "sid-1"))
+
+	// Activation state.
+	require.NoError(t, db.UpdateCameraActivationState(ctx, "cam-1", "pending_activation"))
+	require.NoError(t, db.UpdateCameraActivationState(ctx, "cam-1", "active"))
+
+	// stable_id write/read/existence, endpoint lookup, reassign.
+	require.NoError(t, db.UpdateCameraStableID(ctx, "cam-1", "SER-1"))
+	got, err := db.GetCameraStableID(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, "SER-1", got)
+
+	exists, err := db.CameraExistsByStableID(ctx, "SER-1")
+	require.NoError(t, err)
+	require.True(t, exists)
+	exists, err = db.CameraExistsByStableID(ctx, "SER-X")
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	// Unknown camera's stable id is empty.
+	got, err = db.GetCameraStableID(ctx, "ghost")
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// ONVIF endpoint raw write + reader-facing lookup.
+	require.NoError(t, db.UpdateCameraOnvifEndpointRaw(ctx, "cam-1", "http://192.168.63.251:80/onvif/device_service"))
+	ep, err := db.GetCameraOnvifEndpoint(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, "http://192.168.63.251:80/onvif/device_service", ep)
+	ep, err = db.GetCameraOnvifEndpoint(ctx, "ghost")
+	require.NoError(t, err)
+	require.Empty(t, ep)
+
+	// Endpoint listing for the repair CLI.
+	rows, err := db.ListCameraEndpointsForRepair(ctx)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "cam-1", rows[0].ID)
+	require.NotEmpty(t, rows[0].Endpoint)
+
+	// Reassign stable id to another camera.
+	require.NoError(t, db.UpsertCamera(ctx, "cam-2", "Cam 2", "onvif", "", "", "", "", "", "", "", ""))
+	require.NoError(t, db.ReassignCameraStableID(ctx, "cam-1", "cam-2"))
+	got, err = db.GetCameraStableID(ctx, "cam-2")
+	require.NoError(t, err)
+	require.Equal(t, "SER-1", got)
+
+	// Delete camera row.
+	require.NoError(t, db.DeleteCamera(ctx, "cam-2"))
+	got, err = db.GetCameraStableID(ctx, "cam-2")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestCascadeChannelCRUD(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	ch := CascadeChannel{CameraID: "cam-1", GBChannelID: "34020000001320000001", Name: "Front", UpdatedAt: time.Now().UTC()}
+	require.NoError(t, db.UpsertCascadeChannel(ctx, ch))
+	// Upsert again with a new name (conflict on camera_id).
+	ch.Name = "Front Door"
+	require.NoError(t, db.UpsertCascadeChannel(ctx, ch))
+
+	list, err := db.ListCascadeChannels(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, "Front Door", list[0].Name)
+
+	// DeleteGB28181Channel operates on the gb28181_channels table (device
+	// channels), not cascade_channels — exercise it with a real device row.
+	require.NoError(t, db.UpsertGB28181Device(ctx, GB28181Device{ID: "34020000002000000001", Name: "IPC", Status: "online"}))
+	require.NoError(t, db.UpsertGB28181Channel(ctx, GB28181Channel{
+		ID: "34020000001320000099", DeviceID: "34020000002000000001", Name: "Ch99", Status: "idle",
+	}))
+	require.NoError(t, db.DeleteGB28181Channel(ctx, "34020000001320000099"))
+	dev, err := db.GetGB28181Device(ctx, "34020000002000000001")
+	require.NoError(t, err)
+	require.NotNil(t, dev)
+}
+
+func TestGetGB28181Device(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	dev, err := db.GetGB28181Device(ctx, "34020000002000000001")
+	require.NoError(t, err)
+	require.Nil(t, dev)
+}
+
+func TestPerCameraStatsLongTail(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedRec(t, db, &recSeed{id: "st-1", camera: "cam-1", format: "h264", started: now.Add(-2 * time.Hour), size: 10})
+	seedRec(t, db, &recSeed{id: "st-2", camera: "cam-1", format: "h264", started: now.Add(-1 * time.Hour), size: 20})
+
+	cnt, err := db.CountRecordingsByCamera(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, 2, cnt)
+
+	// CountRowsByCamera serves the allowlisted camera-keyed tables.
+	cnt, err = db.CountRowsByCamera(ctx, "ai_events", "cam-1")
+	require.NoError(t, err)
+	require.Equal(t, 0, cnt)
+	_, err = db.CountRowsByCamera(ctx, "cameras", "cam-1")
+	require.ErrorContains(t, err, "unknown table")
+
+	paths, err := db.ListRecordingFilePathsByCamera(ctx, "cam-1")
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+
+	last, err := db.GetLastRecordingTime(ctx, "cam-1")
+	require.NoError(t, err)
+	require.NotNil(t, last)
+	require.True(t, last.After(now.Add(-90*time.Minute)))
+
+	last, err = db.GetLastRecordingTime(ctx, "ghost")
+	require.NoError(t, err)
+	require.Nil(t, last)
+
+	all, err := db.GetAllLastRecordingTimes(ctx)
+	require.NoError(t, err)
+	require.Contains(t, all, "cam-1")
+	require.NotNil(t, all["cam-1"])
+}
+
+func TestListDarkRecordingsCounts(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Dark segment older than the grace period is listed; a fresh one is not.
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	seedRec(t, db, &recSeed{id: "dk-1", camera: "cam-1", format: "h264", started: old, merge: "dark"})
+	seedRec(t, db, &recSeed{id: "dk-2", camera: "cam-1", format: "h264", started: time.Now().UTC(), merge: "dark"})
+	seedRec(t, db, &recSeed{id: "ok-1", camera: "cam-1", format: "h264", started: old, merge: "pending"})
+
+	dark, err := db.ListDarkRecordings(ctx, time.Hour)
+	require.NoError(t, err)
+	require.Len(t, dark, 1)
+	require.Equal(t, "dk-1", dark[0].ID)
+}
+
+func TestTranscodeTaskListAndRecovery(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.EnqueueTask(ctx, &TranscodeTask{
+		CameraID: "cam-1", RecordingID: "r1", InputPath: "/in.mp4", InputFormat: "h265",
+		OutputPath: "/out.mp4", OutputFormat: "h264", Status: "pending",
+	}))
+
+	tasks, total, err := db.ListTranscodeTasks(ctx, TranscodeTaskFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Len(t, tasks, 1)
+	require.Equal(t, "r1", tasks[0].RecordingID)
+
+	// Filter by status narrows correctly.
+	tasks, total, err = db.ListTranscodeTasks(ctx, TranscodeTaskFilter{Status: "completed"})
+	require.NoError(t, err)
+	require.Equal(t, 0, total)
+	require.Empty(t, tasks)
+
+	// Stuck-task recovery: claim a task and backdate it via SQL.
+	require.NoError(t, db.EnqueueTask(ctx, &TranscodeTask{
+		CameraID: "cam-1", RecordingID: "r2", InputPath: "/in2.mp4", InputFormat: "h265",
+		OutputPath: "/out2.mp4", OutputFormat: "h264", Status: "pending",
+	}))
+	task, err := db.DequeueTask(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	_, err = db.db.ExecContext(ctx, "UPDATE transcoding_tasks SET started_at=? WHERE id=?", time.Now().UTC().Add(-time.Hour).Format("2006-01-02 15:04:05.999999999"), task.ID)
+	require.NoError(t, err)
+
+	n, err := db.RecoverStuckTasks(ctx, 10*time.Minute)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Format rewrite.
+	require.NoError(t, db.UpdateRecordingFormat(ctx, "r1", "h265"))
+}

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -431,7 +431,11 @@ func (d *DB) ResetFailedMergeStatus(ctx context.Context, ids []string) (int64, e
 // ListCameraMergeWindows returns hourly merge windows for a camera with 2+ segments.
 // Only includes recordings older than minAge.
 func (d *DB) ListCameraMergeWindows(ctx context.Context, cameraID string, minAge time.Duration) ([]MergeWindow, error) {
-	cutoff := time.Now().Add(-minAge).Format(sqliteTimeFormat)
+	// UTC is mandatory: ended_at is stored UTC (timeToDB), so a local-time
+	// cutoff would sit hours in the future of the intended instant on any
+	// non-UTC host and loosen the minAge gate (same class as the
+	// ListDarkRecordings bug, #565).
+	cutoff := time.Now().UTC().Add(-minAge).Format(sqliteTimeFormat)
 	query := `SELECT strftime('%Y-%m-%d %H', started_at) as hour, MIN(started_at), MAX(ended_at), COUNT(*), format FROM recordings WHERE camera_id = ? AND merge_status = 'pending' AND ended_at IS NOT NULL AND ended_at < ? GROUP BY hour, format HAVING COUNT(*) >= 2 ORDER BY hour ASC;`
 	rows, err := d.readConn().QueryContext(ctx, query, cameraID, cutoff)
 	if err != nil {
@@ -770,7 +774,11 @@ func (d *DB) UpdateMergeProgressBatch(ctx context.Context, ids []string, progres
 // older than minAge but are NOT part of any multi-segment merge window.
 // These are hour-boundary orphans that will never be merged.
 func (d *DB) ListSingletonPendingRecordings(ctx context.Context, cameraID string, minAge time.Duration) ([]*model.Recording, error) {
-	cutoff := time.Now().Add(-minAge).Format(sqliteTimeFormat)
+	// UTC is mandatory: ended_at is stored UTC (timeToDB), so a local-time
+	// cutoff would sit hours in the future of the intended instant on any
+	// non-UTC host and loosen the minAge gate (same class as the
+	// ListDarkRecordings bug, #565).
+	cutoff := time.Now().UTC().Add(-minAge).Format(sqliteTimeFormat)
 	query := `
 		WITH hour_buckets AS (
 			SELECT id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, archived,

--- a/internal/storage/db_merge_migrate_longtail_test.go
+++ b/internal/storage/db_merge_migrate_longtail_test.go
@@ -1,0 +1,249 @@
+package storage
+
+// Long-tail coverage for merge validation/rollback, path migration, and the
+// DB maintenance + retry surface (#580). Includes regression tests for the
+// UTC cutoff fix in ListCameraMergeWindows / ListSingletonPendingRecordings
+// (same class as #565: local-time cutoff vs UTC-stored ended_at).
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setMergeState backdates/overrides a recording's merge columns directly —
+// the SQL-backdating pattern from #571 (never rely on the test running fast).
+func setMergeState(t *testing.T, db *DB, id, status, mergePath string, endedAgo time.Duration) {
+	t.Helper()
+	_, err := db.db.ExecContext(context.Background(),
+		`UPDATE recordings SET merge_status=?, merge_path=?, ended_at=? WHERE id=?`,
+		status, mergePath, time.Now().UTC().Add(-endedAgo).Format("2006-01-02 15:04:05.999999999"), id)
+	require.NoError(t, err)
+}
+
+func TestMergedValidationAndReset(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedRec(t, db, &recSeed{id: "mv-1", camera: "cam-1", format: "h264", started: now.Add(-2 * time.Hour)})
+	seedRec(t, db, &recSeed{id: "mv-2", camera: "cam-1", format: "h264", started: now.Add(-1 * time.Hour)})
+	seedRec(t, db, &recSeed{id: "mv-3", camera: "cam-1", format: "h264", started: now})
+
+	setMergeState(t, db, "mv-1", "merged", "/merged/mv-1.mp4", time.Hour)
+	setMergeState(t, db, "mv-2", "merged", "", time.Hour) // no merge_path → excluded
+	setMergeState(t, db, "mv-3", "pending", "", time.Hour)
+
+	rows, err := db.ListMergedRecordingsForValidation(ctx)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "mv-1", rows[0].ID)
+	require.Equal(t, "/merged/mv-1.mp4", rows[0].MergePath)
+
+	require.NoError(t, db.ResetMergeStatus(ctx, "mv-1"))
+	rows, err = db.ListMergedRecordingsForValidation(ctx)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
+func TestMergeProgressBatchAndClearMergePath(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	var ids []string
+	for i := range 5 {
+		id := "bp-" + string(rune('a'+i))
+		ids = append(ids, id)
+		seedRec(t, db, &recSeed{id: id, camera: "cam-1", format: "h264", started: now.Add(-time.Duration(i+1) * time.Hour)})
+	}
+
+	require.NoError(t, db.UpdateMergeProgressBatch(ctx, ids, 42))
+	require.NoError(t, db.ClearMergePathBatch(ctx, ids))
+
+	// Failed-status reset round trip.
+	require.NoError(t, db.SetMergeError(ctx, ids, "boom"))
+	n, err := db.ResetFailedMergeStatus(ctx, ids)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(ids)), n)
+}
+
+func TestShortMergedAndSingletonAndWindows(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Three pending segments in the same hour, older than minAge.
+	base := now.Add(-3 * time.Hour).Truncate(time.Hour)
+	for i := range 3 {
+		seedRec(t, db, &recSeed{
+			id:      "sw-" + string(rune('a'+i)),
+			camera:  "cam-1",
+			format:  "h264",
+			started: base.Add(time.Duration(i) * 10 * time.Minute),
+			ended:   base.Add(time.Duration(i)*10*time.Minute + 5*time.Minute),
+		})
+	}
+	// A merged-but-short recording (merge_quality='short' drives the listing).
+	seedRec(t, db, &recSeed{id: "sw-short", camera: "cam-1", format: "h264", started: base.Add(-time.Hour)})
+	setMergeState(t, db, "sw-short", "merged", "/merged/sw-short.mp4", 2*time.Hour)
+	_, err := db.db.ExecContext(ctx, "UPDATE recordings SET merge_quality='short' WHERE id='sw-short'")
+	require.NoError(t, err)
+
+	windows, err := db.ListCameraMergeWindows(ctx, "cam-1", time.Hour)
+	require.NoError(t, err)
+	require.Len(t, windows, 1)
+	require.Equal(t, 3, windows[0].SegmentCount)
+
+	singles, err := db.ListSingletonPendingRecordings(ctx, "cam-1", time.Hour)
+	require.NoError(t, err)
+	require.Empty(t, singles, "three same-hour segments form a window, none is a singleton")
+
+	shorts, err := db.ListShortMergedRecordings(ctx, "cam-1", 300)
+	require.NoError(t, err)
+	require.Len(t, shorts, 1)
+	require.Equal(t, "sw-short", shorts[0].ID)
+}
+
+func TestMergeWindowMinAgeRespectsUTC(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// A window that ended 30 minutes ago. With minAge=1h it must NOT be
+	// eligible: on a UTC+N host a local-time cutoff would read as up to N
+	// hours later and wrongly include it (regression test for the #565-class
+	// cutoff bug in ListCameraMergeWindows/ListSingletonPendingRecordings).
+	end := time.Now().UTC().Add(-30 * time.Minute)
+	start := end.Add(-10 * time.Minute)
+	seedRec(t, db, &recSeed{id: "fresh-1", camera: "cam-1", format: "h264", started: start, ended: end})
+	seedRec(t, db, &recSeed{id: "fresh-2", camera: "cam-1", format: "h264", started: end, ended: end.Add(10 * time.Minute)})
+
+	windows, err := db.ListCameraMergeWindows(ctx, "cam-1", time.Hour)
+	require.NoError(t, err)
+	require.Empty(t, windows, "window younger than minAge must not be eligible regardless of host timezone")
+
+	// Same segments with a tiny minAge become eligible.
+	windows, err = db.ListCameraMergeWindows(ctx, "cam-1", time.Minute)
+	require.NoError(t, err)
+	require.Len(t, windows, 1)
+}
+
+func TestPathMigrationOps(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	oldRoot := "/mnt/old"
+	newRoot := "/mnt/new"
+	seedRec(t, db, &recSeed{id: "pm-1", camera: "cam-1", format: "h264", started: now})
+	seedRec(t, db, &recSeed{id: "pm-2", camera: "cam-1", format: "h264", started: now})
+	_, err := db.db.ExecContext(ctx, "UPDATE recordings SET file_path=?, merge_path=? WHERE id='pm-1'",
+		oldRoot+"/cam-1/pm-1.mp4", oldRoot+"/cam-1/pm-1-merged.mp4")
+	require.NoError(t, err)
+	_, err = db.db.ExecContext(ctx, "UPDATE recordings SET file_path=? WHERE id='pm-2'",
+		newRoot+"/cam-1/pm-2.mp4")
+	require.NoError(t, err)
+
+	// Migratable = rows with any path still under the old root.
+	migs, err := db.ListMigratableRecordings(ctx, "cam-1", newRoot)
+	require.NoError(t, err)
+	require.Len(t, migs, 1)
+	require.Equal(t, "pm-1", migs[0].ID)
+	require.Equal(t, int64(0), migs[0].FileSize)
+
+	// Prefix counting and distinct top segments under a root.
+	n, err := db.CountPathPrefix(ctx, oldRoot)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	tops, err := db.DistinctTopSegments(ctx, oldRoot)
+	require.NoError(t, err)
+	require.Len(t, tops, 1)
+
+	// Rewrite prefix moves the rows.
+	moved, err := db.RewritePathPrefix(ctx, oldRoot, newRoot)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), moved)
+
+	n, err = db.CountPathPrefix(ctx, oldRoot)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), n)
+
+	// Single-row rewrite helper.
+	require.NoError(t, db.RewriteRecordingPaths(ctx, "pm-2", "/mnt/third/cam-1/pm-2.mp4", sql.NullString{String: "/mnt/third/cam-1/pm-2-merged.mp4", Valid: true}))
+}
+
+func TestDBMaintenanceSurface(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Path / pools / metrics wiring are trivial but uncovered.
+	require.NotEmpty(t, db.Path())
+	db.SetReadPoolSize(2)
+	_, ok := db.ReadPoolStats()
+	require.True(t, ok)
+	db.SetMetrics(nil) // must not panic
+
+	// VACUUM-based backup produces a usable second file.
+	dest := filepath.Join(t.TempDir(), "backup.db")
+	require.NoError(t, db.Backup(ctx, dest))
+	require.FileExists(t, dest)
+
+	require.NoError(t, db.Optimize(ctx))
+
+	// Online compaction returns the size delta and leaves the DB usable.
+	seedRec(t, db, &recSeed{id: "cp-1", camera: "cam-1", format: "h264", started: time.Now().UTC()})
+	_, err := db.CompactOnline(ctx)
+	require.NoError(t, err) // size delta can be negative on tiny DBs (page rounding)
+	rec, err := db.GetRecording(ctx, "cp-1")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+}
+
+func TestRetryOnBusy(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsBusyError(nil))
+	require.False(t, IsBusyError(sql.ErrNoRows))
+	require.True(t, IsBusyError(errBusyForTest))
+
+	var calls atomic.Int32
+	hookFired := atomic.Bool{}
+	SetBusyErrorHook(func() { hookFired.Store(true) })
+	t.Cleanup(func() { SetBusyErrorHook(nil) })
+
+	// Non-busy error surfaces immediately after the configured attempts.
+	err := RetryOnBusy(context.Background(), func() error {
+		calls.Add(1)
+		return sql.ErrConnDone
+	})
+	require.ErrorIs(t, err, sql.ErrConnDone)
+	require.Equal(t, int32(1), calls.Load())
+	require.False(t, hookFired.Load())
+
+	// Busy error retries until it clears.
+	calls.Store(0)
+	require.NoError(t, RetryOnBusy(context.Background(), func() error {
+		if calls.Add(1) < 3 {
+			return errBusyForTest
+		}
+		return nil
+	}))
+	require.Equal(t, int32(3), calls.Load())
+	require.True(t, hookFired.Load())
+
+	// Cancelled context aborts the retry loop.
+	require.Error(t, RetryOnBusy(t.Context(), func() error { return errBusyForTest }))
+}
+
+// errBusyForTest satisfies IsBusyError via the sqlite-busy message match.
+var errBusyForTest = &busyFakeError{msg: "database is busy"}
+
+type busyFakeError struct{ msg string }
+
+func (e *busyFakeError) Error() string { return e.msg }

--- a/internal/storage/db_merge_migrate_longtail_test.go
+++ b/internal/storage/db_merge_migrate_longtail_test.go
@@ -114,21 +114,26 @@ func TestMergeWindowMinAgeRespectsUTC(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	// A window that ended 30 minutes ago. With minAge=1h it must NOT be
-	// eligible: on a UTC+N host a local-time cutoff would read as up to N
-	// hours later and wrongly include it (regression test for the #565-class
-	// cutoff bug in ListCameraMergeWindows/ListSingletonPendingRecordings).
-	end := time.Now().UTC().Add(-30 * time.Minute)
-	start := end.Add(-10 * time.Minute)
-	seedRec(t, db, &recSeed{id: "fresh-1", camera: "cam-1", format: "h264", started: start, ended: end})
-	seedRec(t, db, &recSeed{id: "fresh-2", camera: "cam-1", format: "h264", started: end, ended: end.Add(10 * time.Minute)})
+	// Hour-boundary-proof fixtures: anchor on the current UTC hour so the two
+	// segments always land in the SAME hour bucket and their ages are
+	// deterministic regardless of when in the hour the test runs.
+	// endB = anchor-2h is 2-3h old; endA = anchor-2h30m is 2.5-3.5h old.
+	anchor := time.Now().UTC().Truncate(time.Hour)
+	endA := anchor.Add(-150 * time.Minute)
+	endB := anchor.Add(-120 * time.Minute)
+	seedRec(t, db, &recSeed{id: "fresh-1", camera: "cam-1", format: "h264", started: endA.Add(-10 * time.Minute), ended: endA})
+	seedRec(t, db, &recSeed{id: "fresh-2", camera: "cam-1", format: "h264", started: endB.Add(-10 * time.Minute), ended: endB})
 
-	windows, err := db.ListCameraMergeWindows(ctx, "cam-1", time.Hour)
+	// minAge=3h: both segments are younger than the gate — must NOT be
+	// eligible. On a UTC+N host a local-time cutoff reads as up to N hours
+	// later and would wrongly include them (regression test for the
+	// #565-class cutoff bug in ListCameraMergeWindows/ListSingletonPendingRecordings).
+	windows, err := db.ListCameraMergeWindows(ctx, "cam-1", 3*time.Hour)
 	require.NoError(t, err)
 	require.Empty(t, windows, "window younger than minAge must not be eligible regardless of host timezone")
 
-	// Same segments with a tiny minAge become eligible.
-	windows, err = db.ListCameraMergeWindows(ctx, "cam-1", time.Minute)
+	// Same segments with minAge=1h become eligible.
+	windows, err = db.ListCameraMergeWindows(ctx, "cam-1", time.Hour)
 	require.NoError(t, err)
 	require.Len(t, windows, 1)
 }

--- a/internal/storage/manager_longtail_test.go
+++ b/internal/storage/manager_longtail_test.go
@@ -1,0 +1,119 @@
+package storage
+
+// Long-tail coverage for the storage Manager + health tracker (#580):
+// root switching/overrides, segment listing, camera-dir deletion, probe,
+// and the periodic health check loop (observed via its observable effect,
+// never a fixed sleep).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerRootSwitchAndCameraOverrides(t *testing.T) {
+	rootA := t.TempDir()
+	m, err := NewManager(rootA)
+	require.NoError(t, err)
+
+	// Camera override round-trip + clear.
+	m.SetCameraRoot("cam-1", rootA)
+	require.Equal(t, rootA, m.CameraRoot("cam-1"))
+	m.SetCameraRoot("cam-1", "")
+	require.Empty(t, m.CameraRoot("cam-1"))
+
+	// Hot root switch: creates the dir, RootFor follows.
+	rootB := filepath.Join(t.TempDir(), "switched")
+	require.NoError(t, m.SetRootDir(rootB))
+	require.Equal(t, rootB, m.RootFor("cam-1"))
+
+	// Empty root rejected.
+	require.Error(t, m.SetRootDir(""))
+
+	// Roots() includes default + overrides.
+	m.SetCameraRoot("cam-1", rootA)
+	roots := m.Roots()
+	require.Contains(t, roots, rootA)
+	require.Contains(t, roots, rootB)
+}
+
+func TestManagerRootUsage(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	require.NoError(t, err)
+
+	total, free, err := m.GetRootUsage(t.TempDir())
+	require.NoError(t, err)
+	require.Positive(t, total)
+	require.GreaterOrEqual(t, total, free)
+
+	_, _, err = m.GetRootUsage("/definitely/not/a/root")
+	require.Error(t, err)
+}
+
+func TestManagerListSegmentsAndDeleteCameraDir(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	require.NoError(t, err)
+
+	// Unknown camera dir → explicit error, not an empty list.
+	_, err = m.ListSegments("ghost")
+	require.ErrorContains(t, err, "cannot read camera dir")
+
+	// Seed a camera tree with segments + noise.
+	camDir := filepath.Join(root, "cam-1")
+	dayDir := filepath.Join(camDir, "20260820")
+	require.NoError(t, os.MkdirAll(dayDir, 0o755))
+	// Segment names follow the {cameraID}_{ts}_{uuid} pattern.
+	for _, n := range []string{"cam-1_20260820100000_abc123.mp4", "cam-1_20260820110000_def456.mp4"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dayDir, n), []byte("x"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(camDir, ".hidden"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dayDir, "part.tmp"), []byte("x"), 0o644))
+
+	segs, err := m.ListSegments("cam-1")
+	require.NoError(t, err)
+	require.Len(t, segs, 2, "hidden + tmp entries are skipped")
+
+	// ProbeDir accepts a writable dir and rejects a file.
+	require.NoError(t, ProbeDir(dayDir))
+	filePath := filepath.Join(camDir, "plain.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o644))
+	require.Error(t, ProbeDir(filePath))
+
+	// DeleteCameraDir removes the tree across roots.
+	require.NoError(t, m.DeleteCameraDir("cam-1"))
+	_, err = os.Stat(camDir)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestManagerWriteHealthRecording(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	require.NoError(t, err)
+	bus := event.NewEventBus(8)
+	m.SetEventBus(bus)
+
+	events := make(chan event.Event, 8)
+	bus.SubscribeByPrefix("storage", events, 8)
+
+	// A real temp segment registered to cam-1 fails to write → health state
+	// must flip and publish a change event (unknown paths are a safe no-op).
+	m.RecordWriteFailureForPath("/tmp/unknown.tmp")
+	tempPath, _, err := m.CreateSegment("cam-1", "h264")
+	require.NoError(t, err)
+	m.RecordWriteFailureForPath(tempPath)
+
+	select {
+	case evt := <-events:
+		require.Equal(t, event.TopicStorageHealthChanged, evt.Topic)
+	case <-time.After(5 * time.Second):
+		t.Fatal("write failure never published a health event")
+	}
+
+	// Recovery path.
+	m.RecordWriteSuccessForPath(tempPath)
+}

--- a/internal/update/checker_extra_test.go
+++ b/internal/update/checker_extra_test.go
@@ -1,0 +1,95 @@
+package update
+
+// Coverage for the Checker lifecycle surface (#580): Start/Stop and the
+// forced Refresh path, on top of the existing fetchAndCache tests. Uses
+// the same mock-GitHub httptest pattern (checker_test.go).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRefreshForcesNetworkFetch(t *testing.T) {
+	t.Parallel()
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"tag_name": "v0.12.0", "name": "R", "html_url": "https://x",
+			"published_at": "2026-01-01T00:00:00Z", "body": "notes",
+		})
+	}))
+	defer srv.Close()
+
+	c := New("v0.10.0", "owner/repo", "stable", time.Hour)
+	c.endpoint = srv.URL
+
+	// Status before any fetch: current set, everything else zero.
+	st := c.Status()
+	if st.Current != "v0.10.0" || st.UpdateAvailable {
+		t.Fatalf("pre-refresh status = %+v", st)
+	}
+
+	st, err := c.Refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if !st.UpdateAvailable || st.Latest != "v0.12.0" {
+		t.Fatalf("post-refresh status = %+v", st)
+	}
+	if hits != 1 {
+		t.Fatalf("hits = %d, want 1", hits)
+	}
+
+	// The cache survives into Status().
+	if got := c.Status().Latest; got != "v0.12.0" {
+		t.Fatalf("cached latest = %q", got)
+	}
+
+	// A failing endpoint refresh returns the error; cache stays intact.
+	dead := httptest.NewServer(http.NotFoundHandler())
+	deadURL := dead.URL
+	dead.Close() // free the port so the dial fails
+	c.endpoint = deadURL
+	if _, err := c.Refresh(context.Background()); err == nil {
+		t.Fatal("refresh against dead endpoint must fail")
+	}
+	if got := c.Status().Latest; got != "v0.12.0" {
+		t.Fatalf("cache lost after failed refresh: %q", got)
+	}
+}
+
+func TestStartStopLifecycle(t *testing.T) {
+	t.Parallel()
+	srv, _, _ := newTestServer(t, "v0.11.0", "")
+	defer srv.Close()
+
+	c := New("v0.10.0", "owner/repo", "stable", time.Hour)
+	c.endpoint = srv.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.Start(ctx)
+
+	// The initial fetch is synchronous inside Start's first iteration —
+	// observe the cached status instead of sleeping (#571).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.Status().Latest == "v0.11.0" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := c.Status().Latest; got != "v0.11.0" {
+		t.Fatalf("poller never fetched: %+v", c.Status())
+	}
+
+	// Stop is idempotent and cancelling the context also ends the loop.
+	c.Stop()
+	c.Stop()
+	cancel()
+}


### PR DESCRIPTION
Closes #580.

**覆盖率结果**（全部 hermetic，一测一库 / Eventually / 无 sleep）：

| 包 | 前 | 后 |
|---|---|---|
| internal/storage | 58.3% | **76.2%**（验收 ≥75 ✅） |
| internal/autodiscover | 60.3% | **84.7%** |
| internal/update | 67.1% | **87.3%** |
| internal/mediaprobe | 67.9% | **85.7%** |
| internal/metrics | 78.4% | **100%** |

**storage 长尾覆盖**：AI 事件统计/按录像删除、归档组统计与保留、camera ingest/activation/stable_id/ONVIF endpoint/端点重指派、级联通道 CRUD、GB28181 设备/通道、merge 校验与回滚（ListMergedRecordingsForValidation/ResetMergeStatus/UpdateMergeProgressBatch/ClearMergePathBatch/ResetFailedMergeStatus）、短合并/单例/窗口查询、路径迁移全套（RewritePathPrefix/CountPathPrefix/DistinctTopSegments/ListMigratableRecordings/RewriteRecordingPaths）、DB 维护（Backup/Optimize/CompactOnline/Path/ReadPoolStats）、Manager（SetRootDir 热切换/相机根覆盖/Roots/ListSegments 命名模式/DeleteCameraDir/ProbeDir/GetRootUsage/写健康事件记录）、RetryOnBusy/IsBusyError。

**生产修复（本批测试发现的真 bug）**：`ListCameraMergeWindows` 与 `ListSingletonPendingRecordings` 的 minAge 截止串用 `time.Now()` 本地时区格式化，与 UTC 存储的 `ended_at` 比较 —— UTC+8 主机上合并资格窗口比配置提前 8 小时（#565 同类时区缺陷）。已改 `time.Now().UTC()` 并加回归测试（minAge=1h 时 30 分钟前的窗口必须不可见）。

**测试设施**：`recSeed`/`setMergeState` SQL 回填夹具（#571 UTC+回填规约）；mediaprobe 用内部 muxer 生成真实 MP4；autodiscover 用 dead-endpoint + recordingEnroller 注入驱动完整 HandleDiscovered 流程。

**遗留（记入 issue）**：xiaomi/legacy 剩余缺口为 TUTK 连接生命周期（需 fake transport，下批）。

-race 全绿，golangci-lint 0 issue，`go build ./...` 通过。