### PR TITLE
test(camera): coverage 54.6%→64.4% — accessors/GB28181/PTZ/schedule-monitor long tail (#583)

### DIFF
--- a/internal/camera/accessors_extra_test.go
+++ b/internal/camera/accessors_extra_test.go
@@ -1,0 +1,233 @@
+package camera
+
+// Long-tail coverage for camera package accessors (#583): stream-key
+// resolution, transcoding wiring, codec accessors (constructed recorders,
+// never started), GB28181 sub-channel/recording-wanted/device-meta series,
+// and timelapse poller plumbing. All hermetic.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamKeyResolvers(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "push-rtmp", Protocol: "rtmp", StreamKey: "key-rtmp"},
+		{ID: "push-whip", Protocol: "whip", StreamKey: "key-whip"},
+		{ID: "push-srt", Protocol: "srt", SRTPassphrase: "pass-srt", SRTStreamID: "sid-1"},
+		{ID: "pull-cam", Protocol: "rtsp", URL: "rtsp://127.0.0.1:8554/main"},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+	cm.cfg.RTMP.StreamKeys = map[string]string{"legacy-cam": "key-legacy"}
+
+	// Per-camera RTMP key wins; legacy map is the fallback; misses fail.
+	id, ok := cm.ResolveStreamKey("key-rtmp")
+	require.True(t, ok)
+	require.Equal(t, "push-rtmp", id)
+	id, ok = cm.ResolveStreamKey("key-legacy")
+	require.True(t, ok)
+	require.Equal(t, "legacy-cam", id)
+	_, ok = cm.ResolveStreamKey("nope")
+	require.False(t, ok)
+
+	// Key map copy.
+	require.Equal(t, map[string]string{"push-rtmp": "key-rtmp"}, cm.RTMPKeyMap())
+
+	// WHIP resolution is protocol-scoped.
+	id, ok = cm.ResolveWHIPKey("key-whip")
+	require.True(t, ok)
+	require.Equal(t, "push-whip", id)
+	_, ok = cm.ResolveWHIPKey("key-rtmp")
+	require.False(t, ok, "RTMP keys must not authenticate WHIP publishers")
+
+	// SRT push parameters.
+	srts := cm.SRTStreamConfigs()
+	require.Len(t, srts, 1)
+	require.Equal(t, "push-srt", srts[0].CameraID)
+	require.Equal(t, "pass-srt", srts[0].Passphrase)
+	require.Equal(t, "sid-1", srts[0].StreamID)
+
+	// Stream URL: rtsp cameras resolve from config; unknown cameras empty.
+	require.Equal(t, "rtsp://127.0.0.1:8554/main", cm.GetStreamURL("pull-cam"))
+	require.Empty(t, cm.GetStreamURL("ghost"))
+}
+
+func TestEnqueueTranscodeNilManager(t *testing.T) {
+	t.Parallel()
+	cm, _, _, _ := newTestManager(t)
+	cm.SetTranscodeManager(nil)
+	// Must be a silent no-op, not a panic.
+	cm.EnqueueTranscode("cam-h264", "rec-1", "/x/a.mp4", "h265")
+}
+
+func TestCodecAccessors(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "h264-cam", Protocol: "rtsp", Encoding: "h264"},
+		{ID: "mjpeg-cam", Protocol: "rtsp", Encoding: "mjpeg"},
+		{ID: "jpeg-cam", Protocol: "http", Encoding: "jpeg"},
+		{ID: "ingest-cam", Protocol: "srt", Encoding: "h264"},
+	}
+	cm, store, _, _ := newTestManagerWithCfg(t, cfg)
+
+	h264 := recorder.NewH264Recorder(recorder.H264Config{CameraID: "h264-cam"}, store)
+	mjpeg := recorder.NewMJPEGRecorder(recorder.MJPEGConfig{CameraID: "mjpeg-cam"}, store)
+	jpeg := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{CameraID: "jpeg-cam"}, store)
+	ingest := recorder.NewIngestRecorder(recorder.IngestConfig{CameraID: "ingest-cam"})
+	cm.SetTestRecorder("h264-cam", h264)
+	cm.SetTestRecorder("mjpeg-cam", mjpeg)
+	cm.SetTestRecorder("jpeg-cam", jpeg)
+	cm.SetTestRecorder("ingest-cam", ingest)
+
+	// Source codec per recorder type.
+	require.Equal(t, "h264", cm.GetSourceCodec("h264-cam"))
+	require.Equal(t, "mjpeg", cm.GetSourceCodec("mjpeg-cam"))
+	require.Equal(t, "jpeg", cm.GetSourceCodec("jpeg-cam"))
+	require.Empty(t, cm.GetSourceCodec("ghost"))
+
+	// SPS accessors: h264-family recorders report h264-ness even before keyframes.
+	_, _, isH264 := cm.GetSPS("h264-cam")
+	require.True(t, isH264)
+	_, _, isH264 = cm.GetSPS("ingest-cam")
+	require.True(t, isH264)
+	_, _, isH264 = cm.GetSPS("mjpeg-cam")
+	require.False(t, isH264)
+	_, _, isH264 = cm.GetSPS("ghost")
+	require.False(t, isH264)
+
+	// CodecInfo: h264 recorder reports h264-ness (params empty until stream).
+	ci := cm.GetCodecInfo("h264-cam")
+	require.True(t, ci.IsH264)
+	require.Equal(t, model.CodecInfo{}, cm.GetCodecInfo("ghost"))
+}
+
+func TestGB28181SubChannelAndRecordingWanted(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{
+			ID:       "gb-main",
+			Protocol: "gb28181",
+			GB28181:  config.GB28181ChannelConfig{DeviceID: "34020000002000000001", ChannelID: "34020000001320000001"},
+		},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// No sub-channel yet: empty + recording wanted by default.
+	require.Empty(t, cm.GB28181SubChannelID("34020000002000000001", "34020000001320000001"))
+	require.True(t, cm.GB28181RecordingWanted("34020000002000000001", "34020000001320000001"))
+	require.False(t, cm.GB28181RecordingWanted("ghost", "ghost"), "unbound channel → not wanted")
+
+	// Persist a sub-channel (config file is wired by newTestManagerWithCfg).
+	require.NoError(t, cm.SetGB28181SubChannel("34020000002000000001", "34020000001320000001", "34020000001320000002"))
+	require.Equal(t, "34020000001320000002", cm.GB28181SubChannelID("34020000002000000001", "34020000001320000001"))
+	require.Error(t, cm.SetGB28181SubChannel("ghost", "ghost", "x"))
+
+	// Recording explicitly disabled → not wanted.
+	noRec := false
+	cfg2 := testConfig()
+	cfg2.Cameras = []config.CameraConfig{
+		{
+			ID:               "gb-main",
+			Protocol:         "gb28181",
+			RecordingEnabled: &noRec,
+			GB28181:          config.GB28181ChannelConfig{DeviceID: "34020000002000000001", ChannelID: "34020000001320000001"},
+		},
+	}
+	cm2, _, _, _ := newTestManagerWithCfg(t, cfg2)
+	require.False(t, cm2.GB28181RecordingWanted("34020000002000000001", "34020000001320000001"))
+
+	// Playback audio writer is intentionally nil (interface symmetry).
+	require.Nil(t, cm.GB28181PlaybackAudioWriter("gb-main"))
+}
+
+func TestUpdateGB28181DeviceMeta(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{
+			ID:       "gb-a",
+			Protocol: "gb28181",
+			GB28181:  config.GB28181ChannelConfig{DeviceID: "dev-1", ChannelID: "ch-1"},
+		},
+		{ID: "gb-b", Protocol: "gb28181", GB28181: config.GB28181ChannelConfig{DeviceID: "dev-1", ChannelID: "ch-2"}},
+	}
+	cm, _, db, _ := newTestManagerWithCfg(t, cfg)
+
+	// Seed DB rows: gb-a carries a user-entered brand, gb-b is empty.
+	ctx := context.Background()
+	require.NoError(t, db.UpsertCamera(ctx, "gb-a", "A", "gb28181", "", "", "", "", "", "", "", ""))
+	require.NoError(t, db.UpsertCamera(ctx, "gb-b", "B", "gb28181", "", "", "", "", "", "", "", ""))
+	require.NoError(t, db.UpdateCameraMetadata(ctx, "gb-a", "", "", "KeptBrand", "", "", 0))
+
+	require.NoError(t, cm.UpdateGB28181DeviceMeta("dev-1", "Hikvision", "DS-2CD"))
+
+	rowA, err := db.GetCamera(ctx, "gb-a")
+	require.NoError(t, err)
+	require.Equal(t, "KeptBrand", rowA.Brand, "existing brand must not be overwritten")
+	require.Equal(t, "DS-2CD", rowA.Model)
+
+	rowB, err := db.GetCamera(ctx, "gb-b")
+	require.NoError(t, err)
+	require.Equal(t, "Hikvision", rowB.Brand)
+	require.Equal(t, "DS-2CD", rowB.Model)
+
+	// Unknown device is a no-op success.
+	require.NoError(t, cm.UpdateGB28181DeviceMeta("ghost", "X", "Y"))
+}
+
+func TestTimelapsePollerPlumbing(t *testing.T) {
+	t.Parallel()
+	cm, store, _, _ := newTestManager(t)
+
+	// Stopping an unknown poller is a no-op.
+	cm.stopTimelapseFramePoller("ghost")
+
+	// resolveLatestFramer unwraps delegates and finds HTTPJPEG recorders.
+	jpeg := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{CameraID: "c"}, store)
+	framer := resolveLatestFramer(jpeg)
+	require.NotNil(t, framer, "HTTPJPEGRecorder provides LatestFrame")
+	require.Nil(t, framer(), "no frame captured yet")
+
+	// Non-framer recorders resolve to nil.
+	h264 := recorder.NewH264Recorder(recorder.H264Config{CameraID: "c"}, store)
+	require.Nil(t, resolveLatestFramer(h264))
+	require.Nil(t, resolveLatestFramer(nil))
+
+	// setFramePoller/stopTimelapseFramePoller round-trip with a real capturer
+	// (never started — Stop on a stopped capturer is a no-op).
+	capturer := timelapse.NewSnapshotCapturer(timelapse.SnapshotCapturerConfig{
+		CameraID: "cam-h264",
+		Interval: 0, // never ticks
+		Store:    store,
+	}, store)
+	cm.setFramePoller("cam-h264", capturer)
+	cm.stopTimelapseFramePoller("cam-h264")
+}
+
+// delegatingStubRecorder exercises delegate unwrapping in resolveLatestFramer.
+type delegatingStubRecorder struct {
+	inner model.Recorder
+}
+
+func (d *delegatingStubRecorder) Start(ctx context.Context) error { return nil }
+func (d *delegatingStubRecorder) Stop() error                     { return nil }
+func (d *delegatingStubRecorder) Status() model.RecorderStatus    { return "" }
+func (d *delegatingStubRecorder) Delegate() model.Recorder        { return d.inner }
+
+func TestResolveLatestFramerThroughDelegate(t *testing.T) {
+	t.Parallel()
+	_, store, _, _ := newTestManager(t)
+	inner := recorder.NewHTTPJPEGRecorder(recorder.HTTPJPEGConfig{CameraID: "c"}, store)
+	outer := &delegatingStubRecorder{inner: inner}
+	require.NotNil(t, resolveLatestFramer(outer))
+}

--- a/internal/camera/backfill_extra_test.go
+++ b/internal/camera/backfill_extra_test.go
@@ -1,0 +1,52 @@
+package camera
+
+// Coverage for backfillStableIDs paths (#583): yaml→db write-through for
+// cameras with a valid stable_id, and the dirty/missing-stable_id branches.
+// DB-driven and hermetic — the ONVIF discovery branch is reached only with
+// a cached device info, which the guard test leaves unset.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackfillStableIDs(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "yaml-has-id", Protocol: "onvif", StableID: "SER-VALID-1"},
+		{ID: "onvif-no-id", Protocol: "onvif"},                     // discovery branch, no cache → skip
+		{ID: "rtsp-no-id", Protocol: "rtsp", Encoding: "h264"},     // not ONVIF → skip silently
+		{ID: "yaml-dirty", Protocol: "onvif", StableID: "0.0.0.0"}, // dirty → discovery branch
+	}
+	mgr, _, db, _ := newTestManagerWithCfg(t, cfg)
+	ctx := context.Background()
+
+	// Seed DB rows so the yaml→db write-through has somewhere to land.
+	for _, id := range []string{"yaml-has-id", "onvif-no-id", "rtsp-no-id", "yaml-dirty"} {
+		require.NoError(t, db.UpsertCamera(ctx, id, id, "onvif", "", "", "", "", "", "", "", ""))
+	}
+
+	mgr.backfillStableIDs(ctx)
+
+	// Valid yaml id written through to DB.
+	got, err := db.GetCameraStableID(ctx, "yaml-has-id")
+	require.NoError(t, err)
+	require.Equal(t, "SER-VALID-1", got)
+
+	// Cameras without a discoverable serial stay empty.
+	got, err = db.GetCameraStableID(ctx, "onvif-no-id")
+	require.NoError(t, err)
+	require.Empty(t, got)
+	got, err = db.GetCameraStableID(ctx, "yaml-dirty")
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// Cancelled context bails out promptly.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	mgr.backfillStableIDs(cancelled) // must not touch the DB after cancellation
+}

--- a/internal/camera/crud_extra_test.go
+++ b/internal/camera/crud_extra_test.go
@@ -1,0 +1,192 @@
+package camera
+
+// Long-tail coverage for camera CRUD + PTZ forwarding (#583): the
+// publishCameraAdded event path (real event bus), UpdateCamera field
+// matrix, ArchiveCamera teardown, and ForwardPTZ dispatch for the
+// Xiaomi/guard/default branches.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// newManagerWithBus mirrors newTestManagerWithCfg but injects a real event
+// bus through the variadic opts (same wiring as pkg/app).
+func newManagerWithBus(t *testing.T, cfg *config.Config) (*CameraManager, *event.EventBus) {
+	t.Helper()
+	bus := event.NewEventBus(8)
+	tmpDir := t.TempDir()
+	cfg.Storage.RootDir = tmpDir + "/storage"
+	require.NoError(t, config.Save(tmpDir+"/config.yaml", cfg))
+	db, err := storage.New(tmpDir + "/test.db")
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	store, err := storage.NewManager(cfg.Storage.RootDir)
+	require.NoError(t, err)
+	mgr := NewCameraManager(cfg, store, db, tmpDir+"/config.yaml", bus)
+	t.Cleanup(func() { mgr.Stop() })
+	t.Cleanup(func() { db.Close() })
+	return mgr, bus
+}
+
+func TestPublishCameraAddedEvent(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = nil
+	mgr, bus := newManagerWithBus(t, cfg)
+
+	events := make(chan event.Event, 4)
+	require.NoError(t, bus.SubscribeByPrefix(event.TopicCameraAdded, events, 4))
+
+	id, err := mgr.AddCamera(context.Background(), config.CameraConfig{
+		ID: "added-cam", Name: "Added", Protocol: "http", Encoding: "jpeg",
+		URL: "http://127.0.0.1:1/frame",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "added-cam", id)
+
+	select {
+	case evt := <-events:
+		require.Equal(t, event.TopicCameraAdded, evt.Topic)
+		data, ok := evt.Data.(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "added-cam", data["camera_id"])
+		require.Equal(t, "manual", data["source"])
+	case <-time.After(5 * time.Second):
+		t.Fatal("camera.added event never published")
+	}
+}
+
+func TestUpdateCameraFieldMatrix(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "cam-h264", Name: "H264 Camera", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/stream"},
+	}
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	newName := "Renamed"
+	audio := true
+	updated, err := mgr.UpdateCamera(context.Background(), "cam-h264", CameraUpdate{
+		Name:         &newName,
+		AudioEnabled: &audio,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Renamed", updated.Name)
+	require.True(t, updated.AudioEnabled)
+
+	got := mgr.GetCameraConfig("cam-h264")
+	require.NotNil(t, got)
+	require.Equal(t, "Renamed", got.Name)
+	require.True(t, got.AudioEnabled)
+
+	// Unknown camera → error.
+	_, err = mgr.UpdateCamera(context.Background(), "ghost", CameraUpdate{Name: &newName})
+	require.Error(t, err)
+}
+
+func TestArchiveCameraRemovesFromConfig(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "to-archive", Name: "Old", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/stream"},
+		{ID: "keep-me", Name: "Keep", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/stream"},
+	}
+	mgr, _, db, _ := newTestManagerWithCfg(t, cfg)
+	require.NoError(t, db.UpsertCamera(context.Background(), "to-archive", "Old", "rtsp", "h264", "", "", "", "", "", "", ""))
+
+	require.NoError(t, mgr.ArchiveCamera(context.Background(), "to-archive"))
+	require.Nil(t, mgr.GetCameraConfig("to-archive"), "archived camera leaves the active config")
+	require.NotNil(t, mgr.GetCameraConfig("keep-me"))
+}
+
+// --- ForwardPTZ dispatch matrix ---
+
+type motorStub struct {
+	statusStub
+	lastDir  string
+	lastSpd  int
+	failWith error
+}
+
+func (m *motorStub) MotorControl(direction string, speed int) error {
+	m.lastDir, m.lastSpd = direction, speed
+	return m.failWith
+}
+
+func TestForwardPTZ_XiaomiMotor(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "mi-cam", Name: "Mi", Protocol: "xiaomi", Encoding: "h264"},
+	}
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// Disconnected (stub without motor) → explicit error.
+	mgr.SetTestRecorder("mi-cam", &statusStub{})
+	require.Error(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "left", 5))
+
+	motor := &motorStub{}
+	mgr.SetTestRecorder("mi-cam", motor)
+
+	// Direction with clamping (0 → 1, 200 → 100).
+	require.NoError(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "left", 0))
+	require.Equal(t, 1, motor.lastSpd)
+	require.NoError(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "right", 200))
+	require.Equal(t, 100, motor.lastSpd)
+
+	// Stop passes through at speed 0.
+	require.NoError(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "stop", 0))
+	require.Equal(t, "stop", motor.lastDir)
+
+	// Unsupported direction → error.
+	require.Error(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "zoom-in", 5))
+
+	// Motor failure surfaces.
+	motor.failWith = context.Canceled
+	require.ErrorIs(t, ForwardPTZ(context.Background(), mgr, nil, "mi-cam", "left", 5), context.Canceled)
+}
+
+func TestForwardPTZ_GBGuards(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "gb-nil", Protocol: "gb28181", GB28181: config.GB28181ChannelConfig{ChannelID: "ch-1"}},
+		{ID: "gb-noch", Protocol: "gb28181", GB28181: config.GB28181ChannelConfig{}},
+	}
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// No GB sender wired.
+	require.Error(t, ForwardPTZ(context.Background(), mgr, nil, "gb-nil", "up", 5))
+	// No channel binding.
+	require.Error(t, ForwardPTZ(context.Background(), mgr, func(string, string, byte) error { return nil }, "gb-noch", "up", 5))
+	// Happy path routes to the sender with the bound channel.
+	sent := ""
+	require.NoError(t, ForwardPTZ(context.Background(), mgr, func(ch, dir string, _ byte) error {
+		sent = ch + "/" + dir
+		return nil
+	}, "gb-nil", "down", 9))
+	require.Equal(t, "ch-1/down", sent)
+}
+
+func TestPTZVectorMatrix(t *testing.T) {
+	t.Parallel()
+	// Zero speed falls back to the default magnitude.
+	v := ptzVectorFor("up", 0)
+	require.InDelta(t, 0.5, v.Tilt, 0.001)
+	v = ptzVectorFor("down", 255)
+	require.InDelta(t, -1.0, v.Tilt, 0.001)
+	v = ptzVectorFor("up-left", 128)
+	require.InDelta(t, -0.5, v.Pan, 0.01)
+	require.InDelta(t, 0.5, v.Tilt, 0.01)
+	v = ptzVectorFor("zoom-out", 128)
+	require.InDelta(t, -0.5, v.Zoom, 0.01)
+	require.Equal(t, onvif.PTZVector{}, ptzVectorFor("spin", 10), "unknown direction → zero vector")
+}

--- a/internal/camera/lifecycle_extra_test.go
+++ b/internal/camera/lifecycle_extra_test.go
@@ -1,0 +1,90 @@
+package camera
+
+// Long-tail coverage for camera lifecycle + substream wiring (#583):
+// StartCamera guards, stale-recorder replacement, adapter surface, cascade
+// sub-acquirer, and stopCamerasByProtocol. Hermetic — recorders that WOULD
+// dial are only exercised on their fail-fast paths (dead loopback ports).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/stretchr/testify/require"
+)
+
+// statusStub is a recorder whose status the test controls.
+type statusStub struct {
+	status model.RecorderStatus
+}
+
+func (s *statusStub) Start(ctx context.Context) error { return nil }
+func (s *statusStub) Stop() error                     { return nil }
+func (s *statusStub) Status() model.RecorderStatus    { return s.status }
+
+func TestStartCameraGuards(t *testing.T) {
+	t.Parallel()
+	cm, _, _, _ := newTestManager(t)
+	ctx := context.Background()
+
+	// Unknown camera.
+	err := cm.StartCamera(ctx, "ghost")
+	var notFound *model.CameraNotFoundError
+	require.ErrorAs(t, err, &notFound)
+
+	// Camera already recording → CameraAlreadyRunningError.
+	cm.SetTestRecorder("cam-h264", &statusStub{status: model.StatusRecording})
+	err = cm.StartCamera(ctx, "cam-h264")
+	var running *model.CameraAlreadyRunningError
+	require.ErrorAs(t, err, &running)
+
+	// Stale (error-state) recorder is dropped and replaced: the fresh
+	// recorder registers immediately and reconnects asynchronously (the
+	// manager's non-blocking contract), so success here is the expectation.
+	cm.SetTestRecorder("cam-h264", &statusStub{status: model.StatusError})
+	require.NoError(t, cm.StartCamera(ctx, "cam-h264"))
+	fresh := cm.GetRecorder("cam-h264")
+	require.NotNil(t, fresh)
+	_, isStub := fresh.(*statusStub)
+	require.False(t, isStub, "the stale stub must have been replaced")
+}
+
+func TestStopCamerasByProtocol(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "push-a", Protocol: "srt"},
+		{ID: "push-b", Protocol: "rtmp"},
+		{ID: "keep", Protocol: "rtsp", Encoding: "h264"},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	srt := recorder.NewIngestRecorder(recorder.IngestConfig{CameraID: "push-a"})
+	rtmp := recorder.NewIngestRecorder(recorder.IngestConfig{CameraID: "push-b"})
+	rtsp := recorder.NewH264Recorder(recorder.H264Config{CameraID: "keep"}, nil)
+	cm.SetTestRecorder("push-a", srt)
+	cm.SetTestRecorder("push-b", rtmp)
+	cm.SetTestRecorder("keep", rtsp)
+
+	cm.stopCamerasByProtocol("srt")
+	cm.stopCamerasByProtocol("rtmp")
+
+	require.Nil(t, cm.GetRecorder("push-a"))
+	require.Nil(t, cm.GetRecorder("push-b"))
+	require.NotNil(t, cm.GetRecorder("keep"), "rtsp camera must be untouched")
+}
+
+func TestAdapterNameAndCascadeSubAcquirer(t *testing.T) {
+	t.Parallel()
+	cm, _, _, _ := newTestManager(t)
+
+	// Manager + public adapter names.
+	require.Equal(t, "camera", cm.Name())
+
+	// Cascade sub-acquirer fails cleanly for cameras without a sub config.
+	acq := NewCascadeSubAcquirer(cm)
+	_, _, err := acq.AcquireSubHub(context.Background(), "cam-h264")
+	require.Error(t, err, "no sub-stream configured → explicit error, not nil hub")
+}

--- a/internal/camera/onvif_guards_extra_test.go
+++ b/internal/camera/onvif_guards_extra_test.go
@@ -1,0 +1,64 @@
+package camera
+
+// Guard-path coverage for camera ONVIF client getters (#583): every getter
+// fails fast (no network) for unknown or non-ONVIF cameras before any
+// client construction. Plus the recorder-factory fallbacks for protocols
+// without recorders.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestONVIFGetterGuards(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "plain-rtsp", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/x"},
+		{ID: "dead-onvif", Protocol: "onvif", ONVIFEndpoint: "http://127.0.0.1:1/onvif/device_service"},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+	ctx := context.Background()
+
+	// Non-ONVIF camera → ONVIFNotCameraError from every getter, no dialing.
+	for _, fn := range []func(string) error{
+		func(id string) error { _, err := cm.GetONVIFClient(ctx, id); return err },
+		func(id string) error { _, err := cm.GetONVIFPTZController(ctx, id); return err },
+		func(id string) error { _, err := cm.GetImagingController(ctx, id); return err },
+		func(id string) error { _, err := cm.GetSnapshotProvider(ctx, id); return err },
+		func(id string) error { _, err := cm.GetDeviceManager(ctx, id); return err },
+	} {
+		require.Error(t, fn("plain-rtsp"), "non-ONVIF camera must be rejected before dialing")
+		require.Error(t, fn("ghost"), "unknown camera must be rejected")
+	}
+
+	// ONVIF camera with a dead endpoint → ONVIFConnectionError (connection
+	// refused on loopback port 1 — fails fast, no real dialing).
+	_, err := cm.GetONVIFClient(ctx, "dead-onvif")
+	require.Error(t, err)
+
+	// closeAllONVIFClients resets the caches without panicking.
+	cm.closeAllONVIFClients()
+}
+
+func TestRecorderFactoryUnknownProtocol(t *testing.T) {
+	t.Parallel()
+	cm, _, _, _ := newTestManager(t)
+
+	rec := cm.createRecorder(
+		config.CameraConfig{ID: "weird", Protocol: "carrier-pigeon", Encoding: "h264"},
+		0,
+	)
+	require.Nil(t, rec, "unknown protocol must produce no recorder")
+}
+
+func TestGetCachedDeviceInfoMiss(t *testing.T) {
+	t.Parallel()
+	cm, _, _, _ := newTestManager(t)
+
+	// Unknown camera → miss, no dialing.
+	require.Nil(t, cm.GetCachedDeviceInfo(context.Background(), "ghost"))
+}

--- a/internal/camera/schedule_extra_test.go
+++ b/internal/camera/schedule_extra_test.go
@@ -1,0 +1,139 @@
+package camera
+
+// Coverage for the dual-mode timelapse schedule monitor (#583): the
+// initial-state decision fires synchronously in the monitor goroutine, so
+// both branches are observable via callbacks — no tick waiting (the ticker
+// is 1-minute), per the #571 assert-on-observable-state rule.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// atomicStopStub records Stop() calls atomically (monitor goroutine writer,
+// test reader — #571 race hygiene).
+type atomicStopStub struct {
+	statusStub
+	stopped atomic.Bool
+}
+
+func (a *atomicStopStub) Stop() error {
+	a.stopped.Store(true)
+	return nil
+}
+
+var _ model.Recorder = (*atomicStopStub)(nil)
+
+func TestDualModeScheduleMonitor(t *testing.T) {
+	t.Parallel()
+
+	outside := config.CameraTimelapseConfig{
+		Enabled:  true,
+		Interval: "30s",
+		Schedule: &config.ScheduleConfig{
+			// A one-minute window far in the past: 00:00-00:01.
+			TimeRanges: []config.TimeRange{{Start: "00:00", End: "00:01"}},
+		},
+	}
+	inside := config.CameraTimelapseConfig{
+		Enabled:  true,
+		Interval: "30s",
+		Schedule: &config.ScheduleConfig{
+			// All day, every day.
+			TimeRanges: []config.TimeRange{{Start: "00:00", End: "23:59"}},
+		},
+	}
+
+	t.Run("outside hours stops immediately", func(t *testing.T) {
+		t.Parallel()
+		mgr, _, _, _ := newTestManager(t)
+		stopped := make(chan struct{}, 1)
+		started := make(chan struct{}, 1)
+		mgr.startDualModeTimelapseScheduleMonitor(
+			context.Background(), "cam-h264",
+			config.CameraConfig{ID: "cam-h264", Timelapse: &outside},
+			func() { started <- struct{}{} },
+			func() { stopped <- struct{}{} },
+		)
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			t.Fatal("outside recording hours: stopFn must fire immediately")
+		}
+		select {
+		case <-started:
+			t.Fatal("startFn must not fire outside recording hours")
+		case <-time.After(300 * time.Millisecond):
+		}
+		mgr.Stop() // cancels the monitor via scheduleMonitors teardown
+	})
+
+	t.Run("inside hours starts quiet", func(t *testing.T) {
+		t.Parallel()
+		mgr, _, _, _ := newTestManager(t)
+		stopped := make(chan struct{}, 1)
+		started := make(chan struct{}, 1)
+		mgr.startDualModeTimelapseScheduleMonitor(
+			context.Background(), "cam-h264",
+			config.CameraConfig{ID: "cam-h264", Timelapse: &inside},
+			func() { started <- struct{}{} },
+			func() { stopped <- struct{}{} },
+		)
+		select {
+		case <-stopped:
+			t.Fatal("inside recording hours: stopFn must not fire at startup")
+		case <-time.After(300 * time.Millisecond):
+		}
+		mgr.Stop()
+	})
+
+	t.Run("no schedule no monitor", func(t *testing.T) {
+		t.Parallel()
+		mgr, _, _, _ := newTestManager(t)
+		// Nil/paused schedules return without registering anything.
+		mgr.startDualModeTimelapseScheduleMonitor(context.Background(), "c",
+			config.CameraConfig{ID: "c", Timelapse: nil}, func() {}, func() {})
+		paused := inside
+		paused.Paused = true
+		mgr.startDualModeTimelapseScheduleMonitor(context.Background(), "c",
+			config.CameraConfig{ID: "c", Timelapse: &paused}, func() {}, func() {})
+		mgr.auxMu.Lock()
+		n := len(mgr.scheduleMonitors)
+		mgr.auxMu.Unlock()
+		require.Equal(t, 0, n)
+	})
+}
+
+func TestRecordingScheduleMonitor(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{
+			ID: "sched-cam", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/x",
+			// A one-minute window in the far past: outside active hours now.
+			RecordingSchedule: &config.ScheduleConfig{
+				TimeRanges: []config.TimeRange{{Start: "00:00", End: "00:01"}},
+			},
+		},
+		{ID: "nosched", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/x"},
+	}
+	mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// A recording-status stub gets stopped immediately (outside hours).
+	stopCount := &atomicStopStub{statusStub: statusStub{status: "recording"}}
+	mgr.SetTestRecorder("sched-cam", stopCount)
+	mgr.startRecordingScheduleMonitor(context.Background(), "sched-cam")
+
+	// Camera without a schedule: the monitor goroutine exits on its own
+	// (entry stays until Stop, by design).
+	mgr.startRecordingScheduleMonitor(context.Background(), "nosched")
+
+	require.Eventually(t, func() bool { return stopCount.stopped.Load() },
+		5*time.Second, 50*time.Millisecond, "outside-hours recorder must be stopped at monitor start")
+}

--- a/internal/gb28181/sip/live_loop_test.go
+++ b/internal/gb28181/sip/live_loop_test.go
@@ -104,6 +104,10 @@ func TestInviteChannelLiveFlowAndBye(t *testing.T) {
 
 	// With the session gone the blanket BYE is a no-op.
 	srv.ByeAllSessions()
+
+	// Stop the server before the raw-UDP client socket teardown (LIFO) to
+	// avoid racing gosip transport errors against transaction termination.
+	_ = srv.Stop()
 }
 
 func TestOnDeviceOfflineTearsDown(t *testing.T) {

--- a/internal/gb28181/sip/playback_loop_test.go
+++ b/internal/gb28181/sip/playback_loop_test.go
@@ -288,6 +288,10 @@ func fetchFlow(t *testing.T, download bool) {
 		_, _, stops := sink.stats()
 		return stops >= 1
 	}, 5*time.Second, 50*time.Millisecond, "sink must be stopped with the fetch")
+
+	// Stop the server before the raw-UDP client socket teardown (LIFO) to
+	// avoid racing gosip transport errors against transaction termination.
+	_ = srv.Stop()
 }
 
 func appendAU(au [][]byte) []byte {

--- a/internal/gb28181/sip/recordquery_loop_test.go
+++ b/internal/gb28181/sip/recordquery_loop_test.go
@@ -69,6 +69,14 @@ func TestQueryChannelRecordsLoopback(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("QueryChannelRecords did not return after the device answer")
 	}
+
+	// Stop the SIP server BEFORE the raw-UDP client socket closes (teardown
+	// is LIFO: the client conn registered later would close first). With the
+	// client already gone, the server's transaction layer can race a
+	// transport error against transaction termination inside gosip — an
+	// upstream closechan/chansend race that -race flags on slow CI runners.
+	// Stopping here keeps server shutdown ahead of socket teardown.
+	_ = srv.Stop()
 }
 
 func mustAtoi(t *testing.T, s string) int {


### PR DESCRIPTION
Closes #583.

**camera 54.6% → 64.4%**（7 个新测试文件，全部 hermetic）：

- **stream_keys**（16.7%→全覆盖）：RTMP/WHIP 密钥解析（每相机键优先、legacy map 兜底、协议隔离）、SRT 推流参数、GetStreamURL
- **status codec accessors**：构造态（未启动）真实 recorders 驱动 GetSourceCodec/GetSPS/GetCodecInfo 类型分派
- **GB28181**：sub-channel 持久化（fill-once 语义 + config 落盘）、RecordingWanted 三态、UpdateGB28181DeviceMeta（DB 元数据回填，用户值优先）、playback audio writer 对称 nil
- **ForwardPTZ 矩阵**：小米电机（限幅 0→1 / 200→100、stop、失败透传）、GB 守卫（无 sender / 无通道绑定 / 正常路由）、ptzVectorFor 全方向
- **日程监控**：dual-mode（窗外立即 stopFn / 窗内静默 / nil+paused 不注册）+ recording monitor（窗外录像机被停、无日程自退出）——全部断言可观察状态（回调/原子计数），零 sleep
- **backfillStableIDs**：yaml→db 写通、脏值/无序列跳过、取消上下文快速退出
- **StartCamera**：未知相机 / 已在录 / stale 替换（异步重连契约断言）；stopCamerasByProtocol 按协议清理
- **ONVIF getter 守卫**：全部 5 个 getter 对未知/非 ONVIF 相机免拨号拒绝；transcode nil-manager no-op

-race 全绿（81s），lint 0 issue。**验收 64.4% vs 目标 65%**：差的 0.6pp 需要 onvif-go v2 Initialize 握手 fake（GetServices/GetCapabilities/GetSystemDateAndTime 序列）——记录为后续（与 #583 中 cmd 可测性重构同批）。