### PR TITLE
test(recorder+xiaomi): darkframe 全覆盖 + AVI 暗帧检测 movi 偏移生产修复 + 长尾 (#585)

### DIFF
--- a/internal/recorder/accessors_small_test.go
+++ b/internal/recorder/accessors_small_test.go
@@ -1,0 +1,138 @@
+package recorder
+
+// Long-tail coverage for recorder small surfaces (#585): NAL driver
+// parameter-set extraction (h264/h265), ambient sidecar lifecycle, codec
+// accessor labels, backoff wrappers, storage-health helpers, the StubRecorder,
+// and audio-trigger config resolution. Hermetic — recorders are constructed
+// but never started.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// newRecTestStore builds a real storage.Manager on a temp dir.
+func newRecTestStore(t *testing.T) *storage.Manager {
+	t.Helper()
+	m, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+	return m
+}
+
+func TestH264ParamSetExtraction(t *testing.T) {
+	t.Parallel()
+	store := newRecTestStore(t)
+	rec := NewH264Recorder(H264Config{CameraID: "c", SegmentDur: time.Second}, store)
+
+	require.Equal(t, "h264", H264NALDriver{}.codecLabel())
+	require.NotNil(t, H264NALDriver{}.rtpFormat())
+
+	sps := []byte{0x67, 0x42, 0x00, 0x0a}
+	pps := []byte{0x68, 0xce, 0x38}
+	// One access unit carrying SPS(7), PPS(8), IDR(5) and a non-param NAL.
+	au := [][]byte{sps, pps, {0x65, 0x88}, {0x41, 0x10}}
+	rec.Hub = model.NewStreamHub() // wired by camera.initStreamHub in production
+	H264NALDriver{}.extractParamSets(rec.baseRecorder, au)
+
+	require.Equal(t, sps, rec.SPS())
+	require.Equal(t, pps, rec.PPS())
+	require.NotNil(t, rec.GetHub())
+}
+
+func TestH265ParamSetExtraction(t *testing.T) {
+	t.Parallel()
+	rec := NewH265Recorder(H265Config{CameraID: "c", SegmentDur: time.Second}, newRecTestStore(t))
+
+	require.Equal(t, "h265", H265NALDriver{}.codecLabel())
+	require.NotNil(t, H265NALDriver{}.rtpFormat())
+
+	// H265 NAL type = (firstByte>>1)&0x3F: VPS=32 (0x40), SPS=33 (0x42), PPS=34 (0x44).
+	vps := []byte{0x40, 0x01}
+	sps := []byte{0x42, 0x01}
+	pps := []byte{0x44, 0x01}
+	au := [][]byte{vps, sps, pps, {0x26, 0x01}}
+	H265NALDriver{}.extractParamSets(rec.baseRecorder, au)
+
+	require.Equal(t, vps, rec.VPS())
+	require.Equal(t, sps, rec.SPS())
+	require.Equal(t, pps, rec.PPS())
+}
+
+func TestAmbientSidecarLifecycle(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	rec := NewH264Recorder(H264Config{
+		CameraID:   "c",
+		SegmentDur: time.Second,
+		Adaptive:   &AdaptiveConfig{AmbientAudio: true, AmbientArchive: true},
+	}, newRecTestStore(t))
+	b := rec.baseRecorder
+
+	// Disabled path first: a recorder without the adaptive flags gets nil.
+	bare := NewH264Recorder(H264Config{CameraID: "bare", SegmentDur: time.Second}, newRecTestStore(t))
+	require.Nil(t, bare.openAmbientSidecar(filepath.Join(dir, "bare.mp4")))
+
+	// Enabled path: sidecar file is created and appended to.
+	final := filepath.Join(dir, "seg.mp4")
+	f := b.openAmbientSidecar(final)
+	require.NotNil(t, f)
+	b.mu.Lock()
+	b.ambientFile = f
+	b.mu.Unlock()
+
+	b.writeAmbientArchive(nil) // empty write is a no-op
+	b.writeAmbientArchive([]byte{0x01, 0x02})
+	b.closeAmbientSidecar()
+
+	data, err := os.ReadFile(final + ".g711")
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x01, 0x02}, data)
+
+	// Close is idempotent after nil-out.
+	b.closeAmbientSidecar()
+}
+
+func TestBackoffWrappers(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, TieredBackoff(0), TieredBackoff(0))
+	require.Greater(t, TieredBackoff(5).Nanoseconds(), int64(0))
+	require.GreaterOrEqual(t, TieredBackoffWithJitter(3), TieredBackoff(3))
+	require.GreaterOrEqual(t, StorageBackoffWithJitter(), 55*time.Second)
+}
+
+func TestStorageHealthHelpers(t *testing.T) {
+	t.Parallel()
+	require.False(t, isStorageFailed(nil, "c")) // nil store → not failed
+
+	last := time.Now().Add(-2 * time.Minute)
+	newLast, ok := shouldLogHealth(last)
+	require.True(t, ok)
+	require.True(t, newLast.After(last))
+
+	_, ok = shouldLogHealth(time.Now())
+	require.False(t, ok, "health logs are rate-limited")
+}
+
+func TestStubRecorderSurface(t *testing.T) {
+	t.Parallel()
+	s := &StubRecorder{Hub: model.NewStreamHub()}
+	require.NoError(t, s.Start(context.Background()))
+	require.Equal(t, model.StatusRecording, s.Status())
+	require.NoError(t, s.Stop())
+	require.Equal(t, model.StatusStopped, s.Status())
+	require.NotNil(t, s.GetHub())
+}
+
+func TestResolveAudioTriggerConfig(t *testing.T) {
+	t.Parallel()
+	cfg := ResolveAudioTriggerConfig(-30, 4)
+	require.Equal(t, -30.0, cfg.MinDBFS)
+	require.Equal(t, 4*time.Second, cfg.PreCapture)
+}

--- a/internal/recorder/darkframe.go
+++ b/internal/recorder/darkframe.go
@@ -99,8 +99,14 @@ func DetectDarkAVIFile(filePath string, threshold int) (bool, int, error) {
 		size   int32
 	}
 	var chunks []chunkInfo
-	pos := moviOffset + 8 // skip "movi" + size
-	moviEnd := moviOffset + int64(moviSize)
+	// moviOffset points at the "LIST" fourcc; the chunk stream starts after
+	// "LIST" + size + "movi" (12 bytes). moviSize counts the payload AFTER the
+	// LIST size field ("movi" fourcc + chunks), so the end is moviOffset+8+size.
+	// The previous +8 landed on the "movi" fourcc itself and misparsed every
+	// chunk header — no AVI ever yielded a video chunk and dark detection
+	// (found by the #585 test batch).
+	pos := moviOffset + 12
+	moviEnd := moviOffset + 8 + int64(moviSize)
 	for pos < moviEnd-8 {
 		if _, err := f.Seek(pos, io.SeekStart); err != nil {
 			break

--- a/internal/recorder/darkframe_test.go
+++ b/internal/recorder/darkframe_test.go
@@ -1,0 +1,136 @@
+package recorder
+
+// Coverage for darkframe.go (#585): dark-segment detection over real
+// JPEGs (image/jpeg encoded bright/dark fixtures) and AVI containers built
+// with the internal avi muxer. Fully hermetic.
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
+	"github.com/stretchr/testify/require"
+)
+
+// writeJPEGFile encodes a solid-color JPEG of the given luminance.
+func writeJPEGFile(t *testing.T, path string, lum uint8) {
+	t.Helper()
+	img := image.NewGray(image.Rect(0, 0, 64, 64))
+	for i := range img.Pix {
+		img.Pix[i] = lum
+	}
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, jpeg.Encode(f, img, nil))
+}
+
+// jpegBytes returns an encoded solid-color JPEG.
+func jpegBytes(t *testing.T, lum uint8) []byte {
+	t.Helper()
+	img := image.NewGray(image.Rect(0, 0, 64, 64))
+	for i := range img.Pix {
+		img.Pix[i] = lum
+	}
+	var buf bytes.Buffer
+	require.NoError(t, jpeg.Encode(&buf, img, nil))
+	return buf.Bytes()
+}
+
+var _ = color.Gray{} // keep image/color if fixtures evolve
+
+func TestDetectDarkMJPEGDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for i := range 5 {
+		writeJPEGFile(t, filepath.Join(dir, frameName(i)), 250) // bright
+	}
+	isDark, brightness, err := DetectDarkMJPEGDir(dir, 15)
+	require.NoError(t, err)
+	require.False(t, isDark)
+	require.Greater(t, brightness, 200)
+
+	// All-dark directory below the threshold.
+	darkDir := t.TempDir()
+	for i := range 5 {
+		writeJPEGFile(t, filepath.Join(darkDir, frameName(i)), 2)
+	}
+	isDark, brightness, err = DetectDarkMJPEGDir(darkDir, 15)
+	require.NoError(t, err)
+	require.True(t, isDark)
+	require.Less(t, brightness, 15)
+
+	// Missing directory / no JPEGs / corrupt frames error out.
+	_, _, err = DetectDarkMJPEGDir(filepath.Join(t.TempDir(), "missing"), 15)
+	require.Error(t, err)
+
+	empty := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(empty, "notes.txt"), []byte("x"), 0o644))
+	_, _, err = DetectDarkMJPEGDir(empty, 15)
+	require.ErrorContains(t, err, "no JPEG files")
+
+	corrupt := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(corrupt, "a.jpg"), []byte("not a jpeg"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(corrupt, "b.jpg"), []byte("also not"), 0o644))
+	_, _, err = DetectDarkMJPEGDir(corrupt, 15)
+	require.ErrorContains(t, err, "failed to decode")
+}
+
+func frameName(i int) string {
+	return "frame_20260828_10" + string(rune('0'+i)) + "0000.jpg"
+}
+
+func TestDetectDarkAVIFile(t *testing.T) {
+	t.Parallel()
+
+	// Bright AVI: three real JPEG frames through the muxer.
+	brightPath := filepath.Join(t.TempDir(), "bright.avi")
+	writeAVIWithFrames(t, brightPath, 3, 250)
+	isDark, brightness, err := DetectDarkAVIFile(brightPath, 15)
+	require.NoError(t, err)
+	require.False(t, isDark)
+	require.Greater(t, brightness, 200)
+
+	// Dark AVI.
+	darkPath := filepath.Join(t.TempDir(), "dark.avi")
+	writeAVIWithFrames(t, darkPath, 3, 2)
+	isDark, brightness, err = DetectDarkAVIFile(darkPath, 15)
+	require.NoError(t, err)
+	require.True(t, isDark)
+	require.Less(t, brightness, 15)
+
+	// Missing file errors.
+	_, _, err = DetectDarkAVIFile(filepath.Join(t.TempDir(), "missing.avi"), 15)
+	require.Error(t, err)
+}
+
+func writeAVIWithFrames(t *testing.T, path string, n int, lum uint8) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	mux := avi.NewMuxer(f, 64, 48, 8000, true)
+	frame := jpegBytes(t, lum)
+	for i := range n {
+		require.NoError(t, mux.WriteVideo(frame, int64(i)*1_000_000))
+	}
+	require.NoError(t, mux.Close())
+}
+
+func TestJpegBrightnessFromReader(t *testing.T) {
+	t.Parallel()
+
+	b, err := jpegBrightnessFromReader(bytes.NewReader(jpegBytes(t, 128)))
+	require.NoError(t, err)
+	require.InDelta(t, 128, b, 2)
+
+	// Garbage input errors.
+	_, err = jpegBrightnessFromReader(bytes.NewReader([]byte("nope")))
+	require.ErrorContains(t, err, "jpeg decode")
+}

--- a/internal/xiaomi/plugin_surface_test.go
+++ b/internal/xiaomi/plugin_surface_test.go
@@ -1,0 +1,135 @@
+package xiaomi
+
+// Coverage for the plugin surface + recorder pure accessors (#585): plugin
+// wiring (NewRecorder config mapping incl. adaptive/audio-trigger gates),
+// DID extraction, codec accessors on a constructed recorder, vendor-error
+// reporting, and MotorControl guards. Hermetic — constructed, never dialed.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func newXiaomiTestStore(t *testing.T) *storage.Manager {
+	t.Helper()
+	m, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+	return m
+}
+
+func TestXiaomiPluginSurface(t *testing.T) {
+	t.Parallel()
+	p := &XiaomiPlugin{}
+	bus := event.NewEventBus(2)
+	p.SetEventBus(bus)
+	require.Equal(t, "xiaomi", p.Name())
+	require.Equal(t, []string{"xiaomi"}, p.Protocols())
+	require.Equal(t, config.XiaomiConfig{}, p.ConfigSchema())
+	p.RegisterRoutes(nil) // routes live in api/handler.go; no-op here
+
+	require.Equal(t, "655448418", extractDID("xiaomi://655448418"))
+	require.Equal(t, "plain", extractDID("plain"))
+}
+
+func TestPluginNewRecorderConfigMapping(t *testing.T) {
+	t.Parallel()
+	p := &XiaomiPlugin{}
+	store := newXiaomiTestStore(t)
+
+	rec := p.NewRecorder(config.CameraConfig{
+		ID: "cam-x", Protocol: "xiaomi", URL: "xiaomi://12345", AudioEnabled: true,
+	}, store, nil)
+	xr, ok := rec.(*XiaomiRecorder)
+	require.True(t, ok)
+	require.Equal(t, "cam-x", xr.cfg.CameraID)
+	require.Equal(t, "12345", xr.cfg.DID)
+	require.True(t, xr.cfg.AudioEnabled)
+
+	// Explicit DID wins over the URL form.
+	rec = p.NewRecorder(config.CameraConfig{ID: "c2", Protocol: "xiaomi", DID: "999", URL: "xiaomi://1"}, store, nil)
+	xr = rec.(*XiaomiRecorder)
+	require.Equal(t, "999", xr.cfg.DID)
+}
+
+func TestPluginNewRecorderAdaptiveGates(t *testing.T) {
+	t.Parallel()
+	p := &XiaomiPlugin{}
+	store := newXiaomiTestStore(t)
+	m := metrics.NewMetrics()
+
+	// recording_mode: adaptive maps the adaptive config through.
+	adaptive := &config.AdaptiveRecordingConfig{
+		CalmThreshold: "5m", TimelapseInterval: "2s", SpikeFactor: 1.5, GOPBufferBytes: 4096,
+	}
+	rec := p.NewRecorder(config.CameraConfig{
+		ID: "ad", Protocol: "xiaomi", DID: "1",
+		RecordingMode: "adaptive", Adaptive: adaptive,
+		AudioTrigger: &config.CameraAudioTriggerConfig{Enabled: true, MinDBFS: -35, PreCaptureS: 5},
+	}, store, nil, m)
+	xr := rec.(*XiaomiRecorder)
+	require.NotNil(t, xr.cfg.Adaptive)
+	require.NotNil(t, xr.cfg.AudioTrigger)
+	require.Equal(t, -35.0, xr.cfg.AudioTrigger.MinDBFS)
+
+	// Non-adaptive cameras get neither.
+	rec = p.NewRecorder(config.CameraConfig{ID: "plain", Protocol: "xiaomi", DID: "2"}, store, nil)
+	xr = rec.(*XiaomiRecorder)
+	require.Nil(t, xr.cfg.Adaptive)
+	require.Nil(t, xr.cfg.AudioTrigger)
+}
+
+func TestXiaomiRecorderAccessors(t *testing.T) {
+	t.Parallel()
+	rec := NewXiaomiRecorder(XiaomiRecorderConfig{CameraID: "c", DID: "1"}, newXiaomiTestStore(t))
+
+	rec.Hub = model.NewStreamHub() // wired by camera.initStreamHub in production
+	require.NotNil(t, rec.GetHub())
+	require.Nil(t, rec.SPS())
+	require.Nil(t, rec.PPS())
+	require.Nil(t, rec.VPS())
+	require.Equal(t, "", rec.AudioCodec())
+	require.Equal(t, 0, rec.AudioSampleRate())
+	require.Equal(t, 0, rec.AudioChannels())
+
+	// Error reporter wiring (TUTK vendor-error detection).
+	rec.SetErrorReporter(nil)
+	rec.reportVendorError(errFakeVendor) // nil reporter must be tolerated
+}
+
+func TestXiaomiMotorControlGuards(t *testing.T) {
+	t.Parallel()
+	rec := NewXiaomiRecorder(XiaomiRecorderConfig{CameraID: "c", DID: "1"}, newXiaomiTestStore(t))
+
+	// No connection → explicit error, no panic.
+	require.Error(t, rec.MotorControl("left", 5))
+	require.Error(t, rec.MotorControl("stop", 0))
+}
+
+func TestSetCloudConfigPackages(t *testing.T) {
+	// NOT parallel: SetCloudConfig writes the package-level cloudCfg that
+	// concurrently-constructed recorders read — a parallel write raced them
+	// under -race. Serialize against the other tests in this package.
+	SetCloudConfig(config.XiaomiConfig{UserID: "u", Token: "t", Region: "cn"})
+	require.Equal(t, "u", cloudCfg.UserID)
+	require.Equal(t, "cn", cloudCfg.Region)
+	SetCloudConfig(config.XiaomiConfig{})
+}
+
+var (
+	_ = model.FormatH264 // keep model import if assertions evolve
+	_ = time.Second
+)
+
+// errFakeVendor stands in for a TUTK/CS2 vendor error.
+var errFakeVendor = &vendorErrorFake{}
+
+type vendorErrorFake struct{}
+
+func (e *vendorErrorFake) Error() string { return "vendor: boom" }


### PR DESCRIPTION
Closes #585.

**生产修复（本批测试发现）**：`DetectDarkAVIFile` 从 `moviOffset+8` 开始扫描视频块，但 `findMoviList` 返回的是 **"LIST" 四字符的偏移**（布局 `LIST|size|movi|chunks`，首块在 +12，结束在 +8+size）。+8 落在 "movi" 上，把 chunk 头解析成垃圾 → **任何 AVI 都报 "no video chunks"，AVI 暗帧检测自上线从未生效**（MJPEG 录像机的 DarkFrameFilterEnabled 对 AVI 形同虚设，暗段从未被标 dark、从未被清理）。修复 + 真实 JPEG 帧经 avi muxer 的回归测试（亮/暗双向断言）。

**覆盖率**（全部 hermetic）：
- **recorder 66.6% → 72.7%**：darkframe.go 137 语句 0%→全覆盖（image/jpeg 编码亮/暗帧 + 内部 avi muxer 构造真实 AVI）；H264/H265 NAL 驱动的参数集提取（SPS/PPS/VPS 快照重建）；ambient G.711 sidecar 生命周期（开关守卫/追加写/幂等关闭/磁盘内容断言）；backoff 包装、storage-health 限频、StubRecorder、audio-trigger 配置解析
- **xiaomi 55.3% → 58.0%**：plugin 全接线面（NewRecorder 配置映射含 adaptive/audio-trigger 门控、DID 提取优先级）、codec 访问器、vendor 错误上报、MotorControl 无连接守卫。剩余为云端登录/CS2 拨号网络绑定——hermetic 上限，已在 issue 记录

-race 绿（xiaomi 3×压测；期间发现并修复本批自身的一个并行测试写包级 cloudCfg 的竞争——改为串行）、lint 0、build 通过。