### PR TITLE
test(cmd): extract parse*/run* cores for direct subcommand tests (#589)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,7 +139,7 @@ linters:
       - source: 'fmt\.Sscanf\('
         linters: [errcheck]
       # rationale: Stdlib formatting — alternative error handling exists
-      - source: 'fmt\.Fprintf\('
+      - source: 'fmt\.Fprint(f|ln)?\('
         linters: [errcheck]
       # rationale: DB execution — errors handled by driver/logging mechanism
       - source: '\.Exec'

--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -22,7 +24,20 @@ var (
 
 // ---------------------------------------------------------------------------
 // CLI subcommands
+//
+// Each subcommand is a thin shell over a (parse*, run*) pair: parsing is a
+// pure function of args, run* does the work with injected writers and
+// returns an error instead of exiting — the shape the direct tests target.
+// The shells own os.Args, the terminal check, and process exit codes.
 // ---------------------------------------------------------------------------
+
+// errInitConfigExists marks the init "config exists without --force"
+// failure, which historically exits with code 2.
+var errInitConfigExists = errors.New("config file already exists")
+
+// errCleanupHelp marks the cleanup --help path, which prints usage and
+// exits 0.
+var errCleanupHelp = errors.New("cleanup help printed")
 
 // resolveHealthAddr determines the address the health probe should target.
 //
@@ -76,106 +91,163 @@ func resolveHealthAddr(args []string) (string, error) {
 }
 
 func cmdHealth() {
-	addr, err := resolveHealthAddr(os.Args)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+	if err := runHealth(os.Args, os.Stdout, os.Stderr); err != nil {
 		os.Exit(1)
 	}
-	resp, err := http.Get("http://localhost" + addr + "/api/health")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Health check failed: %v\n", err)
-		os.Exit(1)
-	}
-	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
-		fmt.Fprintf(os.Stderr, "Health check failed: HTTP %d\n", resp.StatusCode)
-		os.Exit(1)
-	}
-	resp.Body.Close()
 	os.Exit(0)
 }
 
-func cmdInit() {
-	var password, dataDir, listenAddr, cfgPath, username string
-	var force bool
-	for i := 2; i < len(os.Args); i++ {
-		switch os.Args[i] {
+// runHealth probes /api/health at the resolved address. User-facing failure
+// lines are written to stderr exactly as the CLI always printed them.
+func runHealth(args []string, _, stderr io.Writer) error {
+	addr, err := resolveHealthAddr(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error loading config: %v\n", err)
+
+		return err
+	}
+
+	resp, err := http.Get("http://localhost" + addr + "/api/health")
+	if err != nil {
+		fmt.Fprintf(stderr, "Health check failed: %v\n", err)
+
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		fmt.Fprintf(stderr, "Health check failed: HTTP %d\n", resp.StatusCode)
+
+		return fmt.Errorf("health check failed: HTTP %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	return nil
+}
+
+// initOptions carries the parsed init flags (defaults applied).
+type initOptions struct {
+	password   string
+	dataDir    string
+	listenAddr string
+	cfgPath    string
+	username   string
+	force      bool
+}
+
+// parseInitArgs extracts init flags from args (the full os.Args shape,
+// flags starting at index 2) and applies the defaults.
+func parseInitArgs(args []string) initOptions {
+	var opts initOptions
+	for i := 2; i < len(args); i++ {
+		switch args[i] {
 		case "--password":
 			i++
-			if i < len(os.Args) {
-				password = os.Args[i]
+			if i < len(args) {
+				opts.password = args[i]
 			}
 		case "--data-dir":
 			i++
-			if i < len(os.Args) {
-				dataDir = os.Args[i]
+			if i < len(args) {
+				opts.dataDir = args[i]
 			}
 		case "--listen":
 			i++
-			if i < len(os.Args) {
-				listenAddr = os.Args[i]
+			if i < len(args) {
+				opts.listenAddr = args[i]
 			}
 		case "--config":
 			i++
-			if i < len(os.Args) {
-				cfgPath = os.Args[i]
+			if i < len(args) {
+				opts.cfgPath = args[i]
 			}
 		case "--username":
 			i++
-			if i < len(os.Args) {
-				username = os.Args[i]
+			if i < len(args) {
+				opts.username = args[i]
 			}
 		case "--force":
-			force = true
+			opts.force = true
 		}
 	}
-	if dataDir == "" {
-		dataDir = "/var/lib/mibee-nvr"
+	if opts.dataDir == "" {
+		opts.dataDir = "/var/lib/mibee-nvr"
 	}
-	if listenAddr == "" {
-		listenAddr = ":9090"
+	if opts.listenAddr == "" {
+		opts.listenAddr = ":9090"
 	}
-	if cfgPath == "" {
-		cfgPath = "mibee-nvr.yaml"
+	if opts.cfgPath == "" {
+		opts.cfgPath = "mibee-nvr.yaml"
 	}
-	if username == "" {
-		username = "admin"
+	if opts.username == "" {
+		opts.username = "admin"
+	}
+
+	return opts
+}
+
+func cmdInit() {
+	opts := parseInitArgs(os.Args)
+	err := runInit(opts, os.Stdin, stdinIsTerminal(), os.Stdout, os.Stderr)
+	switch {
+	case err == nil:
+		os.Exit(0)
+	case errors.Is(err, errInitConfigExists):
+		os.Exit(2)
+	default:
+		os.Exit(1)
+	}
+}
+
+// stdinIsTerminal reports whether stdin is an interactive terminal (the
+// condition the password prompt requires).
+func stdinIsTerminal() bool {
+	stat, err := os.Stdin.Stat()
+
+	return err == nil && (stat.Mode()&os.ModeCharDevice) != 0
+}
+
+// runInit writes the initial configuration. The password prompt reads
+// stdin only when interactive (a terminal); piped stdin never prompts.
+func runInit(opts initOptions, stdin io.Reader, interactive bool, stdout, stderr io.Writer) error {
+	password := opts.password
+	if password == "" && interactive {
+		fmt.Fprint(stdout, "Enter password: ")
+		scanner := bufio.NewScanner(stdin)
+		if scanner.Scan() {
+			password = scanner.Text()
+		}
 	}
 	if password == "" {
-		stat, _ := os.Stdin.Stat()
-		if (stat.Mode() & os.ModeCharDevice) != 0 {
-			fmt.Print("Enter password: ")
-			scanner := bufio.NewScanner(os.Stdin)
-			if scanner.Scan() {
-				password = scanner.Text()
-			}
-		}
-		if password == "" {
-			fmt.Fprintln(os.Stderr, "Error: password is required (use --password or provide via terminal)")
-			os.Exit(1)
-		}
+		fmt.Fprintln(stderr, "Error: password is required (use --password or provide via terminal)")
+
+		return errors.New("password is required")
 	}
 	if len(password) < 8 {
-		fmt.Fprintln(os.Stderr, "Error: password must be at least 8 characters")
-		os.Exit(1)
+		fmt.Fprintln(stderr, "Error: password must be at least 8 characters")
+
+		return errors.New("password too short")
 	}
-	if _, err := os.Stat(cfgPath); err == nil && !force {
-		fmt.Fprintf(os.Stderr, "Error: config file %s already exists (use --force to overwrite)\n", cfgPath)
-		os.Exit(2)
+	if _, err := os.Stat(opts.cfgPath); err == nil && !opts.force {
+		fmt.Fprintf(stderr, "Error: config file %s already exists (use --force to overwrite)\n", opts.cfgPath)
+
+		return fmt.Errorf("%w: %s", errInitConfigExists, opts.cfgPath)
 	}
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating data directory: %v\n", err)
-		os.Exit(1)
+	if err := os.MkdirAll(opts.dataDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "Error creating data directory: %v\n", err)
+
+		return fmt.Errorf("create data directory: %w", err)
 	}
 	hash, err := authmw.HashPassword(password)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error hashing password: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error hashing password: %v\n", err)
+
+		return fmt.Errorf("hash password: %w", err)
 	}
 	cfg := config.Config{
-		Server:        config.ServerConfig{Listen: listenAddr},
-		Storage:       config.StorageConfig{RootDir: dataDir, SegmentDuration: "30s"},
-		Auth:          config.AuthConfig{Username: username, PasswordHash: hash},
+		Server:        config.ServerConfig{Listen: opts.listenAddr},
+		Storage:       config.StorageConfig{RootDir: opts.dataDir, SegmentDuration: "30s"},
+		Auth:          config.AuthConfig{Username: opts.username, PasswordHash: hash},
 		Cameras:       []config.CameraConfig{},
 		Cleanup:       config.CleanupConfig{RetentionDays: 30, CheckInterval: "1h", DiskThresholdPercent: 95},
 		FTP:           config.FTPConfig{Port: 2121, PassivePortRange: "2122-2140"},
@@ -189,57 +261,81 @@ func cmdInit() {
 			EnabledCameras:      []string{},
 		},
 	}
-	if err := config.Save(cfgPath, &cfg); err != nil {
-		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
-		os.Exit(1)
+	if err := config.Save(opts.cfgPath, &cfg); err != nil {
+		fmt.Fprintf(stderr, "Error saving config: %v\n", err)
+
+		return fmt.Errorf("save config: %w", err)
 	}
-	fmt.Printf("Configuration saved to %s\n", cfgPath)
-	fmt.Printf("Data directory: %s\n", dataDir)
-	fmt.Println("\nNext steps:")
-	fmt.Printf("  1. Edit %s to add your cameras\n", cfgPath)
-	fmt.Printf("  2. Run: ./mibee-nvr -config %s\n", cfgPath)
-	fmt.Printf("  3. Open http://localhost%s in your browser\n", listenAddr)
-	os.Exit(0)
+	fmt.Fprintf(stdout, "Configuration saved to %s\n", opts.cfgPath)
+	fmt.Fprintf(stdout, "Data directory: %s\n", opts.dataDir)
+	fmt.Fprintln(stdout, "\nNext steps:")
+	fmt.Fprintf(stdout, "  1. Edit %s to add your cameras\n", opts.cfgPath)
+	fmt.Fprintf(stdout, "  2. Run: ./mibee-nvr -config %s\n", opts.cfgPath)
+	fmt.Fprintf(stdout, "  3. Open http://localhost%s in your browser\n", opts.listenAddr)
+
+	return nil
 }
 
 func cmdHashPassword() {
-	if len(os.Args) < 3 {
-		fmt.Fprintln(os.Stderr, "Usage: mibee-nvr hash-password <password>")
+	if err := runHashPassword(os.Args, os.Stdout, os.Stderr); err != nil {
 		os.Exit(1)
 	}
-	hash, err := authmw.HashPassword(os.Args[2])
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Println(hash)
 	os.Exit(0)
 }
 
+// runHashPassword prints the bcrypt hash for args[2].
+func runHashPassword(args []string, stdout, stderr io.Writer) error {
+	if len(args) < 3 {
+		fmt.Fprintln(stderr, "Usage: mibee-nvr hash-password <password>")
+
+		return errors.New("missing password argument")
+	}
+	hash, err := authmw.HashPassword(args[2])
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+
+		return fmt.Errorf("hash password: %w", err)
+	}
+	fmt.Fprintln(stdout, hash)
+
+	return nil
+}
+
 func cmdEncryptConfig() {
+	if err := runEncryptConfig(os.Args, os.Stdout, os.Stderr); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// runEncryptConfig encrypts the plaintext sensitive fields of a config
+// file in place.
+func runEncryptConfig(args []string, stdout, stderr io.Writer) error {
 	cfgPath := "mibee-nvr.yaml"
-	for i := 2; i < len(os.Args); i++ {
-		if os.Args[i] == "--config" {
+	for i := 2; i < len(args); i++ {
+		if args[i] == "--config" {
 			i++
-			if i < len(os.Args) {
-				cfgPath = os.Args[i]
+			if i < len(args) {
+				cfgPath = args[i]
 			}
 		}
 	}
 	fields, err := config.EncryptConfigFile(cfgPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+
+		return err
 	}
 	if len(fields) == 0 {
-		fmt.Println("No plaintext sensitive fields found. All fields are already encrypted or empty.")
+		fmt.Fprintln(stdout, "No plaintext sensitive fields found. All fields are already encrypted or empty.")
 	} else {
-		fmt.Printf("Encrypted %d sensitive field(s) in %s:\n", len(fields), cfgPath)
+		fmt.Fprintf(stdout, "Encrypted %d sensitive field(s) in %s:\n", len(fields), cfgPath)
 		for _, f := range fields {
-			fmt.Printf("  - %s\n", f)
+			fmt.Fprintf(stdout, "  - %s\n", f)
 		}
 	}
-	os.Exit(0)
+
+	return nil
 }
 
 // dispatchSubcommand handles CLI subcommand dispatch.
@@ -268,6 +364,62 @@ func dispatchSubcommand(args []string) {
 	}
 }
 
+// cleanupOptions carries the parsed cleanup flags (config default applied).
+type cleanupOptions struct {
+	cfgPath    string
+	beforeDate string
+	orphans    bool
+	dryRun     bool
+}
+
+// parseCleanupArgs extracts cleanup flags from args (full os.Args shape).
+// --help prints usage to stdout and returns errCleanupHelp.
+func parseCleanupArgs(args []string, stdout io.Writer) (cleanupOptions, error) {
+	var opts cleanupOptions
+	for i := 2; i < len(args); i++ {
+		switch args[i] {
+		case "--config":
+			i++
+			if i < len(args) {
+				opts.cfgPath = args[i]
+			}
+		case "--before":
+			i++
+			if i < len(args) {
+				opts.beforeDate = args[i]
+			}
+		case "--orphans":
+			opts.orphans = true
+		case "--dry-run":
+			opts.dryRun = true
+		case "--help", "-h":
+			fmt.Fprintln(stdout, `cleanup — 录像清理工具
+
+用法:
+  mibee-nvr cleanup [选项]
+
+选项:
+  --before YYYY-MM-DD  删除此日期之前的录像（DB行 + 文件 + AI事件）
+  --orphans            清理孤儿文件（磁盘有但DB无记录的视频文件）
+  --config PATH        配置文件路径（默认 mibee-nvr.yaml）
+  --dry-run            只统计不删除
+
+示例:
+  mibee-nvr cleanup --before 2026-08-07 --dry-run   # 预览清理7月数据
+  mibee-nvr cleanup --before 2026-08-07              # 执行清理
+  mibee-nvr cleanup --orphans --dry-run              # 预览孤儿文件
+  mibee-nvr cleanup --orphans                         # 清理孤儿文件`)
+
+			return opts, errCleanupHelp
+		}
+	}
+	if opts.cfgPath == "" {
+		opts.cfgPath = "mibee-nvr.yaml"
+	}
+
+	return opts, nil
+}
+
 // cmdCleanup 录像清理工具，支持多种模式：
 //
 // 1. 按日期清理（删除 DB 行 + 文件 + 孤儿AI事件）:
@@ -287,101 +439,77 @@ func dispatchSubcommand(args []string) {
 //	--config   配置文件路径（默认 mibee-nvr.yaml）
 //	--dry-run  只统计不删除
 func cmdCleanup() {
-	var cfgPath, beforeDate string
-	var orphans, dryRun bool
-	for i := 2; i < len(os.Args); i++ {
-		switch os.Args[i] {
-		case "--config":
-			i++
-			if i < len(os.Args) {
-				cfgPath = os.Args[i]
-			}
-		case "--before":
-			i++
-			if i < len(os.Args) {
-				beforeDate = os.Args[i]
-			}
-		case "--orphans":
-			orphans = true
-		case "--dry-run":
-			dryRun = true
-		case "--help", "-h":
-			fmt.Println(`cleanup — 录像清理工具
-
-用法:
-  mibee-nvr cleanup [选项]
-
-选项:
-  --before YYYY-MM-DD  删除此日期之前的录像（DB行 + 文件 + AI事件）
-  --orphans            清理孤儿文件（磁盘有但DB无记录的视频文件）
-  --config PATH        配置文件路径（默认 mibee-nvr.yaml）
-  --dry-run            只统计不删除
-
-示例:
-  mibee-nvr cleanup --before 2026-08-07 --dry-run   # 预览清理7月数据
-  mibee-nvr cleanup --before 2026-08-07              # 执行清理
-  mibee-nvr cleanup --orphans --dry-run              # 预览孤儿文件
-  mibee-nvr cleanup --orphans                         # 清理孤儿文件`)
+	opts, err := parseCleanupArgs(os.Args, os.Stdout)
+	if err != nil {
+		if errors.Is(err, errCleanupHelp) {
 			os.Exit(0)
 		}
-	}
-
-	if cfgPath == "" {
-		cfgPath = "mibee-nvr.yaml"
-	}
-	if beforeDate == "" && !orphans {
-		fmt.Fprintln(os.Stderr, "Error: 需要指定 --before 或 --orphans")
-		fmt.Fprintln(os.Stderr, "运行 mibee-nvr cleanup --help 查看用法")
 		os.Exit(1)
+	}
+	if err := runCleanup(opts, os.Stdout, os.Stderr); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// runCleanup loads the config, opens the recordings DB, and executes the
+// selected cleanup modes.
+func runCleanup(opts cleanupOptions, stdout, stderr io.Writer) error {
+	if opts.beforeDate == "" && !opts.orphans {
+		fmt.Fprintln(stderr, "Error: 需要指定 --before 或 --orphans")
+		fmt.Fprintln(stderr, "运行 mibee-nvr cleanup --help 查看用法")
+
+		return errors.New("no cleanup mode specified")
 	}
 
 	// 加载配置获取存储根目录。
-	cfg, err := config.Load(cfgPath)
+	cfg, err := config.Load(opts.cfgPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading config %s: %v\n", cfgPath, err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error loading config %s: %v\n", opts.cfgPath, err)
+
+		return fmt.Errorf("load config: %w", err)
 	}
 	storageRoot := cfg.Storage.RootDir
 	dbPath := storageRoot + "/mibee-nvr.db"
 
 	db, err := sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error opening DB: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error opening DB: %v\n", err)
+
+		return fmt.Errorf("open DB: %w", err)
 	}
 
 	ctx := context.Background()
 	dryRunSuffix := ""
-	if dryRun {
+	if opts.dryRun {
 		dryRunSuffix = " (--dry-run)"
 	}
 
 	// ── 模式 1: 按日期清理 ──
-	if beforeDate != "" {
-		fmt.Printf("=== 按日期清理 (before %s)%s ===\n", beforeDate, dryRunSuffix)
-		cleanupByDate(ctx, db, storageRoot, beforeDate, dryRun)
+	if opts.beforeDate != "" {
+		fmt.Fprintf(stdout, "=== 按日期清理 (before %s)%s ===\n", opts.beforeDate, dryRunSuffix)
+		cleanupByDate(ctx, db, storageRoot, opts.beforeDate, opts.dryRun, stdout, stderr)
 	}
 
 	// ── 模式 2: 清理孤儿文件 ──
-	if orphans {
-		fmt.Printf("\n=== 孤儿文件清理%s ===\n", dryRunSuffix)
-		cleanupOrphanFiles(ctx, db, storageRoot, dryRun)
+	if opts.orphans {
+		fmt.Fprintf(stdout, "\n=== 孤儿文件清理%s ===\n", dryRunSuffix)
+		cleanupOrphanFiles(ctx, db, storageRoot, opts.dryRun, stdout, stderr)
 	}
 
-	fmt.Println("\nCleanup complete.")
+	fmt.Fprintln(stdout, "\nCleanup complete.")
 	db.Close()
-	// CLI 子命令必须显式退出:dispatchSubcommand 在服务器启动之前调用,
-	// 直接 return 会误启动 NVR 服务。db 已显式 Close(见上)。
-	os.Exit(0)
+
+	return nil
 }
 
 // cleanupByDate 删除指定日期之前的录像（文件 + DB 行 + AI 事件）。
-func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate string, dryRun bool) {
+func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate string, dryRun bool, stdout, stderr io.Writer) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT id, file_path, file_size FROM recordings WHERE file_path != '' AND started_at < ?`,
 		beforeDate+" 00:00:00")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  Error querying: %v\n", err)
+		fmt.Fprintf(stderr, "  Error querying: %v\n", err)
 		return
 	}
 	defer rows.Close()
@@ -400,10 +528,10 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 		totalSize += r.size
 	}
 	if err := rows.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "  Warning: iterate recordings: %v\n", err)
+		fmt.Fprintf(stderr, "  Warning: iterate recordings: %v\n", err)
 	}
 
-	fmt.Printf("  Found %d recordings (%.1f GB)\n", len(recs), float64(totalSize)/1e9)
+	fmt.Fprintf(stdout, "  Found %d recordings (%.1f GB)\n", len(recs), float64(totalSize)/1e9)
 	if dryRun || len(recs) == 0 {
 		return
 	}
@@ -421,14 +549,14 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 			freedBytes += r.size
 		}
 	}
-	fmt.Printf("  Files: %d deleted, %.1f GB freed\n", deletedFiles, float64(freedBytes)/1e9)
+	fmt.Fprintf(stdout, "  Files: %d deleted, %.1f GB freed\n", deletedFiles, float64(freedBytes)/1e9)
 
 	// 删除 DB 行。
 	if result, err := db.ExecContext(ctx,
 		`DELETE FROM recordings WHERE file_path != '' AND started_at < ?`,
 		beforeDate+" 00:00:00"); err == nil {
 		if n, _ := result.RowsAffected(); n > 0 {
-			fmt.Printf("  DB: %d rows deleted\n", n)
+			fmt.Fprintf(stdout, "  DB: %d rows deleted\n", n)
 		}
 	}
 
@@ -436,19 +564,19 @@ func cleanupByDate(ctx context.Context, db *sql.DB, storageRoot, beforeDate stri
 	if result, err := db.ExecContext(ctx,
 		`DELETE FROM ai_events WHERE recording_id != '' AND recording_id NOT IN (SELECT id FROM recordings)`); err == nil {
 		if n, _ := result.RowsAffected(); n > 0 {
-			fmt.Printf("  AI events: %d orphaned rows deleted\n", n)
+			fmt.Fprintf(stdout, "  AI events: %d orphaned rows deleted\n", n)
 		}
 	}
 }
 
 // cleanupOrphanFiles 扫描磁盘上的视频文件，删除 DB 中无记录的孤儿文件。
 // 包括：录像目录 + periodic-merge 目录 + 临时文件。
-func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dryRun bool) {
+func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dryRun bool, stdout, stderr io.Writer) {
 	// 加载所有 DB 中的 file_path 到 set。
 	dbPaths := make(map[string]bool)
 	rows, err := db.QueryContext(ctx, `SELECT file_path FROM recordings WHERE file_path != ''`)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  Error querying DB paths: %v\n", err)
+		fmt.Fprintf(stderr, "  Error querying DB paths: %v\n", err)
 		return
 	}
 	defer rows.Close()
@@ -464,9 +592,9 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 		dbPaths[filepath.Clean(p)] = true
 	}
 	if err := rows.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "  Warning: iterate DB paths: %v\n", err)
+		fmt.Fprintf(stderr, "  Warning: iterate DB paths: %v\n", err)
 	}
-	fmt.Printf("  DB has %d recording file paths\n", len(dbPaths))
+	fmt.Fprintf(stdout, "  DB has %d recording file paths\n", len(dbPaths))
 
 	// 扫描磁盘上的视频文件。
 	videoExts := map[string]bool{".mp4": true, ".mkv": true, ".avi": true, ".dav": true, ".flv": true}
@@ -493,20 +621,20 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 		return nil
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  Error walking directory: %v\n", err)
+		fmt.Fprintf(stderr, "  Error walking directory: %v\n", err)
 		return
 	}
 
-	fmt.Printf("  Found %d orphan files (%.1f GB)\n", len(orphanFiles), float64(orphanSize)/1e9)
+	fmt.Fprintf(stdout, "  Found %d orphan files (%.1f GB)\n", len(orphanFiles), float64(orphanSize)/1e9)
 
 	if dryRun || len(orphanFiles) == 0 {
 		// 显示前 10 个孤儿文件路径（帮助用户确认）。
 		for i, p := range orphanFiles {
 			if i >= 10 {
-				fmt.Printf("  ... and %d more\n", len(orphanFiles)-10)
+				fmt.Fprintf(stdout, "  ... and %d more\n", len(orphanFiles)-10)
 				break
 			}
-			fmt.Printf("    %s\n", p)
+			fmt.Fprintf(stdout, "    %s\n", p)
 		}
 		return
 	}
@@ -523,5 +651,5 @@ func cleanupOrphanFiles(ctx context.Context, db *sql.DB, storageRoot string, dry
 			}
 		}
 	}
-	fmt.Printf("  Deleted %d orphan files, %.1f GB freed\n", deleted, float64(freed)/1e9)
+	fmt.Fprintf(stdout, "  Deleted %d orphan files, %.1f GB freed\n", deleted, float64(freed)/1e9)
 }

--- a/cmd/mibee-nvr/cli_test.go
+++ b/cmd/mibee-nvr/cli_test.go
@@ -1,0 +1,664 @@
+package main
+
+// Direct tests for the CLI subcommand cores (issue #589): the parse*/run*
+// split keeps the logic testable without exec-ing the binary — parsing is
+// pure, run* takes injected writers and returns errors.
+
+import (
+	"bytes"
+	"database/sql"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	authmw "github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
+)
+
+// --- parseInitArgs ---
+
+func TestParseInitArgsDefaults(t *testing.T) {
+	opts := parseInitArgs([]string{"mibee-nvr", "init"})
+
+	if opts.dataDir != "/var/lib/mibee-nvr" {
+		t.Errorf("dataDir default = %q", opts.dataDir)
+	}
+	if opts.listenAddr != ":9090" {
+		t.Errorf("listenAddr default = %q", opts.listenAddr)
+	}
+	if opts.cfgPath != "mibee-nvr.yaml" {
+		t.Errorf("cfgPath default = %q", opts.cfgPath)
+	}
+	if opts.username != "admin" {
+		t.Errorf("username default = %q", opts.username)
+	}
+	if opts.force {
+		t.Error("force default must be false")
+	}
+}
+
+func TestParseInitArgsAllFlags(t *testing.T) {
+	opts := parseInitArgs([]string{
+		"mibee-nvr", "init",
+		"--password", "hunter2hunter2",
+		"--data-dir", "/srv/nvr",
+		"--listen", ":9191",
+		"--config", "/etc/nvr.yaml",
+		"--username", "root",
+		"--force",
+	})
+
+	if opts.password != "hunter2hunter2" || opts.dataDir != "/srv/nvr" ||
+		opts.listenAddr != ":9191" || opts.cfgPath != "/etc/nvr.yaml" ||
+		opts.username != "root" || !opts.force {
+		t.Errorf("flags not parsed: %+v", opts)
+	}
+}
+
+// --- runInit ---
+
+func runInitForTest(t *testing.T, args []string, stdin string, interactive bool) (initOptions, *bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	opts := parseInitArgs(args)
+
+	dir := t.TempDir()
+	if opts.dataDir == "/var/lib/mibee-nvr" {
+		opts.dataDir = filepath.Join(dir, "data")
+	}
+	if opts.cfgPath == "mibee-nvr.yaml" {
+		opts.cfgPath = filepath.Join(dir, "mibee-nvr.yaml")
+	}
+
+	err := runInit(opts, strings.NewReader(stdin), interactive, &stdout, &stderr)
+
+	return opts, &stdout, &stderr, err
+}
+
+func TestRunInitWritesConfigAndHash(t *testing.T) {
+	opts, stdout, _, err := runInitForTest(t,
+		[]string{"mibee-nvr", "init", "--password", "correct-horse"}, "", false)
+	if err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+
+	if info, statErr := os.Stat(opts.dataDir); statErr != nil || !info.IsDir() {
+		t.Errorf("data dir not created: %v", statErr)
+	}
+
+	cfg, err := config.Load(opts.cfgPath)
+	if err != nil {
+		t.Fatalf("reload written config: %v", err)
+	}
+
+	if cfg.Auth.Username != "admin" || cfg.Auth.PasswordHash == "" {
+		t.Errorf("auth block wrong: %+v", cfg.Auth)
+	}
+
+	if !authmw.CheckPassword("correct-horse", cfg.Auth.PasswordHash) {
+		t.Error("stored hash does not verify")
+	}
+
+	if !strings.Contains(stdout.String(), "Configuration saved to ") {
+		t.Errorf("success output missing: %q", stdout.String())
+	}
+}
+
+func TestRunInitShortPasswordRejected(t *testing.T) {
+	_, _, stderr, err := runInitForTest(t,
+		[]string{"mibee-nvr", "init", "--password", "short"}, "", false)
+	if err == nil {
+		t.Fatal("short password accepted")
+	}
+
+	if !strings.Contains(stderr.String(), "at least 8 characters") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunInitRequiresPasswordNonInteractive(t *testing.T) {
+	_, _, stderr, err := runInitForTest(t,
+		[]string{"mibee-nvr", "init"}, "", false)
+	if err == nil {
+		t.Fatal("missing password accepted")
+	}
+
+	if !strings.Contains(stderr.String(), "password is required") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunInitPromptPathReadsStdin(t *testing.T) {
+	_, stdout, _, err := runInitForTest(t,
+		[]string{"mibee-nvr", "init"}, "prompted-password", true)
+	if err != nil {
+		t.Fatalf("runInit via prompt: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Enter password: ") {
+		t.Errorf("prompt not shown: %q", stdout.String())
+	}
+}
+
+func TestRunInitExistingConfigNeedsForce(t *testing.T) {
+	opts, _, _, err := runInitForTest(t,
+		[]string{"mibee-nvr", "init", "--password", "correct-horse"}, "", false)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	second := initOptions{
+		password: "correct-horse",
+		dataDir:  opts.dataDir,
+		cfgPath:  opts.cfgPath,
+		username: "admin",
+	}
+
+	err = runInit(second, strings.NewReader(""), false, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("second init without --force accepted")
+	}
+
+	if !strings.Contains(err.Error(), errInitConfigExists.Error()) {
+		t.Errorf("err = %v, want errInitConfigExists", err)
+	}
+
+	second.force = true
+	if err := runInit(second, strings.NewReader(""), false, &stdout, &stderr); err != nil {
+		t.Fatalf("second init with --force: %v", err)
+	}
+}
+
+// --- runHealth ---
+
+func TestRunHealthOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+
+	err := runHealth([]string{"mibee-nvr", "health", "--addr", portOfURL(t, ts.URL)}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runHealth: %v (stderr %q)", err, stderr.String())
+	}
+}
+
+func TestRunHealthNon200(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	var stdout, stderr bytes.Buffer
+
+	err := runHealth([]string{"mibee-nvr", "health", "--addr", portOfURL(t, ts.URL)}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("503 accepted as healthy")
+	}
+
+	if !strings.Contains(stderr.String(), "HTTP 503") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunHealthUnreachable(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	// Port 1 is not a listening service. (A sandbox loopback proxy may
+	// intercept the dial; in that case the response is still not 200 and
+	// runHealth errors either way — only the error itself is asserted.)
+	if err := runHealth([]string{"mibee-nvr", "health", "--addr", ":1"}, &stdout, &stderr); err == nil {
+		t.Fatal("unreachable address accepted as healthy")
+	}
+}
+
+func portOfURL(t *testing.T, rawURL string) string {
+	t.Helper()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(rawURL, "http://"))
+	if err != nil {
+		t.Fatalf("parse port of %q: %v", rawURL, err)
+	}
+
+	return ":" + port
+}
+
+// --- runHashPassword ---
+
+func TestRunHashPasswordRoundtrip(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := runHashPassword([]string{"mibee-nvr", "hash-password", "s3cret-pass"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runHashPassword: %v", err)
+	}
+
+	hash := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(hash, "$2") {
+		t.Fatalf("output not a bcrypt hash: %q", hash)
+	}
+
+	if !authmw.CheckPassword("s3cret-pass", hash) {
+		t.Error("hash does not verify")
+	}
+}
+
+func TestRunHashPasswordUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := runHashPassword([]string{"mibee-nvr", "hash-password"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("missing argument accepted")
+	}
+
+	if !strings.Contains(stderr.String(), "Usage: mibee-nvr hash-password") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+// --- runEncryptConfig ---
+
+func TestRunEncryptConfig(t *testing.T) {
+	t.Setenv("NVR_ENCRYPTION_KEY", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+
+	writeConfigForEncrypt(t, cfgPath, "plain-pass")
+
+	var stdout, stderr bytes.Buffer
+
+	err := runEncryptConfig([]string{"mibee-nvr", "encrypt-config", "--config", cfgPath}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runEncryptConfig: %v (stderr %q)", err, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "auth.password") {
+		t.Errorf("encrypted-field list missing auth.password: %q", stdout.String())
+	}
+
+	// config.Load decrypts transparently, so plaintext removal is
+	// asserted against the raw file bytes.
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read encrypted config: %v", err)
+	}
+
+	if bytes.Contains(raw, []byte("plain-pass")) {
+		t.Fatal("plaintext password survived encryption")
+	}
+
+	// Second run: config.Load decrypts transparently when the key is
+	// set, so the walker sees decrypted plaintext and re-reports the
+	// field every run (values stay encrypted at rest — harmless repeat,
+	// pinned here as the byte-for-byte pre-refactor behavior).
+	stdout.Reset()
+	if err := runEncryptConfig([]string{"mibee-nvr", "encrypt-config", "--config", cfgPath}, &stdout, &stderr); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "auth.password") {
+		t.Errorf("second run output changed: %q", stdout.String())
+	}
+
+	raw2, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("re-read config: %v", err)
+	}
+
+	if bytes.Contains(raw2, []byte("plain-pass")) {
+		t.Error("plaintext leaked back into the file on the second run")
+	}
+}
+
+func writeConfigForEncrypt(t *testing.T, path, password string) {
+	t.Helper()
+
+	content := "auth:\n  username: admin\n  password: " + password + "\nserver:\n  listen: :9090\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// --- parseCleanupArgs ---
+
+func TestParseCleanupArgs(t *testing.T) {
+	var stdout bytes.Buffer
+
+	opts, err := parseCleanupArgs([]string{"mibee-nvr", "cleanup"}, &stdout)
+	if err != nil {
+		t.Fatalf("bare parse: %v", err)
+	}
+
+	if opts.cfgPath != "mibee-nvr.yaml" || opts.beforeDate != "" || opts.orphans || opts.dryRun {
+		t.Errorf("defaults wrong: %+v", opts)
+	}
+
+	opts, err = parseCleanupArgs([]string{
+		"mibee-nvr", "cleanup",
+		"--before", "2026-08-07",
+		"--config", "/tmp/x.yaml",
+		"--orphans", "--dry-run",
+	}, &stdout)
+	if err != nil {
+		t.Fatalf("flag parse: %v", err)
+	}
+
+	if opts.beforeDate != "2026-08-07" || opts.cfgPath != "/tmp/x.yaml" || !opts.orphans || !opts.dryRun {
+		t.Errorf("flags wrong: %+v", opts)
+	}
+}
+
+func TestParseCleanupArgsHelp(t *testing.T) {
+	var stdout bytes.Buffer
+
+	_, err := parseCleanupArgs([]string{"mibee-nvr", "cleanup", "--help"}, &stdout)
+	if err == nil || !strings.Contains(err.Error(), errCleanupHelp.Error()) {
+		t.Fatalf("err = %v, want errCleanupHelp", err)
+	}
+
+	if !strings.Contains(stdout.String(), "--before YYYY-MM-DD") {
+		t.Errorf("help text missing: %q", stdout.String())
+	}
+}
+
+// --- runCleanup ---
+
+func TestRunCleanupNoMode(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := runCleanup(cleanupOptions{cfgPath: "unused.yaml"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("mode-less cleanup accepted")
+	}
+
+	if !strings.Contains(stderr.String(), "--before 或 --orphans") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunCleanupBadConfig(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	err := runCleanup(cleanupOptions{beforeDate: "2026-08-07", cfgPath: filepath.Join(t.TempDir(), "missing.yaml")}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("missing config accepted")
+	}
+}
+
+func TestRunCleanupDryRunEmptyDB(t *testing.T) {
+	dir := t.TempDir()
+	openCleanupDB(t, dir) // schema only — an empty recordings DB
+
+	var stdout, stderr bytes.Buffer
+
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	writeConfigForCleanup(t, cfgPath, dir)
+
+	err := runCleanup(cleanupOptions{beforeDate: "2026-08-07", cfgPath: cfgPath, dryRun: true}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runCleanup: %v (stderr %q)", err, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "Found 0 recordings") {
+		t.Errorf("dry-run output missing: %q", stdout.String())
+	}
+}
+
+func writeConfigForCleanup(t *testing.T, path, rootDir string) {
+	t.Helper()
+
+	content := "storage:\n  root_dir: " + rootDir + "\nserver:\n  listen: :9090\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// openCleanupDB opens a sqlite DB under rootDir with the minimal
+// recordings/ai_events schema the cleanup SQL touches (no rows).
+func openCleanupDB(t *testing.T, rootDir string) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", filepath.Join(rootDir, "mibee-nvr.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, stmt := range []string{
+		`CREATE TABLE recordings (id TEXT PRIMARY KEY, file_path TEXT NOT NULL DEFAULT '', file_size INTEGER NOT NULL DEFAULT 0, started_at TEXT NOT NULL DEFAULT '')`,
+		`CREATE TABLE ai_events (id INTEGER PRIMARY KEY AUTOINCREMENT, recording_id TEXT NOT NULL DEFAULT '')`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("create schema: %v", err)
+		}
+	}
+
+	return db
+}
+
+// writeCleanupDB seeds the cleanup schema with an old and a new
+// recording (real files on disk) plus an orphan video file.
+func writeCleanupDB(t *testing.T, rootDir string) *sql.DB {
+	t.Helper()
+
+	db := openCleanupDB(t, rootDir)
+
+	oldFile := filepath.Join(rootDir, "old.mp4")
+	newFile := filepath.Join(rootDir, "new.mp4")
+	orphanFile := filepath.Join(rootDir, "orphan.mp4")
+	for _, f := range []string{oldFile, newFile, orphanFile} {
+		if err := os.WriteFile(f, bytes.Repeat([]byte("x"), 1024), 0o600); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+
+	exec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(q, args...); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	exec(`INSERT INTO recordings (id, file_path, file_size, started_at) VALUES ('rec-old', ?, 1024, '2026-08-01 10:00:00')`, oldFile)
+	exec(`INSERT INTO recordings (id, file_path, file_size, started_at) VALUES ('rec-new', ?, 1024, '2026-08-20 10:00:00')`, newFile)
+	exec(`INSERT INTO ai_events (recording_id) VALUES ('rec-old')`)
+
+	return db
+}
+
+// --- cleanupByDate / cleanupOrphanFiles (real SQLite) ---
+
+func TestCleanupByDateDryRunDeletesNothing(t *testing.T) {
+	dir := t.TempDir()
+	db := writeCleanupDB(t, dir)
+
+	var stdout, stderr bytes.Buffer
+
+	cleanupByDate(t.Context(), db, dir, "2026-08-07", true, &stdout, &stderr)
+
+	if _, err := os.Stat(filepath.Join(dir, "old.mp4")); err != nil {
+		t.Fatalf("dry-run deleted the old file: %v", err)
+	}
+
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM recordings`).Scan(&rows); err != nil || rows != 2 {
+		t.Errorf("dry-run must keep DB rows, got %d (err %v)", rows, err)
+	}
+}
+
+func TestCleanupByDateDeletesOldKeepsNew(t *testing.T) {
+	dir := t.TempDir()
+	db := writeCleanupDB(t, dir)
+
+	var stdout, stderr bytes.Buffer
+
+	cleanupByDate(t.Context(), db, dir, "2026-08-07", false, &stdout, &stderr)
+
+	if _, err := os.Stat(filepath.Join(dir, "old.mp4")); !os.IsNotExist(err) {
+		t.Errorf("old file still on disk: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "new.mp4")); err != nil {
+		t.Fatalf("new file removed: %v", err)
+	}
+
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM recordings WHERE id='rec-old'`).Scan(&rows); err != nil || rows != 0 {
+		t.Errorf("old DB row survived: %d (err %v)", rows, err)
+	}
+
+	if err := db.QueryRow(`SELECT COUNT(*) FROM recordings WHERE id='rec-new'`).Scan(&rows); err != nil || rows != 1 {
+		t.Errorf("new DB row lost: %d (err %v)", rows, err)
+	}
+
+	var events int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ai_events`).Scan(&events); err != nil || events != 0 {
+		t.Errorf("orphaned AI event survived: %d (err %v)", events, err)
+	}
+}
+
+func TestCleanupOrphanFiles(t *testing.T) {
+	dir := t.TempDir()
+	db := writeCleanupDB(t, dir)
+
+	var stdout, stderr bytes.Buffer
+
+	cleanupOrphanFiles(t.Context(), db, dir, false, &stdout, &stderr)
+
+	if _, err := os.Stat(filepath.Join(dir, "orphan.mp4")); !os.IsNotExist(err) {
+		t.Errorf("orphan file survived: %v", err)
+	}
+
+	for _, keep := range []string{"old.mp4", "new.mp4"} {
+		if _, err := os.Stat(filepath.Join(dir, keep)); err != nil {
+			t.Errorf("recorded file %s removed: %v", keep, err)
+		}
+	}
+
+	if !strings.Contains(stdout.String(), "Deleted 1 orphan files") {
+		t.Errorf("orphan deletion output missing: %q", stdout.String())
+	}
+}
+
+func TestCleanupOrphanFilesDryRun(t *testing.T) {
+	dir := t.TempDir()
+	db := writeCleanupDB(t, dir)
+
+	var stdout, stderr bytes.Buffer
+
+	cleanupOrphanFiles(t.Context(), db, dir, true, &stdout, &stderr)
+
+	if _, err := os.Stat(filepath.Join(dir, "orphan.mp4")); err != nil {
+		t.Fatalf("dry-run deleted the orphan: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "orphan.mp4") {
+		t.Errorf("dry-run should list the orphan path: %q", stdout.String())
+	}
+}
+
+// --- merge-cameras pure helpers ---
+
+func TestListenHostOfMatrix(t *testing.T) {
+	cases := map[string]string{
+		":9090":              "localhost",
+		"0.0.0.0:9090":       "localhost",
+		"[::]:9090":          "localhost",
+		"9090":               "localhost",
+		"":                   "localhost",
+		"192.168.1.5:8080":   "192.168.1.5",
+		"[2001:db8::1]:8080": "2001:db8::1",
+		"example.com:80":     "example.com",
+	}
+
+	for listen, want := range cases {
+		if got := listenHostOf(listen); got != want {
+			t.Errorf("listenHostOf(%q) = %q, want %q", listen, got, want)
+		}
+	}
+}
+
+func TestListenPortOfMatrix(t *testing.T) {
+	cases := map[string]string{
+		":9090":              "9090",
+		"0.0.0.0:9090":       "9090",
+		"192.168.1.5:8080":   "8080",
+		"[2001:db8::1]:8443": "8443",
+		"9191":               "9191",
+		"":                   "9090",
+	}
+
+	for listen, want := range cases {
+		if got := listenPortOf(listen); got != want {
+			t.Errorf("listenPortOf(%q) = %q, want %q", listen, got, want)
+		}
+	}
+}
+
+func TestIsPortOpenPositive(t *testing.T) {
+	// Only the positive case is asserted: this sandbox's loopback
+	// transparent proxy makes "closed port" dials succeed, so negative
+	// assertions are environment-dependent.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().String()
+	if !isPortOpen(addr) {
+		t.Errorf("isPortOpen(%q) = false, want true for a live listener", addr)
+	}
+}
+
+func TestParseFlagForms(t *testing.T) {
+	args := []string{"cmd", "--source", "/a", "--target=/b", "--dry"}
+
+	i := 1
+	if v, ok := parseFlag(args, &i, "source"); !ok || v != "/a" {
+		t.Errorf("space form: %q %v", v, ok)
+	}
+
+	// The space form leaves i on the consumed value; the next flag is i+1.
+	i = 3
+	if v, ok := parseFlag(args, &i, "target"); !ok || v != "/b" {
+		t.Errorf("equals form: %q %v", v, ok)
+	}
+
+	i = 3
+	if _, ok := parseFlag(args, &i, "missing"); ok {
+		t.Error("missing flag reported present")
+	}
+}
+
+func TestParseBoolFlagForms(t *testing.T) {
+	args := []string{"cmd", "--flag", "--off=false", "--on=true"}
+
+	i := 1
+	if v, ok := parseBoolFlag(args, &i, "flag"); !ok || !v {
+		t.Errorf("bare form: %v %v, want true/true", v, ok)
+	}
+
+	i = 2
+	if v, ok := parseBoolFlag(args, &i, "off"); !ok || v {
+		t.Errorf("=false form: %v %v", v, ok)
+	}
+
+	i = 3
+	if v, ok := parseBoolFlag(args, &i, "on"); !ok || !v {
+		t.Errorf("=true form: %v %v", v, ok)
+	}
+
+	i = 0
+	if _, ok := parseBoolFlag(args, &i, "missing"); ok {
+		t.Error("missing bool flag reported present")
+	}
+}


### PR DESCRIPTION
Coverage ladder batch 7 (issue #589): `cmd/mibee-nvr` 15.3% → **29.5%** (target ≥25%).

## Refactor (behavior byte-for-byte preserved)
`cmdInit/cmdHealth/cmdHashPassword/cmdEncryptConfig/cmdCleanup` → **pure `parse*`** + **`run*`** (injected `io.Writer`s, error returns, no `os.Args`/`os.Exit`) + thin shells owning argv, the stdin-terminal check, and exit codes — including the historical quirks: init-exists exits **2**, cleanup `--help` exits **0`, every output string identical. `cleanupByDate`/`cleanupOrphanFiles` take writers.

## Direct tests (no exec, counted by coverage)
- `parseInitArgs` defaults/all flags; `runInit` success (bcrypt verifies via `CheckPassword`, data dir created), short/missing password, interactive prompt path, `--force` semantics
- `runHealth` 200/503/unreachable (httptest)
- `runHashPassword` roundtrip + usage
- `runEncryptConfig`: field list + at-rest plaintext removal. **Behavior note**: the second run re-reports the field because `config.Load` decrypts transparently when the key is set — harmless (values stay encrypted at rest) but the CLI's "already encrypted" message is unreachable with a key present; pinned as-is per the byte-for-byte mandate, flagged for a follow-up in `internal/config`
- `parseCleanupArgs`/`--help`; `runCleanup` no-mode/bad-config/dry-run-empty-DB
- `cleanupByDate`/`cleanupOrphanFiles` against **real SQLite**: dry-run deletes nothing; real run removes old rows+files+orphaned AI events and keeps new ones; orphans removed while recorded files survive
- merge-cameras helpers: `listenHostOf`/`listenPortOf` full matrix, `isPortOpen` **positive-only** (sandbox loopback proxy makes closed-port dials succeed — negative assertions are environment-dependent), `parseFlag`/`parseBoolFlag` all forms (incl. the space-form index-advance convention)

## Verification
- WSL Linux: `go test -race` green (52s)
- Coverage: cmd 15.3% → 29.5%
- Remaining uncovered: main() assembly line + repair/merge-cameras run bodies (documented in the issue as later batches)

Closes #589