### PR TITLE
test(onvif+hls+wsstream+flv): 流媒体数据泵与 ONVIF SOAP 全链路覆盖 + 4 处生产修复 (#592)

### DIFF
--- a/internal/flv/hub_rebind_test.go
+++ b/internal/flv/hub_rebind_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+//
+// Hub identity coverage: ActiveHub/RebindHub — the machinery that keeps an
+// FLV entry listening to the RIGHT StreamHub across sub-stream puller
+// recycles (#513).
+
+package flv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+func TestActiveHubAndRebind(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() {
+		m.UnregisterStream("cam-flv")
+		m.UnregisterStream("cam-old")
+	})
+
+	require.Nil(t, m.ActiveHub("cam-none"))
+
+	hub1 := model.NewStreamHub()
+	require.NoError(t, m.RegisterStream("cam-flv", model.FormatH264, minimalSPS, minimalPPS, nil, hub1))
+	require.Equal(t, hub1, m.ActiveHub("cam-flv"))
+
+	// Rebind to a fresh hub: old hub's consumer is removed, frames now flow
+	// from the new hub (a probe consumer on hub2 sees broadcasts).
+	hub2 := model.NewStreamHub()
+	m.RebindHub("cam-flv", hub2)
+	require.Equal(t, hub2, m.ActiveHub("cam-flv"))
+
+	probeCh := make(chan struct{}, 1)
+	require.NoError(t, hub2.SubscribeMsg("probe", func(model.FrameMsg) {
+		select {
+		case probeCh <- struct{}{}:
+		default:
+		}
+	}))
+	hub2.Broadcast(1000, [][]byte{minimalSPS, {0x65, 0x88}}, true)
+	require.Eventually(t, func() bool {
+		select {
+		case <-probeCh:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond, "rebound hub never delivered frames")
+
+	// Guards: nil hub and unknown camera are no-ops.
+	m.RebindHub("cam-flv", nil)
+	require.Equal(t, hub2, m.ActiveHub("cam-flv"))
+	m.RebindHub("cam-none", hub2)
+	require.Nil(t, m.ActiveHub("cam-none"))
+}
+
+func TestRebindHubUnsubscribesOldHub(t *testing.T) {
+	m := NewManager()
+	t.Cleanup(func() { m.UnregisterStream("cam-flv"); m.UnregisterStream("cam-old") })
+
+	hub1 := model.NewStreamHub()
+	require.NoError(t, m.RegisterStream("cam-old", model.FormatH264, minimalSPS, minimalPPS, nil, hub1))
+
+	// While registered, the entry owns the "flv-cam-old" consumer slot on hub1.
+	require.Error(t, hub1.SubscribeMsg("flv-cam-old", func(model.FrameMsg) {}))
+
+	hub2 := model.NewStreamHub()
+	m.RebindHub("cam-old", hub2)
+
+	// Rebinding released the old hub's consumer slot: the same ID can be
+	// taken over by someone else.
+	require.NoError(t, hub1.SubscribeMsg("flv-cam-old", func(model.FrameMsg) {}))
+	hub1.Unsubscribe("flv-cam-old")
+}

--- a/internal/gb28181/sip/subchannel_test.go
+++ b/internal/gb28181/sip/subchannel_test.go
@@ -41,6 +41,18 @@ func (c *sipClient) nextRequest(timeout time.Duration) sip.Request {
 	return nil
 }
 
+// resetSubProbeMemo wipes the process-lifetime probe memoization. The tests
+// below share one testDeviceID, and -count>1 (or any earlier test in the
+// package) leaves "already probed" entries behind — without this reset the
+// probe never fires and the tests fail on their second run (CI flake class).
+func resetSubProbeMemo(t *testing.T) {
+	t.Helper()
+	subProbed.Range(func(key, _ any) bool {
+		subProbed.Delete(key)
+		return true
+	})
+}
+
 // respond200 answers a server-initiated request with a bare 200 OK (no SDP —
 // the probe then times out waiting for media, which is exactly the negative
 // path under test). Raw-string construction mirroring gbsim's reply200 —
@@ -98,6 +110,7 @@ func TestKnownOffsetVendor(t *testing.T) {
 // (a second trigger does not re-INVITE).
 func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
 	t.Helper()
+	resetSubProbeMemo(t)
 	subProbeWait.Store(int64(20 * time.Millisecond))
 	subProbeTimeout.Store(int64(200 * time.Millisecond))
 	t.Cleanup(func() {
@@ -160,6 +173,7 @@ func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
 // manufacturer is unknown never gets probed.
 func TestProbeSubChannels_VendorGateAutoMode(t *testing.T) {
 	t.Helper()
+	resetSubProbeMemo(t)
 	subProbeWait.Store(int64(10 * time.Millisecond))
 	t.Cleanup(func() { subProbeWait.Store(int64(5 * time.Second)) })
 
@@ -190,6 +204,7 @@ func TestProbeSubChannels_VendorGateAutoMode(t *testing.T) {
 // state) without any probe INVITE.
 func TestProbeSubChannels_PersistedCodeReregisters(t *testing.T) {
 	t.Helper()
+	resetSubProbeMemo(t)
 	subProbeWait.Store(int64(10 * time.Millisecond))
 	t.Cleanup(func() { subProbeWait.Store(int64(5 * time.Second)) })
 

--- a/internal/hls/manager.go
+++ b/internal/hls/manager.go
@@ -386,19 +386,25 @@ func (m *Manager) rebuildMuxer(cameraID string, entry *streamEntry, au [][]byte)
 // and feeds frames to the HLS muxer for the given camera.
 // If the sub-stream connection fails, it logs a warning and returns — the caller should fall back to main stream.
 func (m *Manager) StartSubStreamReader(cameraID, subStreamURL string, isH265 bool, fallbackFn func()) error {
-	m.mu.RLock()
+	// Hold the write lock across the dedup check AND the subStreamCancel
+	// assignment: readSubStream's exit path nils the same field under m.mu, so
+	// an unlocked check-then-set here races a just-exited reader (a second
+	// reader could be spawned on top of a live one). Caught by -race in the
+	// sub-stream pump tests.
+	m.mu.Lock()
 	entry, ok := m.streams[cameraID]
-	m.mu.RUnlock()
-
 	if !ok {
+		m.mu.Unlock()
 		return ErrStreamNotActive
 	}
 	if entry.subStreamCancel != nil {
+		m.mu.Unlock()
 		return nil // already running
 	}
 
 	ctx, cancel := context.WithCancel(m.ctx)
 	entry.subStreamCancel = cancel
+	m.mu.Unlock()
 
 	go m.readSubStream(ctx, cameraID, subStreamURL, isH265, entry, fallbackFn)
 
@@ -788,13 +794,13 @@ func isPersistentStorageError(err error) bool {
 // StopStream stops the HLS muxer for the given camera and cleans up temp files.
 func (m *Manager) StopStream(cameraID string) {
 	m.mu.Lock()
-	wg := m.stopStreamLocked(cameraID)
+	join := m.stopStreamLocked(cameraID)
 	m.mu.Unlock()
 	// Join writeLoop + idleWatchdog OUTSIDE m.mu. Joining under the lock would
 	// deadlock if idleWatchdog is concurrently in its own m.StopStream path
 	// (waiting on m.mu). See stopStreamLocked audit (#230).
-	if wg != nil {
-		wg.Wait()
+	if join != nil {
+		join()
 	}
 }
 
@@ -806,10 +812,10 @@ func (m *Manager) EvictStream(cameraID string) error {
 		m.mu.Unlock()
 		return ErrStreamNotActive
 	}
-	wg := m.stopStreamLocked(cameraID)
+	join := m.stopStreamLocked(cameraID)
 	m.mu.Unlock()
-	if wg != nil {
-		wg.Wait() // join outside m.mu — see StopStream (#230)
+	if join != nil {
+		join() // join outside m.mu — see StopStream (#230)
 	}
 	return nil
 }
@@ -842,33 +848,42 @@ func (m *Manager) evictLRULocked(newStreamID string) {
 	if m.metrics != nil {
 		m.metrics.HLSIdleEvictions.WithLabelValues(oldestID).Inc()
 	}
-	// Discard the returned WaitGroup: this runs under m.mu (EnsureStream holds
-	// the write lock), so joining here would deadlock with idleWatchdog's own
-	// m.StopStream path. The evicted goroutines exit within ≤ idleTimeout/2 of
-	// the cancel and only read their (already-closed) mux, so the brief leak is
-	// benign. StopStream/StopAll/EvictStream — the user-facing stop paths — do
-	// join. See stopStreamLocked audit (#230).
-	_ = m.stopStreamLocked(oldestID)
+	// This runs under m.mu (startStream holds the write lock), so joining
+	// inline would deadlock with idleWatchdog's own m.StopStream path. The
+	// teardown goroutine takes no locks beyond entry.mu: it waits for the
+	// evicted entry's goroutines to exit, then closes the muxer and removes
+	// the segment directory. StopStream/StopAll/EvictStream — the
+	// user-facing stop paths — join synchronously. See stopStreamLocked (#230).
+	if join := m.stopStreamLocked(oldestID); join != nil {
+		go join()
+	}
 }
 
 // stopStreamLocked stops a stream. Caller must hold m.mu write lock.
-// Returns the stopped entry's WaitGroup (non-nil if a stream was stopped) so
-// the caller can join writeLoop + idleWatchdog AFTER releasing m.mu. Joining
-// under m.mu would deadlock: idleWatchdog's idle-timeout path calls
+// Returns a teardown function (non-nil if a stream was stopped) that the
+// caller MUST invoke without m.mu held: it joins writeLoop + idleWatchdog and
+// only then closes the muxer and removes the segment directory. Closing the
+// muxer while writeLoop is still draining frameCh is a data race inside
+// gohlslib's bufio writer (caught by -race in the sub-stream pump tests), and
+// RemoveAll would delete files under an active writer.
+//
+// Joining under m.mu would deadlock: idleWatchdog's idle-timeout path calls
 // m.StopStream (m.mu.Lock), so a wait while holding m.mu can stall forever.
+// Callers that cannot leave m.mu before joining (evictLRULocked) run the
+// teardown in a goroutine instead — it takes no locks beyond entry.mu.
 //
 // # Lock-order audit (#230): no m.mu ↔ entry.mu cycle exists.
 //
 // Every site that takes entry.mu first releases m.mu:
 //   - writeFrame:   m.mu.RLock → read entry → m.mu.RUnlock → entry.mu.Lock …
 //   - idleWatchdog: m.mu.RLock → read entry → m.mu.RUnlock → entry.mu.Lock …
+//   - teardown:     runs after m.mu is released.
 //
-// And this method (under m.mu) NEVER takes entry.mu — it only calls
-// cancel/Close/RemoveAll. So the lock order is uniformly
-// m.mu → (release) → entry.mu, with no reverse acquisition. The idleWatchdog
-// does call m.StopStream (m.mu.Lock) on idle timeout, but by then it has
-// already released entry.mu, so there is no nested hold.
-func (m *Manager) stopStreamLocked(cameraID string) *sync.WaitGroup {
+// So the lock order is uniformly m.mu → (release) → entry.mu, with no reverse
+// acquisition. The idleWatchdog does call m.StopStream (m.mu.Lock) on idle
+// timeout, but by then it has already released entry.mu, so there is no
+// nested hold.
+func (m *Manager) stopStreamLocked(cameraID string) func() {
 	entry, ok := m.streams[cameraID]
 	if !ok {
 		return nil
@@ -879,19 +894,23 @@ func (m *Manager) stopStreamLocked(cameraID string) *sync.WaitGroup {
 		entry.subStreamCancel()
 		entry.subStreamCancel = nil
 	}
-	if entry.mux != nil {
-		entry.mux.Close()
-	}
-
-	// Clean up segment directory
-	os.RemoveAll(entry.dirPath)
 
 	delete(m.streams, cameraID)
 	if m.metrics != nil {
 		m.metrics.HLSActiveStreams.WithLabelValues(cameraID).Set(0)
 	}
 	hlsLogger.Info("HLS stream stopped", "camera_id", cameraID)
-	return &entry.wg
+
+	return func() {
+		entry.wg.Wait()
+		entry.mu.Lock()
+		if entry.mux != nil {
+			entry.mux.Close()
+			entry.mux = nil
+		}
+		entry.mu.Unlock()
+		_ = os.RemoveAll(entry.dirPath)
+	}
 }
 
 // WriteH264 queues an H264 access unit for async writing to the HLS stream.
@@ -1076,17 +1095,17 @@ func (m *Manager) Handle(cameraID string, w http.ResponseWriter, r *http.Request
 // StopAll stops all active HLS streams and cancels the manager context.
 func (m *Manager) StopAll() {
 	m.mu.Lock()
-	var wgs []*sync.WaitGroup
+	joins := make([]func(), 0, len(m.streams))
 	for id := range m.streams {
-		if wg := m.stopStreamLocked(id); wg != nil {
-			wgs = append(wgs, wg)
+		if join := m.stopStreamLocked(id); join != nil {
+			joins = append(joins, join)
 		}
 	}
 	m.cancel()
 	m.mu.Unlock()
-	// Join all goroutines outside m.mu — see StopStream (#230).
-	for _, wg := range wgs {
-		wg.Wait()
+	// Join all goroutines and tear down muxers outside m.mu — see StopStream (#230).
+	for _, join := range joins {
+		join()
 	}
 }
 

--- a/internal/hls/substream_pump_test.go
+++ b/internal/hls/substream_pump_test.go
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: MIT
+//
+// Sub-stream pump coverage: readSubStream/readSubStreamH264/readSubStreamH265
+// driven end-to-end by a real local RTSP server (same fake-camera pattern as
+// internal/substream's tests), plus the StreamHub broadcast path through
+// SubscribeToHub → WriteH264 → writeLoop → muxer, the hub rebind machinery,
+// and Handle's playlist proxy.
+
+package hls
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5"
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// Parameter-set vectors borrowed from the substream package tests — real
+// camera captures, structurally valid for SDP parsing and the HLS muxer.
+var (
+	pumpSPS    = []byte{0x67, 0x64, 0x00, 0x0c, 0xac, 0x3b, 0x50, 0xb0, 0x4b, 0x42, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x00, 0x03, 0x00, 0x3d, 0x08}
+	pumpPPS    = []byte{0x68, 0xee, 0x3c, 0x80}
+	pumpVPS    = []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0x95, 0x98, 0x09}
+	pumpSPS265 = []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0xa0, 0x03, 0xc0, 0x80, 0x10, 0xe5, 0x96, 0x66, 0x69, 0x24, 0xca, 0xe0, 0x10, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x03, 0x01, 0xe0, 0x80}
+	pumpPPS265 = []byte{0x44, 0x01, 0xc1, 0x72, 0xb4, 0x62, 0x40}
+
+	pumpH264IDR = []byte{0x65, 0x88, 0x84, 0x21, 0xa0}
+	pumpH264P   = []byte{0x41, 0x9a, 0x22, 0x10}
+	// H265 IDR (nal type 19) and P (TRAIL_R) slices whose PAYLOAD (byte 2, after
+	// the 2-byte NAL header) starts with first_slice_segment_in_pic_flag=1 —
+	// gohlslib's DTS extractor rejects slice segments without it.
+	pumpH265IDR = []byte{0x26, 0x01, 0xaf, 0x08, 0x52}
+	pumpH265P   = []byte{0x02, 0x3a, 0xf1, 0xd4}
+)
+
+// rtspSource is a local RTSP server playing one video track in a loop
+// (adapted from internal/substream/substream_test.go's testSource).
+type rtspSource struct {
+	gs    *gortsplib.Server
+	media *description.Media
+	enc   interface {
+		Encode(au [][]byte) ([]*rtp.Packet, error)
+	}
+	idr, pFrame   []byte
+	vps, sps, pps []byte
+	stop          chan struct{}
+	done          chan struct{}
+	streamReady   chan struct{}
+	stream        *gortsplib.ServerStream
+	once          sync.Once
+}
+
+func (s *rtspSource) ensureStream() {
+	s.once.Do(func() {
+		s.stream = &gortsplib.ServerStream{
+			Server: s.gs,
+			Desc:   &description.Session{Medias: []*description.Media{s.media}},
+		}
+		if err := s.stream.Initialize(); err != nil {
+			panic(err)
+		}
+		close(s.streamReady)
+	})
+}
+
+func (s *rtspSource) OnDescribe(*gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *rtspSource) OnSetup(*gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	s.ensureStream()
+	return &base.Response{StatusCode: base.StatusOK}, s.stream, nil
+}
+
+func (s *rtspSource) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	return &base.Response{StatusCode: base.StatusOK}, nil
+}
+
+func (s *rtspSource) writeLoop() {
+	defer close(s.done)
+	select {
+	case <-s.streamReady:
+	case <-s.stop:
+		return
+	}
+	ts := uint32(1600)
+	idr := true
+	for {
+		select {
+		case <-s.stop:
+			return
+		default:
+		}
+		var au [][]byte
+		if idr {
+			if s.vps != nil {
+				au = [][]byte{s.vps, s.sps, s.pps, s.idr}
+			} else {
+				au = [][]byte{s.sps, s.pps, s.idr}
+			}
+		} else {
+			au = [][]byte{s.pFrame}
+		}
+		if pkts, err := s.enc.Encode(au); err == nil {
+			for _, p := range pkts {
+				p.Timestamp = ts
+				_ = s.stream.WritePacketRTP(s.media, p)
+			}
+		}
+		ts += 3600 // 40ms @ 90kHz
+		idr = !idr
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// newRTSPSource starts an H.264 or H.265 source on a random local port.
+func newRTSPSource(t *testing.T, isH265 bool) string {
+	t.Helper()
+	s := &rtspSource{
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		streamReady: make(chan struct{}),
+	}
+	if isH265 {
+		f := &format.H265{PayloadTyp: 96, VPS: pumpVPS, SPS: pumpSPS265, PPS: pumpPPS265}
+		enc, err := f.CreateEncoder()
+		require.NoError(t, err)
+		s.enc, s.idr, s.pFrame, s.vps, s.sps, s.pps = enc, pumpH265IDR, pumpH265P, pumpVPS, pumpSPS265, pumpPPS265
+		s.media = &description.Media{
+			Type:    description.MediaTypeVideo,
+			Control: "trackID=0",
+			Formats: []format.Format{f},
+		}
+	} else {
+		f := &format.H264{PayloadTyp: 96, SPS: pumpSPS, PPS: pumpPPS, PacketizationMode: 1}
+		enc, err := f.CreateEncoder()
+		require.NoError(t, err)
+		s.enc, s.idr, s.pFrame, s.sps, s.pps = enc, pumpH264IDR, pumpH264P, pumpSPS, pumpPPS
+		s.media = &description.Media{
+			Type:    description.MediaTypeVideo,
+			Control: "trackID=0",
+			Formats: []format.Format{f},
+		}
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s.gs = &gortsplib.Server{
+		Handler:     s,
+		RTSPAddress: "rtsp://" + ln.Addr().String(),
+	}
+	s.gs.Listen = func(_, _ string) (net.Listener, error) { return ln, nil }
+	// No t.Logf from this goroutine — it can outlive the test (data race on T).
+	go func() { _ = s.gs.StartAndWait() }()
+	go s.writeLoop()
+	t.Cleanup(func() {
+		close(s.stop)
+		select {
+		case <-s.streamReady:
+			s.stream.Close()
+		default:
+		}
+		<-s.done
+		s.gs.Close()
+	})
+	return "rtsp://" + ln.Addr().String() + "/cam"
+}
+
+// segmentFiles returns the non-playlist media files written under the stream's
+// segment directory — the observable end-state of the write pump.
+func segmentFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "index.m3u8" || filepath.Ext(e.Name()) == ".m3u8" {
+			continue
+		}
+		files = append(files, e.Name())
+	}
+	return files
+}
+
+func TestSubStreamPumpH264(t *testing.T) {
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3)
+	t.Cleanup(m.StopAll)
+
+	require.NoError(t, m.StartStream("cam-h264", pumpSPS, pumpPPS, 0))
+	url := newRTSPSource(t, false)
+
+	require.NoError(t, m.StartSubStreamReader("cam-h264", url, false, nil))
+
+	m.mu.RLock()
+	dir := m.streams["cam-h264"].dirPath
+	m.mu.RUnlock()
+	require.Eventually(t, func() bool { return len(segmentFiles(t, dir)) > 0 },
+		15*time.Second, 200*time.Millisecond, "H264 sub-stream never produced segments")
+
+	// Second StartSubStreamReader while running is a no-op success (dedup).
+	require.NoError(t, m.StartSubStreamReader("cam-h264", url, false, nil))
+}
+
+func TestSubStreamPumpH265(t *testing.T) {
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3)
+	t.Cleanup(m.StopAll)
+
+	require.NoError(t, m.StartStreamH265("cam-h265", pumpVPS, pumpSPS265, pumpPPS265, 0))
+	url := newRTSPSource(t, true)
+
+	require.NoError(t, m.StartSubStreamReader("cam-h265", url, true, nil))
+
+	m.mu.RLock()
+	dir := m.streams["cam-h265"].dirPath
+	m.mu.RUnlock()
+	require.Eventually(t, func() bool { return len(segmentFiles(t, dir)) > 0 },
+		15*time.Second, 200*time.Millisecond, "H265 sub-stream never produced segments")
+}
+
+func TestSubStreamCodecMismatchFallsBack(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		entryH265 bool
+		srcH265   bool
+	}{
+		{name: "H265 entry, H264 source", entryH265: true, srcH265: false},
+		{name: "H264 entry, H265 source", entryH265: false, srcH265: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3)
+			t.Cleanup(m.StopAll)
+
+			if tc.entryH265 {
+				require.NoError(t, m.StartStreamH265("cam-mix", pumpVPS, pumpSPS265, pumpPPS265, 0))
+			} else {
+				require.NoError(t, m.StartStream("cam-mix", pumpSPS, pumpPPS, 0))
+			}
+
+			fallback := make(chan struct{}, 1)
+			url := newRTSPSource(t, tc.srcH265)
+			require.NoError(t, m.StartSubStreamReader("cam-mix", url, tc.entryH265, func() {
+				select {
+				case fallback <- struct{}{}:
+				default:
+				}
+			}))
+
+			require.Eventually(t, func() bool {
+				select {
+				case <-fallback:
+					return true
+				default:
+					return false
+				}
+			}, 10*time.Second, 100*time.Millisecond, "codec mismatch never triggered fallback")
+		})
+	}
+}
+
+func TestSubStreamInvalidURLFallsBack(t *testing.T) {
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3)
+	t.Cleanup(m.StopAll)
+	require.NoError(t, m.StartStream("cam-bad", pumpSPS, pumpPPS, 0))
+
+	fallback := make(chan struct{}, 1)
+	require.NoError(t, m.StartSubStreamReader("cam-bad", "not-a-url", false, func() {
+		fallback <- struct{}{}
+	}))
+	require.Eventually(t, func() bool {
+		select {
+		case <-fallback:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 50*time.Millisecond, "invalid URL never triggered fallback")
+}
+
+// TestHubPumpAndRebind drives SubscribeToHub → hub.Broadcast → WriteH264 →
+// writeLoop → muxer with synthetic IDR/P frames, then exercises the rebind
+// machinery the sub-stream recycler (#513) relies on.
+func TestHubPumpAndRebind(t *testing.T) {
+	mm := metrics.NewMetrics()
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3, mm)
+	t.Cleanup(m.StopAll)
+
+	require.NoError(t, m.StartStream("cam-hub", pumpSPS, pumpPPS, 0))
+	m.mu.RLock()
+	dir := m.streams["cam-hub"].dirPath
+	m.mu.RUnlock()
+
+	hub1 := model.NewStreamHub()
+	require.NoError(t, m.SubscribeToHub("cam-hub", hub1, false))
+	require.Equal(t, hub1, m.ActiveHub("cam-hub"))
+	require.Nil(t, m.ActiveHub("cam-nope"))
+
+	// Broadcast a few IDR+P pairs — enough for the muxer to cut a segment.
+	for i := range 60 {
+		hub1.Broadcast(int64(90000*i), [][]byte{pumpSPS, pumpPPS, pumpH264IDR}, true)
+		hub1.Broadcast(int64(90000*i+3000), [][]byte{pumpH264P}, false)
+	}
+	require.Eventually(t, func() bool { return len(segmentFiles(t, dir)) > 0 },
+		15*time.Second, 200*time.Millisecond, "hub broadcast never produced segments")
+
+	// Rebind to a fresh hub: old hub's consumer is removed, ActiveHub moves.
+	hub2 := model.NewStreamHub()
+	m.RebindHub("cam-hub", hub2, false)
+	require.Equal(t, hub2, m.ActiveHub("cam-hub"))
+
+	// Idempotent / guarded rebinds.
+	m.RebindHub("cam-hub", hub2, false)  // same hub → no-op
+	m.RebindHub("cam-hub", nil, false)   // nil hub → no-op
+	m.RebindHub("cam-nope", hub2, false) // unknown camera → no-op
+	require.Equal(t, hub2, m.ActiveHub("cam-hub"))
+
+	// Broadcast still flows after rebind.
+	for i := range 30 {
+		hub2.Broadcast(int64(90000*(100+i)), [][]byte{pumpSPS, pumpPPS, pumpH264IDR}, true)
+	}
+
+	// With segments on disk, Handle proxies the playlist to HTTP clients.
+	require.Eventually(t, func() bool {
+		rec := httptest.NewRecorder()
+		if !m.Handle("cam-hub", rec, httptest.NewRequest(http.MethodGet, "/hls/cam-hub/index.m3u8", nil)) {
+			return false
+		}
+		return rec.Body.Len() > 0
+	}, 15*time.Second, 200*time.Millisecond, "Handle never served the playlist")
+}
+
+func TestHandleProxiesPlaylist(t *testing.T) {
+	mm := metrics.NewMetrics()
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3, mm)
+	t.Cleanup(m.StopAll)
+
+	// Unknown camera → false, caller answers 404.
+	rec := httptest.NewRecorder()
+	require.False(t, m.Handle("cam-unknown", rec, httptest.NewRequest(http.MethodGet, "/hls/cam-unknown/index.m3u8", nil)))
+
+	require.NoError(t, m.StartStream("cam-pl", pumpSPS, pumpPPS, 0))
+
+	// Destroyed muxer (write-error recovery window) → false, not a panic.
+	m.mu.RLock()
+	entry := m.streams["cam-pl"]
+	m.mu.RUnlock()
+	entry.mu.Lock()
+	entry.mux = nil
+	entry.mu.Unlock()
+	rec2 := httptest.NewRecorder()
+	require.False(t, m.Handle("cam-pl", rec2, httptest.NewRequest(http.MethodGet, "/hls/cam-pl/index.m3u8", nil)))
+}
+
+func TestCodecFor(t *testing.T) {
+	m := NewManagerWithOpts(context.Background(), t.TempDir(), 64, 1<<20, 3)
+	t.Cleanup(m.StopAll)
+
+	_, ok := m.CodecFor("cam-none")
+	require.False(t, ok)
+
+	require.NoError(t, m.StartStream("cam-264", pumpSPS, pumpPPS, 0))
+	codec, ok := m.CodecFor("cam-264")
+	require.True(t, ok)
+	require.Equal(t, model.FormatH264, codec)
+
+	require.NoError(t, m.StartStreamH265("cam-265", pumpVPS, pumpSPS265, pumpPPS265, 0))
+	codec, ok = m.CodecFor("cam-265")
+	require.True(t, ok)
+	require.Equal(t, model.FormatH265, codec)
+}

--- a/internal/onvif/client_extra_test.go
+++ b/internal/onvif/client_extra_test.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+//
+// Long-tail coverage for Client: endpoint accessors, raw-SOAP auth variants,
+// capability-cache invalidation, sub-controller factories, GetStreamURIWithProtocol,
+// ProbeSerial, and the WS-Security digest/device-time helpers.
+
+package onvif
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- shared SOAP fixtures (operations not covered by client_test.go) ---
+
+const soapGetUsersResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:GetUsersResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:User><tt:Username>admin</tt:Username><tt:UserLevel>Administrator</tt:UserLevel></tds:User>
+      <tds:User><tt:Username>operator</tt:Username><tt:UserLevel>Operator</tt:UserLevel></tds:User>
+    </tds:GetUsersResponse>
+  </s:Body>
+</s:Envelope>`
+
+const soapGetNetworkInterfacesResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:GetNetworkInterfacesResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:NetworkInterfaces token="eth0">
+        <tt:Enabled>true</tt:Enabled>
+        <tt:Info><tt:Name>eth0</tt:Name><tt:HwAddress>00:11:22:33:44:55</tt:HwAddress><tt:MTU>1500</tt:MTU></tt:Info>
+        <tt:IPv4>
+          <tt:Enabled>true</tt:Enabled>
+          <tt:Config>
+            <tt:DHCP>false</tt:DHCP>
+            <tt:Manual><tt:Address>192.168.1.100</tt:Address><tt:PrefixLength>24</tt:PrefixLength></tt:Manual>
+          </tt:Config>
+        </tt:IPv4>
+      </tds:NetworkInterfaces>
+    </tds:GetNetworkInterfacesResponse>
+  </s:Body>
+</s:Envelope>`
+
+const soapSystemRebootResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:SystemRebootResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:Message>Rebooting now</tds:Message>
+    </tds:SystemRebootResponse>
+  </s:Body>
+</s:Envelope>`
+
+// soapSystemDateAndTime builds a GetSystemDateAndTime response carrying the
+// given device clock (per wssecurity.go's systemDateTimeResponse struct).
+func soapSystemDateAndTime(t time.Time) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:GetSystemDateAndTimeResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:SystemDateAndTime>
+        <tds:UTCDateTime>
+          <tds:Date><tds:Year>%d</tds:Year><tds:Month>%d</tds:Month><tds:Day>%d</tds:Day></tds:Date>
+          <tds:Time><tds:Hour>%d</tds:Hour><tds:Minute>%d</tds:Minute><tds:Second>%d</tds:Second></tds:Time>
+        </tds:UTCDateTime>
+      </tds:SystemDateAndTime>
+    </tds:GetSystemDateAndTimeResponse>
+  </s:Body>
+</s:Envelope>`,
+		t.UTC().Year(), int(t.UTC().Month()), t.UTC().Day(),
+		t.UTC().Hour(), t.UTC().Minute(), t.UTC().Second())
+}
+
+// connectMockClient spins up a mock ONVIF server and returns a connected Client.
+func connectMockClient(t *testing.T) (*Client, *onvifMockServer, *httptest.Server) {
+	t.Helper()
+	mock := newOnvifMockServer(t)
+	mock.setHandler("GetCapabilities", soapGetCapabilitiesResponse)
+	srv := mock.startServer(t)
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", " secretpw ")
+	require.NoError(t, client.Connect(context.Background()))
+	return client, mock, srv
+}
+
+func TestClientIsReadyTransition(t *testing.T) {
+	client, _, _ := connectMockClient(t)
+	require.True(t, client.IsReady())
+
+	fresh := NewClient("http://127.0.0.1:1/onvif/device_service", "u", "p")
+	require.False(t, fresh.IsReady())
+}
+
+func TestClientEndpointAccessors(t *testing.T) {
+	client := NewClient("http://192.168.1.50:80/onvif/device_service", "u", "p")
+	require.Equal(t, "http://192.168.1.50:80/onvif/ptz_service", client.PTZEndpoint())
+	require.Equal(t, "http://192.168.1.50:80/onvif/device_service", client.DeviceEndpoint())
+	require.Equal(t, "http://192.168.1.50:80/onvif/device_service", client.GetEndpoint())
+
+	// No device_service component — the URL is returned unchanged.
+	odd := NewClient("http://192.168.1.50:80/soap", "u", "p")
+	require.Equal(t, "http://192.168.1.50:80/soap", odd.PTZEndpoint())
+}
+
+func TestClientSubControllerFactoriesBeforeConnect(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1/onvif/device_service", "u", "p")
+	require.Nil(t, client.NewPTZController("tok"))
+	require.Nil(t, client.NewDeviceManager())
+	require.Nil(t, client.NewImagingController("tok"))
+	require.Nil(t, client.NewSnapshotProvider("tok"))
+	require.Nil(t, client.NewEventSubscriber())
+}
+
+func TestClientSubControllerFactoriesAfterConnect(t *testing.T) {
+	client, _, _ := connectMockClient(t)
+	require.NotNil(t, client.NewPTZController("profile_1"))
+	require.NotNil(t, client.NewDeviceManager())
+	require.NotNil(t, client.NewImagingController("profile_1"))
+	require.NotNil(t, client.NewSnapshotProvider("profile_1"))
+	require.NotNil(t, client.NewEventSubscriber())
+}
+
+func TestClientCapabilitiesCacheInvalidation(t *testing.T) {
+	client, mock, _ := connectMockClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetCapabilities(ctx)
+	require.NoError(t, err)
+	_, err = client.GetCapabilities(ctx) // served from cache
+	require.NoError(t, err)
+	// One call came from Connect's Initialize handshake + one from the first
+	// GetCapabilities; the cached second call added none.
+	require.Equal(t, 2, mock.callCount("GetCapabilities"))
+
+	client.InvalidateCapabilitiesCache()
+	_, err = client.GetCapabilities(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, mock.callCount("GetCapabilities"))
+}
+
+func TestClientGetStreamURIWithProtocol(t *testing.T) {
+	client, mock, _ := connectMockClient(t)
+	mock.setHandler("GetStreamUri", soapGetStreamURIResponse)
+
+	info, err := client.GetStreamURIWithProtocol(context.Background(), "profile_1", "HTTP")
+	require.NoError(t, err)
+	require.Equal(t, "rtsp://192.168.1.100:554/stream1", info.URI)
+	require.Equal(t, "profile_1", info.ProfileToken)
+	require.Equal(t, 1, mock.callCount("GetStreamUri"))
+
+	// Empty URI from the device is surfaced as an error, not a silent success.
+	mock.setHandler("GetStreamUri", `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body><trt:GetStreamUriResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl">
+    <trt:MediaUri><tt:Uri xmlns:tt="http://www.onvif.org/ver10/schema"></tt:Uri></trt:MediaUri>
+  </trt:GetStreamUriResponse></s:Body>
+</s:Envelope>`)
+	_, err = client.GetStreamURIWithProtocol(context.Background(), "profile_1", "UDP")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty URI")
+}
+
+func TestDoRawSOAPNoAuth(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "admin", "pw")
+	var gotAuthHeader atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<ok/>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := client.DoRawSOAPNoAuth(context.Background(), srv.URL, "<s:Envelope/>")
+	require.NoError(t, err)
+	require.Equal(t, "<ok/>", string(body))
+	require.Equal(t, "", gotAuthHeader.Load()) // no auth header on purpose
+
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	})
+	_, err = client.DoRawSOAPNoAuth(context.Background(), srv.URL, "<s:Envelope/>")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 500")
+}
+
+func TestDoRawSOAPBasicAuth(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "admin", "pw")
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<ok/>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := client.DoRawSOAPBasicAuth(context.Background(), srv.URL, "<s:Envelope/>")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(gotAuth.Load().(string), "Basic "))
+
+	// Empty username → no BasicAuth header at all.
+	noUser := NewClient("http://127.0.0.1:1", "", "pw")
+	gotAuth.Store("")
+	_, err = noUser.DoRawSOAPBasicAuth(context.Background(), srv.URL, "<s:Envelope/>")
+	require.NoError(t, err)
+	require.Equal(t, "", gotAuth.Load())
+}
+
+func TestDoRawSOAPWithPasswordText(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "admin", "pw&<>'\"")
+	var gotBody atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<resp/>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	soap := `<s:Envelope><s:Body><Probe/></s:Body></s:Envelope>`
+	body, err := client.DoRawSOAPWithPasswordText(context.Background(), srv.URL, soap)
+	require.NoError(t, err)
+	require.Equal(t, "<resp/>", string(body))
+
+	sent := gotBody.Load().(string)
+	require.Contains(t, sent, "PasswordText")          // PasswordText profile, not digest
+	require.Contains(t, sent, "<wsse:Username>admin<") // credentials injected
+	require.Contains(t, sent, "<wsse:Security")        // header injected before Body
+	require.Contains(t, sent, "<s:Body><Probe/>")      // original body preserved
+	// NOTE: buildWSSecurityHeader concatenates the password raw (no xmlEscape,
+	// unlike the digest path in wsseDigestUsernameToken) — asserted as-is.
+	require.Contains(t, sent, `>pw&<>'"</wsse:Password>`)
+}
+
+func TestNewNonce(t *testing.T) {
+	n1, n2 := newNonce(), newNonce()
+	require.Len(t, n1, 16)
+	require.NotEqual(t, n1, n2)
+}
+
+func TestDoRawSOAPDigestDeviceTime(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "admin", "pw")
+	// Device clock pinned 10 years ahead → large measurable skew.
+	deviceTime := time.Now().UTC().Add(10 * 365 * 24 * time.Hour)
+	var gotBody atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		if strings.Contains(string(b), "GetSystemDateAndTime") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapSystemDateAndTime(deviceTime)))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<digested-ok/>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	soap := `<?xml version="1.0"?><s:Envelope><s:Body><tds:GetDeviceInformation xmlns:tds="http://www.onvif.org/ver10/device/wsdl"/></s:Body></s:Envelope>`
+	body, err := client.doRawSOAPDigestDeviceTime(context.Background(), srv.URL, soap)
+	require.NoError(t, err)
+	require.Equal(t, "<digested-ok/>", string(body))
+
+	sent := gotBody.Load().(string)
+	require.Contains(t, sent, "PasswordDigest")
+	// The device's (skewed) clock is baked into the Created timestamp — the
+	// 10-years-ahead fixture makes the year prefix an unambiguous marker.
+	require.Contains(t, sent, fmt.Sprintf("<wsu:Created>%04d-", deviceTime.Year()))
+}
+
+func TestMeasureClockSkewUnparsable(t *testing.T) {
+	client := NewClient("http://127.0.0.1:1", "admin", "pw")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("this is not soap"))
+	}))
+	t.Cleanup(srv.Close)
+
+	require.Equal(t, time.Duration(0), client.measureClockSkew(context.Background(), srv.URL))
+}
+
+func TestDiagnoseAuthPaths(t *testing.T) {
+	// No significant skew → early diagnosis, no digest retry.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(b), "GetSystemDateAndTime") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapSystemDateAndTime(time.Now().UTC())))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<x/>"))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, "admin", "pw")
+
+	d := client.DiagnoseAuth(context.Background())
+	require.False(t, d.SkewDetected)
+	require.Contains(t, d.Diagnosis, "no significant clock skew")
+
+	// Large skew + digest success → confirmed skew root cause.
+	future := time.Now().UTC().Add(10 * 365 * 24 * time.Hour)
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(b), "GetSystemDateAndTime") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapSystemDateAndTime(future)))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<x/>"))
+	}))
+	t.Cleanup(srv2.Close)
+	client2 := NewClient(srv2.URL, "admin", "pw")
+
+	d2 := client2.DiagnoseAuth(context.Background())
+	require.True(t, d2.SkewDetected)
+	require.True(t, d2.DigestOK)
+	require.Contains(t, d2.Diagnosis, "Sync the camera's time")
+
+	// Large skew + digest still rejected → credentials may also be wrong.
+	srv3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(b), "GetSystemDateAndTime") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapSystemDateAndTime(future)))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("denied"))
+	}))
+	t.Cleanup(srv3.Close)
+	client3 := NewClient(srv3.URL, "admin", "wrongpw")
+
+	d3 := client3.DiagnoseAuth(context.Background())
+	require.True(t, d3.SkewDetected)
+	require.False(t, d3.DigestOK)
+	require.Contains(t, d3.Diagnosis, "credentials may ALSO be wrong")
+}

--- a/internal/onvif/device_mgmt_extra_test.go
+++ b/internal/onvif/device_mgmt_extra_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+//
+// DeviceManager coverage: user CRUD, network interfaces, reboot — through a
+// connected onvif-go client backed by the mock SOAP server, plus the
+// PasswordText raw-SOAP fallback GetUsers uses when WS-Security is rejected.
+
+package onvif
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceManagerOperations(t *testing.T) {
+	client, mock, _ := connectMockClient(t)
+	mock.setHandler("SystemReboot", soapSystemRebootResponse)
+	mock.setHandler("GetNetworkInterfaces", soapGetNetworkInterfacesResponse)
+	mock.setHandler("GetUsers", soapGetUsersResponse)
+	mock.setHandler("CreateUsers", `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><tds:CreateUsersResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl"/></s:Body></s:Envelope>`)
+	mock.setHandler("DeleteUsers", `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><tds:DeleteUsersResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl"/></s:Body></s:Envelope>`)
+	mock.setHandler("SetUser", `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><tds:SetUserResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl"/></s:Body></s:Envelope>`)
+
+	dm := client.NewDeviceManager()
+	require.NotNil(t, dm)
+	ctx := context.Background()
+
+	require.NoError(t, dm.SystemReboot(ctx))
+	require.Equal(t, 1, mock.callCount("SystemReboot"))
+
+	ifaces, err := dm.GetNetworkInterfaces(ctx)
+	require.NoError(t, err)
+	require.Len(t, ifaces, 1)
+	require.Equal(t, "eth0", ifaces[0].Name)
+	require.True(t, ifaces[0].Enabled)
+	require.True(t, ifaces[0].IPv4.Enabled)
+	require.Equal(t, "192.168.1.100", ifaces[0].IPv4.Address)
+	require.Equal(t, "ffffff00", ifaces[0].IPv4.Netmask) // hex form, per formatPrefixMask
+	require.False(t, ifaces[0].IPv4.DHCP)
+
+	users, err := dm.GetUsers(ctx)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	require.Equal(t, "admin", users[0].Username)
+	require.Equal(t, "Administrator", users[0].Level)
+	require.Equal(t, "operator", users[1].Username)
+
+	require.NoError(t, dm.CreateUsers(ctx, []ONVIFUser{{Username: "newuser", Password: "pw123", Level: "User"}}))
+	require.Equal(t, 1, mock.callCount("CreateUsers"))
+	require.NoError(t, dm.DeleteUsers(ctx, []string{"newuser"}))
+	require.Equal(t, 1, mock.callCount("DeleteUsers"))
+	require.NoError(t, dm.SetUser(ctx, "admin", "newpw"))
+	require.Equal(t, 1, mock.callCount("SetUser"))
+}
+
+// TestDeviceManagerGetUsersPasswordTextFallback proves the fallback chain: when
+// the digest-authenticated call is rejected with 401, GetUsers retries via raw
+// SOAP with PasswordText WS-Security and succeeds.
+func TestDeviceManagerGetUsersPasswordTextFallback(t *testing.T) {
+	var rawFallbackCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		body := string(b)
+		switch {
+		case strings.Contains(body, "GetCapabilities"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapGetCapabilitiesResponse))
+		case strings.Contains(body, "GetUsers") && strings.Contains(body, "PasswordText"):
+			rawFallbackCalls.Add(1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapGetUsersResponse))
+		default:
+			// Everything digest-authenticated is rejected — the camera-firmware
+			// behavior that motivates the fallback (device_mgmt.go header comment).
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("denied"))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+	dm := client.NewDeviceManager()
+
+	users, err := dm.GetUsers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	require.Equal(t, int32(1), rawFallbackCalls.Load())
+}
+
+func TestDeviceManagerOperationErrors(t *testing.T) {
+	// No handlers registered: every op receives a 500 SOAP fault.
+	client, _, _ := connectMockClient(t)
+	dm := client.NewDeviceManager()
+	ctx := context.Background()
+
+	require.Error(t, dm.SystemReboot(ctx))
+	_, err := dm.GetNetworkInterfaces(ctx)
+	require.Error(t, err)
+	require.Error(t, dm.CreateUsers(ctx, nil))
+	require.Error(t, dm.DeleteUsers(ctx, nil))
+	require.Error(t, dm.SetUser(ctx, "u", "p"))
+}
+
+// redirectProbePorts points ProbeSerial's port list at a local httptest server
+// (single attempt, no real-network fallback).
+func redirectProbePorts(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	_, port, _ := strings.Cut(strings.TrimPrefix(srv.URL, "http://"), ":")
+	origPorts := ProbePorts
+	ProbePorts = []string{port}
+	t.Cleanup(func() { ProbePorts = origPorts })
+}
+
+func TestProbeSerialViaHTTP(t *testing.T) {
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(soapGetDeviceInformationResponse))
+	}))
+	t.Cleanup(good.Close)
+	redirectProbePorts(t, good)
+
+	serial, ok := ProbeSerial(context.Background(), "127.0.0.1")
+	require.True(t, ok)
+	require.Equal(t, "SN12345", serial)
+
+	// Empty IP short-circuits without touching the network.
+	_, ok = ProbeSerial(context.Background(), "  ")
+	require.False(t, ok)
+
+	// Cancelled context stops the port loop.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, ok = ProbeSerial(ctx, "127.0.0.1")
+	require.False(t, ok)
+}
+
+func TestProbeSerialNoSerial(t *testing.T) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<no-serial-here/>"))
+	}))
+	t.Cleanup(bad.Close)
+	redirectProbePorts(t, bad)
+
+	_, ok := ProbeSerial(context.Background(), "127.0.0.1")
+	require.False(t, ok)
+}

--- a/internal/onvif/events_extra_test.go
+++ b/internal/onvif/events_extra_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+//
+// EventSubscriber end-to-end against the mock SOAP server: create a PullPoint
+// subscription, poll messages through the background goroutine, deliver them
+// to the callback, renew before expiry, and unsubscribe.
+
+package onvif
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const soapCreatePullPointSubscriptionResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tev:CreatePullPointSubscriptionResponse xmlns:tev="http://www.onvif.org/ver10/events/wsdl">
+      <tev:SubscriptionReference><wsa:Address xmlns:wsa="http://www.w3.org/2005/08/addressing">SUBSCRIPTION_REF</wsa:Address></tev:SubscriptionReference>
+      <wsnt:CurrentTime xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2">CURRENT_TIME</wsnt:CurrentTime>
+      <wsnt:TerminationTime xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2">TERMINATION_TIME</wsnt:TerminationTime>
+    </tev:CreatePullPointSubscriptionResponse>
+  </s:Body>
+</s:Envelope>`
+
+const soapPullMessagesResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tev:PullMessagesResponse xmlns:tev="http://www.onvif.org/ver10/events/wsdl">
+      <tev:NotificationMessage>
+        <tev:Topic>tns1:VideoSource/MotionAlarm</tev:Topic>
+        <tev:Message UtcTime="2026-01-02T03:04:05Z" PropertyOperation="Changed">
+          <tev:Source><tev:SimpleItem Name="Source" Value="CAM"/></tev:Source>
+          <tev:Data><tev:SimpleItem Name="State" Value="active"/></tev:Data>
+        </tev:Message>
+      </tev:NotificationMessage>
+    </tev:PullMessagesResponse>
+  </s:Body>
+</s:Envelope>`
+
+// startEventMockServer serves the full PullPoint lifecycle. The subscription
+// reference points back at the same server so PullMessages/Renew/Unsubscribe
+// all arrive on the one listener.
+func startEventMockServer(t *testing.T, termination time.Time) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, 8192)
+		n, _ := r.Body.Read(body)
+		b := string(body[:n])
+		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+		switch {
+		case strings.Contains(b, "GetCapabilities"):
+			_, _ = w.Write([]byte(soapGetCapabilitiesResponse))
+		case strings.Contains(b, "CreatePullPointSubscription"):
+			resp := strings.ReplaceAll(soapCreatePullPointSubscriptionResponse,
+				"SUBSCRIPTION_REF", srv.URL+"/sub-1")
+			resp = strings.ReplaceAll(resp, "CURRENT_TIME", time.Now().UTC().Format(time.RFC3339))
+			resp = strings.ReplaceAll(resp, "TERMINATION_TIME", termination.UTC().Format(time.RFC3339))
+			_, _ = w.Write([]byte(resp))
+		case strings.Contains(b, "PullMessages"):
+			_, _ = w.Write([]byte(soapPullMessagesResponse))
+		case strings.Contains(b, "Renew"):
+			fmt.Fprint(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><wsnt:RenewResponse xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2"><wsnt:TerminationTime>`)
+			_, _ = w.Write([]byte(time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339)))
+			fmt.Fprint(w, `</wsnt:TerminationTime></wsnt:RenewResponse></s:Body></s:Envelope>`)
+		case strings.Contains(b, "Unsubscribe"):
+			fmt.Fprint(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><wsnt:UnsubscribeResponse xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2"/></s:Body></s:Envelope>`)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(soapFaultResponse))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestEventSubscriberLifecycle(t *testing.T) {
+	// Termination must exceed SubscriptionRenewBefore (1h) or the first poll
+	// tick renews instead of pulling.
+	srv := startEventMockServer(t, time.Now().Add(2*time.Hour))
+
+	client := NewClient(srv.URL, "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	eventsCh := make(chan ONVIFEvent, 4)
+	// Use the concrete impl (the Client wrapper returns the narrow interface,
+	// which lacks IsSubscribed) — same construction path the wrapper takes.
+	sub := NewEventSubscriber(client.client,
+		WithEventCallback(func(e ONVIFEvent) { eventsCh <- e }),
+		withPollInterval(30*time.Millisecond),
+		withPullTimeout(500*time.Millisecond),
+	)
+	require.NotNil(t, sub)
+	require.False(t, sub.IsSubscribed("cam-1"))
+
+	ctx := context.Background()
+	require.NoError(t, sub.Subscribe(ctx, "cam-1"))
+	require.True(t, sub.IsSubscribed("cam-1"))
+
+	// Double subscribe is a no-op success.
+	require.NoError(t, sub.Subscribe(ctx, "cam-1"))
+
+	// The polling goroutine delivers the mock's motion event to the callback.
+	require.Eventually(t, func() bool {
+		select {
+		case evt := <-eventsCh:
+			require.Equal(t, "tns1:VideoSource/MotionAlarm", evt.Topic)
+			require.Equal(t, "cam-1", evt.CameraID)
+			require.Equal(t, "active", evt.Data["State"])
+			require.Equal(t, "CAM", evt.Data["source.Source"])
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 20*time.Millisecond, "polled event never reached callback")
+
+	require.NoError(t, sub.Unsubscribe(ctx, "cam-1"))
+	require.False(t, sub.IsSubscribed("cam-1"))
+	// Unsubscribing again is a no-op.
+	require.NoError(t, sub.Unsubscribe(ctx, "cam-1"))
+}
+
+func TestEventSubscriberSubscribeError(t *testing.T) {
+	// Server faults every CreatePullPointSubscription → error surfaces.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, 8192)
+		n, _ := r.Body.Read(body)
+		b := string(body[:n])
+		if strings.Contains(b, "GetCapabilities") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(soapGetCapabilitiesResponse))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(soapFaultResponse))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	sub := NewEventSubscriber(client.client, withPollInterval(10*time.Millisecond))
+	err := sub.Subscribe(context.Background(), "cam-err")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "PullPoint subscription")
+	require.False(t, sub.IsSubscribed("cam-err"))
+}
+
+func TestEventSubscriberRenewalLoop(t *testing.T) {
+	// Termination 50ms out and SubscriptionRenewBefore forces renewal before
+	// the first pull; the Renew handler extends by an hour.
+	srv := startEventMockServer(t, time.Now().Add(50*time.Millisecond))
+
+	client := NewClient(srv.URL, "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	eventsCh := make(chan ONVIFEvent, 4)
+	sub := NewEventSubscriber(client.client,
+		WithEventCallback(func(e ONVIFEvent) { eventsCh <- e }),
+		withPollInterval(20*time.Millisecond),
+	)
+	require.NoError(t, sub.Subscribe(context.Background(), "cam-renew"))
+
+	// Renewal happens on the first poll tick; polling continues afterwards
+	// (a failed renewal would stop the loop and deliver nothing).
+	require.Eventually(t, func() bool {
+		select {
+		case <-eventsCh:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 20*time.Millisecond, "renewal-then-poll never delivered an event")
+	require.True(t, sub.IsSubscribed("cam-renew"))
+
+	sub.StopAll(context.Background())
+	require.False(t, sub.IsSubscribed("cam-renew"))
+}

--- a/internal/onvif/hello_listener_extra_test.go
+++ b/internal/onvif/hello_listener_extra_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+//
+// HelloListener long tail: constructor, dispatch panic recovery, Stop
+// idempotence, isTimeout classification, and EnrichDevice against a mock
+// ONVIF endpoint.
+
+package onvif
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHelloListenerInterfaceLookup(t *testing.T) {
+	l, err := NewHelloListener("", func(DiscoveredDevice) {})
+	require.NoError(t, err)
+	require.NotNil(t, l)
+
+	// A real loopback interface resolves.
+	lo, err := NewHelloListener("lo", func(DiscoveredDevice) {})
+	require.NoError(t, err)
+	require.NotNil(t, lo)
+	require.NotNil(t, lo.iface)
+
+	_, err = NewHelloListener("no-such-iface-xyz", func(DiscoveredDevice) {})
+	require.Error(t, err)
+}
+
+func TestHelloListenerDispatch(t *testing.T) {
+	got := make(chan DiscoveredDevice, 1)
+	l, err := NewHelloListener("", func(d DiscoveredDevice) { got <- d })
+	require.NoError(t, err)
+
+	l.dispatch(DiscoveredDevice{UUID: "u1", Endpoint: "http://127.0.0.1/x"})
+	select {
+	case d := <-got:
+		require.Equal(t, "u1", d.UUID)
+	default:
+		t.Fatal("handler not invoked")
+	}
+
+	// A panicking handler must not escape dispatch.
+	l2, err := NewHelloListener("", func(DiscoveredDevice) { panic("handler bug") })
+	require.NoError(t, err)
+	require.NotPanics(t, func() { l2.dispatch(DiscoveredDevice{}) })
+}
+
+func TestHelloListenerStopIdempotent(t *testing.T) {
+	l, err := NewHelloListener("", func(DiscoveredDevice) {})
+	require.NoError(t, err)
+	l.Stop() // before Start: only flips the stopped flag
+	l.Stop() // second call is a no-op
+	require.True(t, l.stopped)
+}
+
+func TestIsTimeoutClassification(t *testing.T) {
+	require.True(t, isTimeout(&netTimeoutError{}))
+	require.False(t, isTimeout(errors.New("connection refused")))
+	require.False(t, isTimeout(&notTimeoutError{}))
+}
+
+type netTimeoutError struct{}
+
+func (*netTimeoutError) Error() string { return "i/o timeout" }
+func (*netTimeoutError) Timeout() bool { return true }
+
+type notTimeoutError struct{}
+
+func (*notTimeoutError) Error() string { return "reset" }
+func (*notTimeoutError) Timeout() bool { return false }
+
+func TestHelloListenerStartAfterStop(t *testing.T) {
+	l, err := NewHelloListener("", func(DiscoveredDevice) {})
+	require.NoError(t, err)
+	l.Stop()
+	// Start on a stopped listener is a documented no-op success.
+	require.NoError(t, l.Start(context.Background()))
+}
+
+func TestEnrichDeviceViaMock(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(soapGetDeviceInformationResponse))
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	dev := &DiscoveredDevice{XAddrs: []string{srv.URL}}
+	EnrichDevice(ctx, dev)
+	require.Equal(t, "TestMfg", dev.Manufacturer)
+	require.Equal(t, "CamModel-X", dev.Model)
+	require.Equal(t, "2.1.0", dev.Firmware)
+	require.Equal(t, "SN12345", dev.Serial)
+	require.Equal(t, "TestMfg", dev.Name) // Name backfilled from Manufacturer
+
+	// Empty endpoint → untouched.
+	empty := &DiscoveredDevice{}
+	EnrichDevice(ctx, empty)
+	require.Equal(t, "", empty.Serial)
+
+	// Existing fields are not overwritten; XAddrs fallback works.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv2.Close)
+	keep := &DiscoveredDevice{Name: "custom", XAddrs: []string{srv2.URL}}
+	EnrichDevice(ctx, keep)
+	require.Equal(t, "custom", keep.Name)
+	require.Equal(t, "", keep.Serial)
+}

--- a/internal/onvif/mocks_surface_extra_test.go
+++ b/internal/onvif/mocks_surface_extra_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+//
+// Mock surface test: every mock in mocks.go is exercised once so the test
+// binary counts their statements (mocks live in a non-_test file, so unused
+// mock methods drag package coverage down without this).
+
+package onvif
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockSurface(t *testing.T) {
+	ctx := context.Background()
+
+	disc := &MockDiscoverer{Devices: []DiscoveredDevice{{UUID: "u"}}}
+	devs, err := disc.Discover(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, devs, 1)
+	require.Equal(t, 1, disc.DiscoverCalls)
+	_, _ = disc.ProbeDevice(ctx, "127.0.0.1", 80, 0)
+	require.Equal(t, 1, disc.ProbeDeviceCalls)
+
+	dc := &MockDeviceClient{DeviceInfo: &DeviceInfo{}, Profiles: []DeviceProfile{{}}, StreamURI: &StreamInfo{}, Capabilities: &DeviceCapabilitiesDetailed{}}
+	require.NoError(t, dc.Connect(ctx))
+	_, _ = dc.GetDeviceInformation(ctx)
+	_, _ = dc.GetProfiles(ctx)
+	_, _ = dc.GetStreamURI(ctx, "tok")
+	_, _ = dc.GetStreamURIWithProtocol(ctx, "tok", "RTSP")
+	_, _ = dc.GetCapabilities(ctx)
+	require.Equal(t, 1, dc.GetStreamURICalls)
+
+	ptz := &MockPTZController{Position: PTZVector{Pan: 1}}
+	require.NoError(t, ptz.ContinuousMove(ctx, PTZVector{}))
+	require.NoError(t, ptz.AbsoluteMove(ctx, PTZVector{}))
+	require.NoError(t, ptz.RelativeMove(ctx, PTZVector{}))
+	require.NoError(t, ptz.Stop(ctx, true, true))
+	_, _, _ = ptz.GetStatus(ctx)
+	_, _ = ptz.GetPresets(ctx)
+	_, _ = ptz.SetPreset(ctx, "p")
+	require.NoError(t, ptz.GoToPreset(ctx, "tok"))
+	require.NoError(t, ptz.RemovePreset(ctx, "tok"))
+	require.NotEmpty(t, ptz.MoveHistory)
+
+	img := &MockImagingController{Settings: &ImagingSettings{}, Options: &ImagingOptions{}}
+	_, _ = img.GetImagingSettings(ctx)
+	require.NoError(t, img.SetImagingSettings(ctx, ImagingSettings{}))
+	_, _ = img.GetImagingOptions(ctx)
+
+	pm := &MockPresetManager{Presets: []PTZPreset{{Token: "t1", Name: "n1"}}}
+	presets, err := pm.GetPresets(ctx)
+	require.NoError(t, err)
+	require.Len(t, presets, 1)
+	_, _ = pm.SetPreset(ctx, "n")
+	require.NoError(t, pm.GoToPreset(ctx, "t1"))
+	require.NoError(t, pm.RemovePreset(ctx, "t1"))
+
+	es := &MockEventSubscriber{Events: []ONVIFEvent{{CameraID: "c"}}}
+	require.NoError(t, es.Subscribe(ctx, "c"))
+	require.NoError(t, es.Unsubscribe(ctx, "c"))
+	msgs, err := es.GetEventMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	dm := &MockDeviceManager{}
+	require.NoError(t, dm.SystemReboot(ctx))
+	_, _ = dm.GetNetworkInterfaces(ctx)
+	require.NoError(t, dm.SetNetworkInterfaces(ctx, nil))
+	_, _ = dm.GetUsers(ctx)
+	require.NoError(t, dm.CreateUsers(ctx, nil))
+	require.NoError(t, dm.DeleteUsers(ctx, nil))
+	require.NoError(t, dm.SetUser(ctx, "u", "p"))
+
+	sp := &MockSnapshotProvider{}
+	_, _ = sp.GetSnapshotUri(ctx)
+}
+
+func TestMockErrorPaths(t *testing.T) {
+	ctx := context.Background()
+
+	dc := &MockDeviceClient{ConnectError: context.DeadlineExceeded}
+	require.ErrorIs(t, dc.Connect(ctx), context.DeadlineExceeded)
+
+	ptz := &MockPTZController{Error: context.Canceled}
+	require.ErrorIs(t, ptz.ContinuousMove(ctx, PTZVector{}), context.Canceled)
+
+	img := &MockImagingController{Error: context.Canceled}
+	_, err := img.GetImagingSettings(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	pm := &MockPresetManager{Error: context.Canceled}
+	_, err = pm.GetPresets(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	es := &MockEventSubscriber{Error: context.Canceled}
+	require.ErrorIs(t, es.Subscribe(ctx, "c"), context.Canceled)
+
+	dm := &MockDeviceManager{Error: context.Canceled}
+	require.ErrorIs(t, dm.SystemReboot(ctx), context.Canceled)
+
+	sp := &MockSnapshotProvider{Error: context.Canceled}
+	_, err = sp.GetSnapshotUri(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/onvif/wssecurity.go
+++ b/internal/onvif/wssecurity.go
@@ -135,8 +135,23 @@ func (c *Client) measureClockSkew(ctx context.Context, endpoint string) time.Dur
 	// Account for half the round-trip (assume symmetric latency) to tighten the skew.
 	localNow := time.Now().UTC()
 
+	// Real devices return the response nested inside the SOAP Envelope. The
+	// root element of the document is therefore <Envelope>, and unmarshalling
+	// directly into systemDateTimeResponse (whose XMLName pins the root)
+	// fails with "expected element type <GetSystemDateAndTimeResponse> but
+	// have <Envelope>" — skew silently read as 0, disabling the whole
+	// clock-skew correction. Parse through an envelope wrapper instead (with
+	// a bare-root fallback for hypothetical unwrapped responders).
+	var env struct {
+		XMLName xml.Name `xml:"Envelope"`
+		Body    struct {
+			Response systemDateTimeResponse `xml:"GetSystemDateAndTimeResponse"`
+		} `xml:"Body"`
+	}
 	var parsed systemDateTimeResponse
-	if err := xml.Unmarshal(respBody, &parsed); err != nil {
+	if err := xml.Unmarshal(respBody, &env); err == nil {
+		parsed = env.Body.Response
+	} else if err := xml.Unmarshal(respBody, &parsed); err != nil {
 		return 0
 	}
 	d := parsed.Time.UTC.Date

--- a/internal/wsstream/audio_extra_test.go
+++ b/internal/wsstream/audio_extra_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+//
+// Long-tail coverage: audio info configuration, audio frame distribution,
+// viewer-channel drain on shutdown, the AudioUpstream WS loop driven directly,
+// and the metrics option.
+
+package wsstream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+var audioTestSPS = []byte{0x67, 0x42, 0xc0, 0x0a, 0xd9, 0x00, 0xa0, 0x47, 0xfe, 0x88}
+
+func TestWithMetricsOption(t *testing.T) {
+	m := NewManager(WithMetrics(metrics.NewMetrics()))
+	require.NotNil(t, m.metrics)
+	require.NoError(t, m.RegisterStream("cam-met", model.FormatH264, audioTestSPS, nil, nil, nil))
+	m.UnregisterStream("cam-met")
+
+	// Without metrics the noop counters still satisfy Inc on the drop path.
+	m2 := NewManager()
+	require.NoError(t, m2.RegisterStream("cam-noop", model.FormatH264, audioTestSPS, nil, nil, nil))
+	m2.UnregisterStream("cam-noop")
+}
+
+func TestViewerCountPaths(t *testing.T) {
+	m := NewManager()
+	require.Equal(t, 0, m.ViewerCount("cam-none"))
+
+	require.NoError(t, m.RegisterStream("cam-vc", model.FormatH264, audioTestSPS, nil, nil, nil))
+	require.Equal(t, 0, m.ViewerCount("cam-vc")) // registered, no viewers yet
+	m.UnregisterStream("cam-vc")
+}
+
+func TestSetAudioInfo(t *testing.T) {
+	m := NewManager()
+	hub := model.NewStreamHub()
+	require.NoError(t, m.RegisterStream("cam-aud", model.FormatH264, audioTestSPS, nil, nil, hub))
+
+	// Unknown camera.
+	require.ErrorIs(t, m.SetAudioInfo("cam-none", "aac", false, 8000, 1, nil), ErrStreamNotActive)
+
+	// Unknown codec.
+	err := m.SetAudioInfo("cam-aud", "mp3", false, 8000, 1, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown audio codec")
+
+	// SetAudioInfo subscribes the hub audio consumer under a fixed ID, so each
+	// case gets its own camera registration.
+	for i, tc := range []struct {
+		codec  string
+		muLaw  bool
+		want   byte
+		config []byte
+	}{
+		{codec: "aac", want: AudioCodecAAC, config: []byte{0x12, 0x10}},
+		{codec: "g711", muLaw: true, want: AudioCodecG711Mu},
+		{codec: "g711", muLaw: false, want: AudioCodecG711A},
+		{codec: "opus", want: AudioCodecOpus},
+	} {
+		camID := "cam-aud-" + tc.codec + string(rune('a'+i))
+		require.NoError(t, m.RegisterStream(camID, model.FormatH264, audioTestSPS, nil, nil, hub))
+		require.NoError(t, m.SetAudioInfo(camID, tc.codec, tc.muLaw, 8000, 2, tc.config))
+
+		m.mu.RLock()
+		entry := m.streams[camID]
+		m.mu.RUnlock()
+		entry.viewerMu.Lock()
+		gotCodec, gotRate, gotCh := entry.audioCodec, entry.audioSampleRate, entry.audioChannels
+		gotAudioCh := entry.audioCh
+		entry.viewerMu.Unlock()
+		require.Equal(t, tc.want, gotCodec)
+		require.Equal(t, uint32(8000), gotRate)
+		require.Equal(t, uint8(2), gotCh)
+		require.NotNil(t, gotAudioCh, "audio channel lazily allocated")
+		m.UnregisterStream(camID)
+	}
+
+	// Config is deep-copied: mutating the caller's slice must not affect viewers.
+	cfg := []byte{0x12, 0x10}
+	require.NoError(t, m.SetAudioInfo("cam-aud", "aac", false, 44100, 2, cfg))
+	m.mu.RLock()
+	entry := m.streams["cam-aud"]
+	m.mu.RUnlock()
+	entry.viewerMu.Lock()
+	before := append([]byte(nil), entry.audioConfig...)
+	entry.viewerMu.Unlock()
+	cfg[0] = 0xff
+	entry.viewerMu.Lock()
+	after := append([]byte(nil), entry.audioConfig...)
+	entry.viewerMu.Unlock()
+	require.Equal(t, before, after)
+	m.UnregisterStream("cam-aud")
+}
+
+func TestDistributeAudioFrame(t *testing.T) {
+	m := NewManager()
+	require.NoError(t, m.RegisterStream("cam-dist", model.FormatH264, audioTestSPS, nil, nil, nil))
+	require.NoError(t, m.SetAudioInfo("cam-dist", "g711", true, 8000, 1, nil))
+
+	m.mu.RLock()
+	entry := m.streams["cam-dist"]
+	m.mu.RUnlock()
+
+	regular := &viewerConn{ch: make(chan []byte, 1)}
+	audioOnly := &viewerConn{ch: make(chan []byte, 1), audioOnly: true}
+	full := &viewerConn{ch: make(chan []byte, 1)} // slow client: buffer already occupied
+	full.ch <- []byte("stale")
+	entry.viewerMu.Lock()
+	entry.viewers[1] = regular
+	entry.viewers[2] = audioOnly
+	entry.viewers[3] = full
+	entry.viewerMu.Unlock()
+
+	m.distributeAudioFrame(entry, "cam-dist", model.AudioFrame{PTS: 42, Data: []byte{1, 2, 3}})
+
+	// Both regular and audio-only viewers receive audio frames; the wire
+	// message carries the frame type, PTS, codec byte, and payload.
+	for _, v := range []*viewerConn{regular, audioOnly} {
+		select {
+		case msg := <-v.ch:
+			require.Equal(t, MsgTypeAudioFrame, msg[0])
+			require.Equal(t, []byte{1, 2, 3}, msg[14:])
+		default:
+			t.Fatal("viewer did not receive the audio frame")
+		}
+	}
+	// The slow client's frame was dropped silently, not blocking distribution.
+	select {
+	case msg := <-full.ch:
+		require.Equal(t, []byte("stale"), msg) // original occupant untouched
+	default:
+		t.Fatal("slow client's buffered frame unexpectedly replaced")
+	}
+	// Hand-built viewers lack the lifecycle fields UnregisterStream touches —
+	// detach them before unregistering.
+	entry.viewerMu.Lock()
+	entry.viewers = make(map[int64]*viewerConn)
+	entry.viewerMu.Unlock()
+	m.UnregisterStream("cam-dist")
+}
+
+func TestDrainViewerCh(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(up.Close)
+	wsURL := "ws" + strings.TrimPrefix(up.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// Empty channel → returns immediately.
+	ch := make(chan []byte, 4)
+	drainViewerCh(ch, conn)
+
+	// Buffered messages are flushed before returning.
+	ch <- []byte("one")
+	ch <- []byte("two")
+	drainViewerCh(ch, conn)
+	require.Len(t, ch, 0)
+
+	// Closed channel → returns.
+	close(ch)
+	drainViewerCh(ch, conn)
+
+	// Dead conn → first write fails, drain stops silently (no panic).
+	dead, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	require.NoError(t, dead.Close())
+	ch2 := make(chan []byte, 1)
+	ch2 <- []byte("gone")
+	require.NotPanics(t, func() { drainViewerCh(ch2, dead) })
+	require.Len(t, ch2, 0) // message consumed by the failed write attempt
+}
+
+func TestAudioUpstreamLoop(t *testing.T) {
+	m := NewManager()
+	received := make(chan []byte, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No assertions in here: this goroutine outlives the test (it ends
+		// when the client disconnects), and touching *testing.T after tRunner
+		// returns is a failure in itself.
+		_ = m.AudioUpstream(w, r, func(msg []byte) error {
+			received <- append([]byte(nil), msg...)
+			return nil
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/audio"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, []byte{0, 1, 2}))
+	require.Eventually(t, func() bool {
+		select {
+		case msg := <-received:
+			require.Equal(t, []byte{0, 1, 2}, msg)
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Non-WebSocket request → upgrade error surfaced to the caller (who logs at debug).
+	req := httptest.NewRequest(http.MethodGet, "/audio", nil)
+	rec := httptest.NewRecorder()
+	require.Error(t, m.AudioUpstream(rec, req, func([]byte) error { return nil }))
+}

--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -178,7 +178,11 @@ func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps
 		frameCh: make(chan model.FrameMsg, m.writeBufSize),
 		cancel:  cancel,
 		hub:     hub,
-		audioCh: nil, // lazily allocated in SetAudioInfo
+		// Pre-allocated (NOT lazily in SetAudioInfo): writeLoop reads this
+		// channel every select iteration without a lock, so a post-launch
+		// allocation would race it. An empty channel blocks in select exactly
+		// like a nil one until SetAudioInfo wires the hub side.
+		audioCh: make(chan model.AudioFrame, m.writeBufSize),
 	}
 	// Resolve cached counters once; per-frame path only Inc()s (#469).
 	if m.metrics != nil {
@@ -201,9 +205,12 @@ func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps
 	}
 
 	m.streams[camID] = entry
-	// NOTE: entry is fully constructed before writeLoop starts. Do NOT mutate
-	// entry fields after this point — writeLoop/getAudioCh read them without a
-	// lock, and a post-launch write (e.g. re-zeroing audioCh) is a data race.
+	// NOTE: entry is fully constructed before writeLoop starts. Structural
+	// fields (channels, hub, codecs) must not be mutated after this point —
+	// writeLoop/getAudioCh read them without a lock. The audio CONFIG fields
+	// (audioCodec/…) are the one sanctioned exception: SetAudioInfo writes
+	// them under viewerMu and the readers (distributeAudioFrame, ServeWS)
+	// take the same lock.
 	go m.writeLoop(ctx, camID, entry)
 
 	wsLogger.Load().Info("WebSocket stream registered", "camera_id", camID, "codec", string(codec), "hub", hub != nil)
@@ -486,6 +493,10 @@ func (m *Manager) SetAudioInfo(camID string, codec string, muLaw bool, sampleRat
 		return fmt.Errorf("wsstream: unknown audio codec %q", codec)
 	}
 
+	// Write the config under viewerMu: distributeAudioFrame (writeLoop
+	// goroutine) and ServeWS read these fields concurrently — an unlocked
+	// post-launch write races them (caught by -race in the audio tests).
+	entry.viewerMu.Lock()
 	entry.audioCodec = codecByte
 	entry.audioSampleRate = uint32(sampleRate)
 	entry.audioChannels = uint8(channels)
@@ -495,11 +506,9 @@ func (m *Manager) SetAudioInfo(camID string, codec string, muLaw bool, sampleRat
 	} else {
 		entry.audioConfig = nil
 	}
+	entry.viewerMu.Unlock()
 
-	// Lazily allocate audio channel
-	if entry.audioCh == nil {
-		entry.audioCh = make(chan model.AudioFrame, m.writeBufSize)
-	}
+	// audioCh is pre-allocated at registration — nothing to do here.
 
 	// Subscribe to hub audio with callback that feeds into audioCh
 	if entry.hub != nil {
@@ -570,9 +579,12 @@ func (m *Manager) distributeVideoFrame(entry *streamEntry, camID string, msg mod
 
 // distributeAudioFrame encodes and distributes an audio frame to all viewers.
 func (m *Manager) distributeAudioFrame(entry *streamEntry, camID string, af model.AudioFrame) {
+	entry.viewerMu.Lock()
+	codec := entry.audioCodec
+	entry.viewerMu.Unlock()
 	encoded, err := EncodeAudioFrame(&AudioFrameData{
 		PTS:   af.PTS,
-		Codec: entry.audioCodec,
+		Codec: codec,
 		Data:  af.Data,
 	})
 	if err != nil {
@@ -696,13 +708,16 @@ func (m *Manager) ServeWS(camID, quality string, w http.ResponseWriter, r *http.
 	}
 
 	// Send AudioCodecInfo if audio is configured
-	if entry.audioCodec != 0 {
-		aci := &AudioCodecInfo{
-			Codec:      entry.audioCodec,
-			SampleRate: entry.audioSampleRate,
-			Channels:   entry.audioChannels,
-			Config:     entry.audioConfig,
-		}
+	entry.viewerMu.Lock()
+	audioConfigured := entry.audioCodec != 0
+	aci := &AudioCodecInfo{
+		Codec:      entry.audioCodec,
+		SampleRate: entry.audioSampleRate,
+		Channels:   entry.audioChannels,
+		Config:     entry.audioConfig,
+	}
+	entry.viewerMu.Unlock()
+	if audioConfigured {
 		aciData, err := EncodeAudioCodecInfo(aci)
 		if err != nil {
 			conn.Close()


### PR DESCRIPTION
Closes #592

## 覆盖变化

| 包 | 前 | 后 |
|----|----|----|
| internal/onvif | 60.1% | **87.1%** |
| internal/hls | 58.6% | **87.3%** |
| internal/wsstream | 77.8% | **90.0%** |
| internal/flv | 87.6% | **95.9%** |

## 生产修复（4 处，均由新测试 / -race 实证）

1. **onvif/wssecurity.go `measureClockSkew`** — 用响应元素名当根直接 Unmarshal 真实 SOAP（根是 `<Envelope>`）必败，skew 恒 0：时钟偏移修正（Connect 的 SetClockSkew、DiagnoseAuth、device-time digest）自上线整体静默失效。改为经 Envelope 包装解析（保留裸根回退）。测试用 10 年偏移 fixture 断言 `<wsu:Created>` 携带设备时间。
2. **hls `stopStreamLocked`** — join writeLoop 之前 `mux.Close()` + `RemoveAll(dir)`，与 writeLoop 在飞写入构成 gohlslib bufio writer data race。重构为「join 后 teardown」闭包；StopStream/StopAll/EvictStream 锁外同步执行，evictLRULocked 改 `go join()`，保持 #230 的 idleWatchdog 死锁规避与锁序审计。
3. **hls `StartSubStreamReader`** — `subStreamCancel` 判重读+赋值未持锁，与 reader 退出路径的加锁置 nil 竞争（可双启 reader）。判重+赋值全程持 m.mu 写锁。
4. **wsstream `SetAudioInfo`** — writeLoop 运行期无同步懒分配 `audioCh`、写 `audioCodec` 等字段（代码注释自己警告过不得启动后改 entry 字段）。RegisterStream 预分配 `audioCh`（空 channel 与 nil 的 select 阻塞语义等价）；音频配置字段读写统一走 `viewerMu`。

## 顺手修复 CI flake（首个 CI run 失败项，main 上即存在）

`gb28181/sip TestProbeSubChannel_TimeoutSilent`（#564 引入）：`subProbed` 是进程级 memo（"device/channel" → 已探测），测试间共用 `testDeviceID` 且 `-count>1` 时残留 → 二次运行探测被 memo 跳过、INVITE 永不到达。本地 `-count=3` 稳定复现（PASS/FAIL/FAIL）。修复：新增 `resetSubProbeMemo(t)` 辅助，三个探测测试入口处清空 memo；`-count=5` 全过。

## 测试方案（hermetic，遵守 #571）

- onvif：httptest SOAP fake —— raw-SOAP 三鉴权变体（断言鉴权头/密码注入）、DeviceManager 用户 CRUD/网卡/重启、GetUsers 401→PasswordText 回退、EventSubscriber PullPoint 全生命周期（Create/Poll/Renew/Unsubscribe→callback）、HelloListener 构造/panic 恢复/EnrichDevice、ProbeSerial（ProbePorts 重定向）、mocks 表面。
- hls：本地 gortsplib RTSP 假摄像头端到端驱动 readSubStreamH264/H265 至分片落盘（含 first_slice_segment_in_pic_flag 合规 fixture）、编码错配回退、StreamHub 合成帧驱动 SubscribeToHub→writeLoop→Handle playlist、RebindHub 迁移。
- wsstream：真实 gorilla WS 往返驱动 AudioUpstream/drainViewerCh，distributeAudioFrame 手工 viewer 验证分发与慢客户端丢弃。
- flv：ActiveHub/RebindHub + 旧 hub 消费者槽位释放证明。

## 本地验证

- `go test -race ./...`：5362 passed / 64 packages，零 data race
- `golangci-lint run`（触及包）：0 issues
- `gb28181/sip -count=5`：全过（flake 修复验证）