### PR TITLE
test(camera+cmd): ONVIF 客户端族/rediscovery 守卫 + repair 全子命令与 merge-cameras 真库运行体 (#594)

### DIFF
--- a/cmd/mibee-nvr/merge_cameras_extra_test.go
+++ b/cmd/mibee-nvr/merge_cameras_extra_test.go
@@ -1,0 +1,182 @@
+package main
+
+// merge-cameras long tail (#594): flag parsing matrix, runMergeCameras
+// validation + dry-run plan against a real config/DB pair, and the execute-mode
+// helpers (removeCameraFromConfig / applyTargetOverrides / restoreDBFromBackup)
+// exercised directly. The execute path itself is gated on an isPortOpen probe
+// whose result is environment-dependent (transparent proxies), so it is not
+// driven here.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMergeCamerasFlagsMatrix(t *testing.T) {
+	var f mergeCamerasFlags
+	var rc int
+	withArgs([]string{
+		"mibee-nvr", "merge-cameras", "--source", "src", "--target", "dst",
+		"--config", "/tmp/x.yaml", "--execute", "--force",
+		"--target-onvif-endpoint", "http://1.2.3.4/onvif/device_service",
+		"--target-url", "rtsp://1.2.3.4/sub",
+		"--target-disable-timelapse",
+	}, func() {
+		f, rc = parseMergeCamerasFlags()
+	})
+	require.Equal(t, -1, rc)
+	require.Equal(t, "src", f.sourceID)
+	require.Equal(t, "dst", f.targetID)
+	require.Equal(t, "/tmp/x.yaml", f.cfgPath)
+	require.True(t, f.execute)
+	require.False(t, f.dryRun)
+	require.True(t, f.force)
+	require.Equal(t, "http://1.2.3.4/onvif/device_service", f.targetOnvifEndpoint)
+	require.Equal(t, "rtsp://1.2.3.4/sub", f.targetURL)
+	require.True(t, f.targetDisableTimelase)
+
+	// = form + --dry-run resetting execute.
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--source=a", "--target=b", "--dry-run"}, func() {
+		f, rc = parseMergeCamerasFlags()
+	})
+	require.Equal(t, -1, rc)
+	require.Equal(t, "a", f.sourceID)
+	require.Equal(t, "b", f.targetID)
+	require.True(t, f.dryRun)
+	require.False(t, f.execute)
+
+	// Help exits 0.
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--help"}, func() {
+		_, rc = parseMergeCamerasFlags()
+	})
+	require.Equal(t, 0, rc)
+}
+
+// writeMergeConfig writes a valid two-camera config into dir.
+func writeMergeConfig(t *testing.T, dir string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	content := "storage:\n  root_dir: " + dir + "\n  segment_duration: \"30s\"\n" +
+		"cameras:\n" +
+		"  - id: src-cam\n    name: Source\n    protocol: rtsp\n    encoding: h264\n    url: rtsp://127.0.0.1:1/src\n" +
+		"  - id: dst-cam\n    name: Target\n    protocol: rtsp\n    encoding: h264\n    url: rtsp://127.0.0.1:1/dst\n"
+	require.NoError(t, os.WriteFile(cfgPath, []byte(content), 0o644))
+	return cfgPath
+}
+
+func TestRunMergeCamerasValidation(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMergeConfig(t, dir)
+
+	var rc int
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--source", "src-cam"}, func() { rc = runMergeCameras() })
+	require.Equal(t, 1, rc, "--target is required")
+
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--source", "x", "--target", "x", "--config", cfgPath}, func() { rc = runMergeCameras() })
+	require.Equal(t, 1, rc, "source == target must be refused")
+
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--source", "x", "--target", "y", "--config", cfgPath}, func() { rc = runMergeCameras() })
+	require.Equal(t, 1, rc, "unknown source camera must be refused")
+
+	withArgs([]string{"mibee-nvr", "merge-cameras", "--source", "src-cam", "--target", "ghost", "--config", cfgPath}, func() { rc = runMergeCameras() })
+	require.Equal(t, 1, rc, "unknown target camera must be refused")
+
+	withArgs([]string{
+		"mibee-nvr", "merge-cameras", "--source", "src-cam", "--target", "dst-cam",
+		"--config", filepath.Join(dir, "missing.yaml"),
+	}, func() { rc = runMergeCameras() })
+	require.Equal(t, 1, rc, "missing config must be refused")
+}
+
+func TestRunMergeCamerasDryRunPlan(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeMergeConfig(t, dir)
+
+	// One source recording whose file exists on disk.
+	recFile := filepath.Join(dir, "src-cam", "seg.mp4")
+	require.NoError(t, os.MkdirAll(filepath.Dir(recFile), 0o755))
+	require.NoError(t, os.WriteFile(recFile, []byte("seg"), 0o644))
+	rec := &model.Recording{
+		ID: "mr-1", CameraID: "src-cam", FilePath: recFile, Format: model.FormatH264,
+		StartedAt: time.Now().UTC().Add(-time.Minute), EndedAt: time.Now().UTC(),
+		Duration: 30, FileSize: 3, MergeStatus: model.MergeStatusPending,
+	}
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	require.NoError(t, db.InsertRecording(context.Background(), rec))
+	require.NoError(t, db.Close())
+
+	var rc int
+	withArgs([]string{
+		"mibee-nvr", "merge-cameras", "--source", "src-cam", "--target", "dst-cam",
+		"--config", cfgPath, "--target-url", "rtsp://new/target",
+	}, func() { rc = runMergeCameras() })
+	require.Equal(t, 0, rc)
+
+	// Dry run changed nothing: config still has both cameras, DB row still on source, file in place.
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	require.Len(t, cfg.Cameras, 2)
+	require.FileExists(t, recFile)
+
+	db2, err := storage.New(dbPath)
+	require.NoError(t, err)
+	recs, err := db2.ListRecordings(context.Background(), model.RecordingFilter{CameraID: "src-cam", Limit: 10})
+	require.NoError(t, err)
+	require.NoError(t, db2.Close())
+	require.Len(t, recs, 1)
+}
+
+func TestMergeCamerasExecuteHelpers(t *testing.T) {
+	dir := t.TempDir()
+
+	// removeCameraFromConfig drops only the source and preserves the rest.
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{ID: "a"}, {ID: "b"}, {ID: "c"},
+	}}
+	updated := removeCameraFromConfig(cfg, "b")
+	require.Len(t, updated.Cameras, 2)
+	require.Equal(t, "a", updated.Cameras[0].ID)
+	require.Equal(t, "c", updated.Cameras[1].ID)
+	require.Len(t, cfg.Cameras, 3, "source config must not be mutated")
+
+	// applyTargetOverrides: endpoint/url/disabled-timelapse.
+	tl := config.CameraTimelapseConfig{Enabled: true}
+	cfg2 := &config.Config{Cameras: []config.CameraConfig{{
+		ID: "t", ONVIFEndpoint: "old", URL: "old", Timelapse: &tl,
+	}}}
+	applyTargetOverrides(cfg2, "t", mergeCamerasFlags{
+		targetOnvifEndpoint:   "http://new/onvif",
+		targetURL:             "rtsp://new/stream",
+		targetDisableTimelase: true,
+	})
+	require.Equal(t, "http://new/onvif", cfg2.Cameras[0].ONVIFEndpoint)
+	require.Equal(t, "rtsp://new/stream", cfg2.Cameras[0].URL)
+	require.False(t, cfg2.Cameras[0].Timelapse.Enabled)
+
+	// applyTargetOverrides on a missing camera is a no-op.
+	applyTargetOverrides(cfg2, "ghost", mergeCamerasFlags{targetURL: "x"})
+
+	// restoreDBFromBackup copies the backup bytes over the DB path.
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	backupPath := filepath.Join(dir, "backup.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("corrupted"), 0o644))
+	require.NoError(t, os.WriteFile(backupPath, []byte("good-copy"), 0o644))
+	require.NoError(t, restoreDBFromBackup(dbPath, backupPath))
+	got, err := os.ReadFile(dbPath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("good-copy"), got)
+
+	// A missing backup surfaces an error.
+	require.Error(t, restoreDBFromBackup(dbPath, filepath.Join(dir, "nope.db")))
+}

--- a/cmd/mibee-nvr/repair_extra_test.go
+++ b/cmd/mibee-nvr/repair_extra_test.go
@@ -1,0 +1,374 @@
+package main
+
+// Run-body coverage for the repair subcommands (#594): fragments
+// (report/retry/force-delete), delete-by-format (kept/in-flight/AI-protected
+// guards), prune-intermediate-mp4, reclaim-orphan-merges, normalize-endpoints,
+// merge-status execute, the dispatcher, and the pure helpers — all against a
+// real temp SQLite DB seeded through the storage package.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// seedRepairDB opens <dir>/mibee-nvr.db, applies mut (extra SQL per test),
+// inserts the recordings, and closes — leaving the DB on disk for the run
+// function to reopen via openDBFromConfig.
+func seedRepairDB(t *testing.T, dir string, mut func(*sql.DB), recs ...*model.Recording) {
+	t.Helper()
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	ctx := context.Background()
+	for _, r := range recs {
+		require.NoError(t, db.InsertRecording(ctx, r))
+	}
+	if mut != nil {
+		mut(raw)
+	}
+	require.NoError(t, db.Close())
+	require.NoError(t, raw.Close())
+}
+
+func repairRec(id, camID, format, status string, ended time.Time) *model.Recording {
+	return &model.Recording{
+		ID: id, CameraID: camID, FilePath: "", Format: model.Format(format),
+		StartedAt: ended.Add(-time.Minute), EndedAt: ended, Duration: 60, FileSize: 1024,
+		MergeStatus: status,
+	}
+}
+
+func recordingExists(t *testing.T, dbPath, id string) (found bool, mergeStatus string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer raw.Close()
+	err = raw.QueryRow("SELECT COALESCE(merge_status,'') FROM recordings WHERE id=?", id).Scan(&mergeStatus)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, ""
+	}
+	require.NoError(t, err)
+	return true, mergeStatus
+}
+
+func TestRunRepairDispatch(t *testing.T) {
+	var rc int
+	withArgs([]string{"mibee-nvr", "repair"}, func() { rc = runRepair() })
+	require.Equal(t, 1, rc)
+
+	withArgs([]string{"mibee-nvr", "repair", "--help"}, func() { rc = runRepair() })
+	require.Equal(t, 0, rc)
+
+	withArgs([]string{"mibee-nvr", "repair", "bogus-sub"}, func() { rc = runRepair() })
+	require.Equal(t, 1, rc)
+}
+
+func TestRunRepairFragmentsFlows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	// Validation errors before any DB work.
+	var rc int
+	withArgs([]string{"bin", "repair", "fragments", "--status", "pending", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 1, rc, "live merge status must be refused")
+
+	withArgs([]string{"bin", "repair", "fragments", "--retry", "--force-delete", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 1, rc, "--retry + --force-delete are mutually exclusive")
+
+	withArgs([]string{"bin", "repair", "fragments", "--help"}, func() { rc = runRepairFragments() })
+	require.Equal(t, 0, rc)
+
+	// Empty DB → nothing to do.
+	withArgs([]string{"bin", "repair", "fragments", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 0, rc)
+
+	// Seed one incompatible fragment with an on-disk file.
+	fragFile := filepath.Join(dir, "cam1_frag.mp4")
+	require.NoError(t, os.WriteFile(fragFile, []byte("fragment"), 0o644))
+	rec := repairRec("frag-1", "cam1", "h264", model.MergeStatusIncompatible, time.Now().UTC().Add(-time.Hour))
+	rec.FilePath = fragFile
+	seedRepairDB(t, dir, nil, rec)
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+
+	// Dry run → report only, row and file untouched.
+	withArgs([]string{"bin", "repair", "fragments", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 0, rc)
+	found, status := recordingExists(t, dbPath, "frag-1")
+	require.True(t, found)
+	require.Equal(t, model.MergeStatusIncompatible, status)
+	require.FileExists(t, fragFile)
+
+	// Execute + retry → reset to pending.
+	withArgs([]string{"bin", "repair", "fragments", "--retry", "--execute", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 0, rc)
+	found, status = recordingExists(t, dbPath, "frag-1")
+	require.True(t, found)
+	require.Equal(t, model.MergeStatusPending, status)
+	require.FileExists(t, fragFile)
+
+	// Reset back to incompatible, then execute + force-delete → row + file gone.
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = raw.Exec("UPDATE recordings SET merge_status=? WHERE id=?", model.MergeStatusIncompatible, "frag-1")
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+	withArgs([]string{"bin", "repair", "fragments", "--force-delete", "--execute", "--config", cfgPath}, func() { rc = runRepairFragments() })
+	require.Equal(t, 0, rc)
+	found, _ = recordingExists(t, dbPath, "frag-1")
+	require.False(t, found)
+	require.NoFileExists(t, fragFile)
+
+	// Missing config → error.
+	withArgs([]string{"bin", "repair", "fragments", "--config", filepath.Join(dir, "nope.yaml")}, func() { rc = runRepairFragments() })
+	require.Equal(t, 1, rc)
+}
+
+func TestRunRepairDeleteByFormatFlows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	var rc int
+	withArgs([]string{"bin", "repair", "delete-by-format", "--config", cfgPath}, func() { rc = runRepairDeleteByFormat() })
+	require.Equal(t, 1, rc, "--camera is required")
+
+	withArgs([]string{"bin", "repair", "delete-by-format", "--camera", "cam1", "--config", cfgPath}, func() { rc = runRepairDeleteByFormat() })
+	require.Equal(t, 1, rc, "--keep-format is required")
+
+	withArgs([]string{"bin", "repair", "delete-by-format", "--help"}, func() { rc = runRepairDeleteByFormat() })
+	require.Equal(t, 0, rc)
+
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	tlFile := filepath.Join(dir, "keep_tl.mp4")
+	h264File := filepath.Join(dir, "del_h264.mp4")
+	require.NoError(t, os.WriteFile(tlFile, []byte("tl"), 0o644))
+	require.NoError(t, os.WriteFile(h264File, []byte("h264"), 0o644))
+
+	tl := repairRec("rec-tl", "cam1", "timelapse", model.MergeStatusPending, old)
+	tl.FilePath = tlFile
+	del := repairRec("rec-h264", "cam1", "h264", model.MergeStatusPending, old)
+	del.FilePath = h264File
+	inflight := repairRec("rec-inflight", "cam1", "h264", model.MergeStatusPending, time.Time{})
+	fresh := repairRec("rec-fresh", "cam1", "h264", model.MergeStatusPending, time.Now().UTC())
+	protected := repairRec("rec-ai", "cam1", "h264", model.MergeStatusPending, old)
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	seedRepairDB(t, dir, func(raw *sql.DB) {
+		_, err := raw.Exec("UPDATE recordings SET ai_status='processing' WHERE id=?", protected.ID)
+		require.NoError(t, err)
+	}, tl, del, inflight, fresh, protected)
+
+	// Dry run → nothing deleted.
+	withArgs([]string{"bin", "repair", "delete-by-format", "--camera", "cam1", "--keep-format", "timelapse", "--older-than", "24h", "--config", cfgPath}, func() { rc = runRepairDeleteByFormat() })
+	require.Equal(t, 0, rc)
+	for _, id := range []string{"rec-tl", "rec-h264", "rec-inflight", "rec-fresh", "rec-ai"} {
+		found, _ := recordingExists(t, dbPath, id)
+		require.True(t, found, "dry run must not delete %s", id)
+	}
+
+	// Execute → the aged h264 row is deleted; kept / in-flight / fresh /
+	// AI-protected rows survive.
+	withArgs([]string{"bin", "repair", "delete-by-format", "--camera", "cam1", "--keep-format", "timelapse", "--older-than", "24h", "--execute", "--config", cfgPath}, func() { rc = runRepairDeleteByFormat() })
+	require.Equal(t, 0, rc)
+	found, _ := recordingExists(t, dbPath, "rec-h264")
+	require.False(t, found)
+	require.NoFileExists(t, h264File)
+	for _, id := range []string{"rec-tl", "rec-inflight", "rec-fresh", "rec-ai"} {
+		found, _ = recordingExists(t, dbPath, id)
+		require.True(t, found, "%s must survive the delete", id)
+	}
+	require.FileExists(t, tlFile)
+}
+
+func TestRunRepairPruneIntermediateMP4Flows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	var rc int
+	withArgs([]string{"bin", "repair", "prune-intermediate-mp4", "--help"}, func() { rc = runRepairPruneIntermediateMP4() })
+	require.Equal(t, 0, rc)
+
+	withArgs([]string{"bin", "repair", "prune-intermediate-mp4", "--before", "not-a-date", "--config", cfgPath}, func() { rc = runRepairPruneIntermediateMP4() })
+	require.Equal(t, 1, rc)
+
+	// One daily_merged timelapse with a real intermediate file, one plain
+	// merged (must be skipped), one without merge_path (must be skipped).
+	interFile := filepath.Join(dir, "intermediate.mp4")
+	require.NoError(t, os.WriteFile(interFile, []byte("merged-output"), 0o644))
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	daily := repairRec("rec-daily", "cam1", "timelapse", model.MergeStatusDailyMerged, old)
+	plain := repairRec("rec-plain", "cam1", "timelapse", model.MergeStatusMerged, old)
+	noPath := repairRec("rec-nopath", "cam1", "timelapse", model.MergeStatusDailyMerged, old)
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	seedRepairDB(t, dir, func(raw *sql.DB) {
+		_, err := raw.Exec("UPDATE recordings SET merge_path=? WHERE id='rec-daily'", interFile)
+		require.NoError(t, err)
+		_, err = raw.Exec("UPDATE recordings SET merge_path=? WHERE id='rec-plain'", filepath.Join(dir, "plain.mp4"))
+		require.NoError(t, err)
+	}, daily, plain, noPath)
+
+	// Dry run → file kept.
+	withArgs([]string{"bin", "repair", "prune-intermediate-mp4", "--config", cfgPath}, func() { rc = runRepairPruneIntermediateMP4() })
+	require.Equal(t, 0, rc)
+	require.FileExists(t, interFile)
+
+	// Execute → intermediate removed, merge_path cleared, plain/no-path skipped.
+	withArgs([]string{"bin", "repair", "prune-intermediate-mp4", "--execute", "--config", cfgPath}, func() { rc = runRepairPruneIntermediateMP4() })
+	require.Equal(t, 0, rc)
+	require.NoFileExists(t, interFile)
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	var mergePath string
+	require.NoError(t, raw.QueryRow("SELECT COALESCE(merge_path,'') FROM recordings WHERE id='rec-daily'").Scan(&mergePath))
+	require.Equal(t, "", mergePath, "merge_path pointer must be cleared after pruning")
+	var plainPath string
+	require.NoError(t, raw.QueryRow("SELECT COALESCE(merge_path,'') FROM recordings WHERE id='rec-plain'").Scan(&plainPath))
+	require.NotEqual(t, "", plainPath, "non-daily_merged rows are preserved")
+	require.NoError(t, raw.Close())
+}
+
+func TestRunRepairReclaimOrphanMergesFlows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	// Referenced file (via file_path) + an unreferenced orphan in the nested tree.
+	referenced := filepath.Join(dir, "cam1", "202601", "01", "referenced.mp4")
+	orphan := filepath.Join(dir, "cam1", "202601", "02", "orphan.mp4")
+	require.NoError(t, os.MkdirAll(filepath.Dir(referenced), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(orphan), 0o755))
+	require.NoError(t, os.WriteFile(referenced, []byte("ref"), 0o644))
+	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o644))
+
+	rec := repairRec("rec-ref", "cam1", "h264", model.MergeStatusPending, time.Now().UTC().Add(-time.Hour))
+	rec.FilePath = referenced
+	seedRepairDB(t, dir, nil, rec)
+
+	var rc int
+	withArgs([]string{"bin", "repair", "reclaim-orphan-merges", "--help"}, func() { rc = runRepairReclaimOrphanMerges() })
+	require.Equal(t, 0, rc)
+
+	// Dry run → both files intact.
+	withArgs([]string{"bin", "repair", "reclaim-orphan-merges", "--camera", "cam1", "--config", cfgPath}, func() { rc = runRepairReclaimOrphanMerges() })
+	require.Equal(t, 0, rc)
+	require.FileExists(t, referenced)
+	require.FileExists(t, orphan)
+
+	// Execute → only the unreferenced orphan is removed.
+	withArgs([]string{"bin", "repair", "reclaim-orphan-merges", "--camera", "cam1", "--execute", "--config", cfgPath}, func() { rc = runRepairReclaimOrphanMerges() })
+	require.Equal(t, 0, rc)
+	require.FileExists(t, referenced, "referenced merge output must never be reclaimed")
+	require.NoFileExists(t, orphan)
+}
+
+func TestRunRepairNormalizeEndpointsFlows(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	var rc int
+	withArgs([]string{"bin", "repair", "normalize-endpoints", "--help"}, func() { rc = runRepairNormalizeEndpoints() })
+	require.Equal(t, 0, rc)
+
+	withArgs([]string{"bin", "repair", "normalize-endpoints", "--config", filepath.Join(dir, "nope.yaml")}, func() { rc = runRepairNormalizeEndpoints() })
+	require.Equal(t, 1, rc)
+
+	// Seed a camera row with a non-canonical endpoint (default :80 + uppercase
+	// host + trailing slash).
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	require.NoError(t, db.UpsertCamera(context.Background(), "cam1", "Cam One", "onvif", "h264",
+		"http://192.168.1.50:80/onvif/device_service", "", "", "HTTP://192.168.1.50:80/onvif/device_service/", "", "", ""))
+	require.NoError(t, db.Close())
+
+	// Dry run → unchanged.
+	withArgs([]string{"bin", "repair", "normalize-endpoints", "--config", cfgPath}, func() { rc = runRepairNormalizeEndpoints() })
+	require.Equal(t, 0, rc)
+
+	// Execute → endpoint canonicalized.
+	withArgs([]string{"bin", "repair", "normalize-endpoints", "--execute", "--config", cfgPath}, func() { rc = runRepairNormalizeEndpoints() })
+	require.Equal(t, 0, rc)
+
+	db2, err := storage.New(dbPath)
+	require.NoError(t, err)
+	rows, err := db2.ListCameraEndpointsForRepair(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, db2.Close())
+	require.Len(t, rows, 1)
+	require.Equal(t, "http://192.168.1.50/onvif/device_service", rows[0].Endpoint)
+}
+
+func TestRunRepairMergeStatusExecute(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+
+	// A merged recording whose merge_path points nowhere → stale.
+	rec := repairRec("rec-stale", "cam1", "h264", model.MergeStatusMerged, time.Now().UTC().Add(-time.Hour))
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	seedRepairDB(t, dir, func(raw *sql.DB) {
+		_, err := raw.Exec("UPDATE recordings SET merge_path=? WHERE id='rec-stale'", filepath.Join(dir, "missing.mp4"))
+		require.NoError(t, err)
+	}, rec)
+
+	var rc int
+	withArgs([]string{"bin", "repair", "merge-status", "--config", cfgPath}, func() { rc = runRepairMergeStatus() })
+	require.Equal(t, 0, rc)
+	found, status := recordingExists(t, dbPath, "rec-stale")
+	require.True(t, found)
+	require.Equal(t, model.MergeStatusMerged, status, "dry run must not reset")
+
+	withArgs([]string{"bin", "repair", "merge-status", "--execute", "--config", cfgPath}, func() { rc = runRepairMergeStatus() })
+	require.Equal(t, 0, rc)
+	found, status = recordingExists(t, dbPath, "rec-stale")
+	require.True(t, found)
+	require.Equal(t, "", status, "execute must reset the stale merge status to empty (re-merge eligible)")
+}
+
+func TestRepairPureHelpers(t *testing.T) {
+	require.Equal(t, "0 B", humanBytes(0))
+	require.Equal(t, "1.00 KB", humanBytes(1024))
+	require.Equal(t, "1.50 MB", humanBytes(1536*1024))
+	require.Equal(t, "2.00 GB", humanBytes(2*1024*1024*1024))
+
+	require.Equal(t, []string{"a", "b", "c"}, splitCSV("a,b,c"))
+	require.Equal(t, []string{"incompatible"}, splitCSV("incompatible"))
+	require.Empty(t, splitCSV(""))
+
+	require.True(t, hasSuffix("foo.mp4", ".mp4"))
+	require.False(t, hasSuffix("foo.mp4", ".avi"))
+
+	// MJPEG duration estimation: frame_count>0 short-circuits (no dir read);
+	// frame_count=0 counts .jpg files in the directory.
+	dur, err := estimateMJpegDirDuration("no-such-dir", 25)
+	require.NoError(t, err)
+	require.InDelta(t, 25*mjpegNominalFrameInterval, dur, 1e-9)
+
+	mjpegDir := t.TempDir()
+	for i := range 4 {
+		require.NoError(t, os.WriteFile(filepath.Join(mjpegDir, string(rune('a'+i))+".jpg"), []byte("x"), 0o644))
+	}
+	dur, err = estimateMJpegDirDuration(mjpegDir, 0)
+	require.NoError(t, err)
+	require.InDelta(t, 4*mjpegNominalFrameInterval, dur, 1e-9)
+
+	empty := t.TempDir()
+	_, err = estimateMJpegDirDuration(empty, 0)
+	require.Error(t, err, "a directory without jpeg frames is an error")
+	_, err = estimateMJpegDirDuration(filepath.Join(empty, "missing"), 0)
+	require.Error(t, err)
+}

--- a/internal/camera/onvif_client_extra_test.go
+++ b/internal/camera/onvif_client_extra_test.go
@@ -1,0 +1,367 @@
+package camera
+
+// ONVIF client family coverage (#594): the getters (PTZ / imaging / snapshot /
+// device manager), the PullPoint event subscription lifecycle, rediscovery
+// guard paths, and the codec/accessor long tail — all against an in-package
+// SOAP fake so no camera hardware is needed.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/stretchr/testify/require"
+)
+
+// --- in-package SOAP fake (same routing approach as internal/onvif's mock) ---
+
+const camSOAPCaps = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:GetCapabilitiesResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:Capabilities>
+        <tds:Media XAddr="http://127.0.0.1/onvif/media_service"/>
+        <tds:PTZ XAddr="http://127.0.0.1/onvif/ptz_service"/>
+      </tds:Capabilities>
+    </tds:GetCapabilitiesResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPProfiles = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <trt:GetProfilesResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl">
+      <trt:Profiles token="profile_main">
+        <tt:Name xmlns:tt="http://www.onvif.org/ver10/schema">Main</tt:Name>
+        <trt:VideoSourceConfiguration token="vsc_1">
+          <tt:Name xmlns:tt="http://www.onvif.org/ver10/schema">VSC</tt:Name>
+          <tt:SourceToken xmlns:tt="http://www.onvif.org/ver10/schema">VideoSrcToken1</tt:SourceToken>
+        </trt:VideoSourceConfiguration>
+        <trt:VideoEncoderConfiguration token="enc_1">
+          <tt:Encoding xmlns:tt="http://www.onvif.org/ver10/schema">H264</tt:Encoding>
+          <tt:Resolution xmlns:tt="http://www.onvif.org/ver10/schema">
+            <tt:Width>1920</tt:Width><tt:Height>1080</tt:Height>
+          </tt:Resolution>
+        </trt:VideoEncoderConfiguration>
+      </trt:Profiles>
+    </trt:GetProfilesResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPProfilesEmpty = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <trt:GetProfilesResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl">
+    </trt:GetProfilesResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPDeviceInfo = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tds:GetDeviceInformationResponse xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+      <tds:Manufacturer>FakeMfg</tds:Manufacturer>
+      <tds:Model>FC-100</tds:Model>
+      <tds:FirmwareVersion>9.9</tds:FirmwareVersion>
+      <tds:SerialNumber>SN-CAM-1</tds:SerialNumber>
+      <tds:HardwareId>HW1</tds:HardwareId>
+    </tds:GetDeviceInformationResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPSnapshotURI = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <trt:GetSnapshotUriResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl">
+      <trt:MediaUri>
+        <tt:Uri xmlns:tt="http://www.onvif.org/ver10/schema">http://127.0.0.1/snapshot.jpg</tt:Uri>
+      </trt:MediaUri>
+    </trt:GetSnapshotUriResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPCreatePullPoint = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tev:CreatePullPointSubscriptionResponse xmlns:tev="http://www.onvif.org/ver10/events/wsdl">
+      <tev:SubscriptionReference><wsa:Address xmlns:wsa="http://www.w3.org/2005/08/addressing">SUB_REF</wsa:Address></tev:SubscriptionReference>
+      <wsnt:TerminationTime xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2">TERM</wsnt:TerminationTime>
+    </tev:CreatePullPointSubscriptionResponse>
+  </s:Body>
+</s:Envelope>`
+
+const camSOAPFault = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body><s:Fault><s:Code><s:Value>s:Sender</s:Value></s:Code>
+  <s:Reason><s:Text>nope</s:Text></s:Reason></s:Fault></s:Body>
+</s:Envelope>`
+
+// camSOAPFake routes ONVIF SOAP posts by body content. emptyProfiles switches
+// the GetProfiles response; faulting marks every op as a SOAP fault.
+type camSOAPFake struct {
+	mu            sync.Mutex
+	calls         map[string]int
+	emptyProfiles bool
+	faulting      bool
+	srv           *httptest.Server
+}
+
+func newCamSOAPFake(t *testing.T) *camSOAPFake {
+	t.Helper()
+	f := &camSOAPFake{calls: make(map[string]int)}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		b := string(body)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+
+		action := func() string {
+			for _, probe := range []string{
+				"GetCapabilities", "GetProfiles", "GetDeviceInformation",
+				"GetSnapshotUri", "CreatePullPointSubscription", "Unsubscribe", "GetSystemDateAndTime",
+			} {
+				if strings.Contains(b, probe) {
+					return probe
+				}
+			}
+			return "other"
+		}()
+		f.calls[action]++
+
+		if f.faulting {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, camSOAPFault)
+			return
+		}
+		switch action {
+		case "GetCapabilities":
+			fmt.Fprint(w, camSOAPCaps)
+		case "GetProfiles":
+			if f.emptyProfiles {
+				fmt.Fprint(w, camSOAPProfilesEmpty)
+			} else {
+				fmt.Fprint(w, camSOAPProfiles)
+			}
+		case "GetDeviceInformation":
+			fmt.Fprint(w, camSOAPDeviceInfo)
+		case "GetSnapshotUri":
+			fmt.Fprint(w, camSOAPSnapshotURI)
+		case "CreatePullPointSubscription":
+			resp := strings.ReplaceAll(camSOAPCreatePullPoint, "SUB_REF", f.srv.URL+"/sub-1")
+			resp = strings.ReplaceAll(resp, "TERM", time.Now().Add(24*time.Hour).UTC().Format(time.RFC3339))
+			fmt.Fprint(w, resp)
+		case "Unsubscribe":
+			fmt.Fprint(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><wsnt:UnsubscribeResponse xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2"/></s:Body></s:Envelope>`)
+		default:
+			fmt.Fprint(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body/></s:Envelope>`)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *camSOAPFake) callCount(action string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[action]
+}
+
+func (f *camSOAPFake) setEmptyProfiles(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.emptyProfiles = v
+}
+
+func (f *camSOAPFake) setFaulting(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.faulting = v
+}
+
+func (f *camSOAPFake) onvifCamera(id string) config.CameraConfig {
+	return config.CameraConfig{
+		ID: id, Name: id, Protocol: "onvif", Encoding: "h264",
+		ONVIFEndpoint: f.srv.URL + "/onvif/device_service",
+		Username:      "admin", Password: "pw",
+	}
+}
+
+// newCamManagerWith builds a manager whose config contains the given cameras
+// (no recorder assertions — recorders start asynchronously against the fake).
+func newCamManagerWith(t *testing.T, cams []config.CameraConfig) *CameraManager {
+	t.Helper()
+	cfg := testConfig()
+	cfg.Cameras = cams
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+	return cm
+}
+
+func TestONVIFClientGettersHappyPath(t *testing.T) {
+	t.Parallel()
+	fake := newCamSOAPFake(t)
+	cm := newCamManagerWith(t, []config.CameraConfig{fake.onvifCamera("onvif-happy")})
+	ctx := context.Background()
+
+	client, err := cm.GetONVIFClient(ctx, "onvif-happy")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Cached client reused on the second getter call (single Connect).
+	_, err = cm.GetONVIFClient(ctx, "onvif-happy")
+	require.NoError(t, err)
+
+	// Device info fetched once, then served from the cache.
+	info := cm.GetCachedDeviceInfo(ctx, "onvif-happy")
+	require.NotNil(t, info)
+	require.Equal(t, "FakeMfg", info.Manufacturer)
+	require.Equal(t, "SN-CAM-1", info.SerialNumber)
+	require.NotNil(t, cm.GetCachedDeviceInfo(ctx, "onvif-happy"))
+	require.Equal(t, 1, fake.callCount("GetDeviceInformation"))
+
+	ptz, err := cm.GetONVIFPTZController(ctx, "onvif-happy")
+	require.NoError(t, err)
+	require.NotNil(t, ptz)
+
+	img, err := cm.GetImagingController(ctx, "onvif-happy")
+	require.NoError(t, err)
+	require.NotNil(t, img)
+
+	sp, err := cm.GetSnapshotProvider(ctx, "onvif-happy")
+	require.NoError(t, err)
+	require.NotNil(t, sp)
+	uri, err := sp.GetSnapshotUri(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1/snapshot.jpg", uri)
+
+	dm, err := cm.GetDeviceManager(ctx, "onvif-happy")
+	require.NoError(t, err)
+	require.NotNil(t, dm)
+
+	// Closing evicts the cache; the next getter re-connects.
+	cm.CloseONVIFClient("onvif-happy")
+	_, err = cm.GetONVIFClient(ctx, "onvif-happy")
+	require.NoError(t, err)
+}
+
+func TestONVIFGettersNoProfiles(t *testing.T) {
+	t.Parallel()
+	fake := newCamSOAPFake(t)
+	fake.setEmptyProfiles(true)
+	cm := newCamManagerWith(t, []config.CameraConfig{fake.onvifCamera("onvif-empty")})
+	ctx := context.Background()
+
+	for _, fn := range []func() error{
+		func() error { _, err := cm.GetONVIFPTZController(ctx, "onvif-empty"); return err },
+		func() error { _, err := cm.GetImagingController(ctx, "onvif-empty"); return err },
+		func() error { _, err := cm.GetSnapshotProvider(ctx, "onvif-empty"); return err },
+	} {
+		require.Error(t, fn(), "empty profile list must fail the getter")
+	}
+}
+
+func TestSubscribeONVIFEventsLifecycle(t *testing.T) {
+	t.Parallel()
+	fake := newCamSOAPFake(t)
+	cm := newCamManagerWith(t, []config.CameraConfig{fake.onvifCamera("onvif-evt")})
+	ctx := context.Background()
+
+	require.NoError(t, cm.SubscribeONVIFEvents(ctx, "onvif-evt", func(onvif.ONVIFEvent) {}))
+	// Double subscribe is a no-op success; only one PullPoint was created.
+	require.NoError(t, cm.SubscribeONVIFEvents(ctx, "onvif-evt", func(onvif.ONVIFEvent) {}))
+	require.Equal(t, 1, fake.callCount("CreatePullPointSubscription"))
+
+	require.NoError(t, cm.UnsubscribeONVIFEvents(ctx, "onvif-evt"))
+	require.Equal(t, 1, fake.callCount("Unsubscribe"))
+	// Unsubscribing again is a no-op.
+	require.NoError(t, cm.UnsubscribeONVIFEvents(ctx, "onvif-evt"))
+	require.Equal(t, 1, fake.callCount("Unsubscribe"))
+
+	// StopAll drains any remaining subscribers without error.
+	require.NoError(t, cm.SubscribeONVIFEvents(ctx, "onvif-evt", func(onvif.ONVIFEvent) {}))
+	cm.StopAllONVIFEvents(ctx)
+
+	// A faulting device surfaces the subscription error.
+	fake.setFaulting(true)
+	err := cm.SubscribeONVIFEvents(ctx, "onvif-evt", func(onvif.ONVIFEvent) {})
+	require.Error(t, err)
+}
+
+func TestRediscoverAndReconnectGuards(t *testing.T) {
+	t.Parallel()
+	fake := newCamSOAPFake(t)
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		fake.onvifCamera("onvif-redis"),
+		{ID: "rtsp-cam", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/x"},
+	}
+	// Kill the scan before any probe fires: MaxDuration=1ms expires the scan
+	// context immediately → ErrNotFound → (false, nil) without touching the LAN.
+	cfg.Health.Rediscovery.MaxDuration = "1ms"
+	cfg.Health.Rediscovery.ProbeTimeout = "100ms"
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+	ctx := context.Background()
+
+	// Unknown camera.
+	found, err := cm.RediscoverAndReconnect(ctx, "ghost")
+	require.Error(t, err)
+	require.False(t, found)
+
+	// Non-ONVIF protocol → skipped, no error.
+	found, err = cm.RediscoverAndReconnect(ctx, "rtsp-cam")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	// ONVIF but no stable_id → skipped, no error.
+	found, err = cm.RediscoverAndReconnect(ctx, "onvif-redis")
+	require.NoError(t, err)
+	require.False(t, found)
+
+	// ONVIF + stable_id but the scan budget is exhausted → not found, no error.
+	// (StableID set directly under configMu — the field ensureStableID
+	// populates asynchronously in production.)
+	cm.configMu.Lock()
+	for i := range cm.cfg.Cameras {
+		if cm.cfg.Cameras[i].ID == "onvif-redis" {
+			cm.cfg.Cameras[i].StableID = "SN-CAM-1"
+		}
+	}
+	cm.configMu.Unlock()
+	found, err = cm.RediscoverAndReconnect(ctx, "onvif-redis")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, 0, fake.callCount("GetDeviceInformation"), "no probe may leave the process in the guard tests")
+}
+
+func TestAccessorLongtail(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "cam-a", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/a"},
+		{ID: "cam-b", Protocol: "rtsp", Encoding: "h265", URL: "rtsp://127.0.0.1:1/b"},
+	}
+	cm := newCamManagerWith(t, cfg.Cameras)
+
+	require.Equal(t, 2, cm.CameraCount())
+	require.Nil(t, cm.GetTimelapseMergeMgr())
+	require.Nil(t, cm.GetIngestRecorder("cam-a"))
+	require.Nil(t, cm.GetIngestRecorder("ghost"))
+
+	// Codec accessors work off the registered recorder (async reconnect means
+	// the recorder exists even though the URL is dead).
+	require.Equal(t, "", cm.GetSourceCodec("ghost"))
+	require.Equal(t, model.CodecInfo{}, cm.GetCodecInfo("ghost"))
+
+	// Config-backed stream URL for RTSP cameras.
+	require.Equal(t, "rtsp://127.0.0.1:1/a", cm.GetStreamURL("cam-a"))
+	require.Equal(t, "", cm.GetStreamURL("ghost"))
+}


### PR DESCRIPTION
Closes #594

## 覆盖变化

| 包 | 前 | 后 |
|----|----|----|
| internal/camera | 64.4% | **68.4%** |
| cmd/mibee-nvr | 27.1% | **65.8%** |

## 测试内容（全 hermetic，遵守 #571）

- **camera**：包内 SOAP fake（httptest）驱动全部 ONVIF getter 的成功 / 空 profile / fault 路径；PullPoint 事件订阅生命周期（双订阅去重 → Unsubscribe → StopAll → fault 报错）；`RediscoverAndReconnect` 四条守卫路径（`MaxDuration=1ms` 让扫描预算即刻耗尽，断言零探测发出，不触碰局域网地址）；`CameraCount` / `GetIngestRecorder` / `GetTimelapseMergeMgr` / `GetSourceCodec` / `GetCodecInfo` / `GetStreamURL` 长尾。
- **cmd repair**：真 SQLite 临时库（`storage.New` + `InsertRecording` + SQL 回填 `merge_path`/`ai_status`），`withArgs` 注入 os.Args 驱动 run 函数体 —— fragments（报告 / retry 重置 / force-delete 删行删文件）、delete-by-format（kept / 在写 / AI 保护 / 年龄过滤矩阵）、prune-intermediate-mp4（干跑 + 执行 + merge_path 清指针）、reclaim-orphan-merges（引用文件保护）、normalize-endpoints（规范化落库验证）、merge-status execute（陈旧状态重置）；`humanBytes`/`splitCSV`/`hasSuffix`/`estimateMJpegDirDuration` 纯辅助矩阵。
- **cmd merge-cameras**：flag 解析矩阵（空格与 `=` 两种语法）、五条校验错误路径、dry-run 计划（真 config + DB + 磁盘文件，断言零变更）、执行期辅助直测（`removeCameraFromConfig` 不改源配置、`applyTargetOverrides` 全字段、`restoreDBFromBackup` 字节级还原）。execute 主路径被 `isPortOpen` 探针门控且其结果环境相关（透明代理下 127.0.0.1 任意端口可拨通），按既定纪律不驱动、不写环境相关断言。

## 本地验证

- `go test -race ./...`：5379 passed / 64 packages（whip 包曾出现一次 ICE 日志，单独 + `-count=3` race 复跑均绿，不复现）
- `golangci-lint run`（触及包）：0 issues