### PR TITLE
test(api): handler happy-path coverage — ONVIF services / GB28181 media / camera lifecycle / timelapse (#597)

### DIFF
--- a/internal/api/handler_helpers_extra_test.go
+++ b/internal/api/handler_helpers_extra_test.go
@@ -1,0 +1,128 @@
+package api
+
+// Long-tail helper coverage (#596): the ONVIF error-mapper typed branches,
+// the GB28181 cascade status payload, and the pure xiaomi-local /
+// stream-probe helpers — all direct unit calls, no I/O.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestONVIFErrorMappers(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"camera not found", &model.CameraNotFoundError{CameraID: "c"}, http.StatusNotFound},
+		{"not an onvif camera", &model.ONVIFNotCameraError{CameraID: "c"}, http.StatusBadRequest},
+		{"connection error", &model.ONVIFConnectionError{CameraID: "c", Err: errors.New("dial")}, http.StatusBadGateway},
+		{"no profiles", &model.ONVIFNoProfilesError{CameraID: "c"}, http.StatusNotFound},
+		{"generic", errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mappers := map[string]func(http.ResponseWriter, string, error){
+				"ptz":      handleONVIFPTZError,
+				"imaging":  handleONVIFImagingError,
+				"snapshot": handleONVIFSnapshotError,
+			}
+			for name, mapper := range mappers {
+				w := httptest.NewRecorder()
+				mapper(w, "c", tc.err)
+				require.Equal(t, tc.code, w.Code, name)
+			}
+			// The device-mgmt mapper has no ONVIFNoProfilesError branch —
+			// that error surfaces from GetProfiles which it never calls.
+			dmCode := tc.code
+			var noProfiles *model.ONVIFNoProfilesError
+			if errors.As(tc.err, &noProfiles) {
+				dmCode = http.StatusInternalServerError
+			}
+			w := httptest.NewRecorder()
+			handleONVIFDeviceMgmtError(w, "c", tc.err)
+			require.Equal(t, dmCode, w.Code, "device mgmt")
+		})
+	}
+}
+
+type fakeGBCascade struct {
+	online   bool
+	since    time.Duration
+	sinceOk  bool
+	forwards int
+}
+
+func (f *fakeGBCascade) Online() bool                             { return f.online }
+func (f *fakeGBCascade) RegistrationSince() (time.Duration, bool) { return f.since, f.sinceOk }
+func (f *fakeGBCascade) ForwardCount() int                        { return f.forwards }
+
+func TestGBCascadeStatus(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	// Not wired: disabled payload.
+	w := httptest.NewRecorder()
+	h.handleGB28181CascadeStatus(w, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"enabled":false`)
+
+	// Wired + registered.
+	h.SetGB28181Cascade(&fakeGBCascade{online: true, since: 90 * time.Second, sinceOk: true, forwards: 2})
+	w = httptest.NewRecorder()
+	h.handleGB28181CascadeStatus(w, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"online":true`)
+	require.Contains(t, w.Body.String(), `"forwards":2`)
+	require.Contains(t, w.Body.String(), `"registered_for_seconds":90`)
+
+	// Wired but never registered: no duration field.
+	h.SetGB28181Cascade(&fakeGBCascade{})
+	w = httptest.NewRecorder()
+	h.handleGB28181CascadeStatus(w, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), "registered_for_seconds")
+}
+
+func TestXiaomiLocalPurePaths(t *testing.T) {
+	t.Parallel()
+	t.Run("isXiaomiCameraModel", func(t *testing.T) {
+		t.Parallel()
+		require.True(t, isXiaomiCameraModel("isa.camera.hlc8"))
+		require.True(t, isXiaomiCameraModel("lumi.cateye.v1"))
+		require.True(t, isXiaomiCameraModel("roborock.feeder.v1"))
+		require.False(t, isXiaomiCameraModel("isa.airpurifier.v3"))
+	})
+	t.Run("sessionToResult nil", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, sessionToResult(nil))
+	})
+	t.Run("check vendor without config", func(t *testing.T) {
+		t.Parallel()
+		a := &LocalXiaomiAuth{}
+		_, err := a.CheckVendor(context.TODO(), "did-1")
+		require.ErrorContains(t, err, "xiaomi config not available")
+	})
+}
+
+func TestReasonOrOK(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "connection successful", onvifStreamProbe{StreamOK: true}.reasonOrOK())
+	require.Equal(t, "stream accessible (declared codec corrected by RTSP probe)",
+		onvifStreamProbe{StreamOK: true, CodecLie: true}.reasonOrOK())
+	require.Equal(t, "dial refused", onvifStreamProbe{Reason: "dial refused"}.reasonOrOK())
+}

--- a/internal/api/handlers_camera_extra_test.go
+++ b/internal/api/handlers_camera_extra_test.go
@@ -1,0 +1,293 @@
+package api
+
+// Camera lifecycle/CRUD handler coverage (#596): create validation branches,
+// update (incl. stable_id / sub-stream / protocol-combo guards), archive-style
+// delete, ingest start/stop, recording stats, push status, and the manual
+// rediscover guard paths — against a real CameraManager seeded with passive
+// push/GB28181 cameras (no dial-out, no SIP network).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// newCameraAPIEnv wires a Handler + real CameraManager with:
+//   - ingest-cam: srt push camera (passive recorder — safe to start/stop)
+//   - rtsp-cam:   pull camera that is NEVER started (no dial-out)
+func newCameraAPIEnv(t *testing.T) (*Handler, *camera.CameraManager, string) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	cfgPath := filepath.Join(t.TempDir(), "mibee-nvr.yaml")
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{ID: "ingest-cam", Name: "Ingest", Protocol: "srt", Encoding: "h264", StreamKey: "sk-1"},
+		{ID: "rtsp-cam", Name: "Pull", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/stream"},
+	}}
+	cm := camera.NewCameraManager(cfg, store, db, cfgPath)
+
+	ctx := context.Background()
+	require.NoError(t, db.UpsertCamera(ctx, "ingest-cam", "Ingest", "srt", "h264", "", "", "", "", "", "", ""))
+	require.NoError(t, db.UpsertCamera(ctx, "rtsp-cam", "Pull", "rtsp", "h264", "rtsp://127.0.0.1:1/stream", "", "", "", "", "", ""))
+
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+	h.camMgr = cm
+	h.config = cfg
+	h.configPath = cfgPath
+	return h, cm, cfgPath
+}
+
+func camDo(t *testing.T, h *Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *strings.Reader = strings.NewReader("")
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	return w
+}
+
+func TestCameraStartStopLifecycle(t *testing.T) {
+	t.Parallel()
+	h, cm, _ := newCameraAPIEnv(t)
+
+	// Unknown camera: start maps CameraNotFoundError → 404; stop's
+	// "camera not found" is a plain error → 500 (current contract).
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPost, "/api/cameras/nope/start", "").Code)
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h, http.MethodPost, "/api/cameras/nope/stop", "").Code)
+
+	// No manager → 503.
+	h2, _, _ := newCameraAPIEnv(t)
+	h2.camMgr = nil
+	require.Equal(t, http.StatusServiceUnavailable, camDo(t, h2, http.MethodPost, "/api/cameras/ingest-cam/start", "").Code)
+	require.Equal(t, http.StatusServiceUnavailable, camDo(t, h2, http.MethodPost, "/api/cameras/ingest-cam/stop", "").Code)
+
+	// Start → started; second start → 409 already running; stop → stopped.
+	w := camDo(t, h, http.MethodPost, "/api/cameras/ingest-cam/start", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, cm.GetRecorder("ingest-cam"))
+
+	require.Equal(t, http.StatusConflict, camDo(t, h, http.MethodPost, "/api/cameras/ingest-cam/start", "").Code)
+
+	w = camDo(t, h, http.MethodPost, "/api/cameras/ingest-cam/stop", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Nil(t, cm.GetRecorder("ingest-cam"))
+
+	// Stopping a camera with no running recorder is a plain error → 500
+	// (current contract: StopCamera reports "camera not found" without recorder).
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h, http.MethodPost, "/api/cameras/ingest-cam/stop", "").Code)
+}
+
+func TestCameraUpdate(t *testing.T) {
+	t.Parallel()
+	h, cm, cfgPath := newCameraAPIEnv(t)
+
+	w := camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"name":"Renamed"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var row struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &row))
+	require.Equal(t, "Renamed", row.Name)
+
+	// Persisted to config (snapshot + YAML on disk).
+	cam := cm.GetCameraConfig("ingest-cam")
+	require.NotNil(t, cam)
+	require.Equal(t, "Renamed", cam.Name)
+	disk, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	found := false
+	for i := range disk.Cameras {
+		if disk.Cameras[i].ID == "ingest-cam" {
+			require.Equal(t, "Renamed", disk.Cameras[i].Name)
+			found = true
+		}
+	}
+	require.True(t, found, "updated name must survive persistConfig")
+
+	// Ingest field update persists via UpsertCameraIngest.
+	newKey := "sk-2"
+	require.Equal(t, http.StatusOK, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"stream_key":"sk-2"}`).Code)
+	updated := cm.GetCameraConfig("ingest-cam")
+	require.NotNil(t, updated)
+	require.Equal(t, newKey, updated.StreamKey)
+
+	// Validation branches.
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", "not json").Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"sub_stream_url":"http://x"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"stable_id":"1.2.3.4"}`).Code) // IP rejected (#216)
+	// Protocol-combo guard: encoding h265 on an rtmp camera is invalid (#402 class).
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"encoding":"h265","protocol":"rtmp"}`).Code)
+	// Unknown camera → 404.
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPut, "/api/cameras/nope", `{"name":"x"}`).Code)
+}
+
+func TestCameraDeleteArchive(t *testing.T) {
+	t.Parallel()
+	h, cm, _ := newCameraAPIEnv(t)
+
+	// Managed camera → archived via manager (removed from config).
+	w := camDo(t, h, http.MethodDelete, "/api/cameras/ingest-cam", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Nil(t, cm.GetCameraConfig("ingest-cam"))
+	ctx := context.Background()
+	row, err := h.db.GetCamera(ctx, "ingest-cam")
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.True(t, row.Archived)
+
+	// Second delete is idempotent ("archived").
+	require.Equal(t, http.StatusOK, camDo(t, h, http.MethodDelete, "/api/cameras/ingest-cam", "").Code)
+	// Unknown camera → 404.
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodDelete, "/api/cameras/nope", "").Code)
+
+	// Orphaned DB-only camera (not in config) → archived directly in DB.
+	h2, cm2, _ := newCameraAPIEnv(t)
+	require.NoError(t, h2.db.UpsertCamera(ctx, "orphan", "Orphan", "rtsp", "h264", "rtsp://127.0.0.1:1/x", "", "", "", "", "", ""))
+	require.Nil(t, cm2.GetCameraConfig("orphan"))
+	require.Equal(t, http.StatusOK, camDo(t, h2, http.MethodDelete, "/api/cameras/orphan", "").Code)
+	row, err = h2.db.GetCamera(ctx, "orphan")
+	require.NoError(t, err)
+	require.True(t, row.Archived)
+
+	// No manager → DB-only archive path.
+	h3, _, _ := newCameraAPIEnv(t)
+	h3.camMgr = nil
+	require.Equal(t, http.StatusOK, camDo(t, h3, http.MethodDelete, "/api/cameras/rtsp-cam", "").Code)
+	row, err = h3.db.GetCamera(ctx, "rtsp-cam")
+	require.NoError(t, err)
+	require.True(t, row.Archived)
+}
+
+func TestCameraCreateValidation(t *testing.T) {
+	t.Parallel()
+	h, cm, _ := newCameraAPIEnv(t)
+
+	createdID := func(t *testing.T, w *httptest.ResponseRecorder) string {
+		t.Helper()
+		var row struct {
+			ID string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &row), w.Body.String())
+		require.NotEmpty(t, row.ID)
+		return row.ID
+	}
+
+	// Happy paths. srt: passive recorder, safe to auto-start.
+	w := camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"Push","protocol":"srt","stream_key":"sk-new"}`)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	pushID := createdID(t, w)
+	require.NotNil(t, cm.GetCameraConfig(pushID))
+
+	// gb28181 camera with payload (toConfig/toConfigPtr).
+	w = camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"GB","protocol":"gb28181","gb28181":{"device_id":"34020000001310000009","channel_id":"34020000001320000009","manufacturer":"Fake"}}`)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	gbID := createdID(t, w)
+	gbCam := cm.GetCameraConfig(gbID)
+	require.NotNil(t, gbCam)
+	require.Equal(t, "34020000001310000009", gbCam.GB28181.DeviceID)
+	require.Equal(t, "Fake", gbCam.GB28181.Manufacturer)
+
+	// Validation matrix.
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"protocol":"srt"}`).Code)                // no name
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X"}`).Code)                      // no protocol
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"ftp"}`).Code)     // bad protocol
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"gb28181"}`).Code) // GB needs payload
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"rtsp"}`).Code)    // url required
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"rtsp","url":"not a url"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"rtsp","url":"rtsp://127.0.0.1:1/x","sub_stream_url":"http://y"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", `{"name":"X","protocol":"rtsp_h264","url":"rtsp://127.0.0.1:1/x"}`).Code) // combined rejected
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/cameras", "not json").Code)
+
+	// The created srt camera's recorder was started (passive ingest — no
+	// dial-out) and its ingest fields persisted to the DB.
+	require.NotNil(t, cm.GetRecorder(pushID))
+}
+
+func TestCameraRecordingStats(t *testing.T) {
+	t.Parallel()
+	h, _, _ := newCameraAPIEnv(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i := range 2 {
+		require.NoError(t, h.db.InsertRecording(ctx, &model.Recording{
+			ID:        statsRecID(i),
+			CameraID:  "ingest-cam",
+			Format:    "h264",
+			FilePath:  "/tmp/x" + statsRecID(i),
+			StartedAt: now.Add(-time.Duration(i+1) * time.Hour),
+			EndedAt:   now.Add(-time.Duration(i) * time.Hour),
+			FileSize:  int64(100 * (i + 1)),
+		}))
+	}
+
+	w := camDo(t, h, http.MethodGet, "/api/cameras/ingest-cam/stats", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var stats struct {
+		RecordingCount int   `json:"recording_count"`
+		TotalSize      int64 `json:"total_size"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &stats))
+	require.Equal(t, 2, stats.RecordingCount)
+	require.EqualValues(t, 300, stats.TotalSize)
+}
+
+func statsRecID(i int) string { return "stats-rec-" + string(rune('a'+i)) }
+
+func TestCameraPushStatus(t *testing.T) {
+	t.Parallel()
+	h, _, _ := newCameraAPIEnv(t)
+
+	w := camDo(t, h, http.MethodGet, "/api/cameras/ingest-cam/push-status", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		CameraID string        `json:"camera_id"`
+		Targets  []interface{} `json:"targets"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "ingest-cam", resp.CameraID)
+	require.Empty(t, resp.Targets)
+
+	h2, _, _ := newCameraAPIEnv(t)
+	h2.camMgr = nil
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h2, http.MethodGet, "/api/cameras/ingest-cam/push-status", "").Code)
+}
+
+func TestCameraRediscover(t *testing.T) {
+	t.Parallel()
+	h, _, _ := newCameraAPIEnv(t)
+
+	// Unknown camera → 404.
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPost, "/api/cameras/nope/rediscover", "").Code)
+	// No manager → 503.
+	h2, _, _ := newCameraAPIEnv(t)
+	h2.camMgr = nil
+	require.Equal(t, http.StatusServiceUnavailable, camDo(t, h2, http.MethodPost, "/api/cameras/ingest-cam/rediscover", "").Code)
+	// Non-ONVIF camera without stable_id → (false, nil) — 200 found:false, no scan.
+	w := camDo(t, h, http.MethodPost, "/api/cameras/rtsp-cam/rediscover", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Found  bool   `json:"found"`
+		Reason string `json:"reason"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.False(t, resp.Found)
+	require.NotEmpty(t, resp.Reason)
+}

--- a/internal/api/handlers_gb28181_media_test.go
+++ b/internal/api/handlers_gb28181_media_test.go
@@ -1,0 +1,475 @@
+package api
+
+// GB28181 device-media handler coverage (#596): RecordInfo records, playback /
+// download fetch lifecycle, MANSRTSP control, talk intercom WS + status,
+// alarms/positions, and the camera-bound GB PTZ preset CRUD — all against an
+// in-test GB28181DeviceMedia fake plus the real device manager + PTZ
+// controller (no SIP network).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGBMedia implements GB28181DeviceMedia with call flags for assertions.
+type fakeGBMedia struct {
+	mu sync.Mutex
+
+	records    []manscdp.RecordItem
+	queryErr   error
+	queried    bool
+	startErr   error
+	started    bool
+	downloadEr error
+	downloaded bool
+	stopErr    error
+	stopped    bool
+	controlErr error
+	controlled []string
+
+	startTalkErr error
+	stopTalkErr  error
+	talkActive   bool
+	talkWritten  [][]byte
+
+	playback *gb28181.PlaybackInfo
+
+	alarms    []event.GB28181AlarmEvent
+	positions []gb28181.GBPosition
+}
+
+func (f *fakeGBMedia) QueryChannelRecords(_, _ string, _, _ time.Time) ([]manscdp.RecordItem, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.queried = true
+	return f.records, f.queryErr
+}
+
+func (f *fakeGBMedia) StartPlayback(_, _ string, _, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = true
+	return f.startErr
+}
+
+func (f *fakeGBMedia) StartDownload(_, _ string, _, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.downloaded = true
+	return f.downloadEr
+}
+
+func (f *fakeGBMedia) StopPlayback(string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopped = true
+	return f.stopErr
+}
+
+func (f *fakeGBMedia) PlaybackStatusFor(channelID string) (gb28181.PlaybackInfo, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.playback == nil {
+		return gb28181.PlaybackInfo{}, false
+	}
+	return *f.playback, true
+}
+
+func (f *fakeGBMedia) PlaybackControl(_ string, action string, _ float64, _ float64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.controlled = append(f.controlled, action)
+	return f.controlErr
+}
+
+func (f *fakeGBMedia) StartTalk(_, _ string, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startTalkErr != nil {
+		return f.startTalkErr
+	}
+	f.talkActive = true
+	return nil
+}
+
+func (f *fakeGBMedia) StopTalk(string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.talkActive = false
+	return f.stopTalkErr
+}
+
+func (f *fakeGBMedia) WriteTalkAudio(_ string, alaw []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.talkWritten = append(f.talkWritten, append([]byte(nil), alaw...))
+}
+
+func (f *fakeGBMedia) TalkStatusFor(cameraID string) gb28181.TalkStatus {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return gb28181.TalkStatus{Active: f.talkActive, CameraID: cameraID, Packets: int64(len(f.talkWritten))}
+}
+
+func (f *fakeGBMedia) GB28181Alarms(string) []event.GB28181AlarmEvent { return f.alarms }
+
+func (f *fakeGBMedia) GB28181Positions(string) []gb28181.GBPosition { return f.positions }
+
+func (f *fakeGBMedia) wasStarted() bool    { f.mu.Lock(); defer f.mu.Unlock(); return f.started }
+func (f *fakeGBMedia) wasDownloaded() bool { f.mu.Lock(); defer f.mu.Unlock(); return f.downloaded }
+func (f *fakeGBMedia) wasStopped() bool    { f.mu.Lock(); defer f.mu.Unlock(); return f.stopped }
+func (f *fakeGBMedia) talkPackets() [][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][]byte(nil), f.talkWritten...)
+}
+
+func (f *fakeGBMedia) controlledActions() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.controlled...)
+}
+
+const (
+	gbMediaDeviceID        = "34020000001310000001"
+	gbMediaChannelID       = "34020000001320000001"
+	gbMediaZoomOnlyChannel = "34020000001320000002"
+)
+
+// newGBMediaEnv wires a Handler with the media fake, a registered online
+// PTZ-capable device/channel, and a real CameraManager holding a bound
+// gb28181 camera (plus a pan/tilt-only channel bound to a second camera).
+func newGBMediaEnv(t *testing.T) (*Handler, *fakeGBMedia) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	deviceMgr := gb28181.NewDeviceManager(60 * time.Second)
+	sessionMgr := gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), "3402000000")
+	h := NewHandler(db, store, noopAuthMW(), nil, nil, nil, "", nil, nil, nil, deviceMgr, sessionMgr)
+	t.Cleanup(h.Close)
+
+	media := &fakeGBMedia{}
+	h.SetGB28181DeviceMedia(media)
+	// Deterministic timezone for naive device timestamps.
+	h.SetGB28181Timezone(time.UTC)
+
+	dev := &gb28181.Device{ID: gbMediaDeviceID, Name: "Front Gate", NetAddr: "192.168.1.50:5060"}
+	deviceMgr.Register(dev)
+	deviceMgr.RegisterChannel(dev.ID, &gb28181.Channel{ID: gbMediaChannelID, Name: "Ch1", Parental: 1, PTZType: 2})
+	deviceMgr.RegisterChannel(dev.ID, &gb28181.Channel{ID: gbMediaZoomOnlyChannel, Name: "Ch2", Parental: 1, PTZType: 1})
+
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{
+			ID: "gb-cam", Name: "GB Cam", Protocol: "gb28181", Encoding: "h264",
+			GB28181: config.GB28181ChannelConfig{DeviceID: gbMediaDeviceID, ChannelID: gbMediaChannelID},
+		},
+		{
+			ID: "gb-pancam", Name: "Pan Cam", Protocol: "gb28181", Encoding: "h264",
+			GB28181: config.GB28181ChannelConfig{DeviceID: gbMediaDeviceID, ChannelID: gbMediaZoomOnlyChannel},
+		},
+		{ID: "gb-unbound", Name: "Unbound", Protocol: "gb28181", Encoding: "h264"},
+	}}
+	cm := camera.NewCameraManager(cfg, store, db, filepath.Join(t.TempDir(), "cameras.yaml"))
+	h.camMgr = cm
+	h.SetGB28181PTZ(gb28181.NewPTZController(deviceMgr, &fakePTZSender{}))
+
+	ctx := context.Background()
+	require.NoError(t, db.UpsertCamera(ctx, "gb-cam", "GB Cam", "gb28181", "h264", "", "", "", "", "", "", ""))
+	require.NoError(t, db.UpsertCamera(ctx, "gb-pancam", "Pan Cam", "gb28181", "h264", "", "", "", "", "", "", ""))
+	require.NoError(t, db.UpsertCamera(ctx, "gb-unbound", "Unbound", "gb28181", "h264", "", "", "", "", "", "", ""))
+	return h, media
+}
+
+func gbDo(t *testing.T, h *Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *strings.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	} else {
+		rdr = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	return w
+}
+
+func TestGBChannelRecords(t *testing.T) {
+	t.Parallel()
+	h, media := newGBMediaEnv(t)
+
+	media.records = []manscdp.RecordItem{
+		{Name: "rec1", FilePath: "/dvr/1.mp4", StartTime: "2025-06-01T10:00:00", EndTime: "2025-06-01T10:10:00"},
+		{Name: "rec2", StartTime: "2025-06-01 11:00:00", EndTime: "2025-06-01 11:05:00"}, // space separator
+		{Name: "bad", StartTime: "not-a-time", EndTime: "2025-06-01T12:00:00"},           // dropped
+	}
+	w := gbDo(t, h, http.MethodGet, "/api/gb28181/channels/"+gbMediaChannelID+"/records?start=2025-06-01T00:00:00Z&end=2025-06-02T00:00:00Z", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Count   int `json:"count"`
+		Records []struct {
+			Name      string `json:"name"`
+			StartTime string `json:"start_time"`
+		} `json:"records"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 2, resp.Count, "malformed device entries must be dropped, not fatal")
+	require.Equal(t, "2025-06-01T10:00:00Z", resp.Records[0].StartTime, "naive device time interpreted in the configured GB timezone")
+
+	// Validation matrix.
+	base := "/api/gb28181/channels/" + gbMediaChannelID + "/records"
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, base, "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, base+"?start=xx&end=2025-06-02T00:00:00Z", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, base+"?start=2025-06-01T00:00:00Z&end=yy", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, base+"?start=2025-06-02T00:00:00Z&end=2025-06-01T00:00:00Z", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, base+"?start=2025-06-01T00:00:00Z&end=2025-06-20T00:00:00Z", "").Code)
+	// Unknown channel and query failure.
+	require.Equal(t, http.StatusNotFound, gbDo(t, h, http.MethodGet, "/api/gb28181/channels/999/records?start=2025-06-01T00:00:00Z&end=2025-06-02T00:00:00Z", "").Code)
+	media.queryErr = errors.New("device busy")
+	w = gbDo(t, h, http.MethodGet, base+"?start=2025-06-01T00:00:00Z&end=2025-06-02T00:00:00Z", "")
+	require.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func TestGBChannelPlaybackLifecycle(t *testing.T) {
+	t.Parallel()
+	h, media := newGBMediaEnv(t)
+
+	const path = "/api/gb28181/channels/" + gbMediaChannelID + "/playback"
+	const body = `{"start":"2025-06-01T10:00:00Z","end":"2025-06-01T11:00:00Z"}`
+
+	// Start: accepted.
+	require.Equal(t, http.StatusAccepted, gbDo(t, h, http.MethodPost, path, body).Code)
+	require.True(t, media.wasStarted())
+
+	// Start validation/errors.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, "not json").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, `{"start":"xx","end":"2025-06-01T11:00:00Z"}`).Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"2025-06-01T09:00:00Z"}`).Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"2025-06-03T10:00:00Z"}`).Code) // >24h
+	require.Equal(t, http.StatusNotFound, gbDo(t, h, http.MethodPost, "/api/gb28181/channels/999/playback", body).Code)
+	media.startErr = errors.New("invite timeout")
+	require.Equal(t, http.StatusBadGateway, gbDo(t, h, http.MethodPost, path, body).Code)
+	media.startErr = nil
+
+	// Status: idle then active.
+	w := gbDo(t, h, http.MethodGet, path, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var idle struct {
+		Active bool `json:"active"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &idle))
+	require.False(t, idle.Active)
+
+	media.playback = &gb28181.PlaybackInfo{Active: true, Kind: "playback", ChannelID: gbMediaChannelID, Frames: 42, Paused: true, Scale: 2}
+	w = gbDo(t, h, http.MethodGet, path, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var active struct {
+		Active bool    `json:"active"`
+		Frames int64   `json:"frames"`
+		Paused bool    `json:"paused"`
+		Scale  float64 `json:"scale"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &active))
+	require.True(t, active.Active)
+	require.EqualValues(t, 42, active.Frames)
+	require.True(t, active.Paused)
+	require.Equal(t, 2.0, active.Scale)
+
+	// Control: happy + validation + conflict.
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodPost, path+"/control", `{"action":"pause"}`).Code)
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodPost, path+"/control", `{"action":"seek","position":60}`).Code)
+	require.Equal(t, []string{"pause", "seek"}, media.controlledActions())
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path+"/control", "not json").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path+"/control", `{"action":"fastforward"}`).Code)
+	media.controlErr = errors.New("not playing")
+	require.Equal(t, http.StatusConflict, gbDo(t, h, http.MethodPost, path+"/control", `{"action":"resume"}`).Code)
+	media.controlErr = nil
+
+	// Stop: happy + error.
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodDelete, path, "").Code)
+	require.True(t, media.wasStopped())
+	media.stopErr = errors.New("bye failed")
+	require.Equal(t, http.StatusInternalServerError, gbDo(t, h, http.MethodDelete, path, "").Code)
+}
+
+func TestGBChannelDownloadStart(t *testing.T) {
+	t.Parallel()
+	h, media := newGBMediaEnv(t)
+
+	const path = "/api/gb28181/channels/" + gbMediaChannelID + "/download"
+	require.Equal(t, http.StatusAccepted, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"2025-06-05T10:00:00Z"}`).Code)
+	require.True(t, media.wasDownloaded())
+
+	// Downloads span up to 7 days; a 8-day range is refused.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"2025-06-09T10:00:00Z"}`).Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, "not json").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"bad"}`).Code)
+	require.Equal(t, http.StatusNotFound, gbDo(t, h, http.MethodPost, "/api/gb28181/channels/999/download", `{"start":"2025-06-01T10:00:00Z","end":"2025-06-01T11:00:00Z"}`).Code)
+	media.downloadEr = errors.New("device refused")
+	require.Equal(t, http.StatusBadGateway, gbDo(t, h, http.MethodPost, path, `{"start":"2025-06-01T10:00:00Z","end":"2025-06-01T11:00:00Z"}`).Code)
+}
+
+func TestGBTalkStatusAlarmsPositions(t *testing.T) {
+	t.Parallel()
+	h, media := newGBMediaEnv(t)
+
+	media.alarms = []event.GB28181AlarmEvent{{DeviceID: gbMediaDeviceID}}
+	media.positions = []gb28181.GBPosition{{DeviceID: gbMediaDeviceID, Longitude: "116.4", Latitude: "39.9"}}
+
+	w := gbDo(t, h, http.MethodGet, "/api/cameras/gb-cam/gb28181/talk/status", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var talk struct {
+		Active bool `json:"active"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &talk))
+	require.False(t, talk.Active)
+
+	media.mu.Lock()
+	media.talkActive = true
+	media.mu.Unlock()
+	w = gbDo(t, h, http.MethodGet, "/api/cameras/gb-cam/gb28181/talk/status", "")
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &talk))
+	require.True(t, talk.Active)
+
+	w = gbDo(t, h, http.MethodGet, "/api/gb28181/devices/"+gbMediaDeviceID+"/alarms", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotEmpty(t, w.Body.String())
+
+	w = gbDo(t, h, http.MethodGet, "/api/gb28181/devices/"+gbMediaDeviceID+"/positions", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), "116.4")
+
+	// Nil-media defaults (before wiring): talk inactive, empty alarms/positions.
+	h2, _ := newGBMediaEnv(t)
+	h2.gb28181Media = nil
+	w = gbDo(t, h2, http.MethodGet, "/api/cameras/gb-cam/gb28181/talk/status", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"active":false`)
+	require.Equal(t, http.StatusOK, gbDo(t, h2, http.MethodGet, "/api/gb28181/devices/"+gbMediaDeviceID+"/alarms", "").Code)
+	require.Equal(t, http.StatusOK, gbDo(t, h2, http.MethodGet, "/api/gb28181/devices/"+gbMediaDeviceID+"/positions", "").Code)
+}
+
+// TestGBTalkWS drives the intercom WebSocket: binary frames are forwarded as
+// G.711 audio, text frames ignored, and closing the socket BYEs the session.
+func TestGBTalkWS(t *testing.T) {
+	t.Parallel()
+	h, media := newGBMediaEnv(t)
+
+	srv := httptest.NewServer(h.Routes())
+	t.Cleanup(srv.Close)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/cameras/gb-cam/gb28181/talk"
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, []byte{0x01, 0x55, 0x7f}))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("ignored")))
+	require.NoError(t, conn.Close())
+
+	require.Eventually(t, func() bool {
+		pkts := media.talkPackets()
+		return len(pkts) == 1 && pkts[0][0] == 0x01
+	}, 5*time.Second, 50*time.Millisecond, "binary audio frames must reach WriteTalkAudio exactly once")
+
+	// Setup failure before upgrade ⇒ 502 with context.
+	media.mu.Lock()
+	media.startTalkErr = errors.New("invite rejected")
+	media.mu.Unlock()
+	require.Equal(t, http.StatusBadGateway, gbDo(t, h, http.MethodGet, "/api/cameras/gb-cam/gb28181/talk", "").Code)
+
+	// Camera without GB binding ⇒ 400.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, "/api/cameras/gb-unbound/gb28181/talk", "").Code)
+	// Unknown camera (nil config) ⇒ 400.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodGet, "/api/cameras/nope/gb28181/talk", "").Code)
+}
+
+func TestGBPTZPresetsCRUD(t *testing.T) {
+	t.Parallel()
+	h, _ := newGBMediaEnv(t)
+
+	// Create: token allocated from the DB, SET sent best-effort.
+	w := gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets", `{"name":"gate"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var created struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.Equal(t, "1", created.Token)
+
+	// List: the created preset appears.
+	w = gbDo(t, h, http.MethodGet, "/api/cameras/gb-cam/ptz/presets", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var listResp struct {
+		Presets []struct {
+			Token string `json:"token"`
+			Name  string `json:"name"`
+		} `json:"presets"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Presets, 1)
+	require.Equal(t, "gate", listResp.Presets[0].Name)
+
+	// Goto + delete round-trip.
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets/1/goto", "").Code)
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodDelete, "/api/cameras/gb-cam/ptz/presets/1", "").Code)
+	w = gbDo(t, h, http.MethodGet, "/api/cameras/gb-cam/ptz/presets", "")
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResp))
+	require.Empty(t, listResp.Presets)
+
+	// Validation: name required, unbound camera, bad tokens.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets", `{"name":""}`).Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-unbound/ptz/presets", `{"name":"x"}`).Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets/0/goto", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets/256/goto", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/presets/abc/goto", "").Code)
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodDelete, "/api/cameras/gb-cam/ptz/presets/abc", "").Code)
+}
+
+// TestGBPTZMoveDirections: the ONVIF-style continuous-move endpoint maps onto
+// GB direction bits for gb28181 cameras (one axis at a time).
+func TestGBPTZMoveDirections(t *testing.T) {
+	t.Parallel()
+	h, _ := newGBMediaEnv(t)
+
+	move := func(body string) int {
+		return gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/move", body).Code
+	}
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","zoom":0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","zoom":-0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","tilt":0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","tilt":-0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","pan":0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous","pan":-0.5}`))
+	require.Equal(t, http.StatusOK, move(`{"mode":"continuous"}`)) // zero vector ⇒ stop
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodPost, "/api/cameras/gb-cam/ptz/stop", "").Code)
+
+	// Pan/tilt-only channel (PTZType=1): zoom is refused with ErrZoomUnsupported ⇒ 404.
+	require.Equal(t, http.StatusNotFound, gbDo(t, h, http.MethodPost, "/api/cameras/gb-pancam/ptz/move", `{"mode":"continuous","zoom":0.5}`).Code)
+	require.Equal(t, http.StatusOK, gbDo(t, h, http.MethodPost, "/api/cameras/gb-pancam/ptz/move", `{"mode":"continuous","pan":0.5}`).Code)
+
+	// Guards: unbound camera ⇒ 400; no PTZ controller ⇒ 503.
+	require.Equal(t, http.StatusBadRequest, gbDo(t, h, http.MethodPost, "/api/cameras/gb-unbound/ptz/move", `{"mode":"continuous","pan":1}`).Code)
+	h2, _ := newGBMediaEnv(t)
+	h2.gb28181PTZ = nil
+	require.Equal(t, http.StatusServiceUnavailable, gbDo(t, h2, http.MethodPost, "/api/cameras/gb-cam/ptz/move", `{"mode":"continuous","pan":1}`).Code)
+	require.Equal(t, http.StatusServiceUnavailable, gbDo(t, h2, http.MethodPost, "/api/cameras/gb-cam/ptz/stop", "").Code)
+}

--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -702,9 +702,10 @@ func (h *Handler) handleRetryTimelapseMerge(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Fetch the recording from DB.
+	// Fetch the recording from DB. GetRecording returns (nil, nil) for a
+	// missing row (storage convention) — the nil check is not optional.
 	rec, err := h.db.GetRecording(r.Context(), recordingID)
-	if err != nil {
+	if err != nil || rec == nil {
 		WriteError(w, http.StatusNotFound, "recording not found")
 		return
 	}

--- a/internal/api/handlers_timelapse_extra_test.go
+++ b/internal/api/handlers_timelapse_extra_test.go
@@ -1,0 +1,259 @@
+package api
+
+// Timelapse per-camera config GET/PUT, retry-merge lifecycle (#596), and the
+// Handler setter/capabilities long tail. Uses the same RollingMergeManager
+// pattern as handlers_timelapse_test.go but with a minimal fast merger.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCameraTimelapseGetPut(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	h.config = &config.Config{Cameras: []config.CameraConfig{
+		{ID: "cam-a", Name: "A", Protocol: "srt"},
+	}}
+	h.configPath = filepath.Join(t.TempDir(), "cfg.yaml")
+
+	// No timelapse config → documented defaults.
+	w := camDo(t, h, http.MethodGet, "/api/cameras/cam-a/timelapse", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var def struct {
+		Enabled  bool   `json:"enabled"`
+		Interval string `json:"interval"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &def))
+	require.False(t, def.Enabled)
+	require.Equal(t, "30s", def.Interval)
+
+	// PUT: happy path applies defaults to omitted fields and persists.
+	w = camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"enabled":true,"merge_duration":"8h"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var stored *config.CameraTimelapseConfig
+	for i := range h.config.Cameras {
+		if h.config.Cameras[i].ID == "cam-a" {
+			stored = h.config.Cameras[i].Timelapse
+		}
+	}
+	require.NotNil(t, stored)
+	require.True(t, stored.Enabled)
+	require.Equal(t, "30s", stored.Interval, "default interval applied")
+	require.Equal(t, "auto", stored.FrameSource, "default frame_source applied")
+	require.Equal(t, "8h", stored.MergeDuration)
+	// Round-tripped through disk.
+	disk, err := config.Load(h.configPath)
+	require.NoError(t, err)
+	require.Len(t, disk.Cameras, 1)
+	require.NotNil(t, disk.Cameras[0].Timelapse)
+	require.Equal(t, "8h", disk.Cameras[0].Timelapse.MergeDuration)
+
+	// GET now returns the stored config.
+	w = camDo(t, h, http.MethodGet, "/api/cameras/cam-a/timelapse", "")
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &def))
+	require.True(t, def.Enabled)
+
+	// Validation matrix.
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", "not json").Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"interval":"xx"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"interval":"100ms"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"frame_source":"telepathy"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"merge_mode":"magic"}`).Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"merge_output_fps":99}`).Code)
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPut, "/api/cameras/nope/timelapse", `{"enabled":true}`).Code)
+
+	// Legacy camelCase alias mergeDuration still accepted. PUT replaces the
+	// Timelapse pointer, so re-read the current one instead of `stored`.
+	require.Equal(t, http.StatusOK, camDo(t, h, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"enabled":true,"mergeDuration":"24h"}`).Code)
+	fresh := h.config.Cameras[0].Timelapse
+	require.NotNil(t, fresh)
+	require.Equal(t, "24h", fresh.MergeDuration)
+
+	// Guard branches: no config / no config path.
+	h2 := TestHandler(db, store)
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h2, http.MethodGet, "/api/cameras/cam-a/timelapse", "").Code)
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h2, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"enabled":true}`).Code)
+	h2.config = &config.Config{Cameras: []config.CameraConfig{{ID: "cam-a", Protocol: "srt"}}}
+	require.Equal(t, http.StatusInternalServerError, camDo(t, h2, http.MethodPut, "/api/cameras/cam-a/timelapse", `{"enabled":true}`).Code)
+}
+
+// fastFakeMerger satisfies timelapse.TimelapseMerger, writing a tiny output
+// file so RollingMergeManager's post-merge verification passes.
+type fastFakeMerger struct {
+	merged atomic.Int32
+}
+
+func (m *fastFakeMerger) CanMerge() bool            { return true }
+func (m *fastFakeMerger) Tier() timelapse.MergeTier { return timelapse.TierGo }
+func (m *fastFakeMerger) Merge(_ context.Context, _, outputPath string, _ int) (*timelapse.MergeResult, error) {
+	m.merged.Add(1)
+	if err := os.WriteFile(outputPath, []byte("fake"), 0o644); err != nil {
+		return nil, err
+	}
+	return &timelapse.MergeResult{}, nil
+}
+
+func TestRetryTimelapseMerge(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	// No manager → 503.
+	require.Equal(t, http.StatusServiceUnavailable, camDo(t, h, http.MethodPost, "/api/recordings/r1/retry-merge", "").Code)
+
+	merger := &fastFakeMerger{}
+	h.SetTimelapseMergeMgr(timelapse.NewRollingMergeManager(merger, db, 10, false))
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	seed := func(id, format, mergeStatus, filePath string) {
+		require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+			ID: id, CameraID: "cam-a", Format: model.Format(format), FilePath: filePath,
+			StartedAt: now.Add(-time.Hour), EndedAt: now, MergeStatus: mergeStatus,
+		}))
+	}
+
+	// Guard branches.
+	seed("r404", "h264", "completed", "/tmp/x")
+	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPost, "/api/recordings/missing/retry-merge", "").Code)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/recordings/r404/retry-merge", "").Code, "non-timelapse")
+	seed("r-state", "timelapse", "completed", "/tmp/y")
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/recordings/r-state/retry-merge", "").Code, "not retryable state")
+	seed("r-nodir", "timelapse", "failed", "")
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPost, "/api/recordings/r-nodir/retry-merge", "").Code, "no frame dir")
+
+	// Happy: 202 + merge actually starts (observable via the fake merger).
+	frameDir := filepath.Join(t.TempDir(), "frames")
+	require.NoError(t, os.MkdirAll(frameDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(frameDir, "frame_001.jpg"), []byte("x"), 0o644))
+	seed("r-ok", "timelapse", "failed", frameDir)
+
+	w := camDo(t, h, http.MethodPost, "/api/recordings/r-ok/retry-merge", "")
+	require.Equal(t, http.StatusAccepted, w.Code)
+	var resp struct {
+		Status   string `json:"status"`
+		FrameDir string `json:"frame_dir"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "merge_initiated", resp.Status)
+	require.Equal(t, frameDir, resp.FrameDir)
+
+	require.Eventually(t, func() bool { return merger.merged.Load() == 1 },
+		10*time.Second, 50*time.Millisecond, "rolling merge must run for the retried recording")
+}
+
+func TestFormatOffset(t *testing.T) {
+	t.Parallel()
+	cases := map[int]string{
+		0:          "+0",
+		3600:       "+1",
+		-3600:      "-1",
+		19800:      "+5:30",
+		-12600:     "-3:30",
+		-3600 * 10: "-10",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, formatOffset(in), "input %d", in)
+	}
+}
+
+func TestHandlerSettersNoPanic(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	// Every dependency setter accepts its nil zero value without panicking —
+	// guards the "optional manager" branches across the handler surface.
+	h.SetHealthManager(nil)
+	h.SetStabilityProvider(nil)
+	h.SetDownloader(nil)
+	h.SetRollingMergeMgr(nil)
+	h.SetWHIPServer(nil)
+	h.SetGB28181Cascade(nil)
+	h.SetGB28181Timezone(nil)
+	h.SetGB28181Inviter(nil)
+	h.SetGB28181DeviceMedia(nil)
+	h.SetTranscodeManager(nil)
+	SetUpdateChecker(nil)
+}
+
+func TestCapabilitiesEndpoint(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	rtmpOn := true
+	h.config = &config.Config{
+		Server: config.ServerConfig{Listen: ":9090"},
+		RTMP:   config.RTMPConfig{Enabled: &rtmpOn, Port: 1935},
+		SRT:    config.SRTConfig{Port: 9000},
+	}
+
+	w := camDo(t, h, http.MethodGet, "/api/capabilities", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var caps struct {
+		Ingest struct {
+			RTMP struct {
+				Enabled bool `json:"enabled"`
+				Port    int  `json:"port"`
+			} `json:"rtmp"`
+			SRT struct {
+				Enabled bool `json:"enabled"`
+				Port    int  `json:"port"`
+			} `json:"srt"`
+			WHIP struct {
+				Enabled bool `json:"enabled"`
+				Port    int  `json:"port"`
+			} `json:"whip"`
+		} `json:"ingest"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &caps))
+	require.True(t, caps.Ingest.RTMP.Enabled)
+	require.Equal(t, 1935, caps.Ingest.RTMP.Port)
+	require.False(t, caps.Ingest.SRT.Enabled, "nil SRT enabled flag ⇒ disabled")
+	require.Equal(t, 9000, caps.Ingest.SRT.Port)
+	require.False(t, caps.Ingest.WHIP.Enabled, "no WHIP server wired ⇒ disabled")
+	require.Equal(t, 9090, caps.Ingest.WHIP.Port, "WHIP port mirrors the HTTP listener")
+}
+
+func TestRelayCapabilities(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+
+	w := camDo(t, h, http.MethodGet, "/api/relay/capabilities", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var caps struct {
+		FFmpegRelaySupported bool `json:"ffmpeg_relay_supported"`
+		FFmpegAvailable      bool `json:"ffmpeg_available"`
+		MaxTargetsPerCamera  int  `json:"max_targets_per_camera"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &caps))
+	require.True(t, caps.FFmpegRelaySupported)
+	require.False(t, caps.FFmpegAvailable, "no relay manager wired ⇒ ffmpeg unavailable")
+	require.Equal(t, 10, caps.MaxTargetsPerCamera)
+}

--- a/internal/api/onvif_services_extra_test.go
+++ b/internal/api/onvif_services_extra_test.go
@@ -1,0 +1,460 @@
+package api
+
+// ONVIF services happy-path coverage (#596): PTZ move/status/presets, imaging,
+// device management (reboot/network/users), snapshot URI, profiles and
+// capabilities — driven through a REAL camera.CameraManager whose ONVIF client
+// connects to an in-test SOAP fake. onvif_services_test.go covers only the
+// no-manager / not-found / non-ONVIF error branches; this file exercises the
+// full request → SOAP → response chain hermetically (no camera hardware).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SOAP fake (fixtures adapted from the proven internal/onvif test set) ---
+
+const (
+	apiPTZNS    = "http://www.onvif.org/ver20/ptz/wsdl"
+	apiImgNS    = "http://www.onvif.org/ver20/imaging/wsdl"
+	apiDeviceNS = "http://www.onvif.org/ver10/device/wsdl"
+	apiSchemaNS = "http://www.onvif.org/ver10/schema"
+)
+
+func apiEnvelope(body string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Header/>
+  <s:Body>` + body + `</s:Body>
+</s:Envelope>`
+}
+
+func apiOpResponse(ns, action string) string {
+	var prefix string
+	switch ns {
+	case apiPTZNS:
+		prefix = "tptz"
+	case apiImgNS:
+		prefix = "timg"
+	default:
+		prefix = "tds"
+	}
+	return apiEnvelope(fmt.Sprintf(`<%s:%sResponse xmlns:%s="%s"/>`, prefix, action, prefix, ns))
+}
+
+// apiSOAPFake routes every ONVIF SOAP POST by request-body probe and counts
+// calls. faults marks actions to answer with HTTP 400 + a SOAP Fault body
+// (device-rejected shape used by the fault-tolerant handler branches).
+type apiSOAPFake struct {
+	mu     sync.Mutex
+	calls  map[string]int
+	faults map[string]bool
+	srv    *httptest.Server
+}
+
+func newAPISOAPFake(t *testing.T) *apiSOAPFake {
+	t.Helper()
+	f := &apiSOAPFake{calls: make(map[string]int), faults: make(map[string]bool)}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		b := string(body)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+
+		action := ""
+		for _, probe := range []string{
+			"GetSystemDateAndTime", "GetCapabilities", "GetProfiles", "GetDeviceInformation",
+			"GetSnapshotUri", "ContinuousMove", "AbsoluteMove", "RelativeMove", ":Stop",
+			"GetStatus", "GetPresets", "SetPreset", "GotoPreset", "RemovePreset",
+			"GetImagingSettings", "SetImagingSettings", "GetOptions",
+			"SystemReboot", "GetNetworkInterfaces", "SetNetworkInterfaces",
+			"GetUsers", "CreateUsers", "DeleteUsers", "SetUser",
+		} {
+			if strings.Contains(b, probe) {
+				action = strings.TrimPrefix(probe, ":")
+				break
+			}
+		}
+		if action == "" {
+			action = "other"
+		}
+		f.calls[action]++
+
+		if f.faults[action] {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `<?xml version="1.0"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><s:Fault><s:Reason><s:Text>operation not supported</s:Text></s:Reason></s:Fault></s:Body></s:Envelope>`)
+			return
+		}
+
+		switch action {
+		case "GetCapabilities":
+			// XAddrs point back at this fake so PTZ/imaging ops route here too.
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<tds:GetCapabilitiesResponse xmlns:tds="%s"><tds:Capabilities>
+<tds:Media XAddr="%s/onvif/media_service"/><tds:PTZ XAddr="%s/onvif/ptz_service"/>
+</tds:Capabilities></tds:GetCapabilitiesResponse></s:Body></s:Envelope>`,
+				apiDeviceNS, f.srv.URL, f.srv.URL)
+		case "GetProfiles":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<trt:GetProfilesResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl">
+<trt:Profiles token="profile_main">
+<tt:Name xmlns:tt="%s">Main</tt:Name>
+<trt:VideoSourceConfiguration token="vsc_1"><tt:SourceToken xmlns:tt="%s">VideoSrcToken1</tt:SourceToken></trt:VideoSourceConfiguration>
+<trt:VideoEncoderConfiguration token="enc_1"><tt:Encoding xmlns:tt="%s">H264</tt:Encoding></trt:VideoEncoderConfiguration>
+</trt:Profiles></trt:GetProfilesResponse></s:Body></s:Envelope>`,
+				apiSchemaNS, apiSchemaNS, apiSchemaNS)
+		case "GetDeviceInformation":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<tds:GetDeviceInformationResponse xmlns:tds="%s">
+<tds:Manufacturer>FakeMfg</tds:Manufacturer><tds:Model>FC-100</tds:Model>
+<tds:FirmwareVersion>9.9</tds:FirmwareVersion><tds:SerialNumber>SN-1</tds:SerialNumber>
+</tds:GetDeviceInformationResponse></s:Body></s:Envelope>`, apiDeviceNS)
+		case "GetSnapshotUri":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<trt:GetSnapshotUriResponse xmlns:trt="http://www.onvif.org/ver10/media/wsdl"><trt:MediaUri>
+<tt:Uri xmlns:tt="%s">http://127.0.0.1/snapshot.jpg</tt:Uri></trt:MediaUri>
+</trt:GetSnapshotUriResponse></s:Body></s:Envelope>`, apiSchemaNS)
+		case "GetStatus":
+			fmt.Fprintf(w, apiEnvelope(`<tptz:GetStatusResponse xmlns:tptz="%s">
+<tptz:PTZStatus><tt:Position xmlns:tt="%s"><tt:PanTilt x="0.25" y="-0.5"/><tt:Zoom x="1.5"/></tt:Position>
+<tt:MoveStatus xmlns:tt="%s"><tt:PanTilt>MOVING</tt:PanTilt><tt:Zoom>IDLE</tt:Zoom></tt:MoveStatus>
+<tt:UtcTime xmlns:tt="%s">2025-01-01T00:00:00Z</tt:UtcTime></tptz:PTZStatus>
+</tptz:GetStatusResponse>`), apiPTZNS, apiSchemaNS, apiSchemaNS, apiSchemaNS)
+		case "GetPresets":
+			fmt.Fprintf(w, apiEnvelope(`<tptz:GetPresetsResponse xmlns:tptz="%s">
+<Preset token="1"><Name>Home</Name><PTZPosition xmlns:tt="%s"><tt:PanTilt x="0" y="0"/><tt:Zoom x="0"/></PTZPosition></Preset>
+<Preset token="2"><Name>Gate</Name><PTZPosition xmlns:tt="%s"><tt:PanTilt x="0.5" y="0"/><tt:Zoom x="0"/></PTZPosition></Preset>
+</tptz:GetPresetsResponse>`), apiPTZNS, apiSchemaNS, apiSchemaNS)
+		case "SetPreset":
+			fmt.Fprintf(w, apiEnvelope(`<tptz:SetPresetResponse xmlns:tptz="%s"><tptz:PresetToken>7</tptz:PresetToken></tptz:SetPresetResponse>`), apiPTZNS)
+		case "GetImagingSettings":
+			fmt.Fprintf(w, apiEnvelope(`<timg:GetImagingSettingsResponse xmlns:timg="%s">
+<timg:ImagingSettings xmlns:tt="%s"><tt:Brightness>0.5</tt:Brightness><tt:ColorSaturation>0.4</tt:ColorSaturation>
+<tt:Contrast>0.3</tt:Contrast><tt:Sharpness>0.2</tt:Sharpness></timg:ImagingSettings>
+</timg:GetImagingSettingsResponse>`), apiImgNS, apiSchemaNS)
+		case "GetOptions":
+			fmt.Fprintf(w, apiEnvelope(`<timg:GetOptionsResponse xmlns:timg="%s">
+<timg:ImagingOptions xmlns:tt="%s"><tt:Brightness><tt:Min>0</tt:Min><tt:Max>1</tt:Max></tt:Brightness>
+<tt:Contrast><tt:Min>0</tt:Min><tt:Max>1</tt:Max></tt:Contrast></timg:ImagingOptions>
+</timg:GetOptionsResponse>`), apiImgNS, apiSchemaNS)
+		case "GetUsers":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<tds:GetUsersResponse xmlns:tds="%s">
+<tds:User><tt:Username>admin</tt:Username><tt:UserLevel>Administrator</tt:UserLevel></tds:User>
+<tds:User><tt:Username>operator</tt:Username><tt:UserLevel>Operator</tt:UserLevel></tds:User>
+</tds:GetUsersResponse></s:Body></s:Envelope>`, apiDeviceNS)
+		case "GetNetworkInterfaces":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<tds:GetNetworkInterfacesResponse xmlns:tds="%s"><tds:NetworkInterfaces token="eth0">
+<tt:Enabled>true</tt:Enabled><tt:Info><tt:Name>eth0</tt:Name></tt:Info>
+<tt:IPv4><tt:Enabled>true</tt:Enabled><tt:Config><tt:DHCP>false</tt:DHCP>
+<tt:Manual><tt:Address>192.168.1.100</tt:Address><tt:PrefixLength>24</tt:PrefixLength></tt:Manual></tt:Config></tt:IPv4>
+</tds:NetworkInterfaces></tds:GetNetworkInterfacesResponse></s:Body></s:Envelope>`, apiDeviceNS)
+		case "SystemReboot":
+			fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body>
+<tds:SystemRebootResponse xmlns:tds="%s"><tds:Message>Rebooting now</tds:Message>
+</tds:SystemRebootResponse></s:Body></s:Envelope>`, apiDeviceNS)
+		case "ContinuousMove", "AbsoluteMove", "RelativeMove", "Stop",
+			"GotoPreset", "RemovePreset", "SetImagingSettings",
+			"SetNetworkInterfaces", "CreateUsers", "DeleteUsers", "SetUser":
+			fmt.Fprint(w, apiOpResponse(pickNS(action), action))
+		default:
+			fmt.Fprint(w, apiEnvelope(""))
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func pickNS(action string) string {
+	switch action {
+	case "ContinuousMove", "AbsoluteMove", "RelativeMove", "Stop", "GotoPreset", "RemovePreset":
+		return apiPTZNS
+	case "SetImagingSettings":
+		return apiImgNS
+	default:
+		return apiDeviceNS
+	}
+}
+
+func (f *apiSOAPFake) callCount(action string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[action]
+}
+
+func (f *apiSOAPFake) setFault(action string, on bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.faults[action] = on
+}
+
+// apiONVIFEnv wires a Handler + real CameraManager against the SOAP fake.
+type apiONVIFEnv struct {
+	fake *apiSOAPFake
+	h    *Handler
+}
+
+func newAPIONVIFEnv(t *testing.T) (*apiONVIFEnv, *camera.CameraManager) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	f := newAPISOAPFake(t)
+
+	endpoint := f.srv.URL + "/onvif/device_service"
+	cfg := &config.Config{Cameras: []config.CameraConfig{{
+		ID:            "onvif-cam",
+		Name:          "Fake ONVIF",
+		Protocol:      "onvif",
+		Encoding:      "h264",
+		ONVIFEndpoint: endpoint,
+		Username:      "admin",
+		Password:      "pw",
+	}}}
+	cm := camera.NewCameraManager(cfg, store, db, filepath.Join(t.TempDir(), "cameras.yaml"))
+	require.NoError(t, db.UpsertCamera(context.Background(), "onvif-cam", "Fake ONVIF", "onvif", "h264", "", "admin", "pw", endpoint, "", "", ""))
+
+	h := TestHandler(db, store)
+	t.Cleanup(h.Close)
+	h.camMgr = cm
+	return &apiONVIFEnv{fake: f, h: h}, cm
+}
+
+func (e *apiONVIFEnv) do(t *testing.T, method, path string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	e.h.Routes().ServeHTTP(w, req)
+	return w
+}
+
+func TestAPIONVIFProfilesAndCapabilities(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/onvif/profiles", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var profilesResp struct {
+		Profiles []struct {
+			Token string `json:"token"`
+		} `json:"profiles"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &profilesResp))
+	require.Len(t, profilesResp.Profiles, 1)
+	require.Equal(t, "profile_main", profilesResp.Profiles[0].Token)
+
+	w = env.do(t, http.MethodGet, "/api/cameras/onvif-cam/onvif/capabilities", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var capsResp struct {
+		DeviceInfo struct {
+			SerialNumber string `json:"serial_number"`
+		} `json:"device_info"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &capsResp))
+	require.Equal(t, "SN-1", capsResp.DeviceInfo.SerialNumber, "cached device info must be attached")
+}
+
+func TestAPIONVIFPTZMoveStopStatus(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	for _, mode := range []string{"continuous", "absolute", "relative"} {
+		w := env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/move", `{"mode":"`+mode+`","pan":0.5,"tilt":-0.2,"zoom":0.1}`)
+		require.Equal(t, http.StatusOK, w.Code, mode)
+		require.Equal(t, 1, env.fake.callCount(map[string]string{
+			"continuous": "ContinuousMove", "absolute": "AbsoluteMove", "relative": "RelativeMove",
+		}[mode]))
+	}
+	// Validation: bad body / bad mode.
+	require.Equal(t, http.StatusBadRequest, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/move", "not json").Code)
+	require.Equal(t, http.StatusBadRequest, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/move", `{"mode":"warp"}`).Code)
+
+	w := env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/stop", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, env.fake.callCount("Stop"))
+
+	// Status: position mirrored from the fixture; MOVING pan/tilt ⇒ moving=true.
+	w = env.do(t, http.MethodGet, "/api/cameras/onvif-cam/ptz/status", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var st struct {
+		Pan    float64 `json:"pan"`
+		Tilt   float64 `json:"tilt"`
+		Zoom   float64 `json:"zoom"`
+		Moving bool    `json:"moving"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &st))
+	require.InDelta(t, 0.25, st.Pan, 1e-9)
+	require.InDelta(t, -0.5, st.Tilt, 1e-9)
+	require.InDelta(t, 1.5, st.Zoom, 1e-9)
+	require.True(t, st.Moving)
+}
+
+// TestAPIONVIFPTZStatusFaultTolerance: a device that advertises PTZ but has no
+// PTZ node answers GetStatus with 400 + Fault — the handler must return a
+// default idle status, not a 500.
+func TestAPIONVIFPTZStatusFaultTolerance(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+	env.fake.setFault("GetStatus", true)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/ptz/status", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var st struct {
+		Moving bool `json:"moving"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &st))
+	require.False(t, st.Moving)
+}
+
+func TestAPIONVIFPTZPresets(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/ptz/presets", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var presetsResp struct {
+		Presets []struct {
+			Token string `json:"token"`
+			Name  string `json:"name"`
+		} `json:"presets"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &presetsResp))
+	require.Len(t, presetsResp.Presets, 2)
+	require.Equal(t, "Home", presetsResp.Presets[0].Name)
+
+	w = env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/presets", `{"name":"porch"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	var created struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &created))
+	require.Equal(t, "7", created.Token)
+	// Validation: name required.
+	require.Equal(t, http.StatusBadRequest, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/presets", `{"name":""}`).Code)
+
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/presets/7/goto", "").Code)
+	require.Equal(t, 1, env.fake.callCount("GotoPreset"))
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodDelete, "/api/cameras/onvif-cam/ptz/presets/7", "").Code)
+	require.Equal(t, 1, env.fake.callCount("RemovePreset"))
+
+	// Device-rejected SetPreset ⇒ 500 with the operation-specific message.
+	env.fake.setFault("SetPreset", true)
+	require.Equal(t, http.StatusInternalServerError, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/ptz/presets", `{"name":"x"}`).Code)
+}
+
+func TestAPIONVIFSnapshotUri(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/snapshot/uri", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		URI string `json:"uri"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "http://127.0.0.1/snapshot.jpg", resp.URI)
+
+	// Limited devices: GetSnapshotUri answered with a Fault ⇒ 404 "not supported".
+	env.fake.setFault("GetSnapshotUri", true)
+	require.Equal(t, http.StatusNotFound, env.do(t, http.MethodGet, "/api/cameras/onvif-cam/snapshot/uri", "").Code)
+}
+
+func TestAPIONVIFImaging(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/imaging/settings", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var settings struct {
+		Brightness float64 `json:"brightness"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &settings))
+	require.InDelta(t, 0.5, settings.Brightness, 1e-9)
+
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodPut, "/api/cameras/onvif-cam/imaging/settings", `{"brightness":0.7,"contrast":0.2}`).Code)
+	require.Equal(t, 1, env.fake.callCount("SetImagingSettings"))
+
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodGet, "/api/cameras/onvif-cam/imaging/options", "").Code)
+
+	// Device failure surfaces as 502 Bad Gateway.
+	env.fake.setFault("GetImagingSettings", true)
+	require.Equal(t, http.StatusBadGateway, env.do(t, http.MethodGet, "/api/cameras/onvif-cam/imaging/settings", "").Code)
+}
+
+func TestAPIONVIFDeviceManagement(t *testing.T) {
+	t.Parallel()
+	env, _ := newAPIONVIFEnv(t)
+
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/onvif/reboot", "").Code)
+
+	w := env.do(t, http.MethodGet, "/api/cameras/onvif-cam/onvif/network", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var netResp struct {
+		Interfaces []struct {
+			Name string `json:"name"`
+		} `json:"interfaces"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &netResp))
+	require.Len(t, netResp.Interfaces, 1)
+	require.Equal(t, "eth0", netResp.Interfaces[0].Name)
+
+	// SetNetworkInterfaces is a stub that always reports ErrUnsupported on
+	// this onvif-go version — the handler must surface 501, not a 500/502.
+	require.Equal(t, http.StatusNotImplemented, env.do(t, http.MethodPut, "/api/cameras/onvif-cam/onvif/network", `{"interfaces":[{"name":"eth0","enabled":true}]}`).Code)
+
+	w = env.do(t, http.MethodGet, "/api/cameras/onvif-cam/onvif/users", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	var usersResp struct {
+		Users []struct {
+			Username string `json:"username"`
+		} `json:"users"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &usersResp))
+	require.Len(t, usersResp.Users, 2)
+
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/onvif/users", `{"users":[{"username":"newuser","level":"User"}]}`).Code)
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodDelete, "/api/cameras/onvif-cam/onvif/users", `{"usernames":["newuser"]}`).Code)
+	require.Equal(t, http.StatusOK, env.do(t, http.MethodPut, "/api/cameras/onvif-cam/onvif/users/admin", `{"password":"np"}`).Code)
+
+	// Device-side reboot failure ⇒ 502 with context.
+	env.fake.setFault("SystemReboot", true)
+	require.Equal(t, http.StatusBadGateway, env.do(t, http.MethodPost, "/api/cameras/onvif-cam/onvif/reboot", "").Code)
+}
+
+// TestAPIONVIFConnectionError: with the device gone, the client connect fails
+// and the handlers map ONVIFConnectionError to 502 Bad Gateway.
+func TestAPIONVIFConnectionError(t *testing.T) {
+	t.Parallel()
+	env, cm := newAPIONVIFEnv(t)
+	cm.CloseONVIFClient("onvif-cam")
+	env.fake.srv.Close()
+
+	require.Equal(t, http.StatusBadGateway, env.do(t, http.MethodGet, "/api/cameras/onvif-cam/ptz/status", "").Code)
+}


### PR DESCRIPTION
Closes #597

## 内容
api 是全仓语句加权缺口第一（2533 句 / 60.3%），本 PR 补齐五大簇 happy path（+约 415 句，→ 69.0%）：

| 簇 | 新测试 | 手段 |
|---|---|---|
| ONVIF services（PTZ/imaging/设备管理/snapshot/profiles/capabilities） | 8 | 真 `camera.CameraManager` + 进程内 SOAP fake（XAddr 指回 fake，走完整 onvif-go 客户端链） |
| GB28181 media（records/playback/download/control/talk WS/alarms/positions/预置位 CRUD/方向映射） | 7 | `GB28181DeviceMedia` fake + 真 DeviceManager/PTZController |
| camera lifecycle（create 校验矩阵/update/delete-archive/启停/stats/push-status/rediscover 守卫） | 7 | srt/gb28181 被动录像器（无拨号外联） |
| timelapse（per-camera GET/PUT + retry-merge 全链） | 2 | 最小 fake merger + 真库 |
| 零散（error-mapper typed 分支/cascade status/capabilities/formatOffset/纯 helper） | 4 | 直接单元调用 |

## 生产修复
`handleRetryTimelapseMerge`：`GetRecording` 缺行返回 `(nil, nil)`（存储层约定），handler 只查 `err` → 对不存在的录像发起 retry-merge 触发 nil panic。加 `rec == nil` 检查（新测试覆盖该分支）。

## 验证
- `go test -race ./internal/api/` 全绿（含既有全部 api 测试）
- `golangci-lint run ./internal/api/...` 0 issues
- #571 规约：每测试独立 SQLite、断言可观察状态（Eventually）、无 sleep、无外联