### PR TITLE
test(storage+camera): DB 查询长尾 + 相机访问器/GB28181 播放 sink (#599)

### DIFF
--- a/internal/camera/codec_stream_extra_test.go
+++ b/internal/camera/codec_stream_extra_test.go
@@ -1,0 +1,175 @@
+package camera
+
+// Incremental long-tail coverage (#599) beyond accessors_extra_test.go:
+// GetStreamURL branch set, the GB28181 playback sink + invite/bye hooks with a
+// live (passive) GB recorder, snapshot-URL auto-population against the SOAP
+// fake, the disabled-transcode-config guard, H.265/bare-ONVIF codec-info
+// branches, and the direct ArchiveCamera flow.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStreamURLBranches(t *testing.T) {
+	t.Parallel()
+	cm, store, _, _ := newTestManagerWithCfg(t, func() *config.Config {
+		cfg := testConfig()
+		cfg.Cameras = []config.CameraConfig{
+			{ID: "rtsp-cam", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/main"},
+			{ID: "onvif-cam", Protocol: "onvif", ONVIFEndpoint: "http://127.0.0.1:1/onvif/device_service"},
+		}
+		return cfg
+	}())
+
+	// RTSP camera: the config URL IS the stream URL.
+	require.Equal(t, "rtsp://127.0.0.1:1/main", cm.GetStreamURL("rtsp-cam"))
+	// Unknown camera / ONVIF camera without a recorder.
+	require.Empty(t, cm.GetStreamURL("ghost"))
+	require.Empty(t, cm.GetStreamURL("onvif-cam"))
+
+	// Non-ONVIF recorder behind an ONVIF camera → empty (type assert fails).
+	cm.SetTestRecorder("onvif-cam", recorder.NewH264Recorder(
+		recorder.H264Config{CameraID: "onvif-cam"}, store))
+	require.Empty(t, cm.GetStreamURL("onvif-cam"))
+
+	// Real ONVIF recorder (never started — rtspURL still empty, branch runs).
+	cm.SetTestRecorder("onvif-cam", recorder.NewONVIFRecorder(
+		recorder.ONVIFConfig{CameraID: "onvif-cam"},
+		nil, nil))
+	require.Empty(t, cm.GetStreamURL("onvif-cam"), "unstarted ONVIF recorder has no rtspURL yet")
+}
+
+func TestGB28181PlaybackSinkAndHooks(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{
+			ID: "gb-cam", Name: "GB", Protocol: "gb28181", Encoding: "h264",
+			GB28181: config.GB28181ChannelConfig{DeviceID: "d", ChannelID: "c"},
+		},
+		{ID: "srt-cam", Protocol: "srt", Encoding: "h264"},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+	// Non-GB / unknown cameras → typed error.
+	_, err := cm.NewGB28181PlaybackSink("srt-cam")
+	require.ErrorContains(t, err, "not a GB28181 camera")
+	_, err = cm.NewGB28181PlaybackSink("ghost")
+	require.ErrorContains(t, err, "not a GB28181 camera")
+
+	// GB camera: the sink recorder starts passively and is returned as an
+	// AUWriter; stopping it must be clean.
+	sink, err := cm.NewGB28181PlaybackSink("gb-cam")
+	require.NoError(t, err)
+	require.NotNil(t, sink)
+	if s, ok := sink.(interface{ Stop() error }); ok {
+		require.NoError(t, s.Stop())
+	}
+
+	// Invite/Bye hooks: nil-recorder path then a live passive GB recorder.
+	cm.OnGB28181Invite("ghost")
+	cm.OnGB28181Bye("ghost")
+	gbRec := recorder.NewGB28181Recorder(recorder.GB28181Config{CameraID: "gb-live", Encoding: "h264"}, nil)
+	require.NoError(t, gbRec.Start(context.Background()))
+	t.Cleanup(func() { _ = gbRec.Stop() })
+	cm.SetTestRecorder("gb-live", gbRec)
+	cm.OnGB28181Invite("gb-live")
+	cm.OnGB28181Bye("gb-live")
+}
+
+func TestAutoPopulateSnapshotURLViaFake(t *testing.T) {
+	t.Parallel()
+	fake := newCamSOAPFake(t)
+
+	// Success: URI fetched via the SOAP fake and persisted into config+YAML.
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{fake.onvifCamera("snap-cam")}
+	cm, _, db, cfgPath := newTestManagerWithCfg(t, cfg)
+	require.NoError(t, db.UpsertCamera(context.Background(), "snap-cam", "n", "onvif", "", "", "", "", fake.srv.URL+"/onvif/device_service", "", "", ""))
+
+	cm.autoPopulateSnapshotURL(context.Background(), "snap-cam")
+	require.Equal(t, "http://127.0.0.1/snapshot.jpg", cm.GetCameraConfig("snap-cam").SnapshotURL)
+	disk, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	found := false
+	for i := range disk.Cameras {
+		if disk.Cameras[i].ID == "snap-cam" {
+			require.Equal(t, "http://127.0.0.1/snapshot.jpg", disk.Cameras[i].SnapshotURL)
+			found = true
+		}
+	}
+	require.True(t, found, "snapshot URL must be persisted to YAML")
+
+	// Empty-profiles device: nothing written, no error surface.
+	fake.setEmptyProfiles(true)
+	cfg2 := testConfig()
+	cfg2.Cameras = []config.CameraConfig{fake.onvifCamera("nop-cam")}
+	cm2, _, _, _ := newTestManagerWithCfg(t, cfg2)
+	cm2.autoPopulateSnapshotURL(context.Background(), "nop-cam")
+	require.Empty(t, cm2.GetCameraConfig("nop-cam").SnapshotURL)
+}
+
+func TestCodecInfoH265AndBareONVIF(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{}
+	cm, store, _, _ := newTestManagerWithCfg(t, cfg)
+
+	cm.SetTestRecorder("h265-cam", recorder.NewH265Recorder(
+		recorder.H265Config{CameraID: "h265-cam"}, store))
+	cm.SetTestRecorder("onvif-bare", recorder.NewONVIFRecorder(
+		recorder.ONVIFConfig{CameraID: "onvif-bare"}, nil, nil))
+
+	// H.265 recorder: not flagged h264.
+	require.Equal(t, "h265", cm.GetSourceCodec("h265-cam"))
+	require.False(t, cm.GetCodecInfo("h265-cam").IsH264)
+
+	// Bare ONVIF recorder (no delegate): empty source codec, generic fallback
+	// codec info.
+	require.Empty(t, cm.GetSourceCodec("onvif-bare"))
+	require.True(t, cm.GetCodecInfo("onvif-bare").IsH264, "generic fallback defaults IsH264=true")
+
+	require.Equal(t, model.CodecInfo{}, cm.GetCodecInfo("ghost"))
+}
+
+func TestEnqueueTranscodeDisabledConfig(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{
+			ID: "t-cam", Protocol: "srt", Encoding: "h264",
+			Transcoding: &config.CameraTranscodingConfig{Enabled: false},
+		},
+	}
+	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
+	// Disabled per-camera transcoding: no-op guard, no panic.
+	cm.EnqueueTranscode("t-cam", "rec-1", "/tmp/x.mp4", "h264")
+	cm.EnqueueTranscode("ghost", "rec-1", "/tmp/x.mp4", "h264")
+}
+
+func TestArchiveCameraDirect(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{
+		{ID: "arch-cam", Name: "A", Protocol: "srt", Encoding: "h264"},
+	}
+	cm, _, db, _ := newTestManagerWithCfg(t, cfg)
+	ctx := context.Background()
+	require.NoError(t, db.UpsertCamera(ctx, "arch-cam", "A", "srt", "h264", "", "", "", "", "", "", ""))
+
+	require.NoError(t, cm.ArchiveCamera(ctx, "arch-cam"))
+	require.Nil(t, cm.GetCameraConfig("arch-cam"), "archived camera leaves the YAML config")
+	row, err := db.GetCamera(ctx, "arch-cam")
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.True(t, row.Archived)
+
+	// Unknown camera → error (not found).
+	require.Error(t, cm.ArchiveCamera(ctx, "ghost"))
+}

--- a/internal/camera/onvif_client_extra_test.go
+++ b/internal/camera/onvif_client_extra_test.go
@@ -298,14 +298,22 @@ func TestSubscribeONVIFEventsLifecycle(t *testing.T) {
 
 func TestRediscoverAndReconnectGuards(t *testing.T) {
 	t.Parallel()
-	fake := newCamSOAPFake(t)
 	cfg := testConfig()
+	// The ONVIF camera's endpoint is a DEAD loopback port (not a fake): the
+	// scan-budget case below races the first probe (scanFor's select picks
+	// randomly between ctx.Done and scheduling, and a loopback probe can
+	// complete inside a 1ms budget). With connection-refused the probe can
+	// never match, so the guard outcome is deterministic whichever way the
+	// race resolves — and no probe can leave the machine.
 	cfg.Cameras = []config.CameraConfig{
-		fake.onvifCamera("onvif-redis"),
+		{
+			ID: "onvif-redis", Name: "onvif-redis", Protocol: "onvif", Encoding: "h264",
+			ONVIFEndpoint: "http://127.0.0.1:1/onvif/device_service", Username: "u", Password: "p",
+		},
 		{ID: "rtsp-cam", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:1/x"},
 	}
-	// Kill the scan before any probe fires: MaxDuration=1ms expires the scan
-	// context immediately → ErrNotFound → (false, nil) without touching the LAN.
+	// Bound the scan as extra insurance: expired budget + refused dials both
+	// converge on ErrNotFound.
 	cfg.Health.Rediscovery.MaxDuration = "1ms"
 	cfg.Health.Rediscovery.ProbeTimeout = "100ms"
 	cm, _, _, _ := newTestManagerWithCfg(t, cfg)
@@ -339,7 +347,6 @@ func TestRediscoverAndReconnectGuards(t *testing.T) {
 	found, err = cm.RediscoverAndReconnect(ctx, "onvif-redis")
 	require.NoError(t, err)
 	require.False(t, found)
-	require.Equal(t, 0, fake.callCount("GetDeviceInformation"), "no probe may leave the process in the guard tests")
 }
 
 func TestAccessorLongtail(t *testing.T) {

--- a/internal/gb28181/sip/subchannel_test.go
+++ b/internal/gb28181/sip/subchannel_test.go
@@ -151,11 +151,14 @@ func TestProbeSubChannel_TimeoutSilent(t *testing.T) {
 	}
 	require.True(t, invited, "probe must INVITE the +1 candidate code")
 
-	// Timeout elapses → synthetic channel removed, nothing persisted.
+	// Timeout elapses → synthetic channel removed, nothing persisted. The
+	// 200ms probe timeout is a floor, not a ceiling: on a loaded CI runner the
+	// INVITE transaction teardown (release → SIP BYE) can take seconds, so the
+	// wait budget is generous — green runs still finish in ~200ms.
 	require.Eventually(t, func() bool {
 		_, ok := dm.FindChannel(testDeviceID, candidate)
 		return !ok
-	}, 3*time.Second, 50*time.Millisecond, "synthetic sub-channel must be unregistered after probe timeout")
+	}, 10*time.Second, 50*time.Millisecond, "synthetic sub-channel must be unregistered after probe timeout")
 	require.True(t, fe.subSetEmpty(), "no sub_channel_id may be persisted on probe timeout")
 
 	// Memoized: re-running the probe path issues no second INVITE.

--- a/internal/storage/db_longtail_extra_test.go
+++ b/internal/storage/db_longtail_extra_test.go
@@ -1,0 +1,362 @@
+package storage
+
+// Long-tail DB coverage (#599): PTZ preset CRUD, batched recording queries,
+// mergeable/rolling/pending listings, zero-duration repair family, expired
+// and archive partitions, migration capacity queries, and the pure helpers
+// (chunkIDs, TranscodeTask.MarshalJSON). All against per-test temp SQLite.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPTZPresetCRUDAndTokenAllocation(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Insert is INSERT OR IGNORE: the first name for a token wins.
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, db.InsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: "1", Name: "first", CreatedAt: now}))
+	require.NoError(t, db.InsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: "1", Name: "ignored", CreatedAt: now}))
+
+	// Upsert renames.
+	require.NoError(t, db.UpsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: "1", Name: "renamed", CreatedAt: now}))
+	require.NoError(t, db.UpsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: "10", Name: "ten", CreatedAt: now}))
+	require.NoError(t, db.UpsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: "2", Name: "two", CreatedAt: now}))
+	require.NoError(t, db.UpsertPTZPreset(ctx, PTZPreset{CameraID: "other", Token: "1", Name: "othercam", CreatedAt: now}))
+
+	// List is per-camera, numerically ordered.
+	rows, err := db.ListPTZPresets(ctx, "cam")
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+	require.Equal(t, []string{"1", "2", "10"}, []string{rows[0].Token, rows[1].Token, rows[2].Token})
+	require.Equal(t, "renamed", rows[0].Name, "upsert must rename")
+	require.False(t, rows[0].CreatedAt.IsZero(), "created_at round-trips")
+
+	// Token allocation: lowest free slot, per camera.
+	tok, ok := db.NextPTZPresetToken(ctx, "cam")
+	require.True(t, ok)
+	require.Equal(t, "3", tok)
+	tok, ok = db.NextPTZPresetToken(ctx, "fresh")
+	require.True(t, ok)
+	require.Equal(t, "1", tok)
+
+	// Exhausted: fill 3..255 except the already-taken 10 → false.
+	for n := 3; n <= 255; n++ {
+		if n == 10 {
+			continue
+		}
+		require.NoError(t, db.UpsertPTZPreset(ctx, PTZPreset{CameraID: "cam", Token: itoa(n), Name: "x", CreatedAt: now}))
+	}
+	_, ok = db.NextPTZPresetToken(ctx, "cam")
+	require.False(t, ok, "all 255 slots taken")
+
+	// Delete is idempotent.
+	require.NoError(t, db.DeletePTZPreset(ctx, "cam", "10"))
+	require.NoError(t, db.DeletePTZPreset(ctx, "cam", "10"))
+	rows, err = db.ListPTZPresets(ctx, "cam")
+	require.NoError(t, err)
+	require.Len(t, rows, 254, "255 slots minus the deleted token 10")
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestRecordingsByIDBatchAndDeleteBatch(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	for _, id := range []string{"r1", "r2", "r3"} {
+		require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+			ID: id, CameraID: "cam", Format: "h264", FilePath: "/tmp/" + id,
+			StartedAt: now.Add(-time.Hour), EndedAt: now, MergeStatus: "pending",
+		}))
+	}
+
+	// Batch get: mixed hit/miss (no ORDER BY — assert as a set), empty input → nil,nil.
+	got, err := db.GetRecordingsByIDBatch(ctx, []string{"r2", "missing", "r1"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	ids := []string{got[0].ID, got[1].ID}
+	require.ElementsMatch(t, []string{"r1", "r2"}, ids)
+	for _, g := range got {
+		require.Equal(t, model.MergeStatusPending, g.MergeStatus, "empty merge_status normalizes to pending")
+	}
+	got, err = db.GetRecordingsByIDBatch(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// Batch delete: returns deleted ids; idempotent misses → nil.
+	del, err := db.DeleteRecordingsBatch(ctx, []string{"r1", "r3"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"r1", "r3"}, del)
+	del, err = db.DeleteRecordingsBatch(ctx, []string{"r1"})
+	require.NoError(t, err)
+	require.Nil(t, del)
+	del, err = db.DeleteRecordingsBatch(ctx, nil)
+	require.NoError(t, err)
+	require.Nil(t, del)
+}
+
+// seedRec inserts a completed recording with explicit fields for query tests.
+func seedLongRec(t *testing.T, db *DB, id, cam, format, mergeStatus, path string, started time.Time) {
+	t.Helper()
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: id, CameraID: cam, Format: model.Format(format), FilePath: path,
+		StartedAt: started, EndedAt: started.Add(30 * time.Second),
+		FileSize: 2048, MergeStatus: mergeStatus,
+	}))
+}
+
+func TestMergeableAndRollingQueries(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	seedLongRec(t, db, "in-win", "cam", "h264", "pending", "/a", base)
+	seedLongRec(t, db, "merged", "cam", "h264", "merged", "/b", base.Add(time.Minute))
+	seedLongRec(t, db, "failed", "cam", "h264", "failed", "/c", base.Add(2*time.Minute))
+	seedLongRec(t, db, "out-win", "cam", "h264", "pending", "/d", base.Add(10*time.Minute))
+	seedLongRec(t, db, "tl", "cam", "timelapse", "pending", "/e", base.Add(3*time.Minute))
+	seedLongRec(t, db, "other-cam", "cam2", "h264", "pending", "/f", base.Add(4*time.Minute))
+
+	// Mergeable window query: pending and inside [base, base+5m). The window
+	// query itself carries no format filter — the timelapse row inside the
+	// window is returned too (callers filter by format).
+	segs, err := db.ListMergeableSegments(ctx, "cam", base, base.Add(5*time.Minute))
+	require.NoError(t, err)
+	require.Len(t, segs, 2)
+	require.Equal(t, "in-win", segs[0].ID)
+
+	// Rolling query: pending, non-timelapse; includeFailed adds 'failed';
+	// camera filter; limit; since.
+	segs, err = db.ListPendingSegmentsForRolling(ctx, "cam", false, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, segs, 2, "pending h264 only (timelapse excluded)")
+	segs, err = db.ListPendingSegmentsForRolling(ctx, "cam", true, 0, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, segs, 3, "includeFailed pulls the failed segment")
+	segs, err = db.ListPendingSegmentsForRolling(ctx, "", false, 2, base.Add(90*time.Second))
+	require.NoError(t, err)
+	require.Len(t, segs, 2, "all cameras, bounded by limit and since")
+	for _, s := range segs {
+		require.False(t, s.StartedAt.Before(base.Add(90*time.Second)))
+	}
+}
+
+func TestZeroDurationRepairFamily(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Repair candidate: duration 0, >1MB, non-mjpeg, pending, ended.
+	require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+		ID: "broken", CameraID: "cam", Format: "h264", FilePath: "/tmp/broken",
+		StartedAt: now.Add(-time.Hour), EndedAt: now, FileSize: 2 << 20, MergeStatus: "pending",
+	}))
+	// Not candidates: tiny file / merged status.
+	require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+		ID: "tiny", CameraID: "cam", Format: "h264", FilePath: "/tmp/tiny",
+		StartedAt: now.Add(-time.Hour), EndedAt: now, MergeStatus: "pending",
+	}))
+	require.NoError(t, db.InsertRecording(ctx, &model.Recording{
+		ID: "merged", CameraID: "cam", Format: "h264", FilePath: "/tmp/m",
+		StartedAt: now.Add(-time.Hour), EndedAt: now, FileSize: 2 << 20, MergeStatus: "merged",
+	}))
+
+	broken, err := db.RepairZeroDurationRecordings(ctx)
+	require.NoError(t, err)
+	require.Len(t, broken, 1)
+	require.Equal(t, "broken", broken[0].ID)
+
+	zero, err := db.ListZeroDurationRecordings(ctx, "cam", 10)
+	require.NoError(t, err)
+	require.Len(t, zero, 3, "List is broader than Repair (tiny + merged-status rows count)")
+	zeroAll, err := db.ListZeroDurationRecordings(ctx, "", 0)
+	require.NoError(t, err)
+	require.Len(t, zeroAll, 3)
+
+	// UpdateRecordingDuration fixes it.
+	require.NoError(t, db.UpdateRecordingDuration(ctx, "broken", 3600, now))
+	fixed, err := db.ListZeroDurationRecordings(ctx, "cam", 0)
+	require.NoError(t, err)
+	require.Len(t, fixed, 2)
+	for _, f := range fixed {
+		require.NotEqual(t, "broken", f.ID)
+	}
+}
+
+func TestExpiredRecordingsPartitions(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	old := now.Add(-48 * time.Hour)
+
+	ins := func(id, cam string, ended time.Time, archived bool, size int64) {
+		r := &model.Recording{
+			ID: id, CameraID: cam, Format: "h264", FilePath: "/tmp/" + id,
+			StartedAt: ended.Add(-time.Minute), EndedAt: ended, FileSize: size,
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+		if archived {
+			_, err := db.db.ExecContext(ctx, `UPDATE recordings SET archived=1 WHERE id=?`, id)
+			require.NoError(t, err)
+		}
+	}
+	ins("old-a", "camA", old, false, 100)
+	ins("old-arc", "camA", old, true, 100)
+	ins("new-a", "camA", now, false, 100)
+	ins("old-b", "camB", old, false, 100)
+
+	// Per-camera expired, unarchived partition.
+	rows, err := db.ListExpiredRecordingsByCamera(ctx, "camA", 1)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "old-a", rows[0].ID)
+
+	// Archived partition.
+	rows, err = db.ListExpiredArchivedRecordingsByCamera(ctx, "camA", 1)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "old-arc", rows[0].ID)
+}
+
+func TestMigrationCapacityQueries(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedLongRec(t, db, "a", "camA", "h264", "merged", "/mnt/data/nvr/a.mp4", now)
+	seedLongRec(t, db, "b", "camA", "h264", "merged", "/mnt/data/nvr/b.mp4", now)
+	seedLongRec(t, db, "c", "camB", "h264", "merged", "/other/c.mp4", now)
+
+	ids, err := db.ListCameraIDs(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"camA", "camB"}, ids)
+
+	// Bytes outside the keep-under prefix only.
+	n, err := db.SumMigratableBytes(ctx, "camA", "/mnt/data/nvr")
+	require.NoError(t, err)
+	require.Zero(t, n)
+	n, err = db.SumMigratableBytes(ctx, "camB", "/mnt/data/nvr")
+	require.NoError(t, err)
+	require.EqualValues(t, 2048, n)
+
+	// Path set for one camera.
+	paths, err := db.GetRecordingPathsByCamera(ctx, "camA")
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+	require.True(t, paths["/mnt/data/nvr/a.mp4"])
+}
+
+func TestPendingMJPEGRecordings(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedLongRec(t, db, "mj", "cam", "mjpeg", "pending", "/p/mj", now)
+	seedLongRec(t, db, "jp", "cam", "jpeg", "pending", "/p/jp", now)
+	seedLongRec(t, db, "h", "cam", "h264", "pending", "/p/h", now)
+	seedLongRec(t, db, "mj-done", "cam", "mjpeg", "merged", "/p/md", now)
+	seedLongRec(t, db, "mj-other", "cam2", "mjpeg", "pending", "/p/mo", now)
+
+	rows, err := db.ListPendingMJPEGRecordings(ctx, "cam")
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+}
+
+func TestInsertRecordingWithRetryFastFail(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Non-busy errors surface immediately (no retry sleep).
+	err := db.InsertRecordingWithRetry(ctx, &model.Recording{ID: "", CameraID: "cam"}, 3, time.Millisecond)
+	require.Error(t, err)
+
+	// Success path on the first attempt.
+	require.NoError(t, db.InsertRecordingWithRetry(ctx, &model.Recording{
+		ID: "ok", CameraID: "cam", Format: "h264", FilePath: "/p",
+		StartedAt: now.Add(-time.Minute), EndedAt: now,
+	}, 3, time.Millisecond))
+}
+
+func TestCameraExistsByOnvifEndpointBranches(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Neither endpoint nor serial → false without querying.
+	ok, err := db.CameraExistsByOnvifEndpoint(ctx, "", "")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// Endpoint match.
+	require.NoError(t, db.UpsertCamera(ctx, "c1", "C1", "onvif", "", "", "", "", "http://10.0.0.5/onvif/device_service", "", "", ""))
+	ok, err = db.CameraExistsByOnvifEndpoint(ctx, "http://10.0.0.5/onvif/device_service", "")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Serial match via serial_number / stable_id columns.
+	require.NoError(t, db.UpsertCamera(ctx, "c2", "C2", "onvif", "", "", "", "", "", "", "", "SN-ZZZ"))
+	ok, err = db.CameraExistsByOnvifEndpoint(ctx, "", "SN-ZZZ")
+	require.NoError(t, err)
+	require.True(t, ok)
+	ok, err = db.CameraExistsByOnvifEndpoint(ctx, "", "SN-NOPE")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestChunkIDs(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, chunkIDs(nil, 10))
+	require.Nil(t, chunkIDs([]string{"a"}, 0))
+	require.Equal(t, [][]string{{"a"}}, chunkIDs([]string{"a"}, 10))
+	require.Equal(t,
+		[][]string{{"a", "b"}, {"c"}},
+		chunkIDs([]string{"a", "b", "c"}, 2))
+}
+
+func TestTranscodeTaskMarshalJSON(t *testing.T) {
+	t.Parallel()
+	valid := sql.NullString{String: "boom", Valid: true}
+	task := TranscodeTask{
+		ID: 7, CameraID: "cam", RecordingID: "rec", Status: "failed",
+		Error: valid, StartedAt: sql.NullString{String: "2025-01-01", Valid: true},
+	}
+	b, err := json.Marshal(task)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	require.Equal(t, "boom", m["error"], "valid NullString marshals as the raw string")
+	require.Equal(t, "2025-01-01", m["started_at"])
+	require.NotContains(t, string(b), "String", "sql.NullString struct shape must not leak")
+
+	b, err = json.Marshal(TranscodeTask{ID: 1})
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"error":null`, "invalid NullString marshals as null")
+}


### PR DESCRIPTION
Closes #599

## 内容
- **storage**（76.2% → 82.8%，11 个新测试）：PTZ 预置位 CRUD + token 分配（含 255 槽耗尽）、批量 ID 查询/删除、mergeable 窗口与 rolling 待合并查询（includeFailed/limit/since 全参数）、zero-duration 修复族、过期/归档双分区、迁移容量查询（ListCameraIDs/SumMigratableBytes）、InsertRecordingWithRetry 快速失败、CameraExistsByOnvifEndpoint 分支、chunkIDs、TranscodeTask.MarshalJSON（NullString 不泄漏结构体形状）
- **camera**（68.3% → 70.4%，6 个新测试）：GetStreamURL 全分支、NewGB28181PlaybackSink（被动启动 + 类型错误路径）、OnGB28181Invite/Bye 钩子、autoPopulateSnapshotURL（SOAP fake，成功持久化到 YAML + 空配置设备不写入）、H.265/bare-ONVIF codec 分支、包内 ArchiveCamera

## CI flake 修复（#571 规约类）
`TestRediscoverAndReconnectGuards`（#594 引入）双重竞态：`scanFor` 的 select 在 ctx.Done 与调度之间随机选择 + 回环探测可在 1ms 预算内完成 → 命中 fake → 重启链走到未打桩的 GetStreamURI 失败（-count>1 必现）。修复：守卫测试的相机 endpoint 改指死回环端口 127.0.0.1:1——探测必然连接拒绝、永不匹配，结果与竞态无关地确定。-count=10 验证通过。

## 验证
- `go test -race ./internal/storage/ ./internal/camera/` 全绿
- `golangci-lint` 0 issues
- 每测试独立 SQLite（t.TempDir）、无 sleep 断言、无外联