### PR TITLE
test(cascade+relay): 消除两处 CI flake — 回放分段竞态 + stall 断言竞态

### DIFF
--- a/internal/gb28181/cascade/loopback_test.go
+++ b/internal/gb28181/cascade/loopback_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/manscdp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
@@ -387,6 +389,45 @@ func TestLoopbackRecordInfoQuery(t *testing.T) {
 	require.Contains(t, string(answer.Body()), "<SumNum>2</SumNum>", "both recordings must be reported")
 }
 
+// createPacedPlaybackSegment writes a REAL 5-sample H.264 MP4 (2s per sample)
+// and registers its recording row. The pump streams samples at realtime pace
+// from base=now, so the dialog stays alive for ~10s — long enough for the
+// in-dialog control assertions that follow.
+func createPacedPlaybackSegment(t *testing.T, db interface {
+	InsertRecording(ctx context.Context, r *model.Recording) error
+}, cameraID string, start time.Time,
+) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "seg.mp4")
+
+	sps := []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	m := muxer.NewMP4Muxer(path)
+	trackID, err := m.AddH264Track(sps, pps)
+	require.NoError(t, err)
+	idr := []byte{0x65, 0x88, 0x84, 0x00, 0x01}
+	p := []byte{0x41, 0x9A, 0x33}
+	for i := range 5 {
+		nalu := p
+		if i == 0 || i == 3 {
+			nalu = idr
+		}
+		require.NoError(t, m.WriteSample(trackID, nalu, time.Duration(i)*2*time.Second, 2*time.Second))
+	}
+	require.NoError(t, m.Close())
+
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID:        "pb-1",
+		CameraID:  cameraID,
+		FilePath:  path,
+		Format:    model.FormatH264,
+		StartedAt: start,
+		EndedAt:   start.Add(10 * time.Second),
+		Duration:  10,
+	}))
+}
+
 func TestLoopbackPlaybackInviteAndControl(t *testing.T) {
 	hub := model.NewStreamHub()
 	db := newCascadeTestDB(t)
@@ -394,16 +435,13 @@ func TestLoopbackPlaybackInviteAndControl(t *testing.T) {
 	_, err := svc.catalogItems()
 	require.NoError(t, err)
 
+	// A REAL paced segment, not a dead path: with a nonexistent file the pump
+	// skips the recording, hits "end of media", and self-unregisters within
+	// one DB query — racing (and under coverage load, beating) the ==1 poll
+	// below. Real samples pace from base=now, keeping the dialog alive for
+	// the whole test.
 	now := time.Now().UTC()
-	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
-		ID:        "pb-1",
-		CameraID:  "cam-1",
-		FilePath:  "/tmp/nonexistent.mp4",
-		Format:    model.FormatH264,
-		StartedAt: now.Add(-10 * time.Minute),
-		EndedAt:   now.Add(-5 * time.Minute),
-		Duration:  300,
-	}))
+	createPacedPlaybackSegment(t, db, "cam-1", now.Add(-10*time.Minute))
 
 	pbInvite := up.request(sip.INVITE, lbChannelOne, playSDP(t, "Playback", true), "application/sdp")
 	res := up.roundTrip(pbInvite)

--- a/internal/relay/watchdog_test.go
+++ b/internal/relay/watchdog_test.go
@@ -74,8 +74,11 @@ func TestStallMonitorDetectsFrozenStream(t *testing.T) {
 
 	select {
 	case <-stalled:
-		// watchdog fired — ctx was canceled too
-		require.Error(t, ctx.Err())
+		// watchdog fired. stallMonitor closes(stalled) BEFORE calling
+		// cancel() — poll for the cancellation instead of asserting it
+		// synchronously (the two statements race on the test goroutine).
+		require.Eventually(t, func() bool { return ctx.Err() != nil },
+			2*time.Second, 5*time.Millisecond, "cancel must follow the stalled signal")
 	case <-time.After(3 * time.Second):
 		t.Fatal("watchdog did not fire on a frozen streaming target")
 	}


### PR DESCRIPTION
## 修复 1：cascade 回放 INVITE 竞态
`TestLoopbackPlaybackInviteAndControl` 在覆盖率负载下间歇失败：测试给回放塞的录像指向 `/tmp/nonexistent.mp4`，pump 对不可解析文件走 skip → "end of media" → **自注销**（整个链路只差一次 SQLite 查询），与 `len(playbacks)==1` 轮询抢跑；插桩负载下 pump 先赢 → 5s Eventually 必超时。改用真实 5×2s H.264 分段（muxer 生成，复用 playback_test 构造法），从 base=now 实时推流，会话全程存活——竞态根除。

## 修复 2：relay stall 断言竞态
`TestStallMonitorDetectsFrozenStream`：`stallMonitor` 先 `close(stalled)` 后 `cancel()`，测试 select 醒来后同步断言 `ctx.Err()!=nil` 会与 cancel 抢跑。改为 `require.Eventually` 观察取消（2s/5ms）。

两处均属 #571 反 flake 规约（断言可观察状态、窗口宽松、不依赖调度顺序）。

## 验证
- cascade：单测 + count=2×5 + -race + lint 全绿
- relay：TestStallMonitor 族 count=5 全绿