### PR TITLE
feat(gb28181): allow_same_ip_enroll 开关 + enroll_blocked 提示 — 双协议 auto-enroll 不再被 IP 去重压制 (#596)

### DIFF
--- a/docs/en/gb28181-guide.md
+++ b/docs/en/gb28181-guide.md
@@ -128,6 +128,7 @@ Audio is off by default. Turn on the **Audio** toggle in the camera's edit page 
 | `subscribe_mobile_position` | bool | `false` | Mobile-position subscription |
 | `subscribe_expires` | string | `"3600s"` | Subscription lifetime (auto-renewed at 80%) |
 | `allowed_device_ids` | `[]string` | `[]` | Registration allowlist (empty = allow all) |
+| `allow_same_ip_enroll` | bool | `false` | Keep dual-protocol enrollment: auto-enroll a GB28181 channel even when another camera already streams from the device IP (or matches its ONVIF serial). For deliberate ONVIF + GB28181 side-by-side setups, #596 |
 | `sub_channel_probe` | string | `"auto"` | Sub-channel prober mode: `auto` (probe only Hikvision/Dahua devices) / `on` (probe every device) / `off`, #560 |
 | `sub_channel_probe_offset` | int | `1` | Sub-channel candidate code = main channel code + this offset (Hikvision convention is +1; 0 disables probing). Range 0–99 |
 

--- a/docs/zh/gb28181-guide.md
+++ b/docs/zh/gb28181-guide.md
@@ -128,6 +128,7 @@ cameras:
 | `subscribe_mobile_position` | bool | `false` | 移动位置订阅（静止相机无需开启） |
 | `subscribe_expires` | string | `"3600s"` | 订阅有效期（80% 时自动续订） |
 | `allowed_device_ids` | `[]string` | `[]` | 注册白名单（空 = 允许所有） |
+| `allow_same_ip_enroll` | bool | `false` | 允许同 IP 双协议并存：即使已有相机从该设备 IP 取流（或 ONVIF 序列号匹配），GB28181 通道仍自动建条目。适用于刻意让 ONVIF + GB28181 并存的场景，#596 |
 | `sub_channel_probe` | string | `"auto"` | 子通道探测模式：`auto`（仅探测厂商为海康/大华的设备）/ `on`（探测所有设备）/ `off`（关闭），#560 |
 | `sub_channel_probe_offset` | int | `1` | 子通道候选码 = 主通道码 + 该偏移（海康惯例 +1；0 = 禁用探测），范围 0–99 |
 

--- a/internal/api/handlers_gb28181.go
+++ b/internal/api/handlers_gb28181.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log/slog"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -79,6 +80,12 @@ func (h *Handler) handleListGB28181Devices(w http.ResponseWriter, r *http.Reques
 type gb28181ChannelResponse struct {
 	storage.GB28181Channel
 	PTZType int `json:"PTZType"`
+	// EnrollBlocked is non-empty when auto-enroll suppressed this channel via
+	// the cross-protocol dedup (#596) — another camera already streams from
+	// the device's IP. Computed at display time (mirrors
+	// EnsureGB28181Camera's L1 check); empty when enrolled, no collision, or
+	// gb28181.allow_same_ip_enroll is set.
+	EnrollBlocked string `json:"enroll_blocked,omitempty"`
 }
 
 // handleListGB28181Channels returns the channels for a specific GB28181 device.
@@ -116,10 +123,53 @@ func (h *Handler) handleListGB28181Channels(w http.ResponseWriter, r *http.Reque
 				out.PTZType = live.PTZType
 			}
 		}
+		out.EnrollBlocked = h.gbChannelEnrollBlocked(deviceID, ch.ID)
 		resp = append(resp, out)
 	}
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// gbChannelEnrollBlocked explains why auto-enroll has not created a camera
+// for the channel ("" when it has, or when nothing blocks it). Mirrors the
+// L1 IP-collision branch of camera.EnsureGB28181Camera so the UI can surface
+// suppressed channels instead of leaving them invisible (#596).
+func (h *Handler) gbChannelEnrollBlocked(deviceID, channelID string) string {
+	if h.camMgr == nil {
+		return ""
+	}
+	if _, enrolled := h.camMgr.GB28181CameraIDByChannel(deviceID, channelID); enrolled {
+		return ""
+	}
+	if h.config != nil && h.config.GB28181.AllowSameIPEnroll {
+		return ""
+	}
+	srcIP := h.gbDeviceSourceIP(deviceID)
+	if srcIP == "" {
+		return ""
+	}
+	if existingID, ok := h.camMgr.CameraIDByHostIP(srcIP); ok {
+		return fmt.Sprintf("another camera (%s) already streams from this device IP — set gb28181.allow_same_ip_enroll to enroll both", existingID)
+	}
+	return ""
+}
+
+// gbDeviceSourceIP returns the host part of the device's SIP source address.
+func (h *Handler) gbDeviceSourceIP(deviceID string) string {
+	if h.gb28181DeviceMgr == nil {
+		return ""
+	}
+	d, ok := h.gb28181DeviceMgr.Device(deviceID)
+	if !ok {
+		return ""
+	}
+	d.Mu.RLock()
+	addr := d.NetAddr
+	d.Mu.RUnlock()
+	if host, _, err := net.SplitHostPort(addr); err == nil && host != "" {
+		return host
+	}
+	return addr
 }
 
 // handleCatalogRefresh triggers a SIP MESSAGE catalog request to the device.

--- a/internal/api/handlers_gb28181_test.go
+++ b/internal/api/handlers_gb28181_test.go
@@ -9,8 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
 )
 
 // Test helper function - must use t.Helper()
@@ -666,4 +669,67 @@ func TestAPI_GB28181_AuxSwitch_InvalidSwitch(t *testing.T) {
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400 for switch 0, got %d", rr.Code)
 	}
+}
+
+func TestAPI_GB28181_ListChannels_EnrollBlockedHint(t *testing.T) {
+	t.Parallel()
+
+	type channelHint struct {
+		ID            string `json:"ID"`
+		EnrollBlocked string `json:"enroll_blocked"`
+	}
+
+	setup := func(t *testing.T, allowSameIP bool) *httptest.ResponseRecorder {
+		t.Helper()
+		db, store := setupTestDB(t)
+		ctx := t.Context()
+		now := time.Now()
+		require.NoError(t, db.UpsertGB28181Device(ctx, storage.GB28181Device{
+			ID: "device1", Name: "Dual Protocol Cam", Status: "online",
+			LastKeepalive: now, RegisteredAt: now,
+		}))
+		require.NoError(t, db.UpsertGB28181Channel(ctx, storage.GB28181Channel{
+			ID: "channel1", DeviceID: "device1", Name: "Ch 1", Status: "idle", UpdatedAt: now,
+		}))
+
+		cfg := &config.Config{
+			Storage: config.StorageConfig{RootDir: store.RootDir(), SegmentDuration: "30s"},
+			Cleanup: config.CleanupConfig{RetentionDays: 30, CheckInterval: "1h", DiskThresholdPercent: 95},
+			GB28181: config.GB28181ServerConfig{AllowSameIPEnroll: allowSameIP},
+			Cameras: []config.CameraConfig{{
+				ID: "front-onvif", Name: "Front ONVIF", Protocol: "onvif",
+				ONVIFEndpoint: "http://192.168.63.240/onvif/device_service",
+			}},
+		}
+		camMgr := camera.NewCameraManager(cfg, store, db, "")
+		deviceMgr := gb28181.NewDeviceManager(60 * time.Second)
+		deviceMgr.Register(&gb28181.Device{ID: "device1", NetAddr: "192.168.63.240:5060"})
+		sessionMgr := gb28181.NewSessionManager(gb28181.NewPortManager(30000, 30100), "3402000000")
+		h := NewHandler(db, store, noopAuthMW(), cfg, camMgr, nil, "", nil, nil, nil, deviceMgr, sessionMgr)
+
+		return doRequest(t, h.Routes(), http.MethodGet, "/api/gb28181/devices/device1/channels", nil, "", "")
+	}
+
+	t.Run("blocked without flag", func(t *testing.T) {
+		t.Parallel()
+		rr := setup(t, false)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var channels []channelHint
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &channels))
+		require.Len(t, channels, 1)
+		require.Contains(t, channels[0].EnrollBlocked, "allow_same_ip_enroll",
+			"suppressed channel must explain itself and point at the opt-in")
+	})
+
+	t.Run("no hint with flag", func(t *testing.T) {
+		t.Parallel()
+		rr := setup(t, true)
+		require.Equal(t, http.StatusOK, rr.Code)
+
+		var channels []channelHint
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &channels))
+		require.Len(t, channels, 1)
+		require.Empty(t, channels[0].EnrollBlocked)
+	})
 }

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -102,15 +102,16 @@ func (cm *CameraManager) GetGB28181Recorder(cameraID string) *recorder.GB28181Re
 // enabled — possibly on DIFFERENT interface IPs of the same device): before
 // creating, the manager resolves the device's ONVIF serial (fingerprint cache
 // → DB → live probe of the SIP source IP) and skips when a camera with that
-// serial already exists. sourceIP "" (unknown) skips dedup entirely. Manual
-// camera creation (API/web) is the escape hatch for deliberate dual-protocol
-// setups.
+// serial already exists. sourceIP "" (unknown) skips dedup entirely. Setting
+// gb28181.allow_same_ip_enroll disables both cross-protocol checks (#596 —
+// deliberate dual-protocol setups); manual camera creation (API/web, with
+// allow_duplicate) remains the escape hatch otherwise.
 func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP string) error {
 	// Check if a camera for this channel already exists.
 	if _, ok := cm.GB28181CameraIDByChannel(deviceID, channelID); ok {
 		return nil // Already enrolled
 	}
-	if sourceIP != "" {
+	if sourceIP != "" && !cm.gbAllowSameIPEnroll() {
 		// L1: an existing pull camera streams from the same IP.
 		if existingID, ok := cm.CameraIDByHostIP(sourceIP); ok {
 			slog.Info("gb28181: auto-enroll skipped — another camera already streams from the device IP",
@@ -129,6 +130,9 @@ func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP
 				return nil
 			}
 		}
+	} else if sourceIP != "" {
+		slog.Info("gb28181: cross-protocol dedup bypassed by allow_same_ip_enroll",
+			"device", deviceID, "channel", channelID, "source_ip", sourceIP)
 	}
 
 	cameraName := name
@@ -146,6 +150,11 @@ func (cm *CameraManager) EnsureGB28181Camera(deviceID, channelID, name, sourceIP
 	}
 	_, err := cm.AddCamera(context.Background(), cam)
 	return err
+}
+
+// gbAllowSameIPEnroll reports the gb28181.allow_same_ip_enroll opt-in (#596).
+func (cm *CameraManager) gbAllowSameIPEnroll() bool {
+	return cm.cfg != nil && cm.cfg.GB28181.AllowSameIPEnroll
 }
 
 // gbSerialCache memoizes probed device serials (device_id → serial) for the

--- a/internal/camera/gb28181_dedup_test.go
+++ b/internal/camera/gb28181_dedup_test.go
@@ -180,3 +180,39 @@ func TestResolveGBDeviceSerial_CachesAndPersists(t *testing.T) {
 	require.Equal(t, "NC00000001", serial)
 	require.Zero(t, calls)
 }
+
+func TestEnsureGB28181Camera_AllowSameIPEnrollBypassesDedup(t *testing.T) {
+	// #596: dual-protocol setups opt in via gb28181.allow_same_ip_enroll —
+	// both cross-protocol checks (L1 same-IP, L2 serial) are bypassed and
+	// the GB channel enrolls alongside the existing ONVIF camera.
+	t.Run("same ip L1", func(t *testing.T) {
+		restore := stubProbe("", false)
+		defer restore()
+
+		cfg := gbDedupConfig(t)
+		cfg.GB28181.AllowSameIPEnroll = true
+		mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+		require.NoError(t, mgr.EnsureGB28181Camera(
+			"34020000001310000001", "34020000001320000001", "GB Channel", "192.168.63.240"))
+
+		id, ok := mgr.GB28181CameraIDByChannel("34020000001310000001", "34020000001320000001")
+		require.True(t, ok, "flag must bypass L1 IP dedup")
+		require.Equal(t, "gb-34020000001320000001", id)
+	})
+
+	t.Run("cross-interface serial L2", func(t *testing.T) {
+		restore := stubProbe("NC00000001", true)
+		defer restore()
+
+		cfg := gbDedupConfig(t)
+		cfg.GB28181.AllowSameIPEnroll = true
+		mgr, _, _, _ := newTestManagerWithCfg(t, cfg)
+
+		require.NoError(t, mgr.EnsureGB28181Camera(
+			"34020000001310000001", "34020000001320000001", "GB Channel", "192.168.63.152"))
+
+		_, ok := mgr.GB28181CameraIDByChannel("34020000001310000001", "34020000001320000001")
+		require.True(t, ok, "flag must bypass L2 serial dedup")
+	})
+}

--- a/internal/config/config_gb28181.go
+++ b/internal/config/config_gb28181.go
@@ -28,6 +28,17 @@ type GB28181ServerConfig struct {
 	// AllowedDeviceIDs restricts which devices may register. Empty = allow any.
 	AllowedDeviceIDs []string `yaml:"allowed_device_ids,omitempty"`
 
+	// AllowSameIPEnroll opts GB28181 auto-enroll out of the cross-protocol
+	// dedup (#596): when true, a channel whose device registers from an IP
+	// that already hosts another camera's stream (or whose probed ONVIF
+	// serial matches one — dual-NIC devices) is STILL auto-enrolled as its
+	// own camera. For deliberate dual-protocol setups (ONVIF + GB28181 side
+	// by side). Default false: one camera per physical device. Manual camera
+	// creation keeps its allow_duplicate escape hatch regardless.
+	// YAML-only knob — deliberately no Settings-UI toggle (self-selecting
+	// geek audience, same rationale as auth.local_bypass).
+	AllowSameIPEnroll bool `yaml:"allow_same_ip_enroll,omitempty"`
+
 	// HeartbeatInterval is how often devices are expected to send Keepalive.
 	HeartbeatInterval string `yaml:"heartbeat_interval"` // default "60s"
 


### PR DESCRIPTION
Closes #596

## 问题

同一物理相机同时提供 ONVIF + GB28181 时，auto-enroll 的跨协议去重（L1 同 IP、L2 ONVIF 序列号探测）永久压制 GB 通道建条目；反向路径（手动建相机）有 `allow_duplicate` 逃生门，正向 auto-enroll 却没有任何开关——不对称。

## 方案（issue 请求的选项 1 + 3 组合）

- **`gb28181.allow_same_ip_enroll`**（默认 false）：开启后 `EnsureGB28181Camera` 跳过 L1+L2 两道跨协议去重，GB 通道照常自动建条目。绕过时打 Info 日志留痕。
  - 不采用选项 2（device_id 优先去重）：GB device_id 与相机 ID 天然不同，改为 device_id 优先等于完全废除启发式的保护目的（同 IP=同物理设备）。
  - YAML-only、无 Settings UI 开关——刻意的 self-selecting 极客受众，同 `auth.local_bypass` 惯例。
- **`enroll_blocked` 字段**：`GET /api/gb28181/devices/{id}/channels` 通道条目在"未建条目 + IP 冲突 + 未开开关"时返回原因字符串并指向该开关。展示期计算（镜像 L1 判定），无状态管道、无锁争用。
- 手动建相机的 `allow_duplicate` 不受影响。

## 测试

- `TestEnsureGB28181Camera_AllowSameIPEnrollBypassesDedup`：开关开 → L1 同 IP / L2 跨口序列号两场景均照常建条目
- `TestAPI_GB28181_ListChannels_EnrollBlockedHint`：关→含提示指向开关；开→无提示
- 既有 4 个去重场景测试（关开关时行为不变）全绿；`-race` camera/api/config 三包通过；golangci-lint 0 issues
- 双语文档配置表新增行