### PR TITLE
feat(rtmp): H.265 RTMP push — enhanced-RTMP hvc1 ingest + relay passthrough (#433)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -481,7 +481,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	// Guard the API write boundary with the same protocol+encoding validation
-	// the startup path enforces: an invalid combo saved here (e.g. rtmp+h265
+	// the startup path enforces: an invalid combo saved here (e.g. http+h264
 	// from a non-UI client) bricks the NEXT restart with a fatal config
 	// validation error (#402 bug class).
 	if err := model.ValidateProtocolEncoding(proto, enc); err != nil {
@@ -874,7 +874,7 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 
 	// When protocol or encoding is being changed, validate the RESULTING combo
 	// against the same rules startup enforces — otherwise a partial update
-	// (e.g. encoding h265 on an rtmp camera) saves a config that fails fatally
+	// (e.g. encoding h264 on an http camera) saves a config that fails fatally
 	// on the next restart (#402 bug class).
 	if body.Protocol != nil || body.Encoding != nil {
 		proto, enc := "", ""

--- a/internal/api/handlers_camera_extra_test.go
+++ b/internal/api/handlers_camera_extra_test.go
@@ -133,8 +133,9 @@ func TestCameraUpdate(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", "not json").Code)
 	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"sub_stream_url":"http://x"}`).Code)
 	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"stable_id":"1.2.3.4"}`).Code) // IP rejected (#216)
-	// Protocol-combo guard: encoding h265 on an rtmp camera is invalid (#402 class).
-	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"encoding":"h265","protocol":"rtmp"}`).Code)
+	// Protocol-combo guard (#402 class): encoding h264 on an http camera is
+	// invalid. (rtmp+h265 is valid since enhanced-RTMP ingest, #433.)
+	require.Equal(t, http.StatusBadRequest, camDo(t, h, http.MethodPut, "/api/cameras/ingest-cam", `{"encoding":"h264","protocol":"http"}`).Code)
 	// Unknown camera → 404.
 	require.Equal(t, http.StatusNotFound, camDo(t, h, http.MethodPut, "/api/cameras/nope", `{"name":"x"}`).Code)
 }

--- a/internal/api/handlers_camera_test.go
+++ b/internal/api/handlers_camera_test.go
@@ -648,14 +648,20 @@ func TestCreateCamera_XiaomiDefaultsEncodingHint(t *testing.T) {
 
 // TestCreateCamera_RejectsInvalidEncodingCombo: the create API enforces the
 // same protocol+encoding rules as startup validation, so a non-UI client
-// cannot save a combo (rtmp+h265) that bricks the next restart.
+// cannot save a combo (http+h264) that bricks the next restart. rtmp+h265 is
+// now VALID (enhanced-RTMP hvc1 ingest, #433) and must be accepted.
 func TestCreateCamera_RejectsInvalidEncodingCombo(t *testing.T) {
 	h := setupDedupHandler(t)
 
-	body := `{"name":"RTMP Cam","protocol":"rtmp","encoding":"h265","stream_key":"k1"}`
+	body := `{"name":"HTTP Cam","protocol":"http","encoding":"h264","url":"http://127.0.0.1:9/x.jpg"}`
 	rr := doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(body)), "", "")
 	require.Equal(t, http.StatusBadRequest, rr.Code, "body: %s", rr.Body.String())
 	require.Contains(t, rr.Body.String(), "not valid for protocol")
+
+	// Enhanced-RTMP H.265 ingest (#433): rtmp+h265 is accepted now.
+	h265 := `{"name":"RTMP H265 Cam","protocol":"rtmp","encoding":"h265","stream_key":"k265"}`
+	rr = doRequest(t, h.Routes(), "POST", "/api/cameras/", bytes.NewReader([]byte(h265)), "", "")
+	require.Equal(t, http.StatusCreated, rr.Code, "body: %s", rr.Body.String())
 }
 
 // TestUpdateCamera_RejectsInvalidEncodingCombo: updating the encoding alone is

--- a/internal/camera/status.go
+++ b/internal/camera/status.go
@@ -84,9 +84,14 @@ func (cm *CameraManager) GetSPS(cameraID string) (sps, pps []byte, isH264 bool) 
 	case *recorder.H264Recorder:
 		return r.SPS(), r.PPS(), true
 	case *recorder.IngestRecorder:
-		_, s, p, _ := r.CodecParams()
+		f, s, p, _ := r.CodecParams()
 		if s == nil || p == nil {
-			return nil, nil, true
+			return nil, nil, f != model.FormatH265
+		}
+		if f == model.FormatH265 {
+			// H.265 param sets need the VPS for target-track init — callers
+			// wanting H.265 should use GetCodecInfo (which carries VPS).
+			return nil, nil, false
 		}
 		return s, p, true
 	case *recorder.ONVIFRecorder:
@@ -216,6 +221,21 @@ func (cm *CameraManager) GetCodecInfo(cameraID string) model.CodecInfo {
 			PPS:    r.PPS(),
 			VPS:    r.VPS(),
 			IsH264: xc != model.FormatH265,
+		}
+		if ai, ok := rec.(audioInfo); ok {
+			ci.AudioCodec = ai.AudioCodec()
+			ci.AudioConfig = ai.AudioConfig()
+			ci.AudioSampleRate = ai.AudioSampleRate()
+			ci.AudioChannels = ai.AudioChannels()
+		}
+		return ci
+	case *recorder.IngestRecorder:
+		f, _, _, _ := r.CodecParams()
+		ci := model.CodecInfo{
+			SPS:    r.SPS(),
+			PPS:    r.PPS(),
+			VPS:    r.VPS(),
+			IsH264: f != model.FormatH265,
 		}
 		if ai, ok := rec.(audioInfo); ok {
 			ci.AudioCodec = ai.AudioCodec()

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -514,8 +514,8 @@ func applyConfigDefaults(cfg *Config) {
 				cam.Encoding = "" // ONVIF auto-detects
 			case string(model.ProtoSRT), string(model.ProtoRTMP):
 				// Push cameras: encoding is derived from the published stream.
-				// Default to h264 (the only codec RTMP supports; SRT's current
-				// MPEG-TS demux is also H.264-only).
+				// Default to h264; RTMP H.265 (enhanced-RTMP hvc1, #433) and
+				// SRT H.265 must be declared explicitly via encoding: h265.
 				cam.Encoding = "h264"
 			}
 		}

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -216,7 +216,7 @@ type PushTargetConfig struct {
 	URL                 string                `yaml:"url" json:"url"`           // rtmp://host[:port]/app/key | rtsp://host[:port]/path
 	Enabled             bool                  `yaml:"enabled" json:"enabled"`
 	Platform            string                `yaml:"platform,omitempty" json:"platform,omitempty"`                 // preset name (bilibili/douyin/youtube/kuaishou/generic/empty)
-	TranscodePolicy     string                `yaml:"transcode_policy,omitempty" json:"transcode_policy,omitempty"` // auto/force_sw/off
+	TranscodePolicy     string                `yaml:"transcode_policy,omitempty" json:"transcode_policy,omitempty"` // auto/force_sw/off/passthrough
 	VideoPresetOverride *VideoPresetOverrides `yaml:"video_preset_override,omitempty" json:"video_preset_override,omitempty"`
 	SourceURL           string                `yaml:"source_url,omitempty" json:"source_url,omitempty"` // optional: if set, relay uses FFmpeg to pull from this URL instead of hub
 	UseFFmpeg           bool                  `yaml:"use_ffmpeg,omitempty" json:"use_ffmpeg,omitempty"` // if true, use FFmpeg subprocess for relay (compatibility mode)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -215,10 +215,10 @@ func validateConfigDetails(cfg *Config) error {
 			}
 			// Validate transcode policy.
 			switch pt.TranscodePolicy {
-			case "", "auto", "force_sw", "off":
+			case "", "auto", "force_sw", "off", "passthrough":
 				// valid
 			default:
-				return fmt.Errorf("camera[%d].push_targets[%d].transcode_policy must be one of \"auto\", \"force_sw\", \"off\" (got %q)", i, j, pt.TranscodePolicy)
+				return fmt.Errorf("camera[%d].push_targets[%d].transcode_policy must be one of \"auto\", \"force_sw\", \"off\", \"passthrough\" (got %q)", i, j, pt.TranscodePolicy)
 			}
 			// Validate video preset overrides.
 			if pt.VideoPresetOverride != nil {

--- a/internal/model/nalutil/nalutil.go
+++ b/internal/model/nalutil/nalutil.go
@@ -4,17 +4,21 @@
 // This is the single source of truth for IDR/keyframe detection across the codebase.
 package nalutil
 
-// IsKeyframeNALU checks if a single NALU is an IDR frame.
+// IsKeyframeNALU checks if a single NALU is a keyframe (random access point).
 //
 // H.264: NAL type 5 = IDR (extract via nalu[0] & 0x1F)
-// H.265: NAL type 19 (IDR_W_RADL) and 20 (IDR_N_LP) = IDR (extract via (nalu[0] >> 1) & 0x3F)
+// H.265: NAL types 16-23 = BLA/IDR/CRA (extract via (nalu[0] >> 1) & 0x3F).
+// CRA_NUT (21) matters because encoders like x265 emit CRA — not IDR — for
+// every keyframe after the first; treating only 19/20 as keyframes makes a
+// recorder never see a second keyframe (no segment rollover, no live-preview
+// IDR fast-start replay).
 func IsKeyframeNALU(nalu []byte, isH265 bool) bool {
 	if len(nalu) == 0 {
 		return false
 	}
 	if isH265 {
 		naluType := (nalu[0] >> 1) & 0x3F
-		return naluType == 19 || naluType == 20
+		return naluType >= 16 && naluType <= 23
 	}
 	naluType := nalu[0] & 0x1F
 	return naluType == 5

--- a/internal/model/nalutil/nalutil_test.go
+++ b/internal/model/nalutil/nalutil_test.go
@@ -238,3 +238,20 @@ func TestCrossCodec_H265_IDR_NotDetectedAsH264(t *testing.T) {
 		})
 	}
 }
+
+// TestIsKeyframeNALU_H265_RandomAccessPoints covers the full H.265 random
+// access range (16-23): BLA_W_LP(16) … IDR_N_LP(20), CRA_NUT(21). x265 emits
+// CRA for every keyframe after the first — CRA MUST count as a keyframe or
+// downstream segment rollover / IDR replay never fires again.
+func TestIsKeyframeNALU_H265_RandomAccessPoints(t *testing.T) {
+	for nalType := byte(16); nalType <= 23; nalType++ {
+		// first byte: nalType<<1 | layer-id high bit
+		nalu := []byte{nalType << 1, 0x01}
+		require.True(t, IsKeyframeNALU(nalu, true), "NAL type %d must be a keyframe", nalType)
+	}
+	// TRAIL_R (1), VPS (32), SPS (33), PPS (34) are not keyframes.
+	for _, nalType := range []byte{1, 32, 33, 34} {
+		nalu := []byte{nalType << 1, 0x01}
+		require.False(t, IsKeyframeNALU(nalu, true), "NAL type %d must not be a keyframe", nalType)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -383,9 +383,10 @@ var ValidEncodingsForProtocol = map[string][]string{
 	string(ProtoTimelapse): {""}, // empty string for auto-detect
 	// Push/ingest protocols. SRT config-layer accepts h264/h265, but the current
 	// SRT MPEG-TS demuxer only emits H.264 NALUs (H.265 over SRT is a follow-up).
-	// RTMP is H.264 only (the classic RTMP spec; Enhanced-RTMP H.265 is rare).
+	// RTMP accepts H.265 via Enhanced-RTMP (hvc1 fourcc) — publishers must send
+	// the fourcc sequence header (our relay passthrough policy and FFmpeg do).
 	string(ProtoSRT):  {string(FormatH264), string(FormatH265)},
-	string(ProtoRTMP): {string(FormatH264)},
+	string(ProtoRTMP): {string(FormatH264), string(FormatH265)},
 	// WHIP (browser/OBS WebRTC push-in) is H.264 only — matches WHEP egress
 	// (browser WebRTC H.265 support is still fragmented).
 	string(ProtoWHIP): {string(FormatH264)},

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -27,7 +27,7 @@ var ingestLogger = slog.Default().With("component", "ingest-recorder")
 // irrelevant because the publisher connects to us.
 type IngestConfig struct {
 	CameraID   string
-	Encoding   string // "h264" (H.265 over SRT is a follow-up; RTMP is H.264 only)
+	Encoding   string // "h264" or "h265" (RTMP H.265 via enhanced-RTMP hvc1; SRT H.265 demux is a follow-up)
 	SegmentDur time.Duration
 
 	Store SegmentStore // satisfies *storage.Manager
@@ -44,7 +44,7 @@ type IngestConfig struct {
 	RecordEnabled *bool
 }
 
-// IngestRecorder records H.264 video pushed into the NVR via SRT/RTMP ingest.
+// IngestRecorder records H.264/H.265 video pushed into the NVR via SRT/RTMP ingest.
 //
 // Lifecycle: Start() enters the Idle (waiting) state — no network activity.
 // When a publisher connects, the ingest server calls WriteConnected(). Each
@@ -81,6 +81,7 @@ type IngestRecorder struct {
 	muxer      *muxer.MP4Muxer
 	trackID    int
 	sps, pps   []byte
+	vps        []byte // H.265 only (nil for H.264 sources)
 	curTemp    string
 	curFinal   string
 	segStart   time.Time
@@ -99,6 +100,17 @@ type IngestRecorder struct {
 
 var _ model.Recorder = (*IngestRecorder)(nil)
 
+// isH265 reports whether this recorder was configured for H.265 push ingest.
+func (r *IngestRecorder) isH265() bool { return r.cfg.Encoding == "h265" }
+
+// format is the recording format label derived from the configured encoding.
+func (r *IngestRecorder) format() model.Format {
+	if r.isH265() {
+		return model.FormatH265
+	}
+	return model.FormatH264
+}
+
 // NewIngestRecorder constructs an IngestRecorder. The Hub is injected later by
 // camera.initStreamHub (consistent with every other recorder).
 func NewIngestRecorder(cfg IngestConfig) *IngestRecorder {
@@ -114,6 +126,14 @@ func NewIngestRecorder(cfg IngestConfig) *IngestRecorder {
 // GetHub returns the StreamHub for frame fan-out (satisfies the hubber interface
 // used by getRecorderHub across the API layer).
 func (r *IngestRecorder) GetHub() *model.StreamHub { return r.Hub }
+
+// VPS returns the most recently captured H.265 VPS NAL unit (without start
+// code). Always nil for H.264 sources. Thread-safe.
+func (r *IngestRecorder) VPS() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.vps
+}
 
 // SPS returns the most recently captured H.264 SPS NAL unit (without start code).
 // nil until the publisher has sent a keyframe with param sets. Thread-safe.
@@ -132,12 +152,15 @@ func (r *IngestRecorder) PPS() []byte {
 }
 
 // CodecParams implements model.HLSProvider so the HLS handler can initialize a
-// stream from the SPS/PPS captured during ingest (push cameras). Returns H.264
-// with the current SPS/PPS (vps is nil for H.264). Returns nil params before the
-// publisher's first keyframe arrives.
+// stream from the parameter sets captured during ingest (push cameras). Returns
+// the configured format with the current SPS/PPS (+VPS for H.265). Returns nil
+// params before the publisher's first keyframe arrives.
 func (r *IngestRecorder) CodecParams() (codec model.Format, sps, pps, vps []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.isH265() {
+		return model.FormatH265, r.sps, r.pps, r.vps
+	}
 	return model.FormatH264, r.sps, r.pps, nil
 }
 
@@ -325,13 +348,41 @@ func (r *IngestRecorder) WriteNALU(au [][]byte, ptsTicks int64, _ bool) {
 	r.cacheParamSets(au)
 }
 
-// cacheParamSets extracts SPS/PPS from an incoming delivery (any granularity)
-// and rotates the recording segment when they change. Runs on every WriteNALU
-// call so out-of-band parameter-set deliveries (the RTMP sequence-header feed,
-// which carries no VCL NALU and is never emitted by the assembler) are still
-// captured in time for HLS/FLV/WebRTC initialization. H.264 only — H.265 push
-// ingest is a follow-up (see IngestConfig.Encoding).
+// cacheParamSets extracts parameter sets from an incoming delivery (any
+// granularity) and rotates the recording segment when they change. Runs on
+// every WriteNALU call so out-of-band parameter-set deliveries (the RTMP
+// sequence-header feed, which carries no VCL NALU and is never emitted by the
+// assembler) are still captured in time for HLS/FLV/WebRTC initialization.
+// H.265 sources additionally cache the VPS (required by the hvc1/hvcC track
+// and by consumers that expect the full VPS/SPS/PPS triple in-band).
 func (r *IngestRecorder) cacheParamSets(au [][]byte) {
+	if r.isH265() {
+		vps, sps, pps := nalutil.ExtractParamSetsH265(au)
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if vps != nil {
+			if r.vps != nil && !nalutil.EqualParamSets(r.vps, vps) {
+				ingestLogger.Info("VPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegmentLocked()
+			}
+			r.vps = append([]byte(nil), vps...)
+		}
+		if sps != nil {
+			if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) {
+				ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegmentLocked()
+			}
+			r.sps = append([]byte(nil), sps...)
+		}
+		if pps != nil {
+			if r.pps != nil && !nalutil.EqualParamSets(r.pps, pps) {
+				ingestLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegmentLocked()
+			}
+			r.pps = append([]byte(nil), pps...)
+		}
+		return
+	}
 	sps, pps := nalutil.ExtractParamSetsH264(au)
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -363,7 +414,7 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 		}
 	}()
 
-	isIDR := nalutil.IsIDR(au, r.cfg.Encoding == "h265")
+	isIDR := nalutil.IsIDR(au, r.isH265())
 
 	// ---- Lock scope 1: status transition, shared-state snapshot ----
 	r.mu.Lock()
@@ -377,6 +428,7 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 	hub := r.Hub
 	localSPS := r.sps
 	localPPS := r.pps
+	localVPS := r.vps
 	r.mu.Unlock()
 
 	// ---- Hub broadcast (outside lock, non-blocking by design) ----
@@ -389,11 +441,21 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 	if hub != nil {
 		broadcastAU := au
 		if isIDR && localSPS != nil && localPPS != nil {
-			inSPS, inPPS := nalutil.ExtractParamSetsH264(au)
-			if inSPS == nil || inPPS == nil {
-				broadcastAU = make([][]byte, 0, len(au)+2)
-				broadcastAU = append(broadcastAU, localSPS, localPPS)
-				broadcastAU = append(broadcastAU, au...)
+			if r.isH265() {
+				// H.265 consumers need the full VPS/SPS/PPS triple in-band.
+				inVPS, inSPS, inPPS := nalutil.ExtractParamSetsH265(au)
+				if inVPS == nil || inSPS == nil || inPPS == nil {
+					broadcastAU = make([][]byte, 0, len(au)+3)
+					broadcastAU = append(broadcastAU, localVPS, localSPS, localPPS)
+					broadcastAU = append(broadcastAU, au...)
+				}
+			} else {
+				inSPS, inPPS := nalutil.ExtractParamSetsH264(au)
+				if inSPS == nil || inPPS == nil {
+					broadcastAU = make([][]byte, 0, len(au)+2)
+					broadcastAU = append(broadcastAU, localSPS, localPPS)
+					broadcastAU = append(broadcastAU, au...)
+				}
 			}
 		}
 		hub.Broadcast(ptsTicks, broadcastAU, isIDR)
@@ -408,16 +470,25 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 		return
 	}
 
-	// ---- Find VCL NALU (type 1 non-IDR or type 5 IDR) to write to disk ----
+	// ---- Find VCL NALU to write to disk ----
+	// H.264: type 1 (non-IDR) or 5 (IDR). H.265: any VCL type (0-31, IDR/WPP
+	// slices are 16-21 — the AU carries one VCL NALU per picture here).
 	var vclNALU []byte
 	for _, nalu := range au {
 		if len(nalu) == 0 {
 			continue
 		}
-		naluType := nalu[0] & 0x1F
-		if naluType == 5 || naluType == 1 {
-			vclNALU = nalu
-			break
+		if r.isH265() {
+			if (nalu[0]>>1)&0x3F < 32 {
+				vclNALU = nalu
+				break
+			}
+		} else {
+			naluType := nalu[0] & 0x1F
+			if naluType == 5 || naluType == 1 {
+				vclNALU = nalu
+				break
+			}
 		}
 	}
 	if vclNALU == nil {
@@ -441,7 +512,7 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 		return
 	}
 
-	if localSPS == nil || localPPS == nil {
+	if localSPS == nil || localPPS == nil || (r.isH265() && localVPS == nil) {
 		return
 	}
 
@@ -455,17 +526,28 @@ func (r *IngestRecorder) writeAssembledAU(au [][]byte, ptsTicks int64) {
 	r.mu.Unlock()
 
 	if curMux == nil {
-		tempPath, finalPath, err := r.cfg.Store.CreateSegment(r.cfg.CameraID, string(model.FormatH264))
+		format := r.format()
+		tempPath, finalPath, err := r.cfg.Store.CreateSegment(r.cfg.CameraID, string(format))
 		if err != nil {
 			ingestLogger.Error("failed to create segment", "camera_id", r.cfg.CameraID, "error", err)
 			return
 		}
 		newMux := muxer.NewMP4Muxer(tempPath)
-		newTrackID, err := newMux.AddH264Track(localSPS, localPPS)
-		if err != nil {
-			ingestLogger.Error("failed to add H264 track", "camera_id", r.cfg.CameraID, "error", err)
-			os.Remove(tempPath)
-			return
+		var newTrackID int
+		if r.isH265() {
+			newTrackID, err = newMux.AddH265Track(localVPS, localSPS, localPPS)
+			if err != nil {
+				ingestLogger.Error("failed to add H265 track", "camera_id", r.cfg.CameraID, "error", err)
+				os.Remove(tempPath)
+				return
+			}
+		} else {
+			newTrackID, err = newMux.AddH264Track(localSPS, localPPS)
+			if err != nil {
+				ingestLogger.Error("failed to add H264 track", "camera_id", r.cfg.CameraID, "error", err)
+				os.Remove(tempPath)
+				return
+			}
 		}
 		// Opus audio track (#369): config = 1 byte channels + 2 bytes PreSkip +
 		// 4 bytes InputSampleRate (big-endian) — see muxer.AddAudioTrack.
@@ -583,6 +665,7 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 	// Insert recording entry into the database.
 	var fileSize int64
 	var recordingID string
+	format := r.format()
 	if r.cfg.DB != nil && r.curFinal != "" {
 		now := time.Now()
 		duration := now.Sub(r.segStart).Seconds()
@@ -590,7 +673,7 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 			ID:         strconv.FormatInt(now.UnixNano(), 10),
 			CameraID:   r.cfg.CameraID,
 			FilePath:   r.curFinal,
-			Format:     model.FormatH264,
+			Format:     format,
 			StartedAt:  r.segStart,
 			EndedAt:    now,
 			Duration:   duration,
@@ -611,8 +694,8 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 		r.cfg.EventBus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
 			CameraID:    r.cfg.CameraID,
 			FilePath:    r.curFinal,
-			Format:      string(model.FormatH264),
-			Encoding:    string(model.FormatH264),
+			Format:      string(format),
+			Encoding:    string(format),
 			StartedAt:   r.segStart.Format(time.RFC3339Nano),
 			EndedAt:     time.Now().Format(time.RFC3339Nano),
 			FileSize:    fileSize,
@@ -653,12 +736,12 @@ func (r *IngestRecorder) decActive() {
 
 func (r *IngestRecorder) recordSegmentCreated() {
 	if r.cfg.Metrics != nil {
-		r.cfg.Metrics.SegmentsCreated.WithLabelValues(r.cfg.CameraID, "h264").Inc()
+		r.cfg.Metrics.SegmentsCreated.WithLabelValues(r.cfg.CameraID, string(r.format())).Inc()
 	}
 }
 
 func (r *IngestRecorder) recordBytes(bytes int64) {
 	if r.cfg.Metrics != nil {
-		r.cfg.Metrics.RecordingBytesTotal.WithLabelValues(r.cfg.CameraID, "h264").Add(float64(bytes))
+		r.cfg.Metrics.RecordingBytesTotal.WithLabelValues(r.cfg.CameraID, string(r.format())).Add(float64(bytes))
 	}
 }

--- a/internal/recorder/ingest_test.go
+++ b/internal/recorder/ingest_test.go
@@ -361,3 +361,90 @@ func TestIngestRecorder_SetAudioFormatLockedIn(t *testing.T) {
 	other.SetAudioFormat("g711", 8000, 1)
 	require.Empty(t, other.AudioCodec())
 }
+
+// TestIngestRecorder_H265_RecordsSegment verifies the H.265 push-ingest path
+// (#433, enhanced-RTMP hvc1): the VPS/SPS/PPS triple is cached, the segment is
+// created as an H.265 track, IDR broadcasts carry the param-set triple
+// in-band, and the recording row is format h265.
+func TestIngestRecorder_H265_RecordsSegment(t *testing.T) {
+	store, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+	db := &ingestTestDB{}
+	rec := NewIngestRecorder(IngestConfig{
+		CameraID:   "push-cam-h265",
+		Encoding:   "h265",
+		SegmentDur: 10 * time.Minute,
+		Store:      store,
+		DB:         db,
+	})
+	rec.Hub = model.NewStreamHub()
+	rec.Hub.SetCameraID("push-cam-h265")
+	require.NoError(t, rec.Start(context.Background()))
+	t.Cleanup(func() { _ = rec.Stop() })
+
+	// Out-of-band param-set feed first (mirrors the RTMP sequence-header feed
+	// in internal/rtmp/server.go), then the IDR picture, then P frames.
+	rec.WriteNALU([][]byte{testVPS265, testSPS265, testPPS265}, 0, true)
+	pFrame265 := []byte{0x02, 0x01, 0xaf, 0x09, 0x40, 0xc0, 0x00, 0x10} // TRAIL_R slice (NAL type 1)
+	rec.WriteNALU([][]byte{testIDR265}, 90, true)
+	for i := 2; i <= 6; i++ {
+		rec.WriteNALU([][]byte{pFrame265}, int64(i)*90, false)
+	}
+	require.Equal(t, model.StatusRecording, rec.Status())
+
+	// CodecParams must report the H.265 format with the full triple.
+	f, sps, pps, vps := rec.CodecParams()
+	require.Equal(t, model.FormatH265, f)
+	require.NotNil(t, sps)
+	require.NotNil(t, pps)
+	require.NotNil(t, vps)
+
+	// A subscriber sees IDR AUs carrying the VPS/SPS/PPS triple in-band.
+	var gotIDR bool
+	done := make(chan struct{})
+	subID := "ingest-h265-test"
+	require.NoError(t, rec.Hub.Subscribe(subID, func(_ int64, au [][]byte) {
+		if !gotIDR {
+			gotIDR = true
+			v, s, p := extractTripleForTest(au)
+			require.NotNil(t, v)
+			require.NotNil(t, s)
+			require.NotNil(t, p)
+			close(done)
+		}
+	}))
+	defer rec.Hub.Unsubscribe(subID)
+	// Push another IDR after subscribing so the hub delivers a fresh keyframe.
+	rec.WriteNALU([][]byte{testIDR265}, 700, true)
+	rec.WriteNALU([][]byte{pFrame265}, 800, false)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no IDR broadcast observed within timeout")
+	}
+	require.True(t, gotIDR)
+
+	require.NoError(t, rec.Stop())
+	require.Len(t, db.recordings, 1)
+	require.Equal(t, model.FormatH265, db.recordings[0].Format)
+	files := camFiles(t, store, "push-cam-h265")
+	require.NotEmpty(t, files)
+}
+
+// extractTripleForTest pulls VPS/SPS/PPS out of a broadcast AU (test helper).
+func extractTripleForTest(au [][]byte) (vps, sps, pps []byte) {
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		switch (nalu[0] >> 1) & 0x3F {
+		case 32:
+			vps = nalu
+		case 33:
+			sps = nalu
+		case 34:
+			pps = nalu
+		}
+	}
+	return
+}

--- a/internal/relay/connect_rtmp.go
+++ b/internal/relay/connect_rtmp.go
@@ -27,6 +27,14 @@ func (t *PushTarget) connectRTMP(ctx context.Context) error {
 			t.setStatus(StatusError, msg)
 			return fmt.Errorf("%w: %s", errPermanent, msg)
 		}
+		// H.265 source, passthrough policy — publish natively via
+		// enhanced-RTMP (hvc1 fourcc). Only viable between enhanced-RTMP-aware
+		// receivers (our own NVR ingest, SRS, FFmpeg 6.1+); third-party
+		// platforms (Douyu etc.) mostly reject hvc1, which is why `auto`
+		// keeps transcoding to H.264.
+		if t.Config.TranscodePolicy == "passthrough" {
+			return t.connectRTMPH265Passthrough(ctx)
+		}
 		// H.265 source — transcode if policy allows.
 		if t.Config.TranscodePolicy == "off" {
 			t.setStatus(StatusError, "source is not H.264 (RTMP target requires H.264)")
@@ -265,6 +273,177 @@ func (t *PushTarget) connectRTMP(ctx context.Context) error {
 	t.setStatus(StatusStreaming, "")
 	engineLogger.Info("relay target streaming",
 		"camera_id", t.CameraID, "target_id", t.Config.ID, "protocol", "rtmp", "url", t.Config.URL)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-cbErr:
+		return err
+	}
+}
+
+// connectRTMPH265Passthrough publishes an H.265 source natively via
+// enhanced-RTMP (hvc1 fourcc) without any transcoding (#433). Requires an
+// enhanced-RTMP-aware receiver (our own NVR RTMP ingest, SRS, FFmpeg 6.1+).
+// The gortmplib writer emits the VideoExSequenceStart (hvc1) header plus
+// VideoExFramesX frame messages; the custom handshake conn passes those
+// through its standard writer untouched (the Type-0 interception only
+// rewrites classic AVC/Audio messages for strict FMS receivers, which do not
+// accept hvc1 in the first place).
+//
+// Audio: AAC and G.711 are forwarded when the source has them (same as the
+// H.264 path), but no silent-AAC fallback is injected — passthrough targets
+// are machine-to-machine and synthetic audio would only burn bitrate.
+func (t *PushTarget) connectRTMPH265Passthrough(ctx context.Context) error {
+	t.setStatus(StatusConnecting, "")
+	u, err := url.Parse(t.Config.URL)
+	if err != nil || (u.Scheme != "rtmp" && u.Scheme != "rtmps") {
+		t.setStatus(StatusError, "invalid RTMP url")
+		return errPermanent
+	}
+
+	if t.codecInfoProvider == nil {
+		msg := "passthrough requires a codec info provider"
+		t.setStatus(StatusError, msg)
+		return errPermanent
+	}
+	ci := t.codecInfoProvider()
+	if ci.VPS == nil || ci.SPS == nil || ci.PPS == nil {
+		t.setStatus(StatusError, "source stream not ready (no H.265 VPS/SPS/PPS yet)")
+		return errPermanent
+	}
+
+	videoTrack := &gortmplib.Track{Codec: &codecs.H265{
+		VPS: append([]byte(nil), ci.VPS...),
+		SPS: append([]byte(nil), ci.SPS...),
+		PPS: append([]byte(nil), ci.PPS...),
+	}}
+
+	var (
+		audioTrack *gortmplib.Track
+		audioSubID string
+		g711Track  *gortmplib.Track
+		g711SubID  string
+	)
+	switch ci.AudioCodec {
+	case "aac":
+		if asc := parseASC(ci.AudioConfig); asc != nil {
+			audioTrack = &gortmplib.Track{Codec: &codecs.MPEG4Audio{Config: asc}}
+			audioSubID = "relay-rtmp-h265-" + t.Config.ID + "-audio"
+			engineLogger.Info("relay target adding AAC audio track (h265 passthrough)",
+				"camera_id", t.CameraID, "target_id", t.Config.ID)
+		}
+	case "g711":
+		isMULaw, _ := parseG711Config(ci.AudioConfig)
+		ch := ci.AudioChannels
+		if ch <= 0 {
+			ch = 1
+		}
+		g711Track = &gortmplib.Track{Codec: &codecs.G711{MULaw: isMULaw, ChannelCount: ch}}
+		g711SubID = "relay-rtmp-h265-" + t.Config.ID + "-g711"
+		engineLogger.Info("relay target adding G.711 audio track (h265 passthrough)",
+			"camera_id", t.CameraID, "target_id", t.Config.ID, "mu_law", isMULaw)
+	}
+
+	tracks := []*gortmplib.Track{videoTrack}
+	if audioTrack != nil {
+		tracks = append(tracks, audioTrack)
+	}
+	if g711Track != nil {
+		tracks = append(tracks, g711Track)
+	}
+
+	// width/height/fps are unknown (the h265 SPS parser exposes no helpers in
+	// the vendored mediacommon) — onMetaData omits them, which enhanced-RTMP
+	// receivers tolerate (they configure from the hvc1 sequence header).
+	conn, connCleanup, err := dialRTMPPublish(ctx, t.Config.URL, 0, 0, 0)
+	if err != nil {
+		return err
+	}
+	defer connCleanup()
+
+	writer := &gortmplib.Writer{Conn: conn, Tracks: tracks}
+	if err := writer.Initialize(); err != nil {
+		return err
+	}
+
+	start := time.Now()
+	consumerID := "relay-rtmp-h265-" + t.Config.ID
+	cbErr := make(chan error, 1)
+
+	if err := t.hub.Subscribe(consumerID, func(pts int64, au [][]byte) {
+		// Wall-clock relative PTS, dts == pts (no B-frame reorder), same
+		// convention as the H.264 path.
+		d := time.Since(start)
+		if d < 0 {
+			d = 0
+		}
+		if werr := writer.WriteH265(videoTrack, d, d, au); werr != nil {
+			select {
+			case cbErr <- werr:
+			default:
+			}
+		} else {
+			var n int64
+			for _, nalu := range au {
+				n += int64(len(nalu))
+			}
+			t.bytesSent.Add(n)
+		}
+	}); err != nil {
+		return err
+	}
+	defer t.hub.Unsubscribe(consumerID)
+
+	if audioSubID != "" {
+		if err := t.hub.SubscribeAudio(audioSubID, func(pts int64, codec model.AudioCodec, data []byte) {
+			if codec != model.AudioAAC {
+				return
+			}
+			d := durationFromPTS(pts)
+			if d < 0 {
+				d = 0
+			}
+			if werr := writer.WriteMPEG4Audio(audioTrack, d, data); werr != nil {
+				select {
+				case cbErr <- werr:
+				default:
+				}
+			} else {
+				t.bytesSent.Add(int64(len(data)))
+			}
+		}); err != nil {
+			return err
+		}
+		defer t.hub.UnsubscribeAudio(audioSubID)
+	}
+
+	if g711SubID != "" {
+		if err := t.hub.SubscribeAudio(g711SubID, func(pts int64, codec model.AudioCodec, data []byte) {
+			if codec != model.AudioG711 {
+				return
+			}
+			d := durationFromPTS(pts)
+			if d < 0 {
+				d = 0
+			}
+			if werr := writer.WriteG711(g711Track, d, data); werr != nil {
+				select {
+				case cbErr <- werr:
+				default:
+				}
+			} else {
+				t.bytesSent.Add(int64(len(data)))
+			}
+		}); err != nil {
+			return err
+		}
+		defer t.hub.UnsubscribeAudio(g711SubID)
+	}
+
+	t.setStatus(StatusStreaming, "")
+	engineLogger.Info("relay target streaming (h265 passthrough, enhanced-RTMP hvc1)",
+		"camera_id", t.CameraID, "target_id", t.Config.ID, "url", t.Config.URL)
 
 	select {
 	case <-ctx.Done():

--- a/internal/relay/engine_test.go
+++ b/internal/relay/engine_test.go
@@ -648,3 +648,35 @@ func TestConnectRTMP_NoSourceCodecProviderKeepsLegacyBehavior(t *testing.T) {
 	require.Equal(t, StatusError, target.status)
 	require.Contains(t, target.errMsg, "source is not H.264")
 }
+
+func TestConnectRTMP_H265PassthroughRouting(t *testing.T) {
+	// H.265 source + passthrough policy must route to the enhanced-RTMP hvc1
+	// publisher (#433). With no codec info provider wired the path fails
+	// permanently BEFORE dialing — proving the routing without a live server.
+	target := NewPushTarget("test-cam", PushTargetConfig{
+		ID: "t1", URL: "rtmp://invalid/does/not/matter",
+		Protocol: "rtmp", TranscodePolicy: "passthrough",
+	}, nil, func() ([]byte, []byte, bool) {
+		return nil, nil, false // H.265 source
+	})
+
+	err := target.connectRTMP(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, errPermanent)
+	require.Equal(t, StatusError, target.status)
+	require.Contains(t, target.errMsg, "passthrough requires a codec info provider")
+
+	// With a provider but no VPS/SPS/PPS yet, the target waits as a permanent
+	// "not ready" error (matches the H.264 not-ready semantics).
+	target2 := NewPushTarget("test-cam", PushTargetConfig{
+		ID: "t1", URL: "rtmp://invalid/does/not/matter",
+		Protocol: "rtmp", TranscodePolicy: "passthrough",
+	}, nil, func() ([]byte, []byte, bool) {
+		return nil, nil, false
+	})
+	target2.SetCodecInfoProvider(func() model.CodecInfo { return model.CodecInfo{} })
+
+	err = target2.connectRTMP(context.Background())
+	require.ErrorIs(t, err, errPermanent)
+	require.Contains(t, target2.errMsg, "no H.265 VPS/SPS/PPS")
+}

--- a/internal/rtmp/ingest_test.go
+++ b/internal/rtmp/ingest_test.go
@@ -391,3 +391,63 @@ func TestStreamHubBroadcastNonBlocking(t *testing.T) {
 		t.Fatal("Broadcast blocked — should be non-blocking")
 	}
 }
+
+// TestH265FrameExtraction verifies that an enhanced-RTMP (hvc1 fourcc) H.265
+// publisher is accepted and its frames broadcast to the StreamHub (#433).
+func TestH265FrameExtraction(t *testing.T) {
+	keys := testStreamKeys()
+
+	var receivedFrames [][]byte
+	var mu sync.Mutex
+	hub := model.NewStreamHub()
+	require.NoError(t, hub.Subscribe("test-h265", func(pts int64, au [][]byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		receivedFrames = append(receivedFrames, au...)
+	}))
+
+	srv, addr := startTestServer(t, testResolver(keys), func(string) *model.StreamHub {
+		return hub
+	}, nil, nil)
+
+	u, err := url.Parse("rtmp://" + addr + "/live/test-key-1")
+	require.NoError(t, err)
+	client := &gortmplib.Client{URL: u, Publish: true}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, client.Initialize(ctx))
+	defer client.Close()
+
+	track := &gortmplib.Track{Codec: &codecs.H265{
+		VPS: []byte{0x40, 0x01, 0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0x99, 0x98, 0x09},
+		SPS: []byte{0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90, 0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0xa0, 0x03, 0xc0, 0x80, 0x10, 0xe5, 0x96, 0x66, 0x69, 0x24, 0xca, 0xe0, 0x10, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x03, 0x01, 0xe0, 0x80},
+		PPS: []byte{0x44, 0x01, 0xc1, 0x72, 0xb4, 0x62, 0x40},
+	}}
+	writer := &gortmplib.Writer{Conn: client, Tracks: []*gortmplib.Track{track}}
+	require.NoError(t, writer.Initialize())
+
+	require.Eventually(t, func() bool {
+		return srv.activePublishers() > 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	frameCtx, frameCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer frameCancel()
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-frameCtx.Done():
+				return
+			default:
+			}
+			idrAU := [][]byte{{0x26, 0x01, 0xaf, 0x09, 0x40, 0xc0, 0x00, 0x10}} // IDR_WPP slice
+			_ = writer.WriteH265(track, time.Duration(i*33)*time.Millisecond, time.Duration(i*33)*time.Millisecond, idrAU)
+			time.Sleep(33 * time.Millisecond)
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(receivedFrames) > 0
+	}, 10*time.Second, 100*time.Millisecond, "H.265 frames should be received")
+}

--- a/internal/rtmp/server.go
+++ b/internal/rtmp/server.go
@@ -45,8 +45,8 @@ type Config struct {
 	Addr string
 }
 
-// Server is an RTMP ingest server that receives H.264 streams and
-// distributes frames via StreamHub.
+// Server is an RTMP ingest server that receives H.264 or H.265
+// (enhanced-RTMP hvc1) streams and distributes frames via StreamHub.
 type Server struct {
 	cfg    Config
 	resolv StreamKeyResolver
@@ -243,16 +243,22 @@ func (s *Server) handlePublisher(ctx context.Context, sc *gortmplib.ServerConn, 
 		return
 	}
 
-	// Find H.264 track
+	// Find the video track: H.264 (classic AVC track) or H.265
+	// (enhanced-RTMP hvc1 fourcc).
 	var h264Track *gortmplib.Track
+	var h265Track *gortmplib.Track
 	for _, track := range r.Tracks() {
 		if _, ok := track.Codec.(*codecs.H264); ok {
 			h264Track = track
 			break
 		}
+		if _, ok := track.Codec.(*codecs.H265); ok {
+			h265Track = track
+			break
+		}
 	}
-	if h264Track == nil {
-		logger.Error("no H.264 track found", "camera_id", entry.cameraID)
+	if h264Track == nil && h265Track == nil {
+		logger.Error("no H.264/H.265 track found", "camera_id", entry.cameraID)
 		return
 	}
 
@@ -263,35 +269,53 @@ func (s *Server) handlePublisher(ctx context.Context, sc *gortmplib.ServerConn, 
 		recordCB = s.NALUProvider(entry.cameraID)
 	}
 
-	// Extract SPS/PPS from the RTMP AVCDecoderConfigurationRecord (carried
-	// out-of-band, NOT in VCL access units). Feed them to the IngestRecorder so
-	// it can (a) initialize MP4 segments and (b) prepend SPS/PPS to IDR frames
-	// for downstream consumers (HLS DTS extractor, WebRTC) that expect them
-	// in-band — matching the RTSP path.
-	if h264Codec, ok := h264Track.Codec.(*codecs.H264); ok && h264Codec.SPS != nil && recordCB != nil {
-		recordCB([][]byte{h264Codec.SPS, h264Codec.PPS}, 0, true)
+	// Extract parameter sets from the out-of-band RTMP sequence header
+	// (AVCDecoderConfigurationRecord for H.264, HEVCDecoderConfigurationRecord
+	// for enhanced-RTMP H.265 — carried NOT in VCL access units). Feed them to
+	// the IngestRecorder so it can (a) initialize MP4 segments and (b) prepend
+	// them to IDR frames for downstream consumers (HLS DTS extractor, WebRTC)
+	// that expect them in-band — matching the RTSP path.
+	if h264Track != nil {
+		if h264Codec, ok := h264Track.Codec.(*codecs.H264); ok && h264Codec.SPS != nil && recordCB != nil {
+			recordCB([][]byte{h264Codec.SPS, h264Codec.PPS}, 0, true)
+		}
+	}
+	if h265Track != nil {
+		if h265Codec, ok := h265Track.Codec.(*codecs.H265); ok &&
+			h265Codec.VPS != nil && h265Codec.SPS != nil && h265Codec.PPS != nil && recordCB != nil {
+			recordCB([][]byte{h265Codec.VPS, h265Codec.SPS, h265Codec.PPS}, 0, true)
+		}
 	}
 
 	// Clear deadline for continuous reading
 	conn.SetReadDeadline(time.Time{})
 
-	// Set up H.264 data callback. When an IngestRecorder is wired (the normal
-	// case), WriteNALU itself broadcasts to the camera's StreamHub — AND
-	// prepends cached SPS/PPS to IDR frames, which downstream consumers need.
-	// Broadcasting here too would deliver every AU twice (the hub in
-	// hubRegistry is the SAME object the recorder owns), so the direct
+	// Set up the video data callback. When an IngestRecorder is wired (the
+	// normal case), WriteNALU itself broadcasts to the camera's StreamHub —
+	// AND prepends cached parameter sets to IDR frames, which downstream
+	// consumers need. Broadcasting here too would deliver every AU twice (the
+	// hub in hubRegistry is the SAME object the recorder owns), so the direct
 	// broadcast is only the no-recorder fallback (live-only gateway).
-	r.OnDataH264(h264Track, func(pts time.Duration, dts time.Duration, au [][]byte) {
+	onData := func(pts time.Duration, dts time.Duration, au [][]byte, isH265 bool) {
 		// pts is time.Duration from stream start, convert to 90kHz clock ticks
 		// for compatibility with StreamHub's existing consumers (HLS, WebRTC, FLV).
 		ptsTicks := pts.Nanoseconds() * 90 / 1e6 // ns → 90kHz ticks
-		isIDR := nalutil.IsIDR(au, false)
+		isIDR := nalutil.IsIDR(au, isH265)
 		if recordCB != nil {
 			recordCB(au, ptsTicks, isIDR)
 		} else {
 			entry.hub.Broadcast(ptsTicks, au, isIDR)
 		}
-	})
+	}
+	if h265Track != nil {
+		r.OnDataH265(h265Track, func(pts time.Duration, dts time.Duration, au [][]byte) {
+			onData(pts, dts, au, true)
+		})
+	} else {
+		r.OnDataH264(h264Track, func(pts time.Duration, dts time.Duration, au [][]byte) {
+			onData(pts, dts, au, false)
+		})
+	}
 
 	// Read loop — runs until disconnect or context cancellation
 	for {

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -510,6 +510,10 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	// that actually have enabled targets. Wired to the camera manager so Add/
 	// Update/Remove reconcile targets automatically.
 	relayMgr := relay.NewManager(camMgr.GetHub, camMgr.GetSPS)
+	// Codec info (video VPS/SPS/PPS + audio params) for relay targets — the
+	// H.265 passthrough policy (#433) needs the VPS alongside SPS/PPS, and
+	// audio-aware targets use the audio fields.
+	relayMgr.SetCodecInfoProvider(camMgr.GetCodecInfo)
 	camMgr.SetRelayManager(relayMgr)
 
 	// Step 7.6c: sub-stream recycle callback (#513). When the on-demand

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -117,7 +117,7 @@ export interface PushTargetConfig {
   url: string;
   enabled: boolean;
   platform?: string;
-  transcode_policy?: 'auto' | 'force_sw' | 'off';
+  transcode_policy?: 'auto' | 'force_sw' | 'off' | 'passthrough';
   video_preset_override?: VideoPresetOverrides;
   use_ffmpeg?: boolean;
 }

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -1386,9 +1386,10 @@ async function performCameraSave() {
                     <span class="text-xs th-text-muted whitespace-nowrap">{t('cameras.pushTranscodeNA')}</span>
                   {:else}
                     <select class="input w-auto" value={tgt.transcode_policy || 'auto'}
-                      onchange={(e) => updatePushTarget(tgt.id, { transcode_policy: (e.target as HTMLSelectElement).value as 'auto' | 'force_sw' | 'off' })}>
+                      onchange={(e) => updatePushTarget(tgt.id, { transcode_policy: (e.target as HTMLSelectElement).value as 'auto' | 'force_sw' | 'off' | 'passthrough' })}>
                       <option value="auto">{t('cameras.pushTranscodeAuto')}</option>
                       <option value="force_sw">{t('cameras.pushTranscodeForceSW')}</option>
+                      <option value="passthrough">{t('cameras.pushTranscodePassthrough')}</option>
                       <option value="off">{t('cameras.pushTranscodeRejectH265')}</option>
                     </select>
                   {/if}

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -263,6 +263,7 @@
   "cameras.pushTranscodeForceSW": "Force software encode",
   "cameras.pushTranscodeHW": "HW",
   "cameras.pushTranscodeNA": "No transcode needed (H.264)",
+  "cameras.pushTranscodePassthrough": "H.265 passthrough (no transcode)",
   "cameras.pushTranscodeRejectH265": "Reject H.265 sources",
   "cameras.pushTranscodeSW": "SW",
   "cameras.pushTranscodeThrottled": "throttled",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -256,6 +256,7 @@
   "cameras.pushTranscodeForceSW": "强制软件编码",
   "cameras.pushTranscodeHW": "硬件",
   "cameras.pushTranscodeNA": "无需转码（H.264 直推）",
+  "cameras.pushTranscodePassthrough": "H.265 直推（不转码）",
   "cameras.pushTranscodeRejectH265": "拒绝 H.265 源",
   "cameras.pushTranscodeSW": "软件",
   "cameras.pushTranscodeThrottled": "降速",


### PR DESCRIPTION
Closes #433.

## Ingest 侧
- `internal/rtmp/server.go`: 接受 enhanced-RTMP hvc1 H.265 轨道（`OnDataH265`），HEVC 序列头的 VPS/SPS/PPS 像 AVC 一样先喂给 IngestRecorder
- `internal/recorder/ingest.go`: H.265 泛化 —— VPS 缓存/变更轮转、`AddH265Track`、FormatH265 录像行/事件/指标、IDR 广播在带内补齐 VPS/SPS/PPS 三元组
- `model.ValidEncodingsForProtocol`: rtmp+h265 合法化（其余 #402 组合守卫不变）

## Publisher 侧
- 新 `transcode_policy: passthrough`：H.265 源经 enhanced-RTMP hvc1 原生直推（`connectRTMPH265Passthrough`，AAC/G.711 透传、不注入静音 AAC）。仅适用于 enhanced-RTMP 感知接收端（自家 NVR / SRS / FFmpeg 6.1+）；第三方平台继续用 `auto` 转码
- relay Manager 接通 `codecInfoProvider`（`camMgr.GetCodecInfo`，passthrough 需要 VPS——这是该 provider 的文档化生产后备，此前漏接）
- 配置校验、前端类型/下拉/i18n 同步

## 附带修复（验证过程中发现）
- `nalutil.IsKeyframeNALU` H.265 关键帧范围 19/20 → **16-23**（BLA/IDR/CRA）：x265 首帧之后只发 CRA_NUT(21)，原实现会让录制器永远等不到第二个关键帧——不滚段、无 IDR 快启回放
- `camera.GetSPS` 对 H.265 ingest 相机不再误报 `isH264=true`；`GetCodecInfo` 补 IngestRecorder 分支（含 VPS）

## 端到端验证（本机双实例，VM 不可达改本机）
ffmpeg libx265 → NVR-A(rtmp ingest) → relay passthrough → NVR-B(rtmp ingest)：
- B 侧录像 hevc 640x360，rolling-merge 产物 8670 帧 **0 解码错误**（首段 3 个 POC 错为中途入流的 CRA 开放 GOP 边界，与 RTSP 中途接入同类）
- B 侧 FLV 直播正常出流；`/protocols` 如实回报 hls/ll-hls/flv/wasm
- H.264 路径回归：全部 5424 个 Go 测试（-race）+ 591 前端测试通过，lint 0 issue