### PR TITLE
refactor(camera): recorder 构造注册表化 — recorderBuilders 表 + model.HubHost 接口消灭双 switch (#609)

### DIFF
--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 )
 
 // StreamHandler is a protocol-agnostic interface for live streaming handlers.
@@ -311,28 +310,12 @@ func getCodecParams(rec model.Recorder) (codec model.Format, sps, pps, vps []byt
 	return
 }
 
-// getStreamHub extracts the StreamHub from a recorder.
-// Returns nil if the recorder doesn't have a Hub or it's not set.
+// getStreamHub extracts the StreamHub from a recorder via the GetHub()
+// interface (implemented by every recorder type). Returns nil if the recorder
+// doesn't implement it or the hub is not set.
 func getStreamHub(rec model.Recorder) *model.StreamHub {
 	if h, ok := rec.(interface{ GetHub() *model.StreamHub }); ok {
 		return h.GetHub()
-	}
-	actualRec := unwrapDelegate(rec)
-	switch r := actualRec.(type) {
-	case *recorder.H264Recorder:
-		return r.Hub
-	case *recorder.H265Recorder:
-		return r.Hub
-	case *recorder.MJPEGRecorder:
-		return r.Hub
-	case *recorder.HTTPJPEGRecorder:
-		return r.Hub
-	case *recorder.ONVIFRecorder:
-		return r.Hub
-	case *xiaomi.XiaomiRecorder:
-		return r.Hub
-	case *recorder.GB28181Recorder:
-		return r.Hub
 	}
 	return nil
 }

--- a/internal/camera/recorder_builders.go
+++ b/internal/camera/recorder_builders.go
@@ -1,0 +1,289 @@
+package camera
+
+import (
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
+)
+
+// recorderBuilder constructs a recorder for one protocol family. It returns
+// nil when the protocol/encoding pair is not recordable — createRecorder then
+// reports the camera as non-recordable.
+type recorderBuilder func(cm *CameraManager, cam config.CameraConfig, segDur time.Duration) model.Recorder
+
+// recorderBuilders maps a camera protocol to its recorder constructor. Adding
+// a protocol means adding one entry here plus the recorder type itself — no
+// protocol switch arms to hunt down elsewhere (issue #609).
+var recorderBuilders = map[string]recorderBuilder{
+	string(model.ProtoXiaomi):    (*CameraManager).buildXiaomiRecorder,
+	string(model.ProtoRTSP):      (*CameraManager).buildRTSPRecorder,
+	string(model.ProtoHTTP):      (*CameraManager).buildHTTPJPEGRecorder,
+	string(model.ProtoONVIF):     (*CameraManager).buildONVIFRecorder,
+	string(model.ProtoTimelapse): (*CameraManager).buildTimelapseRecorder,
+	string(model.ProtoGB28181):   (*CameraManager).buildGB28181Recorder,
+	string(model.ProtoSRT):       (*CameraManager).buildIngestRecorder,
+	string(model.ProtoRTMP):      (*CameraManager).buildIngestRecorder,
+	string(model.ProtoWHIP):      (*CameraManager).buildIngestRecorder,
+}
+
+// resolveAdaptiveConfig parses the YAML adaptive-recording overrides into the
+// recorder's resolved form, defaulting unspecified fields (issue #435). The
+// config layer has already validated ranges.
+func resolveAdaptiveConfig(a *config.AdaptiveRecordingConfig) *recorder.AdaptiveConfig {
+	var calm, interval string
+	var spike float64
+	var gop int64
+	var ambient, archive bool
+	if a != nil {
+		calm, interval, spike, gop, ambient, archive = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio, a.AmbientArchive
+	}
+	ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient, archive)
+	return &ac
+}
+
+// resolveAudioTriggerConfig resolves the audio-trigger overrides (issue #478);
+// nil when not armed. G.711-only at the recorder level.
+func resolveAudioTriggerConfig(a *config.CameraAudioTriggerConfig) *recorder.AudioTriggerConfig {
+	if a == nil || !a.Enabled {
+		return nil
+	}
+	at := recorder.ResolveAudioTriggerConfig(a.MinDBFS, a.PreCaptureS)
+	return &at
+}
+
+// buildXiaomiRecorder builds the Xiaomi (CS2/TUTK P2P) recorder plugin.
+func (cm *CameraManager) buildXiaomiRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	plugin := &xiaomi.XiaomiPlugin{}
+	plugin.SetEventBus(cm.eventBus)
+	rec := plugin.NewRecorder(cam, cm.store, cm.db, cm.metrics)
+	// Wire ErrorReporter for TUTK vendor error detection
+	if xr, ok := rec.(*xiaomi.XiaomiRecorder); ok {
+		xr.SetErrorReporter(cm)
+	}
+	return rec
+}
+
+// buildRTSPRecorder builds an RTSP recorder for the camera's encoding
+// (h264/h265/mjpeg).
+func (cm *CameraManager) buildRTSPRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	switch cam.Encoding {
+	case string(model.FormatH264):
+		h264Cfg := recorder.H264Config{
+			CameraID:          cam.ID,
+			RTSPURL:           cam.URL,
+			Username:          cam.Username,
+			Password:          cam.Password,
+			SegmentDur:        segDur,
+			DB:                cm.db,
+			AudioEnabled:      cam.AudioEnabled,
+			AudioInRecordings: cam.AudioInRecordings,
+			EventBus:          cm.eventBus,
+			RecordEnabled:     cam.RecordingEnabled,
+			RingBufCap:        cam.RingBufCap,
+		}
+		if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
+			h264Cfg.FrameWatchdogTimeout = d
+		}
+		if cam.RecordingMode == "adaptive" {
+			h264Cfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
+		}
+		h264Cfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
+		return recorder.NewH264Recorder(h264Cfg, cm.store, cm.metrics)
+	case string(model.FormatH265):
+		h265Cfg := recorder.H265Config{
+			CameraID:          cam.ID,
+			RTSPURL:           cam.URL,
+			Username:          cam.Username,
+			Password:          cam.Password,
+			SegmentDur:        segDur,
+			DB:                cm.db,
+			AudioEnabled:      cam.AudioEnabled,
+			AudioInRecordings: cam.AudioInRecordings,
+			EventBus:          cm.eventBus,
+			RecordEnabled:     cam.RecordingEnabled,
+			RingBufCap:        cam.RingBufCap,
+		}
+		if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
+			h265Cfg.FrameWatchdogTimeout = d
+		}
+		if cam.RecordingMode == "adaptive" {
+			h265Cfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
+		}
+		h265Cfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
+		return recorder.NewH265Recorder(h265Cfg, cm.store, cm.metrics)
+	case string(model.FormatMJPEG):
+		mjpegCfg := recorder.MJPEGConfig{
+			CameraID:               cam.ID,
+			RTSPURL:                cam.URL,
+			SegmentDur:             segDur,
+			SampleInterval:         cam.SampleInterval,
+			DB:                     cm.db,
+			AudioEnabled:           cam.AudioEnabled,
+			EventBus:               cm.eventBus,
+			DarkFrameFilterEnabled: cam.DarkFrameFilterEnabled,
+			DarkFrameThreshold:     cam.DarkFrameThreshold,
+			RecordEnabled:          cam.RecordingEnabled,
+		}
+		return recorder.NewMJPEGRecorder(mjpegCfg, cm.store, cm.metrics)
+	default:
+		return nil
+	}
+}
+
+// buildHTTPJPEGRecorder builds the HTTP-JPEG (ESP32 MiBeeCam style) recorder.
+func (cm *CameraManager) buildHTTPJPEGRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	if cam.Encoding != string(model.EncJPEG) {
+		return nil
+	}
+	httpJpegCfg := recorder.HTTPJPEGConfig{
+		CameraID:               cam.ID,
+		URL:                    cam.URL,
+		SegmentDur:             segDur,
+		Username:               cam.Username,
+		Password:               cam.Password,
+		DB:                     cm.db,
+		AVI:                    cam.HTTPJPEGAVI,
+		EventBus:               cm.eventBus,
+		DarkFrameFilterEnabled: cam.DarkFrameFilterEnabled,
+		DarkFrameThreshold:     cam.DarkFrameThreshold,
+		RecordEnabled:          cam.RecordingEnabled,
+	}
+	return recorder.NewHTTPJPEGRecorder(httpJpegCfg, cm.store, cm.metrics)
+}
+
+// buildONVIFRecorder builds the ONVIF recorder (delegates to an inner
+// H264/H265/JPEG recorder once the stream profile is resolved).
+func (cm *CameraManager) buildONVIFRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	onvifEndpoint := cam.ONVIFEndpoint
+	if onvifEndpoint == "" {
+		onvifEndpoint = cam.URL
+	}
+	onvifClient := cm.reuseOrCreateONVIFClient(cam.ID, onvifEndpoint, cam.Username, cam.Password)
+	onvifCfg := recorder.ONVIFConfig{
+		CameraID:          cam.ID,
+		ProfileToken:      cam.ProfileToken,
+		StreamEncoding:    cam.StreamEncoding,
+		Username:          cam.Username,
+		Password:          cam.Password,
+		SegmentDur:        segDur,
+		DB:                cm.db,
+		AudioEnabled:      cam.AudioEnabled,
+		AudioInRecordings: cam.AudioInRecordings,
+		ONVIFEndpoint:     onvifEndpoint,
+		AVI:               cam.HTTPJPEGAVI,
+		EventBus:          cm.eventBus,
+		RecordEnabled:     cam.RecordingEnabled,
+	}
+	if cam.RecordingMode == "adaptive" {
+		// Validated by config.ValidateCameraRecordingMode (h264/h265 only);
+		// createDelegate ignores it for MJPEG/JPEG encodings.
+		onvifCfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
+		onvifCfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
+	}
+	if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
+		onvifCfg.FrameWatchdogTimeout = d
+	}
+	onvifCfg.RingBufCap = cam.RingBufCap
+	return recorder.NewONVIFRecorder(onvifCfg, onvifClient, cm.store, cm.metrics)
+}
+
+// buildTimelapseRecorder builds a timelapse recorder for the configured frame
+// source (snapshot / rtsp_keyframe / mjpeg).
+func (cm *CameraManager) buildTimelapseRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	frameSource := "auto"
+	if cam.Timelapse != nil && cam.Timelapse.FrameSource != "" {
+		frameSource = cam.Timelapse.FrameSource
+	}
+	if cam.Timelapse == nil || !cam.Timelapse.Enabled {
+		return nil
+	}
+	switch frameSource {
+	case "snapshot":
+		return cm.createTimelapseSnapshotRecorder(cam, segDur)
+	case "rtsp_keyframe":
+		switch cam.Encoding {
+		case "h264", "":
+			h264Cfg := recorder.H264Config{
+				CameraID:     cam.ID,
+				RTSPURL:      cam.URL,
+				Username:     cam.Username,
+				Password:     cam.Password,
+				SegmentDur:   segDur,
+				DB:           cm.db,
+				AudioEnabled: cam.AudioEnabled,
+				RingBufCap:   cam.RingBufCap,
+			}
+			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
+				h264Cfg.FrameWatchdogTimeout = d
+			}
+			return recorder.NewH264Recorder(h264Cfg, cm.store, cm.metrics)
+		case "h265":
+			h265Cfg := recorder.H265Config{
+				CameraID:     cam.ID,
+				RTSPURL:      cam.URL,
+				Username:     cam.Username,
+				Password:     cam.Password,
+				SegmentDur:   segDur,
+				DB:           cm.db,
+				AudioEnabled: cam.AudioEnabled,
+				RingBufCap:   cam.RingBufCap,
+			}
+			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
+				h265Cfg.FrameWatchdogTimeout = d
+			}
+			return recorder.NewH265Recorder(h265Cfg, cm.store, cm.metrics)
+		default:
+			logger.Warn("unsupported encoding for rtsp_keyframe timelapse frame source", "camera_id", cam.ID, "encoding", cam.Encoding)
+			return nil
+		}
+	case "mjpeg", "auto", "":
+		return cm.createTimelapseMJPEGRecorder(cam, segDur)
+	default:
+		logger.Warn("unknown timelapse frame source", "camera_id", cam.ID, "frame_source", frameSource)
+		return nil
+	}
+}
+
+// buildGB28181Recorder builds the passive GB28181 recorder — media flows in
+// only after a SIP INVITE (autoInviteGB28181 drives that at recorder start).
+func (cm *CameraManager) buildGB28181Recorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	enc := cam.Encoding
+	if enc == "" {
+		enc = string(model.FormatH264)
+	}
+	// Full recording pipeline: segments on disk, recordings DB rows,
+	// SegmentCompleted events, metrics — same guarantees as ingest cams.
+	return recorder.NewGB28181Recorder(recorder.GB28181Config{
+		CameraID:      cam.ID,
+		Encoding:      enc,
+		SegmentDur:    segDur,
+		Store:         cm.store,
+		DB:            cm.db,
+		Metrics:       cm.metrics,
+		EventBus:      cm.eventBus,
+		RecordEnabled: cam.RecordingEnabled == nil || *cam.RecordingEnabled,
+		AudioEnabled:  cam.AudioEnabled,
+	}, nil)
+}
+
+// buildIngestRecorder builds the push-ingest recorder shared by SRT / RTMP /
+// WHIP push-in cameras — the hub is created on publisher connect.
+func (cm *CameraManager) buildIngestRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
+	enc := cam.Encoding
+	if enc == "" {
+		enc = string(model.FormatH264)
+	}
+	return recorder.NewIngestRecorder(recorder.IngestConfig{
+		CameraID:      cam.ID,
+		Encoding:      enc,
+		SegmentDur:    segDur,
+		Store:         cm.store,
+		DB:            cm.db,
+		Metrics:       cm.metrics,
+		EventBus:      cm.eventBus,
+		RecordEnabled: cam.RecordingEnabled,
+	})
+}

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -9,247 +9,18 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 )
 
-// createRecorder creates a recorder for the given camera config.
-// Returns nil for unknown protocols.
+// createRecorder creates a recorder for the given camera config by looking
+// the protocol up in recorderBuilders. Returns nil for unknown protocols or
+// unsupported protocol/encoding pairs.
 func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Duration) model.Recorder {
-	// resolveAdaptiveConfig parses the YAML adaptive-recording overrides into the
-	// recorder's resolved form, defaulting unspecified fields (issue #435). The
-	// config layer has already validated ranges.
-	resolveAdaptiveConfig := func(a *config.AdaptiveRecordingConfig) *recorder.AdaptiveConfig {
-		var calm, interval string
-		var spike float64
-		var gop int64
-		var ambient, archive bool
-		if a != nil {
-			calm, interval, spike, gop, ambient, archive = a.CalmThreshold, a.TimelapseInterval, a.SpikeFactor, a.GOPBufferBytes, a.AmbientAudio, a.AmbientArchive
-		}
-		ac := recorder.ResolveAdaptiveConfig(calm, interval, spike, gop, ambient, archive)
-		return &ac
+	build, ok := recorderBuilders[cam.Protocol]
+	if !ok {
+		return nil
 	}
-	// resolveAudioTriggerConfig resolves the audio-trigger overrides (issue
-	// #478); nil when not armed. G.711-only at the recorder level.
-	resolveAudioTriggerConfig := func(a *config.CameraAudioTriggerConfig) *recorder.AudioTriggerConfig {
-		if a == nil || !a.Enabled {
-			return nil
-		}
-		at := recorder.ResolveAudioTriggerConfig(a.MinDBFS, a.PreCaptureS)
-		return &at
-	}
-
-	var rec model.Recorder
-	switch cam.Protocol {
-	case "xiaomi":
-		plugin := &xiaomi.XiaomiPlugin{}
-		plugin.SetEventBus(cm.eventBus)
-		rec = plugin.NewRecorder(cam, cm.store, cm.db, cm.metrics)
-		// Wire ErrorReporter for TUTK vendor error detection
-		if xr, ok := rec.(*xiaomi.XiaomiRecorder); ok {
-			xr.SetErrorReporter(cm)
-		}
-	case string(model.ProtoRTSP):
-		switch cam.Encoding {
-		case string(model.FormatH264):
-			h264Cfg := recorder.H264Config{
-				CameraID:          cam.ID,
-				RTSPURL:           cam.URL,
-				Username:          cam.Username,
-				Password:          cam.Password,
-				SegmentDur:        segDur,
-				DB:                cm.db,
-				AudioEnabled:      cam.AudioEnabled,
-				AudioInRecordings: cam.AudioInRecordings,
-				EventBus:          cm.eventBus,
-				RecordEnabled:     cam.RecordingEnabled,
-				RingBufCap:        cam.RingBufCap,
-			}
-			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
-				h264Cfg.FrameWatchdogTimeout = d
-			}
-			if cam.RecordingMode == "adaptive" {
-				h264Cfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
-			}
-			h264Cfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
-			rec = recorder.NewH264Recorder(h264Cfg, cm.store, cm.metrics)
-		case string(model.FormatH265):
-			h265Cfg := recorder.H265Config{
-				CameraID:          cam.ID,
-				RTSPURL:           cam.URL,
-				Username:          cam.Username,
-				Password:          cam.Password,
-				SegmentDur:        segDur,
-				DB:                cm.db,
-				AudioEnabled:      cam.AudioEnabled,
-				AudioInRecordings: cam.AudioInRecordings,
-				EventBus:          cm.eventBus,
-				RecordEnabled:     cam.RecordingEnabled,
-				RingBufCap:        cam.RingBufCap,
-			}
-			if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
-				h265Cfg.FrameWatchdogTimeout = d
-			}
-			if cam.RecordingMode == "adaptive" {
-				h265Cfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
-			}
-			h265Cfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
-			rec = recorder.NewH265Recorder(h265Cfg, cm.store, cm.metrics)
-		case string(model.FormatMJPEG):
-			mjpegCfg := recorder.MJPEGConfig{
-				CameraID:               cam.ID,
-				RTSPURL:                cam.URL,
-				SegmentDur:             segDur,
-				SampleInterval:         cam.SampleInterval,
-				DB:                     cm.db,
-				AudioEnabled:           cam.AudioEnabled,
-				EventBus:               cm.eventBus,
-				DarkFrameFilterEnabled: cam.DarkFrameFilterEnabled,
-				DarkFrameThreshold:     cam.DarkFrameThreshold,
-				RecordEnabled:          cam.RecordingEnabled,
-			}
-			rec = recorder.NewMJPEGRecorder(mjpegCfg, cm.store, cm.metrics)
-		default:
-			return nil
-		}
-	case string(model.ProtoHTTP):
-		if cam.Encoding != string(model.EncJPEG) {
-			return nil
-		}
-		httpJpegCfg := recorder.HTTPJPEGConfig{
-			CameraID:               cam.ID,
-			URL:                    cam.URL,
-			SegmentDur:             segDur,
-			Username:               cam.Username,
-			Password:               cam.Password,
-			DB:                     cm.db,
-			AVI:                    cam.HTTPJPEGAVI,
-			EventBus:               cm.eventBus,
-			DarkFrameFilterEnabled: cam.DarkFrameFilterEnabled,
-			DarkFrameThreshold:     cam.DarkFrameThreshold,
-			RecordEnabled:          cam.RecordingEnabled,
-		}
-		rec = recorder.NewHTTPJPEGRecorder(httpJpegCfg, cm.store, cm.metrics)
-	case string(model.ProtoONVIF):
-		onvifEndpoint := cam.ONVIFEndpoint
-		if onvifEndpoint == "" {
-			onvifEndpoint = cam.URL
-		}
-		onvifClient := cm.reuseOrCreateONVIFClient(cam.ID, onvifEndpoint, cam.Username, cam.Password)
-		onvifCfg := recorder.ONVIFConfig{
-			CameraID:          cam.ID,
-			ProfileToken:      cam.ProfileToken,
-			StreamEncoding:    cam.StreamEncoding,
-			Username:          cam.Username,
-			Password:          cam.Password,
-			SegmentDur:        segDur,
-			DB:                cm.db,
-			AudioEnabled:      cam.AudioEnabled,
-			AudioInRecordings: cam.AudioInRecordings,
-			ONVIFEndpoint:     onvifEndpoint,
-			AVI:               cam.HTTPJPEGAVI,
-			EventBus:          cm.eventBus,
-			RecordEnabled:     cam.RecordingEnabled,
-		}
-		if cam.RecordingMode == "adaptive" {
-			// Validated by config.ValidateCameraRecordingMode (h264/h265 only);
-			// createDelegate ignores it for MJPEG/JPEG encodings.
-			onvifCfg.Adaptive = resolveAdaptiveConfig(cam.Adaptive)
-			onvifCfg.AudioTrigger = resolveAudioTriggerConfig(cam.AudioTrigger)
-		}
-		if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
-			onvifCfg.FrameWatchdogTimeout = d
-		}
-		onvifCfg.RingBufCap = cam.RingBufCap
-		rec = recorder.NewONVIFRecorder(onvifCfg, onvifClient, cm.store, cm.metrics)
-	case "timelapse":
-		frameSource := "auto"
-		if cam.Timelapse != nil && cam.Timelapse.FrameSource != "" {
-			frameSource = cam.Timelapse.FrameSource
-		}
-		if cam.Timelapse == nil || !cam.Timelapse.Enabled {
-			return nil
-		}
-		switch frameSource {
-		case "snapshot":
-			rec = cm.createTimelapseSnapshotRecorder(cam, segDur)
-		case "rtsp_keyframe":
-			switch cam.Encoding {
-			case "h264", "":
-				h264Cfg := recorder.H264Config{
-					CameraID:     cam.ID,
-					RTSPURL:      cam.URL,
-					Username:     cam.Username,
-					Password:     cam.Password,
-					SegmentDur:   segDur,
-					DB:           cm.db,
-					AudioEnabled: cam.AudioEnabled,
-					RingBufCap:   cam.RingBufCap,
-				}
-				if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
-					h264Cfg.FrameWatchdogTimeout = d
-				}
-				rec = recorder.NewH264Recorder(h264Cfg, cm.store, cm.metrics)
-			case "h265":
-				h265Cfg := recorder.H265Config{
-					CameraID:     cam.ID,
-					RTSPURL:      cam.URL,
-					Username:     cam.Username,
-					Password:     cam.Password,
-					SegmentDur:   segDur,
-					DB:           cm.db,
-					AudioEnabled: cam.AudioEnabled,
-					RingBufCap:   cam.RingBufCap,
-				}
-				if d, err := time.ParseDuration(cam.FrameWatchdogTimeout); err == nil && d > 0 {
-					h265Cfg.FrameWatchdogTimeout = d
-				}
-				rec = recorder.NewH265Recorder(h265Cfg, cm.store, cm.metrics)
-			default:
-				logger.Warn("unsupported encoding for rtsp_keyframe timelapse frame source", "camera_id", cam.ID, "encoding", cam.Encoding)
-				return nil
-			}
-		case "mjpeg", "auto", "":
-			rec = cm.createTimelapseMJPEGRecorder(cam, segDur)
-		default:
-			logger.Warn("unknown timelapse frame source", "camera_id", cam.ID, "frame_source", frameSource)
-			return nil
-		}
-	case string(model.ProtoGB28181):
-		enc := cam.Encoding
-		if enc == "" {
-			enc = string(model.FormatH264)
-		}
-		// Full recording pipeline: segments on disk, recordings DB rows,
-		// SegmentCompleted events, metrics — same guarantees as ingest cams.
-		rec = recorder.NewGB28181Recorder(recorder.GB28181Config{
-			CameraID:      cam.ID,
-			Encoding:      enc,
-			SegmentDur:    segDur,
-			Store:         cm.store,
-			DB:            cm.db,
-			Metrics:       cm.metrics,
-			EventBus:      cm.eventBus,
-			RecordEnabled: cam.RecordingEnabled == nil || *cam.RecordingEnabled,
-			AudioEnabled:  cam.AudioEnabled,
-		}, nil)
-	case string(model.ProtoSRT), string(model.ProtoRTMP), string(model.ProtoWHIP):
-		enc := cam.Encoding
-		if enc == "" {
-			enc = string(model.FormatH264)
-		}
-		rec = recorder.NewIngestRecorder(recorder.IngestConfig{
-			CameraID:      cam.ID,
-			Encoding:      enc,
-			SegmentDur:    segDur,
-			Store:         cm.store,
-			DB:            cm.db,
-			Metrics:       cm.metrics,
-			EventBus:      cm.eventBus,
-			RecordEnabled: cam.RecordingEnabled,
-		})
-	default:
+	rec := build(cm, cam, segDur)
+	if rec == nil {
 		return nil
 	}
 
@@ -270,60 +41,21 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 	return rec
 }
 
-// initStreamHub sets a new StreamHub on the recorder if it has a Hub field.
-// It sets the cameraID for structured logging, labels the hub source for the
-// flow-path view, and wires the standard observability callbacks (shared with
-// push hubs via wireHubMetrics).
+// initStreamHub sets a new StreamHub on the recorder via the model.HubHost
+// interface. It sets the cameraID for structured logging, labels the hub
+// source for the flow-path view (from the recorder's own HubSource), and
+// wires the standard observability callbacks (shared with push hubs via
+// wireHubMetrics). Recorders without a hub (none today) are skipped.
 func initStreamHub(rec model.Recorder, cameraID string, m *metrics.Metrics) {
-	var hub *model.StreamHub
-	source := ""
-	switch r := rec.(type) {
-	case *recorder.H264Recorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "h264"
-	case *recorder.H265Recorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "h265"
-	case *recorder.ONVIFRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "onvif"
-	case *recorder.MJPEGRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "mjpeg"
-	case *recorder.HTTPJPEGRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "http-jpeg"
-	case *xiaomi.XiaomiRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "xiaomi"
-	case *recorder.TimelapseRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "timelapse"
-	case *recorder.StubRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "stub"
-	case *recorder.IngestRecorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "ingest"
-	case *recorder.GB28181Recorder:
-		hub = model.NewStreamHub()
-		r.Hub = hub
-		source = "gb28181"
+	host, ok := rec.(model.HubHost)
+	if !ok {
+		return
 	}
-	if hub != nil {
-		hub.SetCameraID(cameraID)
-		hub.SetSource(source)
-		wireHubMetrics(hub, cameraID, m)
-	}
+	hub := model.NewStreamHub()
+	host.SetHub(hub)
+	hub.SetCameraID(cameraID)
+	hub.SetSource(host.HubSource())
+	wireHubMetrics(hub, cameraID, m)
 }
 
 // autoInviteGB28181 recycles any live session for the camera's channel and

--- a/internal/camera/recorder_factory_test.go
+++ b/internal/camera/recorder_factory_test.go
@@ -1,0 +1,74 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
+)
+
+// knownProtocols is every protocol the config layer accepts. When a new
+// model.Proto* constant is added, extend this list — the test then forces a
+// matching entry in recorderBuilders so createRecorder can never silently
+// return nil for a valid protocol.
+var knownProtocols = []model.Protocol{
+	model.ProtoONVIF,
+	model.ProtoXiaomi,
+	model.ProtoTimelapse,
+	model.ProtoRTSP,
+	model.ProtoHTTP,
+	model.ProtoSRT,
+	model.ProtoRTMP,
+	model.ProtoWHIP,
+	model.ProtoGB28181,
+}
+
+func TestRecorderBuildersCoverAllProtocols(t *testing.T) {
+	for _, p := range knownProtocols {
+		if _, ok := recorderBuilders[string(p)]; !ok {
+			t.Errorf("protocol %q has no recorder builder registered in recorderBuilders", p)
+		}
+	}
+	// No stale entries either: every registered key is a known protocol.
+	known := make(map[string]bool, len(knownProtocols))
+	for _, p := range knownProtocols {
+		known[string(p)] = true
+	}
+	for key := range recorderBuilders {
+		if !known[key] {
+			t.Errorf("recorderBuilders has entry %q which is not a known model protocol", key)
+		}
+	}
+}
+
+func TestInitStreamHubViaHubHost(t *testing.T) {
+	rec := &recorder.StubRecorder{}
+	initStreamHub(rec, "test-cam", nil)
+	hub := rec.GetHub()
+	if hub == nil {
+		t.Fatal("initStreamHub did not set the hub via model.HubHost")
+	}
+	// The recorder's own HubSource must label the hub (flow-path view).
+	if got := rec.HubSource(); got != "stub" {
+		t.Errorf("HubSource() = %q, want %q", got, "stub")
+	}
+	if got := getRecorderHub(rec); got != hub {
+		t.Errorf("getRecorderHub returned %p, want the hub set by initStreamHub (%p)", got, hub)
+	}
+}
+
+// Compile-time guards: every recorder type used by the builders must satisfy
+// the hub interfaces the camera manager relies on.
+var (
+	_ model.HubHost = (*recorder.H264Recorder)(nil)
+	_ model.HubHost = (*recorder.H265Recorder)(nil)
+	_ model.HubHost = (*recorder.ONVIFRecorder)(nil)
+	_ model.HubHost = (*recorder.MJPEGRecorder)(nil)
+	_ model.HubHost = (*recorder.HTTPJPEGRecorder)(nil)
+	_ model.HubHost = (*recorder.TimelapseRecorder)(nil)
+	_ model.HubHost = (*recorder.StubRecorder)(nil)
+	_ model.HubHost = (*recorder.IngestRecorder)(nil)
+	_ model.HubHost = (*recorder.GB28181Recorder)(nil)
+	_ model.HubHost = (*xiaomi.XiaomiRecorder)(nil)
+)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -13,6 +13,16 @@ type Recorder interface {
 	Status() RecorderStatus
 }
 
+// HubHost is an optional interface implemented by recorders that carry a
+// StreamHub for frame fan-out. The camera manager wires a fresh hub via
+// SetHub at recorder creation; HubSource labels the hub for the flow-path
+// observability view. Adding a new recorder type means implementing this
+// interface on the type itself — no camera-manager type switch to extend.
+type HubHost interface {
+	SetHub(hub *StreamHub)
+	HubSource() string
+}
+
 // HLSProvider is an optional interface that recorders can implement
 // to support HLS live streaming. The api handler uses this interface
 // to obtain codec parameters for starting an HLS stream.

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -363,6 +363,10 @@ type codecParams struct {
 // single writer path (writeFrames via the driver's handleParamSet, and the SDP
 // pre-seed in connectAndRecord) — concurrent callers must not interleave
 // partial updates; build the full triplet first, then Store.
+// SetHub wires the StreamHub for frame fan-out (model.HubHost); shared by
+// every recorder embedding baseRecorder. HubSource stays leaf-specific.
+func (b *baseRecorder) SetHub(hub *model.StreamHub) { b.Hub = hub }
+
 func (b *baseRecorder) setCodecParams(sps, pps, vps []byte) {
 	b.codec.Store(&codecParams{
 		sps: append([]byte(nil), sps...),

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -119,6 +119,12 @@ func (r *GB28181Recorder) GetHub() *model.StreamHub {
 	return r.Hub
 }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *GB28181Recorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *GB28181Recorder) HubSource() string { return "gb28181" }
+
 func (r *GB28181Recorder) CodecParams() (codec model.Format, sps, pps, vps []byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -171,6 +171,9 @@ func (r *H264Recorder) Status() model.RecorderStatus {
 // GetHub returns the StreamHub for frame fan-out.
 func (r *H264Recorder) GetHub() *model.StreamHub { return r.Hub }
 
+// HubSource labels the hub for the flow-path observability view.
+func (r *H264Recorder) HubSource() string { return "h264" }
+
 // SPS returns the current H264 Sequence Parameter Set NAL unit (without start bytes).
 // Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
 func (r *H264Recorder) SPS() []byte { s, _, _ := r.codecSnapshot(); return s }

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -162,6 +162,9 @@ func (r *H265Recorder) Status() model.RecorderStatus {
 // GetHub returns the StreamHub for frame fan-out.
 func (r *H265Recorder) GetHub() *model.StreamHub { return r.Hub }
 
+// HubSource labels the hub for the flow-path observability view.
+func (r *H265Recorder) HubSource() string { return "h265" }
+
 // VPS returns the current H265 Video Parameter Set NAL unit (without start bytes).
 // Reads the atomic codec snapshot — safe for concurrent live-preview reads (#219).
 func (r *H265Recorder) VPS() []byte { _, _, v := r.codecSnapshot(); return v }

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -83,6 +83,12 @@ type HTTPJPEGRecorder struct {
 // GetHub returns the StreamHub for frame fan-out.
 func (r *HTTPJPEGRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *HTTPJPEGRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *HTTPJPEGRecorder) HubSource() string { return "http-jpeg" }
+
 // StreamURL returns the MJPEG stream URL.
 func (r *HTTPJPEGRecorder) StreamURL() string { return r.cfg.URL }
 

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -127,6 +127,12 @@ func NewIngestRecorder(cfg IngestConfig) *IngestRecorder {
 // used by getRecorderHub across the API layer).
 func (r *IngestRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *IngestRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *IngestRecorder) HubSource() string { return "ingest" }
+
 // VPS returns the most recently captured H.265 VPS NAL unit (without start
 // code). Always nil for H.264 sources. Thread-safe.
 func (r *IngestRecorder) VPS() []byte {

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -130,6 +130,12 @@ func jpegDimensions(data []byte) (width, height int, ok bool) {
 // GetHub returns the StreamHub for frame fan-out.
 func (r *MJPEGRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *MJPEGRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *MJPEGRecorder) HubSource() string { return "mjpeg" }
+
 // LatestFrame returns the most recently decoded JPEG frame WITHOUT copying.
 // The returned slice is shared and must be treated as read-only by callers.
 // Returns nil if no frame has been decoded yet. Safe for concurrent use.

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -94,6 +94,12 @@ type ONVIFRecorder struct {
 // GetHub returns the StreamHub for frame fan-out.
 func (r *ONVIFRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *ONVIFRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *ONVIFRecorder) HubSource() string { return "onvif" }
+
 // Compile-time check.
 var _ model.Recorder = (*ONVIFRecorder)(nil)
 

--- a/internal/recorder/stub.go
+++ b/internal/recorder/stub.go
@@ -25,6 +25,12 @@ type StubRecorder struct {
 // GetHub returns the StreamHub for frame fan-out. Always nil for StubRecorder.
 func (r *StubRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *StubRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *StubRecorder) HubSource() string { return "stub" }
+
 // Start initializes the stub recorder. It returns immediately without error.
 func (r *StubRecorder) Start(_ context.Context) error {
 	r.mu.Lock()

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -77,6 +77,12 @@ type TimelapseRecorder struct {
 // GetHub returns the StreamHub for frame fan-out (nil for timelapse — no live streaming).
 func (r *TimelapseRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *TimelapseRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *TimelapseRecorder) HubSource() string { return "timelapse" }
+
 // incActive increments the active recordings gauge if metrics is available.
 func (r *TimelapseRecorder) incActive() {
 	if r.metrics != nil {

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -193,6 +193,12 @@ var _ model.Recorder = (*XiaomiRecorder)(nil)
 // GetHub returns the StreamHub for frame fan-out.
 func (r *XiaomiRecorder) GetHub() *model.StreamHub { return r.Hub }
 
+// SetHub wires the StreamHub for frame fan-out (model.HubHost).
+func (r *XiaomiRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+
+// HubSource labels the hub for the flow-path observability view.
+func (r *XiaomiRecorder) HubSource() string { return "xiaomi" }
+
 // SPS returns the current H.264/H.265 SPS NAL unit (without start bytes).
 func (r *XiaomiRecorder) SPS() []byte { return r.sps }
 


### PR DESCRIPTION
## 概要
架构 issue #609 第一批落地：消灭 recorder 构造的散弹式修改热点。行为零变化（纯重排 + 接口化）。

## 改动
1. **协议 switch → 注册表**：`createRecorder()` 的 ~20 分支大 switch 拆为 `recorderBuilders` map（`internal/camera/recorder_builders.go`），每协议一个 `build*Recorder` 方法，逻辑 1:1 平移。新增协议 = 加一个 builder 条目 + recorder 类型本身。
2. **initStreamHub 类型 switch → `model.HubHost` 接口**：新可选接口 `SetHub(*StreamHub)` + `HubSource() string`，10 个 recorder 类型各自实现（hub 标签跟着类型走）；`baseRecorder` 提供共享 `SetHub`，H264/H265 只需实现 `HubSource`。
3. **api `getStreamHub` 死代码清理**：全部 recorder 已实现 `GetHub()`，类型 switch 兜底不可达，删除。
4. **守护测试**：`TestRecorderBuildersCoverAllProtocols` — 加新 `model.Proto*` 常量而不注册 builder 会直接红；反向也查 stale 条目。另有 HubHost 编译期断言。

## 新增协议的改动面（改后）
新 recorder 文件（实现 Recorder + HubHost）→ `recorder_builders.go` 注册 1 行 → config/model 常量。原来还需改 initStreamHub 类型 switch（10 case）已消灭。

## 验证
- `go test -race ./internal/camera/ ./internal/api/ ./internal/recorder/ ./internal/xiaomi/ ./internal/model/` — 1659 tests passed
- `make lint` — 0 issues

Closes #609