### PR TITLE
refactor(recorder): 提取共享 runReconnectLoop — 重连循环/退避/状态迁移单一来源 (#608)

### DIFF
--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -491,9 +491,9 @@ func (b *baseRecorder) setStatus(s model.RecorderStatus) {
 // ---------------------------------------------------------------------------
 
 // run is the template method for the auto-reconnect loop. It wraps
-// connectAndRecord() (provided by the concrete recorder via self) with
-// exponential backoff + jitter. Panic recovery ensures the goroutine never
-// crashes silently.
+// connectAndRecord() (provided by the concrete recorder via self) with the
+// shared runReconnectLoop backoff/state cycle. Panic recovery ensures the
+// goroutine never crashes silently.
 //
 // This method is identical between H.264 and H.265 — the only difference is
 // the logger, which comes from b.log (set by the concrete constructor).
@@ -501,39 +501,15 @@ func (b *baseRecorder) run(ctx context.Context) {
 	defer b.recoverPanic("run")
 	defer close(b.done)
 	defer b.setStatus(model.StatusStopped)
-
-	var retryCount int
-	for {
-		err, connected := b.self.connectAndRecord(ctx)
-		if ctx.Err() != nil {
-			return
-		}
-		if connected {
-			retryCount = 0
-			if b.mtrics != nil {
-				b.mtrics.CameraReconnectBackoffSeconds.WithLabelValues(b.cfg.CameraID).Set(0)
-			}
-		}
-		retryCount++
-		backoff := TieredBackoffWithJitter(retryCount)
-		storageFailed := isStorageFailed(b.store, b.cfg.CameraID)
-		if storageFailed {
-			backoff = StorageBackoffWithJitter()
-		}
-		if b.mtrics != nil {
-			b.mtrics.CameraReconnectBackoffSeconds.WithLabelValues(b.cfg.CameraID).Set(backoff.Seconds())
-		}
-		b.log.Error("connection error, reconnecting",
-			"camera_id", b.cfg.CameraID, "error", err,
-			"backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
-		b.recordError("connection")
-		b.setStatus(model.StatusReconnecting)
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoff):
-		}
-	}
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID:    b.cfg.CameraID,
+		Store:       b.store,
+		Metrics:     b.mtrics,
+		Log:         b.log,
+		Connect:     b.self.connectAndRecord,
+		RecordError: b.recordError,
+		SetStatus:   b.setStatus,
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -272,40 +272,28 @@ func (r *HTTPJPEGRecorder) run(ctx context.Context) {
 	defer r.setStatus(model.StatusStopped)
 	defer r.closeCurrentSegment()
 
-	var retryCount int
-	for {
-		streamCtx, streamCancel := context.WithCancel(ctx)
-		r.mu.Lock()
-		r.cancelStream = streamCancel
-		r.mu.Unlock()
-		err, connected := r.connectAndStream(streamCtx)
-		r.mu.Lock()
-		r.cancelStream = nil
-		r.mu.Unlock()
-		streamCancel()
-
-		if ctx.Err() != nil {
-			return
-		}
-		if connected {
-			retryCount = 0
-		}
-		retryCount++
-		backoff := TieredBackoffWithJitter(retryCount)
-		storageFailed := isStorageFailed(r.store, r.cfg.CameraID)
-		if storageFailed {
-			backoff = StorageBackoffWithJitter()
-		}
-		httpJpegLogger.Error("stream error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
-		r.recordError("connection")
-		r.setStatus(model.StatusReconnecting)
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoff):
-		}
-	}
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID: r.cfg.CameraID,
+		Store:    r.store,
+		Metrics:  r.metrics,
+		Log:      httpJpegLogger,
+		Connect: func(streamCtx context.Context) (error, bool) {
+			// Inner cancellable ctx so the idle watchdog can kill just the
+			// current HTTP stream (not the whole reconnect loop).
+			streamCtx, streamCancel := context.WithCancel(streamCtx)
+			r.mu.Lock()
+			r.cancelStream = streamCancel
+			r.mu.Unlock()
+			err, connected := r.connectAndStream(streamCtx)
+			r.mu.Lock()
+			r.cancelStream = nil
+			r.mu.Unlock()
+			streamCancel()
+			return err, connected
+		},
+		RecordError: r.recordError,
+		SetStatus:   r.setStatus,
+	})
 }
 
 func (r *HTTPJPEGRecorder) idleWatchdog(ctx context.Context) {

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -253,36 +253,15 @@ func (r *MJPEGRecorder) setStatus(s model.RecorderStatus) {
 func (r *MJPEGRecorder) run(ctx context.Context) {
 	defer close(r.done)
 	defer r.setStatus(model.StatusStopped)
-	var retryCount int
-	for {
-		err, connected := r.connectAndRecord(ctx)
-		if ctx.Err() != nil {
-			return
-		}
-		if connected {
-			retryCount = 0
-			if r.metrics != nil {
-				r.metrics.CameraReconnectBackoffSeconds.WithLabelValues(r.cfg.CameraID).Set(0)
-			}
-		}
-		retryCount++
-		backoff := TieredBackoffWithJitter(retryCount)
-		storageFailed := isStorageFailed(r.store, r.cfg.CameraID)
-		if storageFailed {
-			backoff = StorageBackoffWithJitter()
-		}
-		if r.metrics != nil {
-			r.metrics.CameraReconnectBackoffSeconds.WithLabelValues(r.cfg.CameraID).Set(backoff.Seconds())
-		}
-		mjpegLogger.Error("connection error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
-		r.recordError("connection")
-		r.setStatus(model.StatusReconnecting)
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoff):
-		}
-	}
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID:    r.cfg.CameraID,
+		Store:       r.store,
+		Metrics:     r.metrics,
+		Log:         mjpegLogger,
+		Connect:     r.connectAndRecord,
+		RecordError: r.recordError,
+		SetStatus:   r.setStatus,
+	})
 }
 
 func (r *MJPEGRecorder) connectAndRecord(ctx context.Context) (error, bool) {

--- a/internal/recorder/reconnect.go
+++ b/internal/recorder/reconnect.go
@@ -1,0 +1,73 @@
+package recorder
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// reconnectDeps carries the recorder-specific hooks for the shared
+// auto-reconnect loop. Every pull recorder (h264/h265 via baseRecorder, mjpeg,
+// http_jpeg, timelapse) drives the same retry cycle; only the connect function
+// and logging/metrics handles differ.
+type reconnectDeps struct {
+	CameraID string
+	Store    SegmentStore
+	Metrics  *metrics.Metrics // optional — gauge updates skipped when nil
+	Log      *slog.Logger
+
+	// Connect performs one connection+streaming attempt. It returns the
+	// terminal error (nil when the ctx was cancelled mid-attempt) and whether
+	// media actually flowed (resets the backoff tier).
+	Connect func(ctx context.Context) (err error, connected bool)
+
+	// RecordError bumps the recorder's error counter ("connection", ...).
+	RecordError func(errorType string)
+
+	// SetStatus transitions the recorder status (thread-safe).
+	SetStatus func(model.RecorderStatus)
+}
+
+// runReconnectLoop is the shared auto-reconnect cycle: call Connect, on
+// failure sleep with tiered backoff + jitter (storage failures get the flat
+// storage backoff), transition to StatusReconnecting, and retry until ctx is
+// done. Callers keep their own wrappers around it — done-channel close, the
+// final StatusStopped transition, panic recovery, inner stream-cancel
+// plumbing (via the Connect closure), and any idle watchdog goroutines.
+func runReconnectLoop(ctx context.Context, d reconnectDeps) {
+	var retryCount int
+	for {
+		err, connected := d.Connect(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if connected {
+			retryCount = 0
+			if d.Metrics != nil {
+				d.Metrics.CameraReconnectBackoffSeconds.WithLabelValues(d.CameraID).Set(0)
+			}
+		}
+		retryCount++
+		backoff := TieredBackoffWithJitter(retryCount)
+		storageFailed := isStorageFailed(d.Store, d.CameraID)
+		if storageFailed {
+			backoff = StorageBackoffWithJitter()
+		}
+		if d.Metrics != nil {
+			d.Metrics.CameraReconnectBackoffSeconds.WithLabelValues(d.CameraID).Set(backoff.Seconds())
+		}
+		d.Log.Error("connection error, reconnecting",
+			"camera_id", d.CameraID, "error", err,
+			"backoff", backoff, "attempt", retryCount, "storage_failed", storageFailed)
+		d.RecordError("connection")
+		d.SetStatus(model.StatusReconnecting)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+	}
+}

--- a/internal/recorder/reconnect_test.go
+++ b/internal/recorder/reconnect_test.go
@@ -1,0 +1,129 @@
+package recorder
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// runReconnectLoopHarness wires runReconnectLoop to record every observable
+// side effect (connect attempts, status transitions, error-counter bumps).
+type runReconnectLoopHarness struct {
+	mu        sync.Mutex
+	attempts  int
+	statuses  []model.RecorderStatus
+	errTypes  []string
+	connect   func(attempt int) (error, bool)
+	connectMu sync.Mutex
+}
+
+func (h *runReconnectLoopHarness) recordAttempt() int {
+	h.connectMu.Lock()
+	defer h.connectMu.Unlock()
+	h.attempts++
+	return h.attempts
+}
+
+func (h *runReconnectLoopHarness) Connect(_ context.Context) (error, bool) {
+	return h.connect(h.recordAttempt())
+}
+
+func (h *runReconnectLoopHarness) RecordError(t string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.errTypes = append(h.errTypes, t)
+}
+
+func (h *runReconnectLoopHarness) SetStatus(s model.RecorderStatus) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.statuses = append(h.statuses, s)
+}
+
+func (h *runReconnectLoopHarness) recordedStatuses() []model.RecorderStatus {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]model.RecorderStatus(nil), h.statuses...)
+}
+
+func TestRunReconnectLoopRetriesUntilContextDone(t *testing.T) {
+	h := &runReconnectLoopHarness{
+		connect: func(int) (error, bool) { return errors.New("boom"), false },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel while the loop is sleeping in its first backoff.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID:    "test-cam",
+		Log:         slog.Default(),
+		Connect:     h.Connect,
+		RecordError: h.RecordError,
+		SetStatus:   h.SetStatus,
+	})
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("loop did not exit promptly on ctx cancel (took %s)", elapsed)
+	}
+	if h.attempts < 1 {
+		t.Fatalf("expected at least one connect attempt, got %d", h.attempts)
+	}
+	statuses := h.recordedStatuses()
+	if len(statuses) == 0 || statuses[len(statuses)-1] != model.StatusReconnecting {
+		t.Fatalf("expected StatusReconnecting transitions, got %v", statuses)
+	}
+	for _, e := range h.errTypes {
+		if e != "connection" {
+			t.Fatalf("unexpected error counter type %q", e)
+		}
+	}
+	if len(h.errTypes) == 0 {
+		t.Fatal("expected RecordError to be called")
+	}
+}
+
+func TestRunReconnectLoopConnectedAttemptDoesNotRecordError(t *testing.T) {
+	h := &runReconnectLoopHarness{
+		connect: func(attempt int) (error, bool) {
+			if attempt == 1 {
+				// First attempt "connected" but the stream later died with a
+				// ctx cancellation — the loop must exit without any failure
+				// bookkeeping.
+				return ctxErrAdapter{}, true
+			}
+			return errors.New("unreachable"), false
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled: first Connect returns, loop sees ctx.Err() and exits
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID:    "test-cam",
+		Log:         slog.Default(),
+		Connect:     h.Connect,
+		RecordError: h.RecordError,
+		SetStatus:   h.SetStatus,
+	})
+	if len(h.errTypes) != 0 {
+		t.Fatalf("cancelled ctx must not record errors, got %v", h.errTypes)
+	}
+	if len(h.recordedStatuses()) != 0 {
+		t.Fatalf("cancelled ctx must not transition status, got %v", h.recordedStatuses())
+	}
+	if h.attempts != 1 {
+		t.Fatalf("expected exactly 1 attempt, got %d", h.attempts)
+	}
+}
+
+// ctxErrAdapter returns a non-nil error from Connect while ctx is already
+// cancelled — the loop keys its exit on ctx.Err(), not on err == nil.
+type ctxErrAdapter struct{}
+
+func (ctxErrAdapter) Error() string { return "cancelled during connect" }

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -198,36 +198,28 @@ func (r *TimelapseRecorder) run(ctx context.Context) {
 	defer r.setStatus(model.StatusStopped)
 	defer r.closeCurrentSegment()
 
-	var retryCount int
-	for {
-		streamCtx, streamCancel := context.WithCancel(ctx)
-		r.mu.Lock()
-		r.cancelStream = streamCancel
-		r.mu.Unlock()
-		err, connected := r.connectAndStream(streamCtx)
-		r.mu.Lock()
-		r.cancelStream = nil
-		r.mu.Unlock()
-		streamCancel()
-
-		if ctx.Err() != nil {
-			return
-		}
-		if connected {
-			retryCount = 0
-		}
-		retryCount++
-		backoff := TieredBackoffWithJitter(retryCount)
-		timelapseLogger.Error("stream error, reconnecting", "camera_id", r.cfg.CameraID, "error", err, "backoff", backoff, "attempt", retryCount)
-		r.recordError("connection")
-		r.setStatus(model.StatusReconnecting)
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(backoff):
-		}
-	}
+	runReconnectLoop(ctx, reconnectDeps{
+		CameraID: r.cfg.CameraID,
+		Store:    r.store,
+		Metrics:  r.metrics,
+		Log:      timelapseLogger,
+		Connect: func(streamCtx context.Context) (error, bool) {
+			// Inner cancellable ctx so the idle watchdog can kill just the
+			// current HTTP stream (not the whole reconnect loop).
+			streamCtx, streamCancel := context.WithCancel(streamCtx)
+			r.mu.Lock()
+			r.cancelStream = streamCancel
+			r.mu.Unlock()
+			err, connected := r.connectAndStream(streamCtx)
+			r.mu.Lock()
+			r.cancelStream = nil
+			r.mu.Unlock()
+			streamCancel()
+			return err, connected
+		},
+		RecordError: r.recordError,
+		SetStatus:   r.setStatus,
+	})
 }
 
 func (r *TimelapseRecorder) idleWatchdog(ctx context.Context) {


### PR DESCRIPTION
## 概要
架构 issue #608：把 5 个 pull 型 recorder 里逐行重复的自动重连循环收敛为一个共享实现。与 PR #612 互相独立。

## 改动
- 新增 \`internal/recorder/reconnect.go\`：\`runReconnectLoop(ctx, reconnectDeps)\` — 分层退避+抖动、storage 故障感知退避、\`CameraReconnectBackoffSeconds\` 指标、\`StatusReconnecting\` 状态迁移、错误计数。hooks: Connect / RecordError / SetStatus。
- **baseRecorder.run**（h264/h265）与 **MJPEGRecorder.run** 委托共享循环 — 行为不变。
- **http_jpeg / timelapse**：内层 cancelStream 管道保留在 Connect 闭包中；两者补齐 storage 退避 + backoff 指标 + 统一日志（与其他 recorder 一致化，属有意的行为对齐）。
- **xiaomi 不迁移**（有意）：其循环携带 HD↔SD 质量状态机、cateye 唤醒、MISS URL 云解析、连接失败阈值延长退避——专属逻辑占比过高，强行统一会掩盖语义。
- ingest/gb28181 为被动型 recorder（无重连循环），不在本议题范围。

## 效果
改重连/退避策略从 5 处 → 1 处；新增 pull 型 recorder 直接复用 \`runReconnectLoop\`。

## 验证
- \`go test -race ./internal/recorder/ ./internal/camera/ ./internal/api/ ./internal/xiaomi/\` — 1549 tests passed
- \`make lint\` — 0 issues
- 新增 \`reconnect_test.go\`：重试直到 ctx 取消 / 已连接尝试不记账

Closes #608