### PR TITLE
refactor(model): StreamHub 运行时拆出 model — 新 internal/streamhub 包，model 只留纯类型与接口 (#610)

### DIFF
--- a/internal/api/handlers_flow.go
+++ b/internal/api/handlers_flow.go
@@ -14,13 +14,14 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/go-chi/chi/v5"
 )
 
 // FlowCamera is one camera's flow-path snapshot: the hub stats plus the
 // identity/quality context the flow view renders around them.
 type FlowCamera struct {
-	model.HubStats
+	streamhub.HubStats
 	Name     string         `json:"name"`
 	Status   string         `json:"status"`
 	Protocol string         `json:"protocol,omitempty"`
@@ -59,7 +60,7 @@ type FlowCamera struct {
 // sub hub's counters (frames_in/bytes_in/per-consumer fan-out) so the flow
 // tree renders both tiers with the same machinery.
 type FlowSub struct {
-	model.HubStats
+	streamhub.HubStats
 	State string       `json:"state"`
 	Codec model.Format `json:"codec,omitempty"`
 	Refs  int          `json:"refs"`
@@ -122,7 +123,7 @@ func (h *Handler) handleCameraFlow(w http.ResponseWriter, r *http.Request) {
 
 // buildFlowCamera assembles the flow view for one camera. Resolution is parsed
 // on this cold path (per API call) — never on the frame hot path.
-func (h *Handler) buildFlowCamera(cameraID string, hub *model.StreamHub, status model.RecorderStatus, mergeCounts map[string]int) FlowCamera {
+func (h *Handler) buildFlowCamera(cameraID string, hub *streamhub.StreamHub, status model.RecorderStatus, mergeCounts map[string]int) FlowCamera {
 	fc := FlowCamera{
 		HubStats: hub.Snapshot(),
 		Status:   string(status),

--- a/internal/api/handlers_flv.go
+++ b/internal/api/handlers_flv.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/flv"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/go-chi/chi/v5"
 )
@@ -63,7 +64,7 @@ func (h *Handler) handleFLVStream(w http.ResponseWriter, r *http.Request) {
 
 		var codec model.Format
 		var sps, pps, vps []byte
-		var hub *model.StreamHub
+		var hub *streamhub.StreamHub
 		if subSrc != nil {
 			codec, sps, pps, vps = subSrc.CodecParams()
 			hub = subSrc.Hub()

--- a/internal/api/handlers_hls.go
+++ b/internal/api/handlers_hls.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 	"github.com/go-chi/chi/v5"
@@ -24,7 +25,7 @@ import (
 // receives frames via the fan-out architecture.
 // It first unsubscribes any stale "hls" consumer left over from a previous
 // session (e.g. after idle eviction), then subscribes with the new callback.
-func subscribeHLS(hub *model.StreamHub, cameraID string, hlsMgr *hls.Manager, isH265 bool) error {
+func subscribeHLS(hub *streamhub.StreamHub, cameraID string, hlsMgr *hls.Manager, isH265 bool) error {
 	if hub == nil {
 		return nil // no hub, no subscription (shouldn't happen in practice)
 	}
@@ -105,7 +106,7 @@ func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 
 		var codec model.Format
 		var sps, pps, vps []byte
-		var hub *model.StreamHub
+		var hub *streamhub.StreamHub
 		if subSrc != nil {
 			// Sub-stream: parameters from the pull's SDP/in-band snapshot;
 			// the main recorder need not be running at all.
@@ -243,7 +244,7 @@ func (h *Handler) handleStopHLSStream(w http.ResponseWriter, r *http.Request) {
 
 // getRecorderHub extracts the StreamHub from any recorder type.
 // Returns nil if the recorder doesn't have a Hub.
-func getRecorderHub(rec model.Recorder) *model.StreamHub {
+func getRecorderHub(rec model.Recorder) *streamhub.StreamHub {
 	switch r := rec.(type) {
 	case *recorder.H264Recorder:
 		return r.Hub

--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 )
 
@@ -178,7 +179,7 @@ func (h *HLSStreamHandler) startFromProvider(
 	camID string,
 	codec model.Format,
 	sps, pps, vps []byte,
-	hub *model.StreamHub,
+	hub *streamhub.StreamHub,
 	provider model.HLSProvider,
 	opts StreamStartOptions,
 ) error {
@@ -211,7 +212,7 @@ func (h *HLSStreamHandler) startFromProvider(
 }
 
 // subscribeHub handles the sub-stream URL / main stream subscription logic.
-func (h *HLSStreamHandler) subscribeHub(camID string, hub *model.StreamHub, isH265 bool, opts StreamStartOptions) {
+func (h *HLSStreamHandler) subscribeHub(camID string, hub *streamhub.StreamHub, isH265 bool, opts StreamStartOptions) {
 	if hub == nil {
 		return
 	}
@@ -313,8 +314,8 @@ func getCodecParams(rec model.Recorder) (codec model.Format, sps, pps, vps []byt
 // getStreamHub extracts the StreamHub from a recorder via the GetHub()
 // interface (implemented by every recorder type). Returns nil if the recorder
 // doesn't implement it or the hub is not set.
-func getStreamHub(rec model.Recorder) *model.StreamHub {
-	if h, ok := rec.(interface{ GetHub() *model.StreamHub }); ok {
+func getStreamHub(rec model.Recorder) *streamhub.StreamHub {
+	if h, ok := rec.(interface{ GetHub() *streamhub.StreamHub }); ok {
 		return h.GetHub()
 	}
 	return nil

--- a/internal/api/handlers_stream_adapters_test.go
+++ b/internal/api/handlers_stream_adapters_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,14 +28,14 @@ type providerStub struct {
 	sps   []byte
 	pps   []byte
 	vps   []byte
-	hub   *model.StreamHub
+	hub   *streamhub.StreamHub
 }
 
 func (p *providerStub) CodecParams() (model.Format, []byte, []byte, []byte) {
 	return p.codec, p.sps, p.pps, p.vps
 }
 
-func (p *providerStub) GetHub() *model.StreamHub { return p.hub }
+func (p *providerStub) GetHub() *streamhub.StreamHub { return p.hub }
 
 // delegatingStub unwraps to an inner recorder (ONVIF-style).
 type delegatingStub struct {
@@ -230,7 +231,7 @@ func TestGetStreamHubs(t *testing.T) {
 	t.Parallel()
 
 	// GetHub interface path.
-	hub := &model.StreamHub{}
+	hub := &streamhub.StreamHub{}
 	require.Equal(t, hub, getStreamHub(&providerStub{hub: hub}))
 
 	// Recorders without a hub surface fall through to nil. (Concrete

--- a/internal/api/handlers_ws.go
+++ b/internal/api/handlers_ws.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 	"github.com/go-chi/chi/v5"
@@ -92,7 +93,7 @@ func (h *Handler) handleStreamWS(w http.ResponseWriter, r *http.Request) {
 
 		var codec model.Format
 		var sps, pps, vps []byte
-		var hub *model.StreamHub
+		var hub *streamhub.StreamHub
 		if subSrc != nil {
 			// Sub-stream: parameters come from the pull's SDP/in-band
 			// snapshot; the main recorder need not be running at all.

--- a/internal/camera/adapter.go
+++ b/internal/camera/adapter.go
@@ -3,8 +3,9 @@ package camera
 import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	pkgcamera "github.com/Mi-Bee-Studio/MiBeeNvr/pkg/camera"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
+	pkgstreamhub "github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
 )
 
 // Compile-time assertions.
@@ -89,14 +90,14 @@ func (a *publicAdapter) Status(id string) (pkgcamera.Status, error) {
 //
 // Returns the frame distribution hub for the camera. The returned Hub
 // is shared across all callers; each must Subscribe under a unique
-// consumerID. The underlying *model.StreamHub is wrapped via
-// model.NewHubAdapter to satisfy the pkg/streamhub.Hub interface.
-func (a *publicAdapter) Hub(id string) (streamhub.Hub, error) {
+// consumerID. The underlying *streamhub.StreamHub is wrapped via
+// streamhub.NewHubAdapter to satisfy the pkg/streamhub.Hub interface.
+func (a *publicAdapter) Hub(id string) (pkgstreamhub.Hub, error) {
 	h := a.cm.GetHub(id)
 	if h == nil {
 		return nil, pkgcamera.NewNotFoundError(id)
 	}
-	return model.NewHubAdapter(h), nil
+	return streamhub.NewHubAdapter(h), nil
 }
 
 // cameraView adapts a *config.CameraConfig to the pkg/camera.Camera

--- a/internal/camera/cascade_source.go
+++ b/internal/camera/cascade_source.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/cascade"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // cascadeSource adapts the CameraManager to the cascade client's
@@ -82,6 +82,6 @@ func (s cascadeSource) activeCameraIDs() map[string]bool {
 
 // Hub returns the camera's stream hub (nil when the camera has no hub —
 // answered 500 to the upper platform's INVITE).
-func (s cascadeSource) Hub(cameraID string) *model.StreamHub {
+func (s cascadeSource) Hub(cameraID string) *streamhub.StreamHub {
 	return s.cm.GetHub(cameraID)
 }

--- a/internal/camera/config_accessors.go
+++ b/internal/camera/config_accessors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
@@ -350,7 +351,7 @@ func (cm *CameraManager) NewGB28181PlaybackSink(cameraID string) (gb28181.AUWrit
 		RecordEnabled: true,
 		AudioEnabled:  cam.AudioEnabled,
 	}, nil)
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID(cameraID)
 	if err := rec.Start(context.Background()); err != nil {
 		return nil, err

--- a/internal/camera/hub.go
+++ b/internal/camera/hub.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // GetOrCreateHub returns the existing StreamHub for the camera ID, or creates a
@@ -29,20 +29,20 @@ import (
 // swap — hub construction + metrics wiring run inside apply but are pure CPU,
 // no I/O). Two concurrent GetOrCreateHub calls for the same camera return the
 // same hub: the second's apply sees the first's published snapshot.
-func (cm *CameraManager) GetOrCreateHub(cameraID string) *model.StreamHub {
+func (cm *CameraManager) GetOrCreateHub(cameraID string) *streamhub.StreamHub {
 	// Fast path: hub already exists (lock-free).
 	if hub := cm.snapshotHub(cameraID); hub != nil {
 		return hub
 	}
 	// Slow path: create under configMu.
-	var created *model.StreamHub
+	var created *streamhub.StreamHub
 	cm.apply(func(s *snapshot) *snapshot {
 		if existing, ok := s.hubs[cameraID]; ok {
 			// Another goroutine won the race inside apply — reuse its hub.
 			created = existing
 			return s
 		}
-		hub := model.NewStreamHub()
+		hub := streamhub.New()
 		hub.SetCameraID(cameraID)
 		hub.SetSource("push")
 		// Wire the same observability callbacks as initStreamHub so push hubs are
@@ -59,7 +59,7 @@ func (cm *CameraManager) GetOrCreateHub(cameraID string) *model.StreamHub {
 // (frame counters, drop counters, buffer-depth gauges). Shared by
 // initStreamHub and GetOrCreateHub so pull and push hubs are instrumented
 // identically (#469).
-func wireHubMetrics(hub *model.StreamHub, cameraID string, m *metrics.Metrics) {
+func wireHubMetrics(hub *streamhub.StreamHub, cameraID string, m *metrics.Metrics) {
 	if m == nil {
 		return
 	}

--- a/internal/camera/lifecycle.go
+++ b/internal/camera/lifecycle.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Start creates and starts recorders for all enabled cameras in the config.
@@ -431,9 +432,9 @@ func (cm *CameraManager) stopCamerasByProtocol(protocol string) {
 
 // getRecorderHub safely extracts the StreamHub from a recorder using type assertion.
 // Returns nil if the recorder does not implement the hubber interface.
-func getRecorderHub(rec model.Recorder) *model.StreamHub {
+func getRecorderHub(rec model.Recorder) *streamhub.StreamHub {
 	type hubber interface {
-		GetHub() *model.StreamHub
+		GetHub() *streamhub.StreamHub
 	}
 	if h, ok := rec.(hubber); ok {
 		return h.GetHub()

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
@@ -249,7 +250,7 @@ func NewCameraManager(cfg *config.Config, store *storage.Manager, db *storage.DB
 	cm.subStreams = newSubStreamManager(
 		substream.Config{
 			Resolver: cm.resolveSubTarget,
-			WireHub: func(hub *model.StreamHub, cameraID string) {
+			WireHub: func(hub *streamhub.StreamHub, cameraID string) {
 				wireHubMetrics(hub, cameraID, m)
 			},
 		},

--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // createRecorder creates a recorder for the given camera config by looking
@@ -41,17 +42,17 @@ func (cm *CameraManager) createRecorder(cam config.CameraConfig, segDur time.Dur
 	return rec
 }
 
-// initStreamHub sets a new StreamHub on the recorder via the model.HubHost
+// initStreamHub sets a new StreamHub on the recorder via the streamhub.HubHost
 // interface. It sets the cameraID for structured logging, labels the hub
 // source for the flow-path view (from the recorder's own HubSource), and
 // wires the standard observability callbacks (shared with push hubs via
 // wireHubMetrics). Recorders without a hub (none today) are skipped.
 func initStreamHub(rec model.Recorder, cameraID string, m *metrics.Metrics) {
-	host, ok := rec.(model.HubHost)
+	host, ok := rec.(streamhub.HubHost)
 	if !ok {
 		return
 	}
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	host.SetHub(hub)
 	hub.SetCameraID(cameraID)
 	hub.SetSource(host.HubSource())

--- a/internal/camera/recorder_factory_test.go
+++ b/internal/camera/recorder_factory_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 )
 
@@ -47,7 +48,7 @@ func TestInitStreamHubViaHubHost(t *testing.T) {
 	initStreamHub(rec, "test-cam", nil)
 	hub := rec.GetHub()
 	if hub == nil {
-		t.Fatal("initStreamHub did not set the hub via model.HubHost")
+		t.Fatal("initStreamHub did not set the hub via streamhub.HubHost")
 	}
 	// The recorder's own HubSource must label the hub (flow-path view).
 	if got := rec.HubSource(); got != "stub" {
@@ -61,14 +62,14 @@ func TestInitStreamHubViaHubHost(t *testing.T) {
 // Compile-time guards: every recorder type used by the builders must satisfy
 // the hub interfaces the camera manager relies on.
 var (
-	_ model.HubHost = (*recorder.H264Recorder)(nil)
-	_ model.HubHost = (*recorder.H265Recorder)(nil)
-	_ model.HubHost = (*recorder.ONVIFRecorder)(nil)
-	_ model.HubHost = (*recorder.MJPEGRecorder)(nil)
-	_ model.HubHost = (*recorder.HTTPJPEGRecorder)(nil)
-	_ model.HubHost = (*recorder.TimelapseRecorder)(nil)
-	_ model.HubHost = (*recorder.StubRecorder)(nil)
-	_ model.HubHost = (*recorder.IngestRecorder)(nil)
-	_ model.HubHost = (*recorder.GB28181Recorder)(nil)
-	_ model.HubHost = (*xiaomi.XiaomiRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.H264Recorder)(nil)
+	_ streamhub.HubHost = (*recorder.H265Recorder)(nil)
+	_ streamhub.HubHost = (*recorder.ONVIFRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.MJPEGRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.HTTPJPEGRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.TimelapseRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.StubRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.IngestRecorder)(nil)
+	_ streamhub.HubHost = (*recorder.GB28181Recorder)(nil)
+	_ streamhub.HubHost = (*xiaomi.XiaomiRecorder)(nil)
 )

--- a/internal/camera/registry.go
+++ b/internal/camera/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // This file implements the copy-on-write snapshot registry that replaces the
@@ -35,7 +36,7 @@ import (
 // callers must go through apply() to publish a new pointer.
 type snapshot struct {
 	recorders    map[string]model.Recorder       // camera_id → running recorder (nil slot = not running)
-	hubs         map[string]*model.StreamHub     // camera_id → StreamHub (single source of truth for pull+push)
+	hubs         map[string]*streamhub.StreamHub // camera_id → StreamHub (single source of truth for pull+push)
 	configs      map[string]*config.CameraConfig // camera_id → config pointer (into cm.cfg.Cameras or a copy)
 	failedStarts map[string]error                // camera_id → last start failure (surfaced as StatusError to health)
 }
@@ -44,7 +45,7 @@ type snapshot struct {
 func newSnapshot() *snapshot {
 	return &snapshot{
 		recorders:    make(map[string]model.Recorder),
-		hubs:         make(map[string]*model.StreamHub),
+		hubs:         make(map[string]*streamhub.StreamHub),
 		configs:      make(map[string]*config.CameraConfig),
 		failedStarts: make(map[string]error),
 	}
@@ -55,7 +56,7 @@ func newSnapshot() *snapshot {
 func (s *snapshot) clone() *snapshot {
 	c := &snapshot{
 		recorders:    make(map[string]model.Recorder, len(s.recorders)),
-		hubs:         make(map[string]*model.StreamHub, len(s.hubs)),
+		hubs:         make(map[string]*streamhub.StreamHub, len(s.hubs)),
 		configs:      make(map[string]*config.CameraConfig, len(s.configs)),
 		failedStarts: make(map[string]error, len(s.failedStarts)),
 	}
@@ -144,16 +145,16 @@ func (cm *CameraManager) snapshotRecorder(cameraID string) model.Recorder {
 }
 
 // snapshotHub returns the StreamHub for cameraID, or nil.
-func (cm *CameraManager) snapshotHub(cameraID string) *model.StreamHub {
+func (cm *CameraManager) snapshotHub(cameraID string) *streamhub.StreamHub {
 	return cm.loadSnapshot().hubs[cameraID]
 }
 
 // snapshotHubs returns a copy of the camera_id → hub map for iteration
 // (stats flusher, flow-path API). Copy avoids holding the snapshot while
 // iterating.
-func (cm *CameraManager) snapshotHubs() map[string]*model.StreamHub {
+func (cm *CameraManager) snapshotHubs() map[string]*streamhub.StreamHub {
 	s := cm.loadSnapshot()
-	hubs := make(map[string]*model.StreamHub, len(s.hubs))
+	hubs := make(map[string]*streamhub.StreamHub, len(s.hubs))
 	for id, hub := range s.hubs {
 		hubs[id] = hub
 	}
@@ -162,7 +163,7 @@ func (cm *CameraManager) snapshotHubs() map[string]*model.StreamHub {
 
 // Hubs is the public read-only view of all registered StreamHubs, used by the
 // /api/streams flow-path endpoint (#469).
-func (cm *CameraManager) Hubs() map[string]*model.StreamHub {
+func (cm *CameraManager) Hubs() map[string]*streamhub.StreamHub {
 	return cm.snapshotHubs()
 }
 

--- a/internal/camera/status.go
+++ b/internal/camera/status.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/health"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 )
 
@@ -67,7 +68,7 @@ func (cm *CameraManager) SetTestRecorder(cameraID string, rec model.Recorder) {
 // none exists. This is the read-only lookup consumed by HLS/WebRTC/FLV/WS
 // handlers (they fall back to getRecorderHub, but push-only cameras — srt/rtmp —
 // expose their hub through this registry). Lock-free read.
-func (cm *CameraManager) GetHub(cameraID string) *model.StreamHub {
+func (cm *CameraManager) GetHub(cameraID string) *streamhub.StreamHub {
 	return cm.snapshotHub(cameraID)
 }
 

--- a/internal/camera/substream.go
+++ b/internal/camera/substream.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/cascade"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 )
 
@@ -149,7 +150,7 @@ func NewCascadeSubAcquirer(cm *CameraManager) cascade.SubStreamAcquirer {
 
 type cascadeSubAcquirer struct{ cm *CameraManager }
 
-func (a cascadeSubAcquirer) AcquireSubHub(ctx context.Context, cameraID string) (*model.StreamHub, func(), error) {
+func (a cascadeSubAcquirer) AcquireSubHub(ctx context.Context, cameraID string) (*streamhub.StreamHub, func(), error) {
 	src, err := a.cm.AcquireSubStream(ctx, cameraID)
 	if err != nil {
 		return nil, nil, err

--- a/internal/camera/timelapse.go
+++ b/internal/camera/timelapse.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
@@ -430,7 +431,7 @@ func (cm *CameraManager) startRecordingScheduleMonitor(ctx context.Context, came
 
 // startTimelapseKeyframeExtractor creates and starts a KeyframeExtractor for the given camera,
 // subscribing it to the provided StreamHub. The extractor is stored in the manager for lifecycle management.
-func (cm *CameraManager) startTimelapseKeyframeExtractor(cameraID string, cam config.CameraConfig, hub *model.StreamHub, rec model.Recorder) error {
+func (cm *CameraManager) startTimelapseKeyframeExtractor(cameraID string, cam config.CameraConfig, hub *streamhub.StreamHub, rec model.Recorder) error {
 	if effectiveDualModeFrameSource(cam) != "rtsp_keyframe" {
 		return nil
 	}

--- a/internal/flv/hub_rebind_test.go
+++ b/internal/flv/hub_rebind_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 func TestActiveHubAndRebind(t *testing.T) {
@@ -24,13 +25,13 @@ func TestActiveHubAndRebind(t *testing.T) {
 
 	require.Nil(t, m.ActiveHub("cam-none"))
 
-	hub1 := model.NewStreamHub()
+	hub1 := streamhub.New()
 	require.NoError(t, m.RegisterStream("cam-flv", model.FormatH264, minimalSPS, minimalPPS, nil, hub1))
 	require.Equal(t, hub1, m.ActiveHub("cam-flv"))
 
 	// Rebind to a fresh hub: old hub's consumer is removed, frames now flow
 	// from the new hub (a probe consumer on hub2 sees broadcasts).
-	hub2 := model.NewStreamHub()
+	hub2 := streamhub.New()
 	m.RebindHub("cam-flv", hub2)
 	require.Equal(t, hub2, m.ActiveHub("cam-flv"))
 
@@ -62,13 +63,13 @@ func TestRebindHubUnsubscribesOldHub(t *testing.T) {
 	m := NewManager()
 	t.Cleanup(func() { m.UnregisterStream("cam-flv"); m.UnregisterStream("cam-old") })
 
-	hub1 := model.NewStreamHub()
+	hub1 := streamhub.New()
 	require.NoError(t, m.RegisterStream("cam-old", model.FormatH264, minimalSPS, minimalPPS, nil, hub1))
 
 	// While registered, the entry owns the "flv-cam-old" consumer slot on hub1.
 	require.Error(t, hub1.SubscribeMsg("flv-cam-old", func(model.FrameMsg) {}))
 
-	hub2 := model.NewStreamHub()
+	hub2 := streamhub.New()
 	m.RebindHub("cam-old", hub2)
 
 	// Rebinding released the old hub's consumer slot: the same ID can be

--- a/internal/flv/manager.go
+++ b/internal/flv/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var flvLogger = slog.Default().With("component", "flv-manager")
@@ -50,7 +51,7 @@ type streamEntry struct {
 	viewerMu  sync.Mutex
 	frameCh   chan model.FrameMsg
 	cancel    context.CancelFunc
-	hub       *model.StreamHub
+	hub       *streamhub.StreamHub
 	hubSubID  string
 	// clockBase is the unix-ms wallclock this entry's FLV tag StreamID
 	// deltas are measured from (#481). Fixed at registration so the shared
@@ -120,7 +121,7 @@ func NewManager(opts ...Option) *Manager {
 
 // RegisterStream registers a camera stream for FLV output.
 // The recorder's StreamHub is used to receive live frames.
-func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *model.StreamHub) error {
+func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *streamhub.StreamHub) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -203,7 +204,7 @@ func (m *Manager) UnregisterStream(camID string) { m.unregisterStream(camID) }
 
 // ActiveHub returns the StreamHub the registered entry is currently
 // subscribed to (nil when the stream is not active).
-func (m *Manager) ActiveHub(camID string) *model.StreamHub {
+func (m *Manager) ActiveHub(camID string) *streamhub.StreamHub {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	entry, ok := m.streams[camID]
@@ -217,7 +218,7 @@ func (m *Manager) ActiveHub(camID string) *model.StreamHub {
 // puller (#513) restarts with a FRESH hub after each idle recycle; without a
 // rebind the entry keeps listening to the dead hub and every viewer goes
 // black forever. Mirrors wsstream.Manager.RebindHub.
-func (m *Manager) RebindHub(camID string, hub *model.StreamHub) {
+func (m *Manager) RebindHub(camID string, hub *streamhub.StreamHub) {
 	if hub == nil {
 		return
 	}

--- a/internal/flv/manager_test.go
+++ b/internal/flv/manager_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- Test Helpers ---
@@ -25,9 +26,9 @@ func newTestManager(t *testing.T) *Manager {
 
 // newTestManagerWithHub creates a Manager and a StreamHub for integration testing.
 // The hub is passed to RegisterStream per-stream, not set on the Manager.
-func newTestManagerWithHub(t *testing.T) (*Manager, *model.StreamHub) {
+func newTestManagerWithHub(t *testing.T) (*Manager, *streamhub.StreamHub) {
 	t.Helper()
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr := NewManager(WithMaxViewers(3), withWriteBufSize(10))
 	return mgr, hub
 }

--- a/internal/gb28181/cascade/cascade_test.go
+++ b/internal/gb28181/cascade/cascade_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/psmux"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/mickeyzzc/gb28181-go/manscdp"
 	"github.com/stretchr/testify/require"
 )
@@ -17,8 +17,8 @@ type fakeSource struct {
 	cams []CameraInfo
 }
 
-func (f fakeSource) Cameras() []CameraInfo       { return f.cams }
-func (f fakeSource) Hub(string) *model.StreamHub { return nil }
+func (f fakeSource) Cameras() []CameraInfo           { return f.cams }
+func (f fakeSource) Hub(string) *streamhub.StreamHub { return nil }
 
 func newCascadeTestDB(t *testing.T) *storage.DB {
 	t.Helper()
@@ -267,13 +267,13 @@ func TestForwardDeviceControl_LensNotForwarded(t *testing.T) {
 // --- sub-stream forwarding (#512) -------------------------------------------------
 
 type fakeSubAcquirer struct {
-	hub     *model.StreamHub
+	hub     *streamhub.StreamHub
 	err     error
 	calls   int
 	release chan struct{}
 }
 
-func (f *fakeSubAcquirer) AcquireSubHub(context.Context, string) (*model.StreamHub, func(), error) {
+func (f *fakeSubAcquirer) AcquireSubHub(context.Context, string) (*streamhub.StreamHub, func(), error) {
 	f.calls++
 	if f.err != nil {
 		return nil, nil, f.err
@@ -284,10 +284,10 @@ func (f *fakeSubAcquirer) AcquireSubHub(context.Context, string) (*model.StreamH
 // hubSource is a fakeSource whose Hub returns a real hub for one camera.
 type hubSource struct {
 	fakeSource
-	hub *model.StreamHub
+	hub *streamhub.StreamHub
 }
 
-func (f hubSource) Hub(string) *model.StreamHub { return f.hub }
+func (f hubSource) Hub(string) *streamhub.StreamHub { return f.hub }
 
 var errNoSubForTest = &testError{"no sub-stream configured"}
 
@@ -298,7 +298,7 @@ func (e *testError) Error() string { return e.msg }
 // A wanted sub forward subscribes to the SUB hub, records the swap, and drops
 // the acquisition reference on close.
 func TestMediaSessionSubStreamForward(t *testing.T) {
-	mainHub, subHub := model.NewStreamHub(), model.NewStreamHub()
+	mainHub, subHub := streamhub.New(), streamhub.New()
 	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
 	acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
 	svc.SetSubStreamAcquirer(acq)
@@ -326,7 +326,7 @@ func TestMediaSessionSubStreamForward(t *testing.T) {
 
 // Acquisition failure degrades to a main-stream forward — never a dead session.
 func TestMediaSessionSubStreamFallbackToMain(t *testing.T) {
-	mainHub := model.NewStreamHub()
+	mainHub := streamhub.New()
 	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
 	svc.SetSubStreamAcquirer(&fakeSubAcquirer{err: errNoSubForTest, release: make(chan struct{}, 1)})
 
@@ -346,7 +346,7 @@ func TestMediaSessionSubStreamFallbackToMain(t *testing.T) {
 // A BYE racing the acquisition: close() first ⇒ run drops the freshly granted
 // reference and never subscribes.
 func TestMediaSessionSubStreamCloseDuringAcquire(t *testing.T) {
-	mainHub, subHub := model.NewStreamHub(), model.NewStreamHub()
+	mainHub, subHub := streamhub.New(), streamhub.New()
 	svc := New(testCfg(), hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", SubStream: true}}}, mainHub}, nil)
 	acq := &fakeSubAcquirer{hub: subHub, release: make(chan struct{}, 1)}
 	svc.SetSubStreamAcquirer(acq)

--- a/internal/gb28181/cascade/loopback_test.go
+++ b/internal/gb28181/cascade/loopback_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
 	"github.com/ghettovoice/gosip/sip/parser"
@@ -247,7 +248,7 @@ func TestServiceNameAndNoUpperStart(t *testing.T) {
 }
 
 func TestLoopbackInviteLiveForwardAndBye(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
 	_, err := svc.catalogItems()
@@ -303,7 +304,7 @@ func TestLoopbackInviteLiveForwardAndBye(t *testing.T) {
 }
 
 func TestLoopbackInviteHiddenCameraRefused(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front", CascadeHidden: true}}}, hub}, db)
 	_, err := svc.catalogItems()
@@ -325,7 +326,7 @@ func TestLoopbackInviteNoHub(t *testing.T) {
 
 func TestLoopbackSubscribeCatalogNotify(t *testing.T) {
 	db := newCascadeTestDB(t)
-	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, model.NewStreamHub()}, db)
+	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, streamhub.New()}, db)
 
 	sub := up.request(sip.SUBSCRIBE, testCfg().LocalDeviceID, "", "")
 	sub.AppendHeader(&sip.GenericHeader{HeaderName: "Event", Contents: "Catalog"})
@@ -349,7 +350,7 @@ func TestLoopbackSubscribeCatalogNotify(t *testing.T) {
 }
 
 func TestLoopbackRecordInfoQuery(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
 	_, err := svc.catalogItems()
@@ -429,7 +430,7 @@ func createPacedPlaybackSegment(t *testing.T, db interface {
 }
 
 func TestLoopbackPlaybackInviteAndControl(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
 	_, err := svc.catalogItems()

--- a/internal/gb28181/cascade/media.go
+++ b/internal/gb28181/cascade/media.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/psmux"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/ghettovoice/gosip"
 	"github.com/ghettovoice/gosip/sip"
 )
@@ -45,7 +46,7 @@ type mediaSession struct {
 	// sub-stream forward (#512), otherwise the camera's main hub. close()
 	// unsubscribes through it. Guarded by mu: run()'s async sub acquisition
 	// can swap it while a concurrent BYE runs close().
-	hub *model.StreamHub
+	hub *streamhub.StreamHub
 	// releaseSub drops the sub-stream reference acquired for the sub tier.
 	releaseSub func()
 	// wantSub: the camera opted into the low-res cascade tier; run()
@@ -336,7 +337,7 @@ func (ms *mediaSession) localPort() int {
 }
 
 // run subscribes to the camera's hub and pumps frames until stopped.
-func (ms *mediaSession) run(hub *model.StreamHub) {
+func (ms *mediaSession) run(hub *streamhub.StreamHub) {
 	// Sub-stream tier (#512): swap the forwarded hub for the on-demand
 	// low-res pull. Bounded by the manager's ready timeout; failure (no sub
 	// config / pull not ready) degrades to main — quality negotiation never

--- a/internal/gb28181/cascade/service.go
+++ b/internal/gb28181/cascade/service.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	mbsip "github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181/sip"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/ghettovoice/gosip"
 	"github.com/ghettovoice/gosip/sip"
 	"github.com/mickeyzzc/gb28181-go/manscdp"
@@ -54,14 +54,14 @@ type CameraInfo struct {
 // camera manager adapts to it (pkg/app wiring).
 type CameraSource interface {
 	Cameras() []CameraInfo
-	Hub(cameraID string) *model.StreamHub
+	Hub(cameraID string) *streamhub.StreamHub
 }
 
 // SubStreamAcquirer grants the cascade access to the on-demand sub-stream
 // tier (#513): one INVITE holds one reference for its lifetime. Nil (or an
 // error) falls back to main-stream forwarding.
 type SubStreamAcquirer interface {
-	AcquireSubHub(ctx context.Context, cameraID string) (hub *model.StreamHub, release func(), err error)
+	AcquireSubHub(ctx context.Context, cameraID string) (hub *streamhub.StreamHub, release func(), err error)
 }
 
 // upper is one upper-platform registration session (#370): its own REGISTER /

--- a/internal/gb28181/cascade/upperflow_test.go
+++ b/internal/gb28181/cascade/upperflow_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/ghettovoice/gosip/log"
 	"github.com/ghettovoice/gosip/sip"
 	"github.com/ghettovoice/gosip/sip/parser"
@@ -88,7 +88,7 @@ func serveRegistration(t *testing.T, up *upperSocket, stop <-chan struct{}) {
 }
 
 func TestLoopbackRegisterDigestDanceAndKeepalive(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
 
@@ -106,7 +106,7 @@ func TestLoopbackRegisterDigestDanceAndKeepalive(t *testing.T) {
 }
 
 func TestLoopbackCatalogQueryAnswer(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front"}}}, hub}, db)
 	_, err := svc.catalogItems()
@@ -138,7 +138,7 @@ func TestLoopbackDeviceInfoQueryAnswer(t *testing.T) {
 // TestLoopbackMediaPump drives real frames through the hub and asserts RTP
 // packets land on the INVITEd media address — the full forward path.
 func TestLoopbackMediaPump(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	db := newCascadeTestDB(t)
 	svc, up := startLoopbackService(t, hubSource{fakeSource{cams: []CameraInfo{{ID: "cam-1", Name: "Front", Encoding: "h264"}}}, hub}, db)
 	_, err := svc.catalogItems()

--- a/internal/gb28181/rtp.go
+++ b/internal/gb28181/rtp.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/pion/rtp"
 )
 
@@ -42,7 +42,7 @@ const rtpReadBufSize = 65535
 // TCP passive mode: Accepts TCP connections with RFC 4571 or 0x24 framing.
 type Receiver struct {
 	cameraID    string
-	hub         *model.StreamHub
+	hub         *streamhub.StreamHub
 	portManager *PortManager
 	tcpMode     TCPMode
 
@@ -105,7 +105,7 @@ type Receiver struct {
 }
 
 // NewReceiver creates a new GB28181 RTP receiver.
-func NewReceiver(cameraID string, hub *model.StreamHub, portManager *PortManager) *Receiver {
+func NewReceiver(cameraID string, hub *streamhub.StreamHub, portManager *PortManager) *Receiver {
 	return &Receiver{
 		cameraID:         cameraID,
 		hub:              hub,

--- a/internal/gb28181/rtp_test.go
+++ b/internal/gb28181/rtp_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Helper to build a test RTP packet with marker bit set.
@@ -45,7 +45,7 @@ func buildTestMPEGPSPayload() []byte {
 func TestNewReceiver(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test-cam", hub, pm)
 
@@ -59,7 +59,7 @@ func TestNewReceiver(t *testing.T) {
 func TestReceiverStopWithoutStart(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test", hub, pm)
 
@@ -70,7 +70,7 @@ func TestReceiverStopWithoutStart(t *testing.T) {
 func TestSetTCPMode(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test", hub, pm)
 
@@ -87,7 +87,7 @@ func TestSetTCPMode(t *testing.T) {
 func TestReceiverUDPBasic(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test-cam", hub, pm)
 
@@ -148,7 +148,7 @@ func TestReceiverUDPBasic(t *testing.T) {
 func TestReceiverMetrics(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("metrics-test", hub, pm)
 
@@ -161,7 +161,7 @@ func TestReceiverMetrics(t *testing.T) {
 func TestReceiverCodec(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test", hub, pm)
 
@@ -172,7 +172,7 @@ func TestReceiverCodec(t *testing.T) {
 func TestReceiverDoubleStop(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("test", hub, pm)
 
@@ -187,7 +187,7 @@ func TestReceiverStartStopRace(t *testing.T) {
 	t.Helper()
 
 	for range 50 {
-		hub := model.NewStreamHub()
+		hub := streamhub.New()
 		pm := NewPortManager(50000, 50100)
 		rec := NewReceiver("race-test", hub, pm)
 
@@ -226,7 +226,7 @@ func TestReceiverStartStopRace(t *testing.T) {
 func TestReceiverJitterBufferMarkerBit(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("jitter-test", hub, pm)
 
@@ -279,7 +279,7 @@ func TestReceiverJitterBufferMarkerBit(t *testing.T) {
 func TestReceiverSequenceWrap(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("wrap-test", hub, pm)
 
@@ -335,7 +335,7 @@ func TestReceiverSequenceWrap(t *testing.T) {
 func TestReceiverTCPModeRFC4571(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("tcp-test", hub, pm)
 	rec.SetTCPMode(TCPModeRFC4571)
@@ -396,7 +396,7 @@ func TestReceiverTCPModeRFC4571(t *testing.T) {
 func TestReceiverTCPMode0x24(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("tcp-0x24-test", hub, pm)
 	rec.SetTCPMode(TCPMode0x24)
@@ -459,7 +459,7 @@ func TestReceiverTCPMode0x24(t *testing.T) {
 func TestReceiverTCPModeAutoDetectRFC4571(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("auto-detect-test", hub, pm)
 	rec.SetTCPMode(TCPModeAuto)
@@ -523,7 +523,7 @@ func TestReceiverTCPModeAutoDetectRFC4571(t *testing.T) {
 func TestReceiverTCPModeAutoDetect0x24(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("auto-detect-0x24-test", hub, pm)
 	rec.SetTCPMode(TCPModeAuto)
@@ -589,7 +589,7 @@ func TestReceiverTCPModeAutoDetect0x24(t *testing.T) {
 func TestReceiverNALUCallback(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("callback-test", hub, pm)
 
@@ -640,7 +640,7 @@ func TestReceiverNALUCallback(t *testing.T) {
 func TestReceiverStartNilConn(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("nil-conn-test", hub, pm)
 
@@ -655,7 +655,7 @@ func TestReceiverStartNilConn(t *testing.T) {
 func TestReceiverMultipleAUs(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("multi-au-test", hub, pm)
 
@@ -702,7 +702,7 @@ func TestReceiverMultipleAUs(t *testing.T) {
 func TestReceiverOutOrderPackets(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("ooo-test", hub, pm)
 
@@ -757,7 +757,7 @@ func TestReceiverOutOrderPackets(t *testing.T) {
 func TestReceiverMaxJitterBufferSize(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	pm := NewPortManager(50000, 50010)
 	rec := NewReceiver("jitter-size-test", hub, pm)
 	rec.maxJitterPackets = 4 // Reduce for testing

--- a/internal/gb28181/session.go
+++ b/internal/gb28181/session.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/mickeyzzc/gb28181-go/manscdp"
 )
 
@@ -35,7 +35,7 @@ type session struct {
 	deviceID  string
 	channel   *Channel
 	receiver  *Receiver
-	hub       *model.StreamHub
+	hub       *streamhub.StreamHub
 	port      uint16
 
 	mu     sync.Mutex
@@ -223,9 +223,9 @@ func (sm *SessionManager) Invite(channel *Channel, serverIP string, deviceAddr s
 
 	// Use the provided AU callback (from the recorder) instead of creating
 	// an orphaned hub. When onAU is nil (tests), fall back to a local hub.
-	var hub *model.StreamHub
+	var hub *streamhub.StreamHub
 	if onAU == nil {
-		hub = model.NewStreamHub()
+		hub = streamhub.New()
 		hub.SetCameraID(channel.ID)
 	}
 	receiver := NewReceiver(channel.ID, hub, sm.portManager)
@@ -628,7 +628,7 @@ func (sm *SessionManager) inviteFetch(channel *Channel, serverIP string, start, 
 	))
 
 	// Create StreamHub for this session
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID(channel.ID)
 
 	// Create receiver
@@ -745,7 +745,7 @@ func (sm *SessionManager) SetPlaybackByeSender(sender func(channelID string) err
 }
 
 // GetHub returns the StreamHub for the given channelID, or nil if no active session.
-func (sm *SessionManager) GetHub(channelID string) *model.StreamHub {
+func (sm *SessionManager) GetHub(channelID string) *streamhub.StreamHub {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if sess, ok := sm.sessions[channelID]; ok {

--- a/internal/health/manager.go
+++ b/internal/health/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Manager orchestrates all health monitoring layers:
@@ -452,9 +453,9 @@ func (m *Manager) GetAllHealth() map[string]*model.CameraHealth {
 }
 
 // getHub extracts the StreamHub from a recorder via type assertion.
-func getHub(recorder model.Recorder) *model.StreamHub {
+func getHub(recorder model.Recorder) *streamhub.StreamHub {
 	type hubber interface {
-		GetHub() *model.StreamHub
+		GetHub() *streamhub.StreamHub
 	}
 	if h, ok := recorder.(hubber); ok {
 		return h.GetHub()

--- a/internal/health/manager_test.go
+++ b/internal/health/manager_test.go
@@ -8,18 +8,19 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- Mocks ---
 
 // mockRecorder implements model.Recorder and supports GetHub().
 type mockRecorder struct {
-	hub    *model.StreamHub
+	hub    *streamhub.StreamHub
 	mu     sync.Mutex
 	status model.RecorderStatus
 }
 
-func (r *mockRecorder) GetHub() *model.StreamHub {
+func (r *mockRecorder) GetHub() *streamhub.StreamHub {
 	return r.hub
 }
 
@@ -33,7 +34,7 @@ func (r *mockRecorder) Status() model.RecorderStatus {
 
 func newMockRecorderWithHub() *mockRecorder {
 	return &mockRecorder{
-		hub:    model.NewStreamHub(),
+		hub:    streamhub.New(),
 		status: model.StatusRecording,
 	}
 }

--- a/internal/hls/manager.go
+++ b/internal/hls/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var hlsLogger = slog.Default().With("component", "hls-manager")
@@ -69,7 +70,7 @@ type streamEntry struct {
 	// hub is the StreamHub the entry's "hls" consumer is subscribed to.
 	// Set by SubscribeToHub; compared by the sub-stream recycler (#513) to
 	// decide whether this entry still belongs to a recycled pull generation.
-	hub *model.StreamHub
+	hub *streamhub.StreamHub
 	// wg tracks the writeLoop + idleWatchdog goroutines so stopStreamLocked
 	// can join them before returning. Without this, the goroutines briefly
 	// outlive the entry (they touch entry.mux / entry.dirPath), leaking
@@ -1115,7 +1116,7 @@ func (m *Manager) StopAll() {
 // #469: uses AddOnDrop (callback list) — the old direct assignment silently
 // destroyed the camera manager's hub-level Prometheus wiring as soon as any
 // HLS subscriber attached.
-func (m *Manager) SubscribeToHub(cameraID string, hub *model.StreamHub, isH265 bool) error {
+func (m *Manager) SubscribeToHub(cameraID string, hub *streamhub.StreamHub, isH265 bool) error {
 	m.mu.Lock()
 	if entry, ok := m.streams[cameraID]; ok {
 		entry.hub = hub
@@ -1142,7 +1143,7 @@ func (m *Manager) SubscribeToHub(cameraID string, hub *model.StreamHub, isH265 b
 // subscribed to (nil when the stream is not active). The sub-stream recycler
 // (#513) compares this against the recycled hub to avoid stopping an entry
 // that already rebound to a fresh pull generation.
-func (m *Manager) ActiveHub(cameraID string) *model.StreamHub {
+func (m *Manager) ActiveHub(cameraID string) *streamhub.StreamHub {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	entry, ok := m.streams[cameraID]
@@ -1157,13 +1158,13 @@ func (m *Manager) ActiveHub(cameraID string) *model.StreamHub {
 // parameters stay from registration; puller restarts preserve the camera's
 // parameter sets in practice, and the recycle path stops the entry anyway, so
 // the rebind is only a short-window safety net.
-func (m *Manager) RebindHub(cameraID string, hub *model.StreamHub, isH265 bool) {
+func (m *Manager) RebindHub(cameraID string, hub *streamhub.StreamHub, isH265 bool) {
 	if hub == nil {
 		return
 	}
 	m.mu.RLock()
 	entry, ok := m.streams[cameraID]
-	oldHub := (*model.StreamHub)(nil)
+	oldHub := (*streamhub.StreamHub)(nil)
 	if ok {
 		oldHub = entry.hub
 	}

--- a/internal/hls/substream_pump_test.go
+++ b/internal/hls/substream_pump_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Parameter-set vectors borrowed from the substream package tests — real
@@ -307,7 +308,7 @@ func TestHubPumpAndRebind(t *testing.T) {
 	dir := m.streams["cam-hub"].dirPath
 	m.mu.RUnlock()
 
-	hub1 := model.NewStreamHub()
+	hub1 := streamhub.New()
 	require.NoError(t, m.SubscribeToHub("cam-hub", hub1, false))
 	require.Equal(t, hub1, m.ActiveHub("cam-hub"))
 	require.Nil(t, m.ActiveHub("cam-nope"))
@@ -321,7 +322,7 @@ func TestHubPumpAndRebind(t *testing.T) {
 		15*time.Second, 200*time.Millisecond, "hub broadcast never produced segments")
 
 	// Rebind to a fresh hub: old hub's consumer is removed, ActiveHub moves.
-	hub2 := model.NewStreamHub()
+	hub2 := streamhub.New()
 	m.RebindHub("cam-hub", hub2, false)
 	require.Equal(t, hub2, m.ActiveHub("cam-hub"))
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -13,20 +13,10 @@ type Recorder interface {
 	Status() RecorderStatus
 }
 
-// HubHost is an optional interface implemented by recorders that carry a
-// StreamHub for frame fan-out. The camera manager wires a fresh hub via
-// SetHub at recorder creation; HubSource labels the hub for the flow-path
-// observability view. Adding a new recorder type means implementing this
-// interface on the type itself — no camera-manager type switch to extend.
-type HubHost interface {
-	SetHub(hub *StreamHub)
-	HubSource() string
-}
-
 // HLSProvider is an optional interface that recorders can implement
 // to support HLS live streaming. The api handler uses this interface
 // to obtain codec parameters for starting an HLS stream.
-// Frame delivery uses StreamHub.Subscribe/Unsubscribe directly.
+// Frame delivery uses internal/streamhub.StreamHub Subscribe/Unsubscribe directly.
 type HLSProvider interface {
 	// CodecParams returns the current codec parameters detected from the stream.
 	// Returns nil slices if codec info frames have not been received yet.

--- a/internal/recorder/accessors_small_test.go
+++ b/internal/recorder/accessors_small_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,7 @@ func TestH264ParamSetExtraction(t *testing.T) {
 	pps := []byte{0x68, 0xce, 0x38}
 	// One access unit carrying SPS(7), PPS(8), IDR(5) and a non-param NAL.
 	au := [][]byte{sps, pps, {0x65, 0x88}, {0x41, 0x10}}
-	rec.Hub = model.NewStreamHub() // wired by camera.initStreamHub in production
+	rec.Hub = streamhub.New() // wired by camera.initStreamHub in production
 	H264NALDriver{}.extractParamSets(rec.baseRecorder, au)
 
 	require.Equal(t, sps, rec.SPS())
@@ -122,7 +123,7 @@ func TestStorageHealthHelpers(t *testing.T) {
 
 func TestStubRecorderSurface(t *testing.T) {
 	t.Parallel()
-	s := &StubRecorder{Hub: model.NewStreamHub()}
+	s := &StubRecorder{Hub: streamhub.New()}
 	require.NoError(t, s.Start(context.Background()))
 	require.Equal(t, model.StatusRecording, s.Status())
 	require.NoError(t, s.Stop())

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -50,6 +50,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // BaseConfig holds the shared configuration fields used by all RTSP video
@@ -320,7 +321,7 @@ type baseRecorder struct {
 
 	// Stream fan-out to HLS, WebRTC, etc. Initialized by camera manager
 	// via initStreamHub(). Non-blocking broadcasts.
-	Hub *model.StreamHub
+	Hub *streamhub.StreamHub
 
 	// Adaptive write-density state (issue #435). Tier 3: created by
 	// resetAdaptive (connectAndRecord, BEFORE the writeFrames goroutine and
@@ -363,9 +364,9 @@ type codecParams struct {
 // single writer path (writeFrames via the driver's handleParamSet, and the SDP
 // pre-seed in connectAndRecord) — concurrent callers must not interleave
 // partial updates; build the full triplet first, then Store.
-// SetHub wires the StreamHub for frame fan-out (model.HubHost); shared by
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost); shared by
 // every recorder embedding baseRecorder. HubSource stays leaf-specific.
-func (b *baseRecorder) SetHub(hub *model.StreamHub) { b.Hub = hub }
+func (b *baseRecorder) SetHub(hub *streamhub.StreamHub) { b.Hub = hub }
 
 func (b *baseRecorder) setCodecParams(sps, pps, vps []byte) {
 	b.codec.Store(&codecParams{

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var gb28181Logger = slog.Default().With("component", "gb28181-recorder")
@@ -45,7 +46,7 @@ type GB28181Config struct {
 type GB28181Recorder struct {
 	cfg GB28181Config
 	// Hub is set by camera.initStreamHub (same pattern as H264Recorder.Hub).
-	Hub           *model.StreamHub
+	Hub           *streamhub.StreamHub
 	mu            sync.Mutex
 	status        model.RecorderStatus
 	sps, pps, vps []byte
@@ -79,7 +80,7 @@ var (
 )
 
 // NewGB28181Recorder creates a recorder for a GB28181 channel camera.
-func NewGB28181Recorder(cfg GB28181Config, hub *model.StreamHub) *GB28181Recorder {
+func NewGB28181Recorder(cfg GB28181Config, hub *streamhub.StreamHub) *GB28181Recorder {
 	if cfg.SegmentDur < time.Millisecond {
 		cfg.SegmentDur = 10 * time.Minute
 	}
@@ -115,12 +116,12 @@ func (r *GB28181Recorder) Status() model.RecorderStatus {
 	return r.status
 }
 
-func (r *GB28181Recorder) GetHub() *model.StreamHub {
+func (r *GB28181Recorder) GetHub() *streamhub.StreamHub {
 	return r.Hub
 }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *GB28181Recorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *GB28181Recorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *GB28181Recorder) HubSource() string { return "gb28181" }

--- a/internal/recorder/gb28181_test.go
+++ b/internal/recorder/gb28181_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +30,7 @@ func newGBRecorder(t *testing.T, cameraID, encoding string, segDur time.Duration
 		Store:         store,
 		RecordEnabled: true,
 	}, nil)
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID(cameraID)
 	require.NoError(t, rec.Start(context.Background()))
 	rec.OnInvite()
@@ -202,7 +203,7 @@ func TestGB28181Recorder_InterfaceCompliance(t *testing.T) {
 
 // TestGB28181Recorder_GetHub tests GetHub method.
 func TestGB28181Recorder_GetHub(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	rec := NewGB28181Recorder(GB28181Config{CameraID: "test-cam", Encoding: "h264"}, hub)
 
 	require.Equal(t, hub, rec.GetHub())
@@ -263,7 +264,7 @@ func TestGB28181Recorder_RecordDisabled(t *testing.T) {
 		Store:         store,
 		RecordEnabled: false,
 	}, nil)
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("live-only")
 	require.NoError(t, rec.Start(context.Background()))
 	rec.OnInvite()
@@ -374,7 +375,7 @@ func TestGB28181Recorder_AudioIntoSegment(t *testing.T) {
 		RecordEnabled: true,
 		AudioEnabled:  true,
 	}, nil)
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("audio-cam")
 	require.NoError(t, rec.Start(context.Background()))
 	rec.OnInvite()
@@ -437,7 +438,7 @@ func TestGB28181Recorder_HubAudioBroadcast(t *testing.T) {
 		RecordEnabled: true,
 		AudioEnabled:  true,
 	}, nil)
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("hub-audio")
 	require.NoError(t, rec.Start(context.Background()))
 	rec.OnInvite()

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var h264Logger = slog.Default().With("component", "h264-recorder")
@@ -169,7 +170,7 @@ func (r *H264Recorder) Status() model.RecorderStatus {
 }
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *H264Recorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *H264Recorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *H264Recorder) HubSource() string { return "h264" }

--- a/internal/recorder/h264_test.go
+++ b/internal/recorder/h264_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var (
@@ -595,7 +596,7 @@ type audioCollector struct {
 	done   chan struct{}
 }
 
-func newAudioCollector(hub *model.StreamHub, id string) *audioCollector {
+func newAudioCollector(hub *streamhub.StreamHub, id string) *audioCollector {
 	c := &audioCollector{done: make(chan struct{})}
 	hub.SubscribeAudio(id, func(pts int64, codec model.AudioCodec, data []byte) {
 		c.mu.Lock()
@@ -629,7 +630,7 @@ func (c *audioCollector) count() int {
 	return len(c.frames)
 }
 
-func (c *audioCollector) close(hub *model.StreamHub, id string) {
+func (c *audioCollector) close(hub *streamhub.StreamHub, id string) {
 	hub.UnsubscribeAudio(id)
 }
 
@@ -640,7 +641,7 @@ func TestH264Recorder_AudioBroadcast(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewH264Recorder(H264Config{
 		CameraID:          "cam-audio",
@@ -692,7 +693,7 @@ func TestH264Recorder_AudioDisabled_StillRecordsVideo(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewH264Recorder(H264Config{
 		CameraID:     "cam-noaudio",

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var h265Logger = slog.Default().With("component", "h265-recorder")
@@ -160,7 +161,7 @@ func (r *H265Recorder) Status() model.RecorderStatus {
 }
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *H265Recorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *H265Recorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *H265Recorder) HubSource() string { return "h265" }

--- a/internal/recorder/h265_test.go
+++ b/internal/recorder/h265_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var (
@@ -219,7 +220,7 @@ func TestH265Recorder_AudioBroadcast(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewH265Recorder(H265Config{
 		CameraID:          "cam-audio-h265",
@@ -271,7 +272,7 @@ func TestH265Recorder_AudioDisabled_StillRecordsVideo(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewH265Recorder(H265Config{
 		CameraID:     "cam-noaudio-h265",

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var httpJpegLogger = slog.Default().With("component", "http-jpeg-recorder")
@@ -65,8 +66,8 @@ type HTTPJPEGRecorder struct {
 	curFinalPath    string
 	segStart        time.Time
 	frameCount      int
-	Hub             *model.StreamHub // Frame fan-out (nil for HTTP-JPEG — no HLS support, reserved for future consumers)
-	lastHealthLogAt time.Time        // throttled log for storage health failures
+	Hub             *streamhub.StreamHub // Frame fan-out (nil for HTTP-JPEG — no HLS support, reserved for future consumers)
+	lastHealthLogAt time.Time            // throttled log for storage health failures
 
 	// latestFrame caches the most recent JPEG frame for snapshot polling.
 	// Stored as an atomic pointer to a freshly-allocated, immutable []byte so concurrent
@@ -81,10 +82,10 @@ type HTTPJPEGRecorder struct {
 }
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *HTTPJPEGRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *HTTPJPEGRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *HTTPJPEGRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *HTTPJPEGRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *HTTPJPEGRecorder) HubSource() string { return "http-jpeg" }

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var ingestLogger = slog.Default().With("component", "ingest-recorder")
@@ -62,7 +63,7 @@ type IngestRecorder struct {
 	status model.RecorderStatus
 
 	// Hub is set by camera.initStreamHub (same pattern as H264Recorder.Hub).
-	Hub *model.StreamHub
+	Hub *streamhub.StreamHub
 
 	// auAsm regroups delivered NALUs into picture-complete AUs before fan-out
 	// (push publishers disagree on delivery granularity; see AUAssembler).
@@ -125,10 +126,10 @@ func NewIngestRecorder(cfg IngestConfig) *IngestRecorder {
 
 // GetHub returns the StreamHub for frame fan-out (satisfies the hubber interface
 // used by getRecorderHub across the API layer).
-func (r *IngestRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *IngestRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *IngestRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *IngestRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *IngestRecorder) HubSource() string { return "ingest" }

--- a/internal/recorder/ingest_test.go
+++ b/internal/recorder/ingest_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // ingestTestDB is a minimal RecordingDB that records inserted recordings in-memory.
@@ -48,7 +49,7 @@ func newIngestRecorder(t *testing.T, segDur time.Duration) (*IngestRecorder, *st
 		Store:      store,
 		DB:         db,
 	})
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("push-cam")
 	require.NoError(t, rec.Start(context.Background()))
 	return rec, store, db
@@ -328,7 +329,7 @@ func TestIngestRecorder_AudioLiveOnly(t *testing.T) {
 		DB:            db,
 		RecordEnabled: &liveOnly,
 	})
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("push-live")
 	require.NoError(t, rec.Start(context.Background()))
 	t.Cleanup(func() { _ = rec.Stop() })
@@ -377,7 +378,7 @@ func TestIngestRecorder_H265_RecordsSegment(t *testing.T) {
 		Store:      store,
 		DB:         db,
 	})
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("push-cam-h265")
 	require.NoError(t, rec.Start(context.Background()))
 	t.Cleanup(func() { _ = rec.Stop() })

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var mjpegLogger = slog.Default().With("component", "mjpeg-recorder")
@@ -68,7 +69,7 @@ type MJPEGRecorder struct {
 	frameCh         chan []byte
 	dropped         atomic.Int64
 	latestFrame     atomic.Pointer[[]byte] // cached latest JPEG frame for zero-copy polling
-	Hub             *model.StreamHub       // Frame fan-out (nil for MJPEG — no HLS support, reserved for future consumers)
+	Hub             *streamhub.StreamHub   // Frame fan-out (nil for MJPEG — no HLS support, reserved for future consumers)
 	lastHealthLogAt time.Time              // throttled log for storage health failures
 
 	// Audio/AVI fields
@@ -128,10 +129,10 @@ func jpegDimensions(data []byte) (width, height int, ok bool) {
 }
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *MJPEGRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *MJPEGRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *MJPEGRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *MJPEGRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *MJPEGRecorder) HubSource() string { return "mjpeg" }

--- a/internal/recorder/mjpeg_test.go
+++ b/internal/recorder/mjpeg_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // generateTestJPEG creates a valid 16x16 JPEG image for testing.
@@ -452,7 +453,7 @@ func TestMJPEGRecorderWithAudio(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewMJPEGRecorder(MJPEGConfig{
 		CameraID:     "cam-mjpeg-audio",
@@ -527,7 +528,7 @@ func TestMJPEGRecorderNoAudio(t *testing.T) {
 	defer srv.close()
 
 	mgr := newTestManager(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	rec := NewMJPEGRecorder(MJPEGConfig{
 		CameraID:     "cam-noaudio",

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var onvifRecLogger = slog.Default().With("component", "onvif-recorder")
@@ -66,7 +67,7 @@ type ONVIFRecorder struct {
 	onvifClient onvif.DeviceClient
 	store       SegmentStore
 	metrics     *metrics.Metrics
-	Hub         *model.StreamHub // Frame fan-out, passed to delegate recorders
+	Hub         *streamhub.StreamHub // Frame fan-out, passed to delegate recorders
 
 	// newRecorder is a function that creates the delegate recorder.
 	// Overridable in tests to inject a mock recorder.
@@ -92,10 +93,10 @@ type ONVIFRecorder struct {
 }
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *ONVIFRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *ONVIFRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *ONVIFRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *ONVIFRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *ONVIFRecorder) HubSource() string { return "onvif" }

--- a/internal/recorder/stub.go
+++ b/internal/recorder/stub.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // StubRecorder is a no-op recorder that implements model.Recorder.
@@ -19,14 +20,14 @@ type StubRecorder struct {
 	done   chan struct{}
 	status model.RecorderStatus
 
-	Hub *model.StreamHub
+	Hub *streamhub.StreamHub
 }
 
 // GetHub returns the StreamHub for frame fan-out. Always nil for StubRecorder.
-func (r *StubRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *StubRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *StubRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *StubRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *StubRecorder) HubSource() string { return "stub" }

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
@@ -70,15 +71,15 @@ type TimelapseRecorder struct {
 	segStart     time.Time
 	frameCount   int
 
-	Hub             *model.StreamHub
+	Hub             *streamhub.StreamHub
 	lastHealthLogAt time.Time // throttled log for storage health failures
 }
 
 // GetHub returns the StreamHub for frame fan-out (nil for timelapse — no live streaming).
-func (r *TimelapseRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *TimelapseRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *TimelapseRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *TimelapseRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *TimelapseRecorder) HubSource() string { return "timelapse" }

--- a/internal/relay/engine.go
+++ b/internal/relay/engine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/backoff"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/livetranscode"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
 
@@ -83,7 +84,7 @@ type PushTarget struct {
 	CameraID string
 	Config   PushTargetConfig
 
-	hub               *model.StreamHub
+	hub               *streamhub.StreamHub
 	spsProvider       SPSProvider
 	codecInfoProvider func() model.CodecInfo
 	sourceCodec       SourceCodecProvider
@@ -123,7 +124,7 @@ type PushTarget struct {
 }
 
 // NewPushTarget constructs an idle target. It does not connect until Run.
-func NewPushTarget(cameraID string, cfg PushTargetConfig, hub *model.StreamHub, sps SPSProvider) *PushTarget {
+func NewPushTarget(cameraID string, cfg PushTargetConfig, hub *streamhub.StreamHub, sps SPSProvider) *PushTarget {
 	return &PushTarget{
 		CameraID:    cameraID,
 		Config:      cfg,

--- a/internal/relay/manager.go
+++ b/internal/relay/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
 
@@ -15,7 +16,7 @@ var managerLogger = slog.Default().With("component", "relay-manager")
 
 // CameraHubProvider returns the StreamHub for a camera id (or nil). Backed by
 // CameraManager.GetHub in production.
-type CameraHubProvider func(cameraID string) *model.StreamHub
+type CameraHubProvider func(cameraID string) *streamhub.StreamHub
 
 // SPSCameraProvider returns the source camera's current SPS/PPS + H.264 flag,
 // looked up by camera id. The Manager adapts this per-target into the

--- a/internal/relay/manager_loop_test.go
+++ b/internal/relay/manager_loop_test.go
@@ -14,13 +14,14 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 	"github.com/stretchr/testify/require"
 )
 
 func newTestManager() *Manager {
 	return NewManager(
-		func(string) *model.StreamHub { return model.NewStreamHub() },
+		func(string) *streamhub.StreamHub { return streamhub.New() },
 		func(string) ([]byte, []byte, bool) { return []byte{0x67}, []byte{0x68}, true },
 	)
 }
@@ -112,7 +113,7 @@ func TestPushTarget_RunNilHub(t *testing.T) {
 
 func TestConnectAndStream_UnsupportedProtocol(t *testing.T) {
 	target := NewPushTarget("cam1", PushTargetConfig{ID: "t1", Protocol: "carrier-pigeon"},
-		model.NewStreamHub(), func() ([]byte, []byte, bool) { return nil, nil, true })
+		streamhub.New(), func() ([]byte, []byte, bool) { return nil, nil, true })
 	err := target.connectAndStream(context.Background())
 	require.ErrorIs(t, err, errPermanent)
 	st := target.Status()
@@ -124,7 +125,7 @@ func TestConnectAndStream_UnsupportedProtocol(t *testing.T) {
 // without any live server.
 func TestConnectRTSP_ConnectionRefused(t *testing.T) {
 	target := NewPushTarget("cam1", PushTargetConfig{ID: "t1", Protocol: "rtsp", URL: "rtsp://127.0.0.1:1/x"},
-		model.NewStreamHub(), func() ([]byte, []byte, bool) { return []byte{0x67}, []byte{0x68}, true })
+		streamhub.New(), func() ([]byte, []byte, bool) { return []byte{0x67}, []byte{0x68}, true })
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	err := target.connectAndStream(ctx)

--- a/internal/relay/rtmp_loop_test.go
+++ b/internal/relay/rtmp_loop_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/bluenviron/gortmplib/pkg/amf0"
 	"github.com/bluenviron/gortmplib/pkg/bytecounter"
 	"github.com/bluenviron/gortmplib/pkg/message"
@@ -206,6 +206,6 @@ func TestConnectRTMPFullFlow(t *testing.T) {
 	}
 }
 
-func newHubForRelay() *model.StreamHub {
-	return model.NewStreamHub()
+func newHubForRelay() *streamhub.StreamHub {
+	return streamhub.New()
 }

--- a/internal/relay/watchdog_test.go
+++ b/internal/relay/watchdog_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/bluenviron/gortmplib/pkg/bytecounter"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +54,7 @@ func newWatchdogTarget(t *testing.T) *PushTarget {
 		Protocol: "rtmp",
 		URL:      "rtmp://127.0.0.1:1935/live/key",
 		Enabled:  true,
-	}, &model.StreamHub{}, func() ([]byte, []byte, bool) { return nil, nil, false })
+	}, &streamhub.StreamHub{}, func() ([]byte, []byte, bool) { return nil, nil, false })
 	require.NotNil(t, target)
 	target.stallAfter = 200 * time.Millisecond
 	return target

--- a/internal/rtmp/ingest_test.go
+++ b/internal/rtmp/ingest_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bluenviron/gortmplib/pkg/codecs"
 	"github.com/stretchr/testify/require"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // helper: start an RTMP server on a random port for testing
@@ -132,10 +132,10 @@ func TestStreamKeyResolution(t *testing.T) {
 	var mu sync.Mutex
 
 	resolv := testResolver(keys)
-	hubFn := func(cameraID string) *model.StreamHub {
-		return model.NewStreamHub()
+	hubFn := func(cameraID string) *streamhub.StreamHub {
+		return streamhub.New()
 	}
-	onConn := func(cameraID string, hub *model.StreamHub) {
+	onConn := func(cameraID string, hub *streamhub.StreamHub) {
 		mu.Lock()
 		resolved[cameraID] = true
 		mu.Unlock()
@@ -159,8 +159,8 @@ func TestStreamKeyResolution(t *testing.T) {
 func TestRTMPHandshake(t *testing.T) {
 	keys := testStreamKeys()
 
-	srv, addr := startTestServer(t, testResolver(keys), func(string) *model.StreamHub {
-		return model.NewStreamHub()
+	srv, addr := startTestServer(t, testResolver(keys), func(string) *streamhub.StreamHub {
+		return streamhub.New()
 	}, nil, nil)
 
 	// Basic TCP connect
@@ -179,7 +179,7 @@ func TestH264FrameExtraction(t *testing.T) {
 
 	var receivedFrames [][]byte
 	var mu sync.Mutex
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	// Subscribe a consumer to capture frames
 	err := hub.Subscribe("test", func(pts int64, au [][]byte) {
@@ -189,7 +189,7 @@ func TestH264FrameExtraction(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	hubFn := func(cameraID string) *model.StreamHub {
+	hubFn := func(cameraID string) *streamhub.StreamHub {
 		return hub
 	}
 
@@ -236,7 +236,7 @@ func TestH264FrameExtraction(t *testing.T) {
 // TestFrameDistributionToStreamHub tests that frames from RTMP are properly
 // distributed to multiple StreamHub consumers.
 func TestFrameDistributionToStreamHub(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	var mu sync.Mutex
 	consumer1Count := 0
@@ -281,8 +281,8 @@ func TestDisconnectCleanup(t *testing.T) {
 	disconnected := make(map[string]bool)
 	var mu sync.Mutex
 
-	hubFn := func(cameraID string) *model.StreamHub {
-		return model.NewStreamHub()
+	hubFn := func(cameraID string) *streamhub.StreamHub {
+		return streamhub.New()
 	}
 	onDisc := func(cameraID string) {
 		mu.Lock()
@@ -323,8 +323,8 @@ func TestDisconnectCleanup(t *testing.T) {
 func TestInvalidStreamKey(t *testing.T) {
 	keys := testStreamKeys()
 
-	srv, addr := startTestServer(t, testResolver(keys), func(string) *model.StreamHub {
-		return model.NewStreamHub()
+	srv, addr := startTestServer(t, testResolver(keys), func(string) *streamhub.StreamHub {
+		return streamhub.New()
 	}, nil, nil)
 
 	// Connect with invalid key — should not register
@@ -345,8 +345,8 @@ func TestInvalidStreamKey(t *testing.T) {
 func TestServerStartStop(t *testing.T) {
 	keys := testStreamKeys()
 
-	srv, _ := startTestServer(t, testResolver(keys), func(string) *model.StreamHub {
-		return model.NewStreamHub()
+	srv, _ := startTestServer(t, testResolver(keys), func(string) *streamhub.StreamHub {
+		return streamhub.New()
 	}, nil, nil)
 
 	require.NotNil(t, srv.addr())
@@ -362,7 +362,7 @@ func TestExtractStreamKey_NilURL(t *testing.T) {
 // TestStreamHubBroadcastNonBlocking tests that StreamHub.Broadcast does not
 // block even when consumer buffers are full.
 func TestStreamHubBroadcastNonBlocking(t *testing.T) {
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	// Subscribe a slow consumer that never reads
 	err := hub.Subscribe("slow", func(pts int64, au [][]byte) {
@@ -399,14 +399,14 @@ func TestH265FrameExtraction(t *testing.T) {
 
 	var receivedFrames [][]byte
 	var mu sync.Mutex
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	require.NoError(t, hub.Subscribe("test-h265", func(pts int64, au [][]byte) {
 		mu.Lock()
 		defer mu.Unlock()
 		receivedFrames = append(receivedFrames, au...)
 	}))
 
-	srv, addr := startTestServer(t, testResolver(keys), func(string) *model.StreamHub {
+	srv, addr := startTestServer(t, testResolver(keys), func(string) *streamhub.StreamHub {
 		return hub
 	}, nil, nil)
 

--- a/internal/rtmp/server.go
+++ b/internal/rtmp/server.go
@@ -12,8 +12,8 @@ import (
 	"github.com/bluenviron/gortmplib"
 	"github.com/bluenviron/gortmplib/pkg/codecs"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var logger = slog.Default().With("component", "rtmp-server")
@@ -24,11 +24,11 @@ type StreamKeyResolver func(streamKey string) (cameraID string, ok bool)
 
 // CameraHubProvider returns the StreamHub for a given camera.
 // Returns nil if no hub is available for the camera.
-type CameraHubProvider func(cameraID string) *model.StreamHub
+type CameraHubProvider func(cameraID string) *streamhub.StreamHub
 
 // OnPublisherConnect is called when a publisher connects for a camera.
 // The implementation should set up the StreamHub and register the virtual camera.
-type OnPublisherConnect func(cameraID string, hub *model.StreamHub)
+type OnPublisherConnect func(cameraID string, hub *streamhub.StreamHub)
 
 // OnPublisherDisconnect is called when a publisher disconnects for a camera.
 // The implementation should clean up the virtual camera and hub.
@@ -67,7 +67,7 @@ type Server struct {
 
 type publisherEntry struct {
 	cameraID string
-	hub      *model.StreamHub
+	hub      *streamhub.StreamHub
 	cancel   context.CancelFunc
 }
 
@@ -197,7 +197,7 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 
 	hub := s.hubFn(cameraID)
 	if hub == nil {
-		hub = model.NewStreamHub()
+		hub = streamhub.New()
 	}
 
 	pCtx, pCancel := context.WithCancel(ctx)

--- a/internal/rtsp/server.go
+++ b/internal/rtsp/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/liberrors"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var rtspLogger = slog.Default().With("component", "rtsp-server")
@@ -38,7 +39,7 @@ type StreamInfo struct {
 	SPS   []byte
 	PPS   []byte
 	VPS   []byte // H.265 only
-	Hub   *model.StreamHub
+	Hub   *streamhub.StreamHub
 }
 
 // Ready reports whether the stream has everything needed to build an SDP.
@@ -133,7 +134,7 @@ type cameraStream struct {
 	sps      []byte
 	pps      []byte
 	vps      []byte
-	hub      *model.StreamHub
+	hub      *streamhub.StreamHub
 	subID    string
 
 	stream *gortsplib.ServerStream // template stream: DESCRIBE/SDP source, never written

--- a/internal/rtsp/server_test.go
+++ b/internal/rtsp/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Minimal-but-plausible parameter sets (contents are opaque to the server;
@@ -40,7 +41,7 @@ type testServer struct {
 	*Server
 	t       *testing.T
 	url     string
-	hub     *model.StreamHub
+	hub     *streamhub.StreamHub
 	codec   model.Format
 	sps     []byte
 	pps     []byte
@@ -58,7 +59,7 @@ func startTestServer(t *testing.T, cfg Config) *testServer {
 
 	ts := &testServer{
 		t:       t,
-		hub:     model.NewStreamHub(),
+		hub:     streamhub.New(),
 		codec:   model.FormatH264,
 		sps:     tSPS,
 		pps:     tPPS,
@@ -463,7 +464,7 @@ func TestRTSPStreamRebuildOnParamAndHubChange(t *testing.T) {
 	require.Equal(t, newSPS, cs2.media.Formats[0].(*format.H264).SPS, "SDP format must carry the new SPS")
 
 	// Recorder restart → new hub → full rebuild even with identical params.
-	ts.hub = model.NewStreamHub()
+	ts.hub = streamhub.New()
 	cs3 := s.streamFor("cam-1")
 	require.NotNil(t, cs3)
 	require.NotSame(t, cs2, cs3)

--- a/internal/srt/listener.go
+++ b/internal/srt/listener.go
@@ -10,29 +10,29 @@ import (
 	srt "github.com/datarhei/gosrt"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Listener manages an SRT listener that accepts incoming connections,
 // maps them to cameras via streamid, and distributes frames via StreamHub.
 type Listener struct {
 	cfg       config.SRTConfig
-	hubs      map[string]*model.StreamHub // camera_id → StreamHub
-	receivers map[string]*Receiver        // camera_id → active receiver
+	hubs      map[string]*streamhub.StreamHub // camera_id → StreamHub
+	receivers map[string]*Receiver            // camera_id → active receiver
 	mu        sync.RWMutex
 	server    *srt.Server
 	running   bool
 
 	// OnConnect is called when a new connection is established.
 	// If nil, the listener auto-creates a StreamHub for unknown cameras.
-	OnConnect func(cameraID string, hub *model.StreamHub)
+	OnConnect func(cameraID string, hub *streamhub.StreamHub)
 
 	// HubProvider returns the shared StreamHub for a camera ID. When set, the
 	// listener uses the hub from the central registry (CameraManager) instead of
 	// a locally-created orphan hub, so pushed frames reach the live consumers
 	// (HLS/WebRTC/FLV/WS) and the IngestRecorder. If nil, the listener falls
 	// back to its internal hubs map (legacy behavior).
-	HubProvider func(cameraID string) *model.StreamHub
+	HubProvider func(cameraID string) *streamhub.StreamHub
 
 	// OnDisconnect is called when a publisher disconnects. Used to notify the
 	// IngestRecorder to close its in-flight segment and return to Idle.
@@ -49,14 +49,14 @@ type Listener struct {
 func NewListener(cfg config.SRTConfig) *Listener {
 	return &Listener{
 		cfg:       cfg,
-		hubs:      make(map[string]*model.StreamHub),
+		hubs:      make(map[string]*streamhub.StreamHub),
 		receivers: make(map[string]*Receiver),
 	}
 }
 
 // registerHub registers a StreamHub for a camera ID.
 // This is used to connect SRT streams to existing camera pipelines.
-func (l *Listener) registerHub(cameraID string, hub *model.StreamHub) {
+func (l *Listener) registerHub(cameraID string, hub *streamhub.StreamHub) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.hubs[cameraID] = hub
@@ -82,7 +82,7 @@ func (l *Listener) addr() net.Addr {
 // HubProvider (the CameraManager's central registry) so pushed frames reach the
 // recorder + live consumers; otherwise it falls back to the local hubs map.
 // Returns nil if neither has a hub. Caller must hold l.mu.
-func (l *Listener) getHubLocked(cameraID string) *model.StreamHub {
+func (l *Listener) getHubLocked(cameraID string) *streamhub.StreamHub {
 	if l.HubProvider != nil {
 		if hub := l.HubProvider(cameraID); hub != nil {
 			return hub
@@ -174,7 +174,7 @@ func (l *Listener) StartCallers() error {
 		if hub == nil {
 			logger.Warn("SRT caller: no hub registered for camera, creating new one",
 				"camera_id", stream.CameraID)
-			hub = model.NewStreamHub()
+			hub = streamhub.New()
 			l.hubs[stream.CameraID] = hub
 		}
 
@@ -214,7 +214,7 @@ func (l *Listener) handleConnect(req srt.ConnRequest) srt.ConnType {
 	// Find or create hub
 	hub := l.getHubLocked(cameraID)
 	if hub == nil {
-		hub = model.NewStreamHub()
+		hub = streamhub.New()
 		l.hubs[cameraID] = hub
 	}
 
@@ -254,7 +254,7 @@ func (l *Listener) handlePublish(conn srt.Conn) {
 	l.mu.Lock()
 	hub := l.getHubLocked(cameraID)
 	if hub == nil {
-		hub = model.NewStreamHub()
+		hub = streamhub.New()
 		l.hubs[cameraID] = hub
 	}
 

--- a/internal/srt/listener_test.go
+++ b/internal/srt/listener_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // mockConn implements srt.Conn for testing purposes.
@@ -44,7 +44,7 @@ func TestHandlePublishPanicCleanup(t *testing.T) {
 
 	// Set OnConnect to panic — simulates a failure after the receiver is added to the map.
 	// This exercises the defer-based panic recovery in handlePublish().
-	ln.OnConnect = func(cid string, hub *model.StreamHub) {
+	ln.OnConnect = func(cid string, hub *streamhub.StreamHub) {
 		panic("simulated panic for testing")
 	}
 

--- a/internal/srt/receiver.go
+++ b/internal/srt/receiver.go
@@ -12,8 +12,8 @@ import (
 	srt "github.com/datarhei/gosrt"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var logger = slog.Default().With("component", "srt-receiver")
@@ -26,7 +26,7 @@ type Receiver struct {
 	address    string
 	passphrase string
 	streamID   string
-	hub        *model.StreamHub
+	hub        *streamhub.StreamHub
 	conn       srt.Conn
 	done       chan struct{}
 	running    atomic.Bool
@@ -42,7 +42,7 @@ type Receiver struct {
 }
 
 // NewReceiver creates a new SRT receiver for the given stream configuration.
-func NewReceiver(stream config.SRTStream, hub *model.StreamHub) *Receiver {
+func NewReceiver(stream config.SRTStream, hub *streamhub.StreamHub) *Receiver {
 	return &Receiver{
 		cameraID:   stream.CameraID,
 		mode:       stream.Mode,

--- a/internal/srt/receiver_test.go
+++ b/internal/srt/receiver_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 func TestNewReceiver(t *testing.T) {
@@ -26,7 +26,7 @@ func TestNewReceiver(t *testing.T) {
 		Passphrase: "test-password-123",
 		StreamID:   "test-stream",
 	}
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	rec := NewReceiver(stream, hub)
 
 	require.Equal(t, "test-cam", rec.cameraID)
@@ -38,7 +38,7 @@ func TestNewReceiver(t *testing.T) {
 func TestReceiverStopWithoutStart(t *testing.T) {
 	t.Helper()
 
-	rec := NewReceiver(config.SRTStream{CameraID: "test", Mode: "listener"}, model.NewStreamHub())
+	rec := NewReceiver(config.SRTStream{CameraID: "test", Mode: "listener"}, streamhub.New())
 	err := rec.Stop()
 	require.NoError(t, err)
 }
@@ -46,7 +46,7 @@ func TestReceiverStopWithoutStart(t *testing.T) {
 func TestReceiverFrameDistribution(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	stream := config.SRTStream{
 		CameraID: "dist-test",
 		Mode:     "listener",
@@ -96,7 +96,7 @@ func TestReceiverFrameDistribution(t *testing.T) {
 func TestStreamHubMultipleConsumers(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	var count1, count2 atomic.Int32
 
@@ -137,7 +137,7 @@ func TestListenerRegisterHub(t *testing.T) {
 	t.Helper()
 
 	ln := NewListener(config.SRTConfig{Port: 9002})
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	ln.registerHub("test-cam", hub)
 
@@ -153,7 +153,7 @@ func TestListenerUnregisterHub(t *testing.T) {
 	t.Helper()
 
 	ln := NewListener(config.SRTConfig{Port: 9003})
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	ln.registerHub("test-cam", hub)
 	ln.registerHubAndStopReceiver("test-cam")
 
@@ -249,7 +249,7 @@ func TestParseStreamIDEdgeCases(t *testing.T) {
 func TestReceiverMetrics(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	rec := NewReceiver(config.SRTStream{CameraID: "metrics-test", Mode: "listener"}, hub)
 
 	require.Equal(t, int64(0), rec.frameCount.Load())
@@ -263,7 +263,7 @@ func TestConnectCallback(t *testing.T) {
 	ln := NewListener(config.SRTConfig{Port: 9005})
 
 	var connectCalled atomic.Bool
-	ln.OnConnect = func(cameraID string, hub *model.StreamHub) {
+	ln.OnConnect = func(cameraID string, hub *streamhub.StreamHub) {
 		connectCalled.Store(true)
 	}
 
@@ -294,7 +294,7 @@ func TestListenerDoubleStop(t *testing.T) {
 func TestDisconnectCleanup(t *testing.T) {
 	t.Helper()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	stream := config.SRTStream{
 		CameraID: "cleanup-test",
 		Mode:     "listener",
@@ -354,7 +354,7 @@ func TestReceiverStartStopRace(t *testing.T) {
 
 	for i := range 100 {
 		mock := &mockSRTConn{}
-		hub := model.NewStreamHub()
+		hub := streamhub.New()
 		rec := NewReceiver(config.SRTStream{
 			CameraID: fmt.Sprintf("race-test-%d", i),
 			Mode:     "listener",

--- a/internal/streamhub/adapter.go
+++ b/internal/streamhub/adapter.go
@@ -1,6 +1,7 @@
-package model
+package streamhub
 
 import (
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	pkgstreamhub "github.com/Mi-Bee-Studio/MiBeeNvr/pkg/streamhub"
 )
 
@@ -9,9 +10,9 @@ var _ pkgstreamhub.Hub = (*HubAdapter)(nil)
 
 // HubAdapter wraps *StreamHub to satisfy pkg/streamhub.Hub.
 //
-// StreamHub's native callback types (model.FrameCallback,
-// model.AudioCallback) are structurally similar but not identical to
-// pkg/streamhub's types — model.AudioCallback uses AudioCodec (a
+// StreamHub's native callback types (streamhub.FrameCallback,
+// streamhub.AudioCallback) are structurally similar but not identical to
+// pkg/streamhub's types — AudioCallback uses model.AudioCodec (a
 // defined string type) while pkg/streamhub uses plain string. The
 // adapter bridges these via zero-cost type conversions.
 //
@@ -42,9 +43,9 @@ func (a *HubAdapter) Unsubscribe(consumerID string) {
 
 // SubscribeAudio registers an audio frame callback. The pkg-streamhub
 // callback (which receives a plain string codec) is bridged to the
-// internal AudioCallback (which receives AudioCodec).
+// internal AudioCallback (which receives model.AudioCodec).
 func (a *HubAdapter) SubscribeAudio(consumerID string, cb pkgstreamhub.AudioCallback) error {
-	return a.Hub.SubscribeAudio(consumerID, func(pts int64, codec AudioCodec, data []byte) {
+	return a.Hub.SubscribeAudio(consumerID, func(pts int64, codec model.AudioCodec, data []byte) {
 		cb(pts, string(codec), data)
 	})
 }

--- a/internal/streamhub/frame_trace_test.go
+++ b/internal/streamhub/frame_trace_test.go
@@ -1,4 +1,4 @@
-package model
+package streamhub
 
 import (
 	"context"
@@ -65,7 +65,7 @@ func attrInt(r slog.Record, key string) int64 {
 
 func newCaptureHub(t *testing.T, camID string) (*StreamHub, *captureHandler) {
 	t.Helper()
-	h := NewStreamHub()
+	h := New()
 	h.SetCameraID(camID)
 	h.consumerBufferSize = 5
 	ch := &captureHandler{}

--- a/internal/streamhub/stream_stats_test.go
+++ b/internal/streamhub/stream_stats_test.go
@@ -1,4 +1,4 @@
-package model
+package streamhub
 
 // Tests for the #469 observability additions: Snapshot(), per-consumer
 // bytes/dwell, SubscribeMsg IngestAt relay, compositional drop callbacks,
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStreamHub_Snapshot(t *testing.T) {
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-snap")
 	hub.SetSource("h264")
 
@@ -54,7 +55,7 @@ func TestStreamHub_Snapshot(t *testing.T) {
 }
 
 func TestStreamHub_SnapshotEmpty(t *testing.T) {
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-empty")
 	snap := hub.Snapshot()
 	require.Empty(t, snap.Consumers)
@@ -63,11 +64,11 @@ func TestStreamHub_SnapshotEmpty(t *testing.T) {
 }
 
 func TestStreamHub_SubscribeMsgRelaysIngestAt(t *testing.T) {
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-msg")
 
-	got := make(chan FrameMsg, 4)
-	require.NoError(t, hub.SubscribeMsg("ws-cam-msg", func(msg FrameMsg) {
+	got := make(chan model.FrameMsg, 4)
+	require.NoError(t, hub.SubscribeMsg("ws-cam-msg", func(msg model.FrameMsg) {
 		got <- msg
 	}))
 
@@ -88,7 +89,7 @@ func TestStreamHub_SubscribeMsgRelaysIngestAt(t *testing.T) {
 func TestStreamHub_AddOnDropFiresAllCallbacks(t *testing.T) {
 	// Regression for the #469 Phase 0 bug: HLS assigning hub.OnDrop destroyed
 	// the camera manager's wiring. AddOnDrop must fan out to every registrant.
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-drop")
 	hub.consumerBufferSize = 1
 
@@ -139,7 +140,7 @@ func TestStreamHub_AddOnDropFiresAllCallbacks(t *testing.T) {
 }
 
 func TestStreamHub_TrySendIDRCountsEvictedAndIDRDrops(t *testing.T) {
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-idr")
 	hub.consumerBufferSize = 3
 
@@ -194,7 +195,7 @@ func TestStreamHub_TrySendIDRCountsEvictedAndIDRDrops(t *testing.T) {
 }
 
 func TestStreamHub_AudioDropFiresOnDrop(t *testing.T) {
-	hub := NewStreamHub()
+	hub := New()
 	hub.SetCameraID("cam-audio")
 
 	var fired int32
@@ -204,12 +205,12 @@ func TestStreamHub_AudioDropFiresOnDrop(t *testing.T) {
 	})
 
 	block := make(chan struct{})
-	require.NoError(t, hub.SubscribeAudio("audio-stuck", func(pts int64, codec AudioCodec, data []byte) {
+	require.NoError(t, hub.SubscribeAudio("audio-stuck", func(pts int64, codec model.AudioCodec, data []byte) {
 		<-block
 	}))
 	// audio buffer is 50 — overflow it
 	for i := range 60 {
-		hub.BroadcastAudio(int64(i), AudioG711U, []byte{0x00})
+		hub.BroadcastAudio(int64(i), model.AudioG711U, []byte{0x00})
 	}
 	require.GreaterOrEqual(t, fired, int32(1), "audio overflow should fire drop callbacks")
 	close(block)

--- a/internal/streamhub/stream_test.go
+++ b/internal/streamhub/stream_test.go
@@ -1,4 +1,4 @@
-package model
+package streamhub
 
 import (
 	"fmt"
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/stretchr/testify/require"
 )
 
 // helper must be used in all test helpers (project convention).
 func newTestStreamHub(t *testing.T) *StreamHub {
 	t.Helper()
-	return NewStreamHub()
+	return New()
 }
 
 func TestStreamHub_SubscribeAndBroadcast(t *testing.T) {
@@ -244,7 +245,7 @@ type frameInfo struct {
 // audioFrameInfo holds a received audio frame for test assertions.
 type audioFrameInfo struct {
 	pts   int64
-	codec AudioCodec
+	codec model.AudioCodec
 	data  []byte
 }
 
@@ -260,7 +261,7 @@ func TestStreamHub_AudioSubscribeAndBroadcast(t *testing.T) {
 	// 3 audio consumers subscribe
 	for _, id := range []string{"audio-1", "audio-2", "audio-3"} {
 		cid := id
-		err := hub.SubscribeAudio(cid, func(pts int64, codec AudioCodec, data []byte) {
+		err := hub.SubscribeAudio(cid, func(pts int64, codec model.AudioCodec, data []byte) {
 			mu.Lock()
 			received[cid] = append(received[cid], audioFrameInfo{pts: pts, codec: codec, data: data})
 			mu.Unlock()
@@ -270,7 +271,7 @@ func TestStreamHub_AudioSubscribeAndBroadcast(t *testing.T) {
 
 	// Broadcast 5 audio frames
 	for i := range int64(5) {
-		hub.BroadcastAudio(i, AudioAAC, []byte{byte(i)})
+		hub.BroadcastAudio(i, model.AudioAAC, []byte{byte(i)})
 	}
 
 	// Wait for async delivery
@@ -290,7 +291,7 @@ func TestStreamHub_AudioSubscribeAndBroadcast(t *testing.T) {
 		require.Len(t, frames, 5, "%s should have 5 frames", id)
 		for i, f := range frames {
 			require.Equal(t, int64(i), f.pts, "%s frame %d pts mismatch", id, i)
-			require.Equal(t, AudioAAC, f.codec, "%s frame %d codec mismatch", id, i)
+			require.Equal(t, model.AudioAAC, f.codec, "%s frame %d codec mismatch", id, i)
 		}
 	}
 }
@@ -299,22 +300,22 @@ func TestStreamHub_AudioNonBlockingDrop(t *testing.T) {
 	hub := newTestStreamHub(t)
 
 	var slowReceived atomic.Int32
-	err := hub.SubscribeAudio("slow", func(pts int64, codec AudioCodec, data []byte) {
+	err := hub.SubscribeAudio("slow", func(pts int64, codec model.AudioCodec, data []byte) {
 		slowReceived.Add(1)
 		time.Sleep(50 * time.Millisecond)
 	})
 	require.NoError(t, err)
 
 	var fastReceived atomic.Int32
-	err = hub.SubscribeAudio("fast", func(pts int64, codec AudioCodec, data []byte) {
+	err = hub.SubscribeAudio("fast", func(pts int64, codec model.AudioCodec, data []byte) {
 		fastReceived.Add(1)
 	})
 	require.NoError(t, err)
 
 	// Broadcast should return quickly — not blocked by slow consumer
 	start := time.Now()
-	hub.BroadcastAudio(1, AudioAAC, []byte{0x01})
-	hub.BroadcastAudio(2, AudioAAC, []byte{0x02})
+	hub.BroadcastAudio(1, model.AudioAAC, []byte{0x01})
+	hub.BroadcastAudio(2, model.AudioAAC, []byte{0x02})
 	elapsed := time.Since(start)
 	require.Less(t, elapsed, 50*time.Millisecond, "BroadcastAudio should not block on slow consumers")
 
@@ -336,13 +337,13 @@ func TestStreamHub_AudioUnsubscribeNoLeak(t *testing.T) {
 	hub := newTestStreamHub(t)
 
 	var received atomic.Int32
-	err := hub.SubscribeAudio("leaky", func(pts int64, codec AudioCodec, data []byte) {
+	err := hub.SubscribeAudio("leaky", func(pts int64, codec model.AudioCodec, data []byte) {
 		received.Add(1)
 	})
 	require.NoError(t, err)
 
 	// Should receive before unsubscribe
-	hub.BroadcastAudio(1, AudioAAC, []byte{0x01})
+	hub.BroadcastAudio(1, model.AudioAAC, []byte{0x01})
 	require.Eventually(t, func() bool {
 		return received.Load() == 1
 	}, 2*time.Second, 10*time.Millisecond)
@@ -351,7 +352,7 @@ func TestStreamHub_AudioUnsubscribeNoLeak(t *testing.T) {
 	hub.UnsubscribeAudio("leaky")
 
 	// Should NOT receive after unsubscribe
-	hub.BroadcastAudio(2, AudioAAC, []byte{0x02})
+	hub.BroadcastAudio(2, model.AudioAAC, []byte{0x02})
 	time.Sleep(50 * time.Millisecond)
 	require.Equal(t, int32(1), received.Load(), "should not receive audio after unsubscribe")
 
@@ -361,10 +362,10 @@ func TestStreamHub_AudioUnsubscribeNoLeak(t *testing.T) {
 func TestStreamHub_AudioDoubleSubscribeError(t *testing.T) {
 	hub := newTestStreamHub(t)
 
-	err := hub.SubscribeAudio("dup", func(pts int64, codec AudioCodec, data []byte) {})
+	err := hub.SubscribeAudio("dup", func(pts int64, codec model.AudioCodec, data []byte) {})
 	require.NoError(t, err)
 
-	err = hub.SubscribeAudio("dup", func(pts int64, codec AudioCodec, data []byte) {})
+	err = hub.SubscribeAudio("dup", func(pts int64, codec model.AudioCodec, data []byte) {})
 	require.Error(t, err, "duplicate audio subscribe should return error")
 
 	hub.UnsubscribeAudio("dup")
@@ -381,7 +382,7 @@ func TestStreamHub_AudioDropTracking(t *testing.T) {
 
 	blockCh := make(chan struct{})
 	var received atomic.Int32
-	err := hub.SubscribeAudio("tiny", func(pts int64, codec AudioCodec, data []byte) {
+	err := hub.SubscribeAudio("tiny", func(pts int64, codec model.AudioCodec, data []byte) {
 		received.Add(1)
 		<-blockCh
 	})
@@ -389,7 +390,7 @@ func TestStreamHub_AudioDropTracking(t *testing.T) {
 
 	// Send many frames — buffer (50) will fill up, causing drops
 	for i := range 100 {
-		hub.BroadcastAudio(int64(i), AudioG711, []byte{byte(i)})
+		hub.BroadcastAudio(int64(i), model.AudioG711, []byte{byte(i)})
 	}
 
 	// Wait for buffer to fill
@@ -429,7 +430,7 @@ func TestStreamHub_AudioConcurrentSubscribeUnsubscribe(t *testing.T) {
 			defer wg.Done()
 			cid := fmt.Sprintf("audio-%d", id)
 			for range iterations {
-				_ = hub.SubscribeAudio(cid, func(pts int64, codec AudioCodec, data []byte) {})
+				_ = hub.SubscribeAudio(cid, func(pts int64, codec model.AudioCodec, data []byte) {})
 				hub.UnsubscribeAudio(cid)
 			}
 		}(i)
@@ -440,7 +441,7 @@ func TestStreamHub_AudioConcurrentSubscribeUnsubscribe(t *testing.T) {
 		go func(id int) {
 			defer wg.Done()
 			for j := range iterations {
-				hub.BroadcastAudio(int64(j), AudioAAC, []byte{byte(id)})
+				hub.BroadcastAudio(int64(j), model.AudioAAC, []byte{byte(id)})
 			}
 		}(i)
 	}
@@ -725,7 +726,7 @@ func helperHighContention(t *testing.T, audio bool) {
 					}
 				}
 				if audio {
-					err := hub.SubscribeAudio(cid, func(pts int64, codec AudioCodec, data []byte) {
+					err := hub.SubscribeAudio(cid, func(pts int64, codec model.AudioCodec, data []byte) {
 						if id%3 == 0 {
 							time.Sleep(time.Microsecond)
 						}
@@ -752,7 +753,7 @@ func helperHighContention(t *testing.T, audio bool) {
 			for j := range iterations {
 				isIDR := j%10 == 0 // 10% IDR frames to exercise trySendIDR
 				if audio {
-					hub.BroadcastAudio(int64(j), AudioAAC, []byte{byte(id)})
+					hub.BroadcastAudio(int64(j), model.AudioAAC, []byte{byte(id)})
 				} else {
 					hub.Broadcast(int64(j), [][]byte{{byte(id)}}, isIDR)
 				}
@@ -795,7 +796,7 @@ func helperHighContention(t *testing.T, audio bool) {
 // helperDropRateHub creates a hub with small buffer for drop rate testing.
 func helperDropRateHub(t *testing.T) *StreamHub {
 	t.Helper()
-	hub := NewStreamHub()
+	hub := New()
 	hub.consumerBufferSize = 5
 	hub.SetCameraID("drop-rate-test-cam")
 	return hub

--- a/internal/streamhub/streamhub.go
+++ b/internal/streamhub/streamhub.go
@@ -1,4 +1,4 @@
-package model
+package streamhub
 
 import (
 	"fmt"
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/frametrace"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 )
 
@@ -25,22 +26,22 @@ const SubStreamKeySuffix = "/sub"
 // frames are dropped silently to protect the recording pipeline.
 type FrameCallback func(pts int64, au [][]byte)
 
-// MsgCallback receives the full FrameMsg — an opt-in variant of FrameCallback
+// MsgCallback receives the full model.FrameMsg — an opt-in variant of FrameCallback
 // for consumers that need per-frame metadata (notably IngestAt, used by
 // wsstream to relay end-to-end live latency). Kept separate so the widely
 // implemented FrameCallback signature (and its pkg/streamhub mirror) stays
 // stable (#469).
-type MsgCallback func(msg FrameMsg)
+type MsgCallback func(msg model.FrameMsg)
 
 // AudioCallback is called for each decoded audio frame.
 // Implementations MUST be non-blocking — if the internal buffer is full,
 // frames are dropped silently to protect the recording/streaming pipeline.
-type AudioCallback func(pts int64, codec AudioCodec, data []byte)
+type AudioCallback func(pts int64, codec model.AudioCodec, data []byte)
 
 // audioFrameMsg is an internal audio frame representation passed through consumer channels.
 type audioFrameMsg struct {
 	pts   int64
-	codec AudioCodec
+	codec model.AudioCodec
 	data  []byte
 }
 
@@ -67,7 +68,7 @@ func (c *audioConsumer) drain() {
 // goroutine can measure queue dwell latency without touching the producer
 // hot path.
 type queuedFrame struct {
-	msg        FrameMsg
+	msg        model.FrameMsg
 	enqueuedAt int64 // unix nano
 }
 
@@ -125,6 +126,16 @@ func frameSize(au [][]byte) int {
 	return n
 }
 
+// HubHost is an optional interface implemented by recorders that carry a
+// StreamHub for frame fan-out. The camera manager wires a fresh hub via
+// SetHub at recorder creation; HubSource labels the hub for the flow-path
+// observability view. Adding a new recorder type means implementing this
+// interface on the type itself — no camera-manager type switch to extend.
+type HubHost interface {
+	SetHub(hub *StreamHub)
+	HubSource() string
+}
+
 // StreamHub distributes frames from a single source to multiple consumers.
 // Each consumer is identified by a unique string ID and runs in its own goroutine
 // with a buffered channel, so slow consumers never block others.
@@ -178,19 +189,19 @@ type StreamHub struct {
 	// All access is guarded by h.mu (set in distributeFrame under h.mu; read &
 	// drained in Subscribe under h.mu), matching the locking discipline of
 	// consumers — no separate lock is needed.
-	idrCache     []FrameMsg
+	idrCache     []model.FrameMsg
 	idrCacheSize int // max cached IDRs (ring); 0 disables replay (legacy behavior)
 
 	// Jitter buffer state — only activated when out-of-order frames are detected.
 	jitterBufferEnabled  atomic.Bool
-	jitterBufferSize     int           // max frames to buffer before flush (default: 5)
-	jitterBufferTimeout  time.Duration // max wait before flushing partial buffer (default: 500ms)
-	jitterBuffer         []FrameMsg    // buffered frames awaiting reordering
-	jitterBufferMu       sync.Mutex    // protects jitter buffer state
-	jitterBufferTimer    *time.Timer   // timeout flush timer
-	jitterBufferLastPTS  int64         // last PTS seen, for disorder detection
-	jitterBufferReorders atomic.Int64  // total out-of-order detections
-	jitterBufferActive   atomic.Bool   // quick check if buffer may have frames
+	jitterBufferSize     int              // max frames to buffer before flush (default: 5)
+	jitterBufferTimeout  time.Duration    // max wait before flushing partial buffer (default: 500ms)
+	jitterBuffer         []model.FrameMsg // buffered frames awaiting reordering
+	jitterBufferMu       sync.Mutex       // protects jitter buffer state
+	jitterBufferTimer    *time.Timer      // timeout flush timer
+	jitterBufferLastPTS  int64            // last PTS seen, for disorder detection
+	jitterBufferReorders atomic.Int64     // total out-of-order detections
+	jitterBufferActive   atomic.Bool      // quick check if buffer may have frames
 	// OnJitterBufferFlush is called when jitter buffer flushes reordered frames.
 	// Receives cameraID and number of frames flushed.
 	OnJitterBufferFlush func(cameraID string, count int)
@@ -209,7 +220,7 @@ type StreamHub struct {
 const DefaultIDRCacheSize = 3
 
 // NewStreamHub creates a new StreamHub with no consumers.
-func NewStreamHub() *StreamHub {
+func New() *StreamHub {
 	return &StreamHub{
 		consumers:             make(map[string]*consumerEntry),
 		audioConsumers:        make(map[string]*audioConsumer),
@@ -307,7 +318,7 @@ func (h *StreamHub) Subscribe(id string, cb FrameCallback) error {
 	return nil
 }
 
-// SubscribeMsg registers a consumer that receives the full FrameMsg (including
+// SubscribeMsg registers a consumer that receives the full model.FrameMsg (including
 // IngestAt wallclock). Same semantics as Subscribe; see MsgCallback.
 func (h *StreamHub) SubscribeMsg(id string, cb MsgCallback) error {
 	h.mu.Lock()
@@ -349,9 +360,9 @@ func (h *StreamHub) cacheIDRLocked(pts int64, au [][]byte) {
 	if len(h.idrCache) >= h.idrCacheSize {
 		// Ring: drop oldest. copy-in-place keeps the backing array.
 		copy(h.idrCache, h.idrCache[1:])
-		h.idrCache[len(h.idrCache)-1] = FrameMsg{PTS: pts, AU: cp, IsKeyframe: true}
+		h.idrCache[len(h.idrCache)-1] = model.FrameMsg{PTS: pts, AU: cp, IsKeyframe: true}
 	} else {
-		h.idrCache = append(h.idrCache, FrameMsg{PTS: pts, AU: cp, IsKeyframe: true})
+		h.idrCache = append(h.idrCache, model.FrameMsg{PTS: pts, AU: cp, IsKeyframe: true})
 	}
 }
 
@@ -362,7 +373,7 @@ func (h *StreamHub) cacheIDRLocked(pts int64, au [][]byte) {
 // new consumer's channel AFTER releasing h.mu (see Subscribe) to avoid a
 // lock-order inversion: the consumer's drain callback may acquire an outer lock
 // (e.g. wsstream.Manager.mu) that the Subscribe caller still holds.
-func (h *StreamHub) latestCompleteIDRLocked() *FrameMsg {
+func (h *StreamHub) latestCompleteIDRLocked() *model.FrameMsg {
 	if h.idrCacheSize == 0 || len(h.idrCache) == 0 {
 		return nil
 	}
@@ -481,7 +492,7 @@ func (h *StreamHub) distributeFrame(pts int64, au [][]byte, isIDR bool) {
 			e.entry.sendMu.RUnlock()
 			continue
 		}
-		msg := FrameMsg{PTS: pts, AU: au, IsKeyframe: isIDR, IngestAt: now}
+		msg := model.FrameMsg{PTS: pts, AU: au, IsKeyframe: isIDR, IngestAt: now}
 		select {
 		case e.entry.ch <- queuedFrame{msg: msg, enqueuedAt: now}:
 			e.entry.sends.Add(1)
@@ -545,7 +556,7 @@ func (h *StreamHub) detectDisorder(pts int64) bool {
 // bufferAndMaybeFlush adds a frame to the jitter buffer and flushes if full.
 func (h *StreamHub) bufferAndMaybeFlush(pts int64, au [][]byte, isIDR bool) {
 	h.jitterBufferMu.Lock()
-	h.jitterBuffer = append(h.jitterBuffer, FrameMsg{PTS: pts, AU: au, IsKeyframe: isIDR})
+	h.jitterBuffer = append(h.jitterBuffer, model.FrameMsg{PTS: pts, AU: au, IsKeyframe: isIDR})
 	h.jitterBufferActive.Store(true)
 	if h.OnJitterBufferDepth != nil {
 		h.OnJitterBufferDepth(h.cameraID, len(h.jitterBuffer))
@@ -567,7 +578,7 @@ func (h *StreamHub) bufferAndMaybeFlush(pts int64, au [][]byte, isIDR bool) {
 
 // flushJitterBufferLocked sorts the jitter buffer by PTS and returns the sorted frames.
 // Must be called with jitterBufferMu held.
-func (h *StreamHub) flushJitterBufferLocked() []FrameMsg {
+func (h *StreamHub) flushJitterBufferLocked() []model.FrameMsg {
 	if len(h.jitterBuffer) == 0 {
 		return nil
 	}
@@ -616,7 +627,7 @@ func (h *StreamHub) resetJitterBufferTimer() {
 // frame from the channel and retrying. Every evicted non-IDR frame counts as a
 // drop (it is genuinely lost); if no space can be made, the IDR itself is
 // dropped and counted in idrDrops. Returns true if the IDR was enqueued.
-func (h *StreamHub) trySendIDR(consumerID string, entry *consumerEntry, msg FrameMsg) bool {
+func (h *StreamHub) trySendIDR(consumerID string, entry *consumerEntry, msg model.FrameMsg) bool {
 	ch := entry.ch
 	// Drain one oldest frame (non-blocking). If it was an IDR, put it back
 	// and try to drain the next one. We want to preserve IDRs.
@@ -793,7 +804,7 @@ func (h *StreamHub) UnsubscribeAudio(id string) {
 // drop counter is incremented atomically.
 //
 // BroadcastAudio does NOT wait for any consumer to process the frame.
-func (h *StreamHub) BroadcastAudio(pts int64, codec AudioCodec, data []byte) {
+func (h *StreamHub) BroadcastAudio(pts int64, codec model.AudioCodec, data []byte) {
 	h.lastAudioFrameAt.Store(time.Now().UnixNano())
 	// Observability: fire audio broadcast callback
 	if h.OnBroadcastAudio != nil {

--- a/internal/substream/substream.go
+++ b/internal/substream/substream.go
@@ -4,7 +4,7 @@
 // is pulled over RTSP ONLY while consumers hold references — the pull stops
 // after an idle timeout with zero references, so a camera whose sub stream
 // is never watched costs nothing (#513). Decoded access units fan out through
-// a dedicated model.StreamHub, which egress endpoints (WS/FLV/HLS) consume
+// a dedicated streamhub.StreamHub, which egress endpoints (WS/FLV/HLS) consume
 // under the camera's "/sub" stream key.
 package substream
 
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var (
@@ -101,7 +102,7 @@ type Config struct {
 	FrameStallTimeout time.Duration
 	// WireHub attaches observability callbacks to each created hub (camera
 	// manager wires Prometheus; optional).
-	WireHub func(hub *model.StreamHub, cameraID string)
+	WireHub func(hub *streamhub.StreamHub, cameraID string)
 }
 
 func (c *Config) normalize() {
@@ -132,7 +133,7 @@ type params struct {
 // parameters egress endpoints need to register players.
 type Source struct {
 	cameraID    string
-	hub         *model.StreamHub
+	hub         *streamhub.StreamHub
 	params      atomic.Pointer[params]
 	ready       chan struct{}
 	readyOne    sync.Once
@@ -144,7 +145,7 @@ type Source struct {
 func (s *Source) CameraID() string { return s.cameraID }
 
 // Hub returns the fan-out hub for this sub-stream.
-func (s *Source) Hub() *model.StreamHub { return s.hub }
+func (s *Source) Hub() *streamhub.StreamHub { return s.hub }
 
 // CodecParams returns the current codec parameter snapshot. Before the first
 // keyframe the codec is "" — egress endpoints treat that as "not ready".
@@ -194,7 +195,7 @@ type Manager struct {
 	// unsubscribe protocol consumers the managers cannot reach themselves
 	// (notably HLS's "hls" consumer — the HLS entry does not store its hub).
 	// Set once at wiring time via SetOnRecycle before traffic arrives.
-	onRecycle func(cameraID string, hub *model.StreamHub)
+	onRecycle func(cameraID string, hub *streamhub.StreamHub)
 	// gbPuller serves KindGB28181 targets (nil → those targets error and the
 	// source reconnects until wired). Set at app wiring via SetGBPuller.
 	gbPuller GBPuller
@@ -211,7 +212,7 @@ func NewManager(cfg Config) *Manager {
 
 // SetOnRecycle registers the recycle callback (see Manager.onRecycle). Only
 // call during wiring, before the first Acquire.
-func (m *Manager) SetOnRecycle(fn func(cameraID string, hub *model.StreamHub)) {
+func (m *Manager) SetOnRecycle(fn func(cameraID string, hub *streamhub.StreamHub)) {
 	m.mu.Lock()
 	m.onRecycle = fn
 	m.mu.Unlock()
@@ -290,7 +291,7 @@ func (m *Manager) Acquire(ctx context.Context, cameraID string) (*Source, error)
 
 	src := &Source{
 		cameraID: cameraID,
-		hub:      model.NewStreamHub(),
+		hub:      streamhub.New(),
 		ready:    make(chan struct{}),
 	}
 	src.hub.SetCameraID(cameraID)
@@ -477,7 +478,7 @@ func (m *Manager) Status(cameraID string) *SourceStatus {
 
 // Hub returns the camera's sub-stream hub — nil when no entry exists. The
 // flow view reads its full consumer fan-out (sends/drops/dwell per consumer).
-func (m *Manager) Hub(cameraID string) *model.StreamHub {
+func (m *Manager) Hub(cameraID string) *streamhub.StreamHub {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if e, ok := m.sources[cameraID]; ok {

--- a/internal/substream/substream_test.go
+++ b/internal/substream/substream_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // Parameter-set vectors borrowed from the RTSP output server tests (real
@@ -361,8 +362,8 @@ func TestAcquireSharesSourceAcrossConsumers(t *testing.T) {
 	time.Sleep(400 * time.Millisecond) // > 3× idle timeout
 	require.NotEmpty(t, m.Snapshot())  // still there
 
-	recycled := make(chan *model.StreamHub, 1)
-	m.SetOnRecycle(func(id string, hub *model.StreamHub) {
+	recycled := make(chan *streamhub.StreamHub, 1)
+	m.SetOnRecycle(func(id string, hub *streamhub.StreamHub) {
 		if id == "cam-1" {
 			recycled <- hub
 		}

--- a/internal/timelapse/keyframe_extractor.go
+++ b/internal/timelapse/keyframe_extractor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var kfeLogger = slog.Default().With("component", "keyframe-extractor")
@@ -83,7 +84,7 @@ type KeyframeExtractor struct {
 	db         RecordingDB
 	mergeMgr   *RollingMergeManager
 	mu         sync.Mutex
-	hub        *model.StreamHub
+	hub        *streamhub.StreamHub
 	consumerID string
 
 	// Latest IDR frame access unit (deep-copied in callback).
@@ -151,7 +152,7 @@ func NewKeyframeExtractor(cfg KeyframeExtractorConfig) *KeyframeExtractor {
 // Start subscribes to the given StreamHub and begins the capture loop.
 // The hub must belong to an active recorder for the same camera.
 // Returns an error if the extractor is already running or if subscription fails.
-func (k *KeyframeExtractor) Start(ctx context.Context, hub *model.StreamHub) error {
+func (k *KeyframeExtractor) Start(ctx context.Context, hub *streamhub.StreamHub) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 

--- a/internal/timelapse/keyframe_extractor_test.go
+++ b/internal/timelapse/keyframe_extractor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -161,7 +162,7 @@ func makeH265AU(nalTypes ...int) [][]byte {
 
 func TestKeyframeExtractor_StartStopLifecycle(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	// Simulate a regular recorder's hub by subscribing something.
 	hub.SetCameraID("cam-1")
@@ -207,7 +208,7 @@ func TestKeyframeExtractor_StartStopLifecycle(t *testing.T) {
 
 func TestKeyframeExtractor_SubscribesToHub(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -239,7 +240,7 @@ func TestKeyframeExtractor_SubscribesToHub(t *testing.T) {
 
 func TestKeyframeExtractor_NonBlockingCallback(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -276,7 +277,7 @@ func TestKeyframeExtractor_NonBlockingCallback(t *testing.T) {
 
 func TestKeyframeExtractor_CapturesIDRFrames(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -316,7 +317,7 @@ func TestKeyframeExtractor_CapturesIDRFrames(t *testing.T) {
 
 func TestKeyframeExtractor_FallsBackToPFrame(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -360,7 +361,7 @@ func TestKeyframeExtractor_FallsBackToPFrame(t *testing.T) {
 // that the merger would reject as "frames missing SPS".
 func TestKeyframeExtractor_SkipsCaptureWithoutParamSets(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -394,7 +395,7 @@ func TestKeyframeExtractor_SkipsCaptureWithoutParamSets(t *testing.T) {
 
 func TestKeyframeExtractor_H265IDRDetection(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -446,7 +447,7 @@ func TestKeyframeExtractor_H265IDRDetection(t *testing.T) {
 
 func TestKeyframeExtractor_SegmentRotation(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	// Short segment duration so we can test rotation.
@@ -482,7 +483,7 @@ func TestKeyframeExtractor_SegmentRotation(t *testing.T) {
 func TestKeyframeExtractor_StoresRecordingInDB(t *testing.T) {
 	store := newMockSegmentStore(t)
 	db := newMockRecordingDB()
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -534,7 +535,7 @@ func TestKeyframeExtractor_StoresRecordingInDB(t *testing.T) {
 
 func TestKeyframeExtractor_DoesNotBlockOriginalRecorder(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -579,7 +580,7 @@ func TestKeyframeExtractor_DoesNotBlockOriginalRecorder(t *testing.T) {
 
 func TestKeyframeExtractor_CapturesLatestIDRAfterInterval(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -624,7 +625,7 @@ func TestKeyframeExtractor_CapturesLatestIDRAfterInterval(t *testing.T) {
 
 func TestKeyframeExtractor_ProducesValidFrameFiles(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -690,7 +691,7 @@ func TestKeyframeExtractor_ProducesValidFrameFiles(t *testing.T) {
 func TestKeyframeExtractor_MultipleSegmentsOverTime(t *testing.T) {
 	store := newMockSegmentStore(t)
 	db := newMockRecordingDB()
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	// Very short segment duration for rapid rotation.
@@ -782,7 +783,7 @@ func countNALUs(data []byte) int {
 func TestKeyframeExtractor_FormatTimelapse(t *testing.T) {
 	store := newMockSegmentStore(t)
 	db := newMockRecordingDB()
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -840,7 +841,7 @@ func TestKeyframeExtractor_FormatTimelapse(t *testing.T) {
 // while frames continue arriving. This exercises the lifecycle-frames interaction.
 func TestKeyframeExtractor_ConcurrentStartStopDuringBroadcast(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{
@@ -886,7 +887,7 @@ func TestKeyframeExtractor_ConcurrentStartStopDuringBroadcast(t *testing.T) {
 // goroutines simultaneously while the extractor is actively capturing.
 func TestKeyframeExtractor_ConcurrentFrameBroadcast(t *testing.T) {
 	store := newMockSegmentStore(t)
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	hub.SetCameraID("cam-1")
 
 	ext := NewKeyframeExtractor(KeyframeExtractorConfig{

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var logger = slog.Default().With("component", "webrtc-manager")
@@ -48,7 +49,7 @@ type peerEntry struct {
 	lastAudioPTS int64
 	cancel       context.CancelFunc
 	camID        string // owning camera (no quality suffix) — logging/metrics
-	streamKey    string // camPeers/hubSubs key: camID or camID+model.SubStreamKeySuffix (#513)
+	streamKey    string // camPeers/hubSubs key: camID or camID+streamhub.SubStreamKeySuffix (#513)
 	sessionID    string
 	lastUsed     time.Time
 	frameCh      chan model.FrameMsg
@@ -219,7 +220,7 @@ func (a audioConfig) capability() webrtc.RTPCodecCapability {
 
 // hubSubscription tracks a StreamHub subscription for a camera.
 type hubSubscription struct {
-	hub             *model.StreamHub
+	hub             *streamhub.StreamHub
 	subID           string
 	audioSubscribed bool // SetAudioInfo ran against this hub instance
 }
@@ -359,12 +360,12 @@ func (m *Manager) CanHandle(codec model.Format) bool {
 
 // RegisterStream subscribes to a StreamHub for live frames. key is normally
 // the camera ID (main stream) but may carry the sub-stream suffix
-// (camID+model.SubStreamKeySuffix) when the api handler serves quality=sub —
+// (camID+streamhub.SubStreamKeySuffix) when the api handler serves quality=sub —
 // main and sub entries then coexist as independent buckets. If hub is nil,
 // this is a no-op. Safe to call multiple times for the same key.
 // sps (optional, the stream's codec params) selects the H.264 profile
 // variant offered for this stream's track — see NewManager's codec list.
-func (m *Manager) RegisterStream(key string, hub *model.StreamHub, sps []byte) {
+func (m *Manager) RegisterStream(key string, hub *streamhub.StreamHub, sps []byte) {
 	if hub == nil {
 		return
 	}
@@ -394,7 +395,7 @@ func (m *Manager) RegisterStream(key string, hub *model.StreamHub, sps []byte) {
 // RegisteredHub returns the StreamHub a stream key is currently subscribed to,
 // or nil when the key has no registration. Callers use it to detect a stale
 // hub (recycled sub-stream puller) before unregistering (#513).
-func (m *Manager) RegisteredHub(key string) *model.StreamHub {
+func (m *Manager) RegisteredHub(key string) *streamhub.StreamHub {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if sub, ok := m.hubSubs[key]; ok {
@@ -574,12 +575,12 @@ func (m *Manager) WriteH264(key string, pts int64, au [][]byte) {
 
 // CreateWHEPSession creates a new WHEP session for the given stream. streamKey
 // is normally the camera ID (main stream); the api handler passes the
-// sub-stream key (camID+model.SubStreamKeySuffix) for quality=sub sessions —
+// sub-stream key (camID+streamhub.SubStreamKeySuffix) for quality=sub sessions —
 // main and sub sessions live in independent peer buckets. It processes the SDP
 // offer, creates a PeerConnection with H.264 video only, and returns the SDP
 // answer and session ID.
 func (m *Manager) CreateWHEPSession(streamKey string, offerSDP []byte) (answerSDP []byte, sessionID string, err error) {
-	camID := strings.TrimSuffix(streamKey, model.SubStreamKeySuffix)
+	camID := strings.TrimSuffix(streamKey, streamhub.SubStreamKeySuffix)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -811,7 +812,7 @@ func (m *Manager) DeleteWHEPSession(sessionID string) error {
 	camID := entry.camID
 	key := entry.streamKey
 	if m.mets != nil {
-		cameraTotal := len(m.camPeers[camID]) + len(m.camPeers[camID+model.SubStreamKeySuffix])
+		cameraTotal := len(m.camPeers[camID]) + len(m.camPeers[camID+streamhub.SubStreamKeySuffix])
 		if cameraTotal == 0 {
 			m.mets.WebRTCActivePeers.DeleteLabelValues(camID)
 		} else {
@@ -1057,7 +1058,7 @@ func (m *Manager) idleWatchdog(ctx context.Context, entry *peerEntry) {
 func (m *Manager) activePeerCount(camID string) int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return len(m.camPeers[camID]) + len(m.camPeers[camID+model.SubStreamKeySuffix])
+	return len(m.camPeers[camID]) + len(m.camPeers[camID+streamhub.SubStreamKeySuffix])
 }
 
 // PeerCount returns the number of active WHEP peers for the given camera

--- a/internal/webrtc/manager_test.go
+++ b/internal/webrtc/manager_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- Test Helpers ---
@@ -462,7 +463,7 @@ func TestWHEPAudioMuxing(t *testing.T) {
 	mgr := NewManager()
 	defer mgr.StopAll()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr.RegisterStream("audio-cam", hub, nil)
 	require.NoError(t, mgr.SetAudioInfo("audio-cam", "g711", true, 8000, 1))
 	// AAC is not a WebRTC codec — the manager leaves the camera video-only.
@@ -497,7 +498,7 @@ func TestSetAudioInfoALaw(t *testing.T) {
 	mgr := NewManager()
 	defer mgr.StopAll()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr.RegisterStream("alaw-cam", hub, nil)
 	require.NoError(t, mgr.SetAudioInfo("alaw-cam", "g711", false, 8000, 1))
 
@@ -522,7 +523,7 @@ func TestSetAudioInfoIdempotent(t *testing.T) {
 	mgr := NewManager()
 	defer mgr.StopAll()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr.RegisterStream("cam", hub, nil)
 	require.NoError(t, mgr.SetAudioInfo("cam", "g711", true, 8000, 1))
 	require.NoError(t, mgr.SetAudioInfo("cam", "g711", true, 8000, 1))
@@ -662,7 +663,7 @@ func TestRegisterStream(t *testing.T) {
 	mgr := newTestManager(t)
 	defer mgr.StopAll()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 
 	// Register should subscribe to hub
 	mgr.RegisterStream("test-cam", hub, nil)
@@ -697,7 +698,7 @@ func TestRegisterStreamDeliversFrames(t *testing.T) {
 	connectWHEP(t, mgr, "test-cam", client.pc, offerSDP)
 
 	// Register stream with a hub
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr.RegisterStream("test-cam", hub, nil)
 
 	// Broadcast a frame through the hub
@@ -721,8 +722,8 @@ func TestRegisterStreamDeliversFrames(t *testing.T) {
 func TestStopAllCleansUpHubSubs(t *testing.T) {
 	mgr := newTestManager(t)
 
-	hub1 := model.NewStreamHub()
-	hub2 := model.NewStreamHub()
+	hub1 := streamhub.New()
+	hub2 := streamhub.New()
 
 	mgr.RegisterStream("cam-1", hub1, nil)
 	mgr.RegisterStream("cam-2", hub2, nil)
@@ -957,8 +958,8 @@ func TestFmtpForProfile(t *testing.T) {
 // from the dead hub: frozen video until a page reload).
 func TestRegisterStreamRebindsOnHubChange(t *testing.T) {
 	m := NewManager()
-	hub1 := model.NewStreamHub()
-	hub2 := model.NewStreamHub()
+	hub1 := streamhub.New()
+	hub2 := streamhub.New()
 
 	m.RegisterStream("cam-rebind", hub1, nil)
 	require.Same(t, hub1, m.hubSubs["cam-rebind"].hub)
@@ -983,7 +984,7 @@ func TestAudioForwarding(t *testing.T) {
 	mgr := newTestManager(t)
 	defer mgr.StopAll()
 
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	mgr.RegisterStream("audio-cam", hub, nil)
 	require.NoError(t, mgr.SetAudioInfo("audio-cam", "g711", true, 8000, 1))
 
@@ -1074,10 +1075,10 @@ func TestSubStreamKeySessions(t *testing.T) {
 		ended = append(ended, key)
 	})
 
-	mainHub := model.NewStreamHub()
-	subHub := model.NewStreamHub()
+	mainHub := streamhub.New()
+	subHub := streamhub.New()
 	mgr.RegisterStream("cam-1", mainHub, nil)
-	subKey := "cam-1" + model.SubStreamKeySuffix
+	subKey := "cam-1" + streamhub.SubStreamKeySuffix
 	mgr.RegisterStream(subKey, subHub, nil)
 	require.Equal(t, subHub, mgr.RegisteredHub(subKey), "sub key registered on its own hub")
 	require.Equal(t, mainHub, mgr.RegisteredHub("cam-1"), "main key registration unaffected")

--- a/internal/whip/server.go
+++ b/internal/whip/server.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pion/interceptor"
 	"github.com/pion/webrtc/v4"
 
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var logger = slog.Default().With("component", "whip-server")
@@ -55,7 +55,7 @@ const (
 type StreamKeyResolver func(streamKey string) (cameraID string, ok bool)
 
 // CameraHubProvider returns the StreamHub for a camera (nil = create fresh).
-type CameraHubProvider func(cameraID string) *model.StreamHub
+type CameraHubProvider func(cameraID string) *streamhub.StreamHub
 
 // NALUCallback forwards an assembled H.264 access unit to the IngestRecorder.
 // ptsTicks is a 90 kHz value; isIDR marks keyframes.
@@ -72,7 +72,7 @@ type Server struct {
 	resolv StreamKeyResolver
 	hubFn  CameraHubProvider
 	// onConn/onDisc mirror the RTMP server lifecycle hooks.
-	onConn func(cameraID string, hub *model.StreamHub)
+	onConn func(cameraID string, hub *streamhub.StreamHub)
 	onDisc func(cameraID string)
 	// NALUProvider returns the recording callback for a camera (nil = record
 	// nothing, live-only passthrough). AudioProvider likewise for audio.
@@ -99,7 +99,7 @@ type Server struct {
 func NewServer(
 	resolv StreamKeyResolver,
 	hubFn CameraHubProvider,
-	onConn func(cameraID string, hub *model.StreamHub),
+	onConn func(cameraID string, hub *streamhub.StreamHub),
 	onDisc func(cameraID string),
 	iceServers []webrtc.ICEServer,
 ) *Server {
@@ -315,7 +315,7 @@ func (s *Server) createSession(cameraID, streamKey string, offerSDP []byte) ([]b
 
 	hub := s.hubFn(cameraID)
 	if hub == nil {
-		hub = model.NewStreamHub()
+		hub = streamhub.New()
 	}
 
 	var naluCB NALUCallback

--- a/internal/whip/server_test.go
+++ b/internal/whip/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- test scaffolding ---
@@ -28,7 +29,7 @@ import (
 type testHarness struct {
 	server   *Server
 	router   *chi.Mux
-	hub      *model.StreamHub
+	hub      *streamhub.StreamHub
 	resolver map[string]string // streamKey → cameraID
 
 	mu          sync.Mutex
@@ -46,15 +47,15 @@ func newTestHarness(t *testing.T) *testHarness {
 	t.Helper()
 	h := &testHarness{
 		resolver: map[string]string{"test-key": "cam-whip"},
-		hub:      model.NewStreamHub(),
+		hub:      streamhub.New(),
 	}
 	h.server = NewServer(
 		func(key string) (string, bool) {
 			camID, ok := h.resolver[key]
 			return camID, ok
 		},
-		func(cameraID string) *model.StreamHub { return h.hub },
-		func(cameraID string, _ *model.StreamHub) {
+		func(cameraID string) *streamhub.StreamHub { return h.hub },
+		func(cameraID string, _ *streamhub.StreamHub) {
 			h.mu.Lock()
 			h.onConnCalls++
 			h.mu.Unlock()
@@ -389,7 +390,7 @@ func TestWHIPPushToRealRecorder(t *testing.T) {
 		Store:      store,
 		DB:         db,
 	})
-	rec.Hub = model.NewStreamHub()
+	rec.Hub = streamhub.New()
 	rec.Hub.SetCameraID("cam-whip")
 	require.NoError(t, rec.Start(context.Background()))
 	t.Cleanup(func() { _ = rec.Stop() })

--- a/internal/whip/track.go
+++ b/internal/whip/track.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // jitterLatency bounds how long the depacketizer waits for out-of-order or
@@ -24,7 +25,7 @@ const jitterLatency = 200 * time.Millisecond
 // segments). When no recorder is wired (live-only gateway without the camera
 // registered), frames fall back to a direct hub broadcast so live preview
 // still works.
-func (s *Server) handleVideoTrack(ctx context.Context, sess *session, hub *model.StreamHub, naluCB NALUCallback, track *webrtc.TrackRemote) {
+func (s *Server) handleVideoTrack(ctx context.Context, sess *session, hub *streamhub.StreamHub, naluCB NALUCallback, track *webrtc.TrackRemote) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Warn("WHIP video track handler panic recovered",
@@ -79,7 +80,7 @@ func (s *Server) handleVideoTrack(ctx context.Context, sess *session, hub *model
 // handleAudioTrack forwards Opus frames to the IngestRecorder (dual-write:
 // hub BroadcastAudio + MP4 WriteAudioSample inside the recorder). Non-Opus
 // audio tracks are drained but dropped — G.711 push-in has no producer today.
-func (s *Server) handleAudioTrack(ctx context.Context, sess *session, hub *model.StreamHub, track *webrtc.TrackRemote) {
+func (s *Server) handleAudioTrack(ctx context.Context, sess *session, hub *streamhub.StreamHub, track *webrtc.TrackRemote) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Warn("WHIP audio track handler panic recovered",

--- a/internal/wsstream/audio_extra_test.go
+++ b/internal/wsstream/audio_extra_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var audioTestSPS = []byte{0x67, 0x42, 0xc0, 0x0a, 0xd9, 0x00, 0xa0, 0x47, 0xfe, 0x88}
@@ -45,7 +46,7 @@ func TestViewerCountPaths(t *testing.T) {
 
 func TestSetAudioInfo(t *testing.T) {
 	m := NewManager()
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	require.NoError(t, m.RegisterStream("cam-aud", model.FormatH264, audioTestSPS, nil, nil, hub))
 
 	// Unknown camera.

--- a/internal/wsstream/manager.go
+++ b/internal/wsstream/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/frametrace"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/gorilla/websocket"
 )
 
@@ -56,7 +57,7 @@ type streamEntry struct {
 	viewerMu  sync.Mutex
 	frameCh   chan model.FrameMsg
 	cancel    context.CancelFunc
-	hub       *model.StreamHub
+	hub       *streamhub.StreamHub
 	hubSubID  string
 	dropCount atomic.Int64
 
@@ -160,7 +161,7 @@ func NewManager(opts ...Option) *Manager {
 
 // RegisterStream registers a camera stream for WebSocket output.
 // The recorder's StreamHub is used to receive live frames.
-func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *model.StreamHub) error {
+func (m *Manager) RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *streamhub.StreamHub) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -313,7 +314,7 @@ func (m *Manager) IsActive(camID string) bool {
 
 // ActiveHub returns the StreamHub the registered entry is currently
 // subscribed to (nil when the stream is not active).
-func (m *Manager) ActiveHub(camID string) *model.StreamHub {
+func (m *Manager) ActiveHub(camID string) *streamhub.StreamHub {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	entry, ok := m.streams[camID]
@@ -327,7 +328,7 @@ func (m *Manager) ActiveHub(camID string) *model.StreamHub {
 // reconnect get a FRESH hub from the camera manager; without a rebind the
 // entry keeps listening to the dead hub and every viewer goes black forever
 // (observed on flaky MJPEG cameras whose recorder reconnects often).
-func (m *Manager) RebindHub(camID string, hub *model.StreamHub) {
+func (m *Manager) RebindHub(camID string, hub *streamhub.StreamHub) {
 	if hub == nil {
 		return
 	}
@@ -882,7 +883,7 @@ func (m *Manager) AudioUpstream(w http.ResponseWriter, r *http.Request, handler 
 
 // Ensure Manager satisfies expected interface.
 var _ interface {
-	RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *model.StreamHub) error
+	RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *streamhub.StreamHub) error
 	UnregisterStream(camID string)
 	IsActive(camID string) bool
 	viewerCount(camID string) int

--- a/internal/wsstream/manager_test.go
+++ b/internal/wsstream/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,12 +22,12 @@ import (
 
 // ─── helpers ─────────────────────────────────────────────────────────────
 
-func newTestHub(t *testing.T) *model.StreamHub {
+func newTestHub(t *testing.T) *streamhub.StreamHub {
 	t.Helper()
-	return model.NewStreamHub()
+	return streamhub.New()
 }
 
-func broadcastFrame(t *testing.T, hub *model.StreamHub, pts int64, au [][]byte) {
+func broadcastFrame(t *testing.T, hub *streamhub.StreamHub, pts int64, au [][]byte) {
 	t.Helper()
 	hub.Broadcast(pts, au, false)
 }
@@ -839,7 +840,7 @@ func TestWriteFrame_H265KeyframeDetection(t *testing.T) {
 // TestManagerInterface verifies the Manager satisfies expected interface.
 func TestManagerInterface(t *testing.T) {
 	var _ interface {
-		RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *model.StreamHub) error
+		RegisterStream(camID string, codec model.Format, sps, pps, vps []byte, hub *streamhub.StreamHub) error
 		UnregisterStream(camID string)
 		IsActive(camID string) bool
 		viewerCount(camID string) int
@@ -1000,7 +1001,7 @@ func TestServeWS_NoConcurrentWriteOnIdle(t *testing.T) {
 
 func BenchmarkWriteFrame(b *testing.B) {
 	m := NewManager(WithWriteBufSize(100))
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	_ = m.RegisterStream("cam1", model.FormatH264, sampleSPS, samplePPS, nil, hub)
 	defer m.StopAll()
 

--- a/internal/xiaomi/cloud_safety_test.go
+++ b/internal/xiaomi/cloud_safety_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- Cloud constructor defaults ---
@@ -380,7 +381,7 @@ func TestXiaomiRecorderHLSFrameH265IDR(t *testing.T) {
 	r.sps = []byte{0x42, 0x01, 0x01}
 	r.pps = []byte{0x44, 0x01, 0xc1}
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var mu sync.Mutex
@@ -418,7 +419,7 @@ func TestXiaomiRecorderHLSFrameUnknownCodec(t *testing.T) {
 	r.codecOK = true
 	r.streamStart = time.Now()
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var mu sync.Mutex

--- a/internal/xiaomi/plugin_surface_test.go
+++ b/internal/xiaomi/plugin_surface_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,7 +90,7 @@ func TestXiaomiRecorderAccessors(t *testing.T) {
 	t.Parallel()
 	rec := NewXiaomiRecorder(XiaomiRecorderConfig{CameraID: "c", DID: "1"}, newXiaomiTestStore(t))
 
-	rec.Hub = model.NewStreamHub() // wired by camera.initStreamHub in production
+	rec.Hub = streamhub.New() // wired by camera.initStreamHub in production
 	require.NotNil(t, rec.GetHub())
 	require.Nil(t, rec.SPS())
 	require.Nil(t, rec.PPS())

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 var xiaomiLogger = slog.Default().With("component", "xiaomi-recorder")
@@ -150,8 +151,8 @@ type XiaomiRecorder struct {
 	// Audio state (probed from first audio packet)
 	audioCodecID uint32 // MISS codec ID for audio (0 = not detected yet)
 
-	Hub         *model.StreamHub // Frame fan-out to multiple consumers (HLS, WebRTC, etc.)
-	streamStart time.Time        // For PTS rebase (used by forwardHLS)
+	Hub         *streamhub.StreamHub // Frame fan-out to multiple consumers (HLS, WebRTC, etc.)
+	streamStart time.Time            // For PTS rebase (used by forwardHLS)
 
 	currentQuality   string // effective quality for next connectAndRecord attempt
 	noMediaFailCount int    // no-media failures since the last stable-streaming window (issue #502: true consecutive semantics)
@@ -191,10 +192,10 @@ type XiaomiRecorder struct {
 var _ model.Recorder = (*XiaomiRecorder)(nil)
 
 // GetHub returns the StreamHub for frame fan-out.
-func (r *XiaomiRecorder) GetHub() *model.StreamHub { return r.Hub }
+func (r *XiaomiRecorder) GetHub() *streamhub.StreamHub { return r.Hub }
 
-// SetHub wires the StreamHub for frame fan-out (model.HubHost).
-func (r *XiaomiRecorder) SetHub(hub *model.StreamHub) { r.Hub = hub }
+// SetHub wires the StreamHub for frame fan-out (streamhub.HubHost).
+func (r *XiaomiRecorder) SetHub(hub *streamhub.StreamHub) { r.Hub = hub }
 
 // HubSource labels the hub for the flow-path observability view.
 func (r *XiaomiRecorder) HubSource() string { return "xiaomi" }

--- a/internal/xiaomi/recorder_safety_test.go
+++ b/internal/xiaomi/recorder_safety_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- processH264NALU: SPS/PPS detection and segment creation ---
@@ -252,7 +253,7 @@ func TestForwardHLSSetsSPSPPSOnH264IDR(t *testing.T) {
 	r.pps = []byte{0x68, 0xce}
 
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 	var mu sync.Mutex
 	var receivedAU [][]byte
@@ -287,7 +288,7 @@ func TestForwardHLSSetsVPS_SPS_PPSOnH265IDR(t *testing.T) {
 	r.sps = []byte{0x42, 0x01}
 	r.pps = []byte{0x44, 0x01}
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var mu sync.Mutex
@@ -320,7 +321,7 @@ func TestForwardHLSH264NonIDRNoPrefix(t *testing.T) {
 	r.sps = []byte{0x67}
 	r.pps = []byte{0x68}
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var mu sync.Mutex
@@ -656,7 +657,7 @@ func TestHLSSubscribeConcurrent(t *testing.T) {
 	r.streamStart = time.Now()
 
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var calls atomic.Int32

--- a/internal/xiaomi/recorder_test.go
+++ b/internal/xiaomi/recorder_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // --- Annex B / AVCC conversion tests ---
@@ -417,7 +418,7 @@ func TestXiaomiRecorderHLSFrameCallback(t *testing.T) {
 	r.codecOK = true
 	r.streamStart = time.Now()
 	if r.Hub == nil {
-		r.Hub = model.NewStreamHub()
+		r.Hub = streamhub.New()
 	}
 
 	var mu sync.Mutex
@@ -716,7 +717,7 @@ func TestXiaomiRecorderAudioForwardWhenEnabled(t *testing.T) {
 		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
-	r.Hub = model.NewStreamHub()
+	r.Hub = streamhub.New()
 	r.streamStart = time.Now()
 	r.codec = model.FormatH264
 	r.codecOK = true
@@ -760,7 +761,7 @@ func TestXiaomiRecorderAudioSkippedWhenDisabled(t *testing.T) {
 		AudioEnabled: false,
 	}, &noopSegmentStore{})
 
-	r.Hub = model.NewStreamHub()
+	r.Hub = streamhub.New()
 	r.streamStart = time.Now()
 	r.codec = model.FormatH264
 	r.codecOK = true
@@ -793,7 +794,7 @@ func TestXiaomiRecorderAudioUnknownCodecSkipped(t *testing.T) {
 		AudioInRecordings: true,
 	}, &noopSegmentStore{})
 
-	r.Hub = model.NewStreamHub()
+	r.Hub = streamhub.New()
 	r.streamStart = time.Now()
 	r.codec = model.FormatH264
 	r.codecOK = true

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -39,7 +39,6 @@ import (
 	authmw "github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware/remotelog"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/migration"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/motion"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mqtt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
@@ -47,6 +46,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/srt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/upload"
@@ -471,7 +471,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		// the session is deleted (viewer DELETE, connection-state failure, or
 		// the idle watchdog). Main-key sessions carry no suffix and no-op.
 		deps.webrtcMgr.SetOnSessionEnd(func(streamKey string) {
-			if id, isSub := strings.CutSuffix(streamKey, model.SubStreamKeySuffix); isSub {
+			if id, isSub := strings.CutSuffix(streamKey, streamhub.SubStreamKeySuffix); isSub {
 				camMgr.ReleaseSubStream(id)
 			}
 		})
@@ -528,8 +528,8 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	// ride the same gate: their hub subscription is dropped so a new viewer
 	// re-registers on the fresh pull (existing sessions idle-timeout).
 	if subMgr := camMgr.SubStreams(); subMgr != nil {
-		subMgr.SetOnRecycle(func(cameraID string, recycledHub *model.StreamHub) {
-			key := cameraID + model.SubStreamKeySuffix
+		subMgr.SetOnRecycle(func(cameraID string, recycledHub *streamhub.StreamHub) {
+			key := cameraID + streamhub.SubStreamKeySuffix
 			if wsMgr.ActiveHub(key) == recycledHub {
 				wsMgr.UnregisterStream(key)
 			}
@@ -595,7 +595,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			// CameraHubProvider: hand the publisher the SAME hub the recorder owns.
 			camMgr.GetOrCreateHub,
 			// OnPublisherConnect: mark the IngestRecorder as streaming.
-			func(cameraID string, _ *model.StreamHub) {
+			func(cameraID string, _ *streamhub.StreamHub) {
 				if ir := camMgr.GetIngestRecorder(cameraID); ir != nil {
 					ir.WriteConnected()
 				}
@@ -628,7 +628,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		deps.whipServer = whip.NewServer(
 			camMgr.ResolveWHIPKey,
 			camMgr.GetOrCreateHub,
-			func(cameraID string, _ *model.StreamHub) {
+			func(cameraID string, _ *streamhub.StreamHub) {
 				if ir := camMgr.GetIngestRecorder(cameraID); ir != nil {
 					ir.WriteConnected()
 				}
@@ -706,7 +706,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		}
 		deps.srtListener = srt.NewListener(cfg.SRT)
 		deps.srtListener.HubProvider = camMgr.GetOrCreateHub
-		deps.srtListener.OnConnect = func(cameraID string, _ *model.StreamHub) {
+		deps.srtListener.OnConnect = func(cameraID string, _ *streamhub.StreamHub) {
 			if ir := camMgr.GetIngestRecorder(cameraID); ir != nil {
 				ir.WriteConnected()
 			}

--- a/pkg/app/rtsp_provider.go
+++ b/pkg/app/rtsp_provider.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
 // rtspStreamProvider adapts the camera manager to the RTSP output server's
@@ -22,7 +23,7 @@ func rtspStreamProvider(camMgr *camera.CameraManager) rtsp.StreamProvider {
 		if provider, ok := unwrapRTSPDelegate(rec).(model.HLSProvider); ok {
 			info.Codec, info.SPS, info.PPS, info.VPS = provider.CodecParams()
 		}
-		if h, ok := rec.(interface{ GetHub() *model.StreamHub }); ok {
+		if h, ok := rec.(interface{ GetHub() *streamhub.StreamHub }); ok {
 			info.Hub = h.GetHub()
 		}
 		if info.Codec == "" || info.Hub == nil {

--- a/pkg/streamhub/hub.go
+++ b/pkg/streamhub/hub.go
@@ -2,8 +2,8 @@
 // external (out-of-module) consumers, primarily the commercial P2P module
 // that needs to subscribe to camera frames for WebRTC tracks.
 //
-// The concrete implementation lives at internal/model.StreamHub. Adapters
-// in internal/model satisfy this interface via HubBridge.
+// The concrete implementation lives at internal/streamhub.StreamHub.
+// Adapters in internal/streamhub satisfy this interface via HubAdapter.
 package streamhub
 
 // FrameCallback is invoked for each video access unit.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/upload"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/wsstream"
 	"github.com/gorilla/websocket"
@@ -1463,7 +1464,7 @@ func TestWebSocketStreamIntegration(t *testing.T) {
 	// so we can test the full WebSocket flow without a real camera.
 	sampleSPS := []byte{0x67, 0x42, 0xc0, 0x1e, 0xd9, 0x00, 0xa0, 0x47, 0xfe, 0xd8}
 	samplePPS := []byte{0x68, 0xce, 0x38, 0x80}
-	hub := model.NewStreamHub()
+	hub := streamhub.New()
 	err = wsMgr.RegisterStream(cameraID, model.FormatH264, sampleSPS, samplePPS, nil, hub)
 	require.NoError(t, err)
 	require.True(t, wsMgr.IsActive(cameraID))


### PR DESCRIPTION
## 概要
架构 issue #610：全仓最大耦合点 \`model.StreamHub\`（59+ 文件引用的运行时组件）移出 model 包。与 PR #612 / #613 互相独立（见下方合并顺序说明）。

## 改动
- \`internal/model/stream.go\`(954行) → \`internal/streamhub/streamhub.go\`：StreamHub 本体、消费者管理、抖动缓冲、乱序检测、统计快照、回调类型（FrameCallback/MsgCallback/AudioCallback）、\`SubStreamKeySuffix\` 常量。构造函数 \`NewStreamHub()\` 更名为 \`New()\`。
- \`internal/model/adapter.go\` → \`internal/streamhub/adapter.go\`：HubAdapter（pkg/streamhub.Hub 防腐桥接）随迁。
- 测试随迁：stream_test.go / stream_stats_test.go / frame_trace_test.go（47+ 用例）。
- **81 个文件机械替换**：\`model.StreamHub\`→\`streamhub.StreamHub\` 等 9 个符号；清理只为 hub 引入的 model import。
- \`FrameMsg\` / \`AudioCodec\` 留守 model（纯数据类型，8 个包在用）；依赖单向 \`streamhub → model\`，无环。
- \`pkg/streamhub\` 公开接口零变化（pkg/camera.Manager.Hub 返回类型不动）。

## 效果
model 从"类型+接口+流枢纽运行时+错误+NAL 工具"五职 → 纯类型与接口；新代码 import streamhub 即可，不再把 954 行运行时拖进类型包。

## 合并顺序说明
本 PR 与 #612（model.HubHost）在 model/types.go 有小冲突：#612 把 HubHost 加在 model（引用 \`*StreamHub\`），本 PR 移走 StreamHub 后 HubHost 应落在 streamhub 包。**建议先合 #612**，我会把本分支 rebase 并顺手将 HubHost 迁到 streamhub（一处小改）。

## 验证
- \`go test ./...\` — 5424 tests / 64 packages 全过
- \`go test -race ./internal/streamhub/ ./internal/camera/ ./internal/wsstream/\` — 339 passed
- \`make lint\` — 0 issues

Closes #610