### PR TITLE
refactor(api): handlers_camera.go 按域拆分 — 1552 行 → 4 个按域文件 (#611)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -1,28 +1,21 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
-	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 	"github.com/go-chi/chi/v5"
 )
-
-// --- Camera and stats endpoints ---
 
 // cameraRowForAPI normalizes camera rows for API responses.
 // For ONVIF cameras, it exposes onvif_endpoint as url so the frontend
@@ -32,6 +25,21 @@ func cameraRowForAPI(row *storage.CameraRow) {
 		row.URL = row.ONVIFEndpoint
 	}
 }
+
+// injectYAMLConfigFields overlays the per-camera YAML-config fields that are NOT
+// stored in (or not read by) the DB query onto a CameraRow. The DB is the source
+// of truth for core columns (name/protocol/encoding/url/status/…), but several
+// fields live only in mibee-nvr.yaml (transcoding, channel, audio_enabled, push
+// targets, recording gate, dark-frame filter, recording schedule, stable_id,
+// subnet hints, ingest keys). Without this overlay the API response is missing
+// them — which previously made PUT /api/cameras/{id} return a row with
+// push_targets/recording_enabled absent and audio_enabled at its zero value
+// (false), so any caller trusting the PUT response (instead of re-GETting) saw
+// its just-saved data "missing" (issue #297).
+//
+// cfg may be nil (no-op). If the camera ID is not found in cfg.Cameras the row
+// is returned unchanged. Callers: handleListCameras, handleGetCamera,
+// handleUpdateCamera — all three now share this so list/get/update agree.
 
 // injectYAMLConfigFields overlays the per-camera YAML-config fields that are NOT
 // stored in (or not read by) the DB query onto a CameraRow. The DB is the source
@@ -235,364 +243,6 @@ var validProtocols = map[string]bool{
 }
 
 // gb28181ChannelPayload is the API shape of a camera's GB28181 binding.
-type gb28181ChannelPayload struct {
-	DeviceID     string `json:"device_id"`
-	ChannelID    string `json:"channel_id"`
-	Manufacturer string `json:"manufacturer,omitempty"`
-}
-
-// createBodyHost extracts the host IP from a create-camera body's URL or
-// ONVIF endpoint ("" when neither carries one). Feeds the cross-protocol
-// dedup against registered GB28181 devices.
-func createBodyHost(rawURL, onvifEndpoint string) string {
-	for _, raw := range []string{strings.TrimSpace(rawURL), strings.TrimSpace(onvifEndpoint)} {
-		if raw == "" {
-			continue
-		}
-		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
-			return u.Hostname()
-		}
-		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
-			return host
-		}
-	}
-	return ""
-}
-
-func (p *gb28181ChannelPayload) toConfig() config.GB28181ChannelConfig {
-	return config.GB28181ChannelConfig{
-		DeviceID:     p.DeviceID,
-		ChannelID:    p.ChannelID,
-		Manufacturer: p.Manufacturer,
-	}
-}
-
-func (p *gb28181ChannelPayload) toConfigPtr() *config.GB28181ChannelConfig {
-	if p == nil {
-		return nil
-	}
-	cfg := p.toConfig()
-	return &cfg
-}
-
-func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Name          string `json:"name"`
-		Protocol      string `json:"protocol"`
-		URL           string `json:"url"`
-		Username      string `json:"username"`
-		Password      string `json:"password"`
-		Enabled       *bool  `json:"enabled"`
-		Description   string `json:"description"`
-		Location      string `json:"location"`
-		Brand         string `json:"brand"`
-		Model         string `json:"model"`
-		SerialNumber  string `json:"serial_number"`
-		ONVIFEndpoint string `json:"onvif_endpoint"`
-		ProfileToken  string `json:"profile_token"`
-		// Sub-stream (#512): manual sub profile token + manual sub stream URL.
-		SubProfileToken string                        `json:"sub_profile_token"`
-		SubStreamURL    string                        `json:"sub_stream_url"`
-		StreamEncoding  string                        `json:"stream_encoding"`
-		Encoding        string                        `json:"encoding"`
-		Timelapse       *config.CameraTimelapseConfig `json:"timelapse"`
-		Channel         string                        `json:"channel"`
-		AudioEnabled    *bool                         `json:"audio_enabled"`
-		// Keep the camera's real audio track in recorded segments (default off).
-		AudioInRecordings *bool `json:"audio_in_recordings"`
-		// Recording gate: false = live-only (no segments written). nil = record.
-		RecordingEnabled *bool `json:"recording_enabled"`
-		// Cascade gate: false = hidden from the GB28181 cascade catalog and
-		// INVITEs refused. nil = default (exposed).
-		CascadeEnabled *bool `json:"cascade_enabled"`
-		// Cascade tier: forward the sub-stream instead of main (#512).
-		CascadeSubStream bool `json:"cascade_sub_stream"`
-		// Recording mode (#435): ""/"continuous" or "adaptive" (+ tuning).
-		RecordingMode string                          `json:"recording_mode"`
-		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
-		// Audio trigger (#478): loudness input for adaptive recording.
-		AudioTrigger *config.CameraAudioTriggerConfig `json:"audio_trigger"`
-		// Push/ingest fields (SRT/RTMP)
-		StreamKey     string `json:"stream_key"`
-		SRTPassphrase string `json:"srt_passphrase"`
-		SRTStreamID   string `json:"srt_stream_id"`
-		// Push-out relay targets + retention
-		PushTargets       []config.PushTargetConfig `json:"push_targets"`
-		PushRetentionDays *int                      `json:"push_retention_days"`
-		// IP self-healing: stable hardware ID (ONVIF serial) + candidate subnets.
-		StableID    string   `json:"stable_id"`
-		SubnetHints []string `json:"subnet_hints"`
-		// GB28181 SIP device/channel binding (protocol "gb28181")
-		GB28181 *gb28181ChannelPayload `json:"gb28181"`
-		// AllowDuplicate opts in to adding a pull camera (onvif/rtsp/http)
-		// whose host IP already belongs to a registered GB28181 device.
-		// Default false: one camera per physical device.
-		AllowDuplicate bool `json:"allow_duplicate"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		WriteError(w, http.StatusBadRequest, "invalid request body")
-		return
-	}
-	if body.Name == "" {
-		WriteError(w, http.StatusBadRequest, "name is required")
-		return
-	}
-	if isGBCamera := body.Protocol == "gb28181"; isGBCamera {
-		if body.GB28181 == nil || strings.TrimSpace(body.GB28181.DeviceID) == "" || strings.TrimSpace(body.GB28181.ChannelID) == "" {
-			WriteError(w, http.StatusBadRequest, "gb28181 device_id and channel_id are required for gb28181 cameras")
-			return
-		}
-	}
-	if body.Protocol == "" {
-		WriteError(w, http.StatusBadRequest, "protocol is required")
-		return
-	}
-	if !validProtocols[body.Protocol] {
-		WriteError(w, http.StatusBadRequest, fmt.Sprintf("invalid protocol %q, must be one of: rtsp, http, onvif, srt, rtmp, whip, xiaomi, timelapse, gb28181", body.Protocol))
-		return
-	}
-	// Push/ingest cameras (srt/rtmp/whip): no URL — the publisher connects to us.
-	isPush := body.Protocol == "srt" || body.Protocol == "rtmp" || body.Protocol == "whip"
-	// GB28181 cameras: no URL — identified by SIP DeviceID/ChannelID.
-	isGB28181 := body.Protocol == "gb28181"
-	// Cross-protocol dedup: a pull camera (onvif/rtsp/http) whose host IP
-	// matches a registered GB28181 device is the same physical camera — the
-	// GB28181 auto-enroll skips it symmetrically. Refuse unless the caller
-	// explicitly opts in (dual-protocol setups) with allow_duplicate.
-	if !isPush && !isGB28181 && h.gb28181DeviceMgr != nil {
-		if host := createBodyHost(body.URL, body.ONVIFEndpoint); host != "" {
-			conflict := ""
-			for _, d := range h.gb28181DeviceMgr.AllDevices() {
-				d.Mu.RLock()
-				netAddr := d.NetAddr
-				d.Mu.RUnlock()
-				devHost := netAddr
-				if h2, _, err := net.SplitHostPort(netAddr); err == nil && h2 != "" {
-					devHost = h2
-				}
-				if devHost == host {
-					conflict = fmt.Sprintf("a GB28181 device (%s) is already connected from %s", d.ID, host)
-					break
-				}
-			}
-			// L2: dual-NIC devices register GB28181 from a different interface
-			// IP than the ONVIF endpoint. Probe the create-host's ONVIF serial
-			// and match it against cached GB28181 device fingerprints. Skipped
-			// entirely when no fingerprints exist (no dual-protocol device has
-			// ever registered) so normal setups pay no probe latency.
-			if conflict == "" && h.db != nil {
-				if fps, err := h.db.ListGB28181Fingerprints(r.Context()); err == nil && len(fps) > 0 {
-					if serial, ok := onvif.ProbeSerial(r.Context(), host); ok {
-						for _, fp := range fps {
-							if fp.Serial == serial {
-								conflict = fmt.Sprintf("a GB28181 device (%s) with the same hardware serial (%s) is already connected", fp.DeviceID, serial)
-								break
-							}
-						}
-					}
-				}
-			}
-			if conflict != "" {
-				if !body.AllowDuplicate {
-					logger.Warn("create camera refused: same physical camera already connected via GB28181", "host", host)
-					WriteError(w, http.StatusConflict, conflict+
-						" — this looks like the same physical camera. Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both")
-					return
-				}
-				logger.Info("create camera: allow_duplicate set despite GB28181 dedup match", "host", host)
-			}
-		}
-	}
-	// ONVIF cameras: accept url OR onvif_endpoint
-	if body.Protocol == "onvif" {
-		endpoint := body.ONVIFEndpoint
-		if endpoint == "" {
-			endpoint = body.URL
-		}
-		if endpoint == "" {
-			WriteError(w, http.StatusBadRequest, "url or onvif_endpoint is required for ONVIF cameras")
-			return
-		}
-		body.ONVIFEndpoint = endpoint
-		body.URL = "" // Don't store in url field for ONVIF
-		// Check for duplicate ONVIF endpoint
-		if h.db != nil {
-			existingCams, _ := h.db.ListCameras(r.Context())
-			for _, ec := range existingCams {
-				if ec.Protocol == "onvif" && ec.ONVIFEndpoint == body.ONVIFEndpoint {
-					WriteError(w, http.StatusConflict, "ONVIF camera with this endpoint already exists")
-					return
-				}
-			}
-		}
-	} else if !isPush && !isGB28181 && body.URL == "" {
-		WriteError(w, http.StatusBadRequest, "url is required")
-		return
-	}
-	// Validate URL format for cameras that have one (not ONVIF, not push, not gb28181)
-	if body.Protocol != "onvif" && !isPush && !isGB28181 && body.URL != "" && !validateURL(body.URL) {
-		WriteError(w, http.StatusBadRequest, "invalid URL format")
-		return
-	}
-	// Sub-stream URL must be RTSP when provided (#512).
-	if body.SubStreamURL != "" && !strings.HasPrefix(body.SubStreamURL, "rtsp://") && !strings.HasPrefix(body.SubStreamURL, "rtsps://") {
-		WriteError(w, http.StatusBadRequest, "sub_stream_url must be an rtsp:// or rtsps:// URL")
-		return
-	}
-	// 0.10.0+: combined protocol strings are no longer accepted.
-	proto := body.Protocol
-	enc := body.Encoding
-	if strings.Contains(proto, "_") {
-		WriteError(w, http.StatusBadRequest,
-			fmt.Sprintf("protocol %q: combined format is no longer supported; use separate protocol and encoding fields", proto))
-		return
-	}
-	// Set default encoding if still empty
-	if enc == "" {
-		switch proto {
-		case "rtsp":
-			enc = "h264"
-		case "http":
-			enc = "jpeg"
-		case "srt", "rtmp", "whip":
-			// Push cameras: encoding derived from the published stream (H.264 default).
-			enc = "h264"
-		case "gb28181":
-			// Hint only — the recorder detects the real codec from PS stream NALUs.
-			enc = "h264"
-		case "xiaomi":
-			// Hint only — the Xiaomi recorder probes H264/H265 from the MISS
-			// stream at runtime; the list/get probe backfill corrects the label
-			// for H.265 devices. Without this default the UI's deliberate
-			// encoding omission (auto-detect protocols send none) persisted an
-			// empty encoding that failed startup validation fatally (#402).
-			enc = "h264"
-		case "onvif":
-			// Auto-detect encoding from ONVIF device profiles
-			if body.StreamEncoding == "" {
-				if detected := probeONVIFEncoding(r.Context(), body.ONVIFEndpoint, body.Username, body.Password); detected != "" {
-					body.StreamEncoding = detected
-					enc = strings.ToLower(detected)
-					logger.Info("auto-detected ONVIF encoding", "camera", body.Name, "encoding", enc)
-				}
-			} else {
-				enc = strings.ToLower(body.StreamEncoding)
-			}
-		}
-	}
-	// Guard the API write boundary with the same protocol+encoding validation
-	// the startup path enforces: an invalid combo saved here (e.g. http+h264
-	// from a non-UI client) bricks the NEXT restart with a fatal config
-	// validation error (#402 bug class).
-	if err := model.ValidateProtocolEncoding(proto, enc); err != nil {
-		WriteError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	// Same boundary validation for the recording mode (#435, #402 class).
-	if err := config.ValidateCameraRecordingMode(config.CameraConfig{
-		ID:            body.Name,
-		Encoding:      enc,
-		RecordingMode: body.RecordingMode,
-		Adaptive:      body.Adaptive,
-	}); err != nil {
-		WriteError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	cam := config.CameraConfig{
-		Name:              body.Name,
-		Protocol:          proto,
-		Encoding:          enc,
-		URL:               body.URL,
-		Username:          body.Username,
-		Password:          body.Password,
-		ONVIFEndpoint:     body.ONVIFEndpoint,
-		ProfileToken:      body.ProfileToken,
-		SubProfileToken:   body.SubProfileToken,
-		SubStreamURL:      body.SubStreamURL,
-		StreamEncoding:    body.StreamEncoding,
-		Timelapse:         body.Timelapse,
-		Channel:           body.Channel,
-		AudioEnabled:      body.AudioEnabled != nil && *body.AudioEnabled,
-		AudioInRecordings: body.AudioInRecordings != nil && *body.AudioInRecordings,
-		RecordingEnabled:  body.RecordingEnabled,
-		CascadeEnabled:    body.CascadeEnabled,
-		CascadeSubStream:  body.CascadeSubStream,
-		RecordingMode:     body.RecordingMode,
-		Adaptive:          body.Adaptive,
-		AudioTrigger:      body.AudioTrigger,
-		StreamKey:         body.StreamKey,
-		SRTPassphrase:     body.SRTPassphrase,
-		SRTStreamID:       body.SRTStreamID,
-		PushTargets:       body.PushTargets,
-		PushRetentionDays: body.PushRetentionDays,
-		StableID:          body.StableID,
-		SubnetHints:       body.SubnetHints,
-	}
-	if body.GB28181 != nil {
-		cam.GB28181 = body.GB28181.toConfig()
-	}
-
-	// Reject a dirty stable_id at the API boundary so it can't be frozen as the
-	// camera's permanent identity (which would break rediscovery — see #216).
-	// An empty stable_id is allowed (ONVIF cameras auto-populate it later).
-	if strings.TrimSpace(cam.StableID) != "" && !config.IsValidStableID(cam.StableID) {
-		WriteError(w, http.StatusBadRequest, fmt.Sprintf("stable_id %q is not a valid hardware identity (must be 3–64 chars of [A-Za-z0-9:_-], not all-same-character; rejects IPs, URLs, all-zero MACs)", cam.StableID))
-		return
-	}
-
-	if h.camMgr == nil {
-		WriteError(w, http.StatusInternalServerError, "camera manager not available")
-		return
-	}
-	id, err := h.camMgr.AddCamera(r.Context(), cam)
-	if err != nil {
-		var cae *model.CameraAlreadyExistsError
-		if errors.As(err, &cae) {
-			writeAPIError(w, http.StatusConflict, err)
-		} else {
-			logger.Error("failed to add camera", "camera_id", id, "error", err, "path", r.URL.Path)
-			WriteError(w, http.StatusInternalServerError, "failed to add camera")
-		}
-		return
-	}
-
-	// Notify merge scheduler if camera has timelapse config
-	if body.Timelapse != nil && body.Timelapse.MergeDuration != "" && h.mergeScheduler != nil {
-		if dur, err := config.ParseMergeDuration(body.Timelapse.MergeDuration); err == nil {
-			h.mergeScheduler.AddOrUpdate(id, dur)
-		}
-	}
-	// Persist DB-only metadata fields
-	if body.Description != "" || body.Location != "" || body.Brand != "" || body.Model != "" || body.SerialNumber != "" {
-		if err := h.db.UpdateCameraMetadata(r.Context(), id, body.Description, body.Location, body.Brand, body.Model, body.SerialNumber, 0); err != nil {
-			logger.Warn("failed to set camera metadata", "camera_id", id, "error", err)
-		}
-	}
-	// Persist push/ingest fields for srt/rtmp cameras.
-	if isPush {
-		if err := h.db.UpsertCameraIngest(r.Context(), id, body.StreamKey, body.SRTPassphrase, body.SRTStreamID); err != nil {
-			logger.Warn("failed to set camera ingest fields", "camera_id", id, "error", err)
-		}
-	}
-	// Return CameraRow with status
-	row, _ := h.db.GetCamera(r.Context(), id)
-	if row != nil {
-		if h.camMgr != nil {
-			row.Status = h.camMgr.CameraStatus(id)
-		}
-		// Inject last_seen from DB
-		lastSeen, err := h.db.GetLastRecordingTime(r.Context(), id)
-		if err == nil {
-			row.LastSeen = lastSeen
-		}
-		cameraRowForAPI(row)
-		writeJSON(w, http.StatusCreated, row)
-	} else {
-		cam.ID = id
-		writeJSON(w, http.StatusCreated, cam)
-	}
-}
 
 func (h *Handler) handleGetCamera(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
@@ -632,6 +282,11 @@ func (h *Handler) handleGetCamera(w http.ResponseWriter, r *http.Request) {
 // or "" when there is no running recorder or its codec hasn't been detected
 // yet. It is a thin wrapper over GetRecorder + getCodecParams so callers don't
 // repeat the nil-recorder / empty-codec dance.
+
+// probeCodec returns the live recorder's runtime-detected codec for a camera,
+// or "" when there is no running recorder or its codec hasn't been detected
+// yet. It is a thin wrapper over GetRecorder + getCodecParams so callers don't
+// repeat the nil-recorder / empty-codec dance.
 func probeCodec(camMgr *camera.CameraManager, id string) model.Format {
 	if camMgr == nil {
 		return ""
@@ -649,12 +304,21 @@ func probeCodec(camMgr *camera.CameraManager, id string) model.Format {
 // the actual stream), otherwise the stored value as a fallback (covers offline
 // cameras / codec-not-yet-detected). Centralizing this keeps the list, get, and
 // /protocols read-paths consistent (#166) and gives a single seam to test.
+
+// resolveEncoding picks the displayed encoding for a camera: the recorder's
+// runtime-probed codec when it is non-empty (authoritative — the recorder reads
+// the actual stream), otherwise the stored value as a fallback (covers offline
+// cameras / codec-not-yet-detected). Centralizing this keeps the list, get, and
+// /protocols read-paths consistent (#166) and gives a single seam to test.
 func resolveEncoding(stored string, probe model.Format) string {
 	if probe != "" {
 		return string(probe)
 	}
 	return stored
 }
+
+// handleCameraPushStatus returns the runtime status of a camera's push-out relay
+// targets (RTMP/RTSP). Used by the camera card/form to show live relay state.
 
 // handleCameraPushStatus returns the runtime status of a camera's push-out relay
 // targets (RTMP/RTSP). Used by the camera card/form to show live relay state.
@@ -1015,450 +679,6 @@ func (h *Handler) handleDeleteCamera(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "archived"})
-}
-
-func (h *Handler) handleCameraRecordingStats(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	count, totalSize, err := h.db.GetCameraRecordingStats(r.Context(), id)
-	if err != nil {
-		WriteError(w, http.StatusInternalServerError, "failed to get camera stats")
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]interface{}{"recording_count": count, "total_size": totalSize})
-}
-
-func (h *Handler) handleStartCamera(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	if h.camMgr == nil {
-		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
-		return
-	}
-	if err := h.camMgr.StartCamera(r.Context(), id); err != nil {
-		switch {
-		case errors.As(err, new(*model.CameraNotFoundError)):
-			writeAPIError(w, http.StatusNotFound, err)
-		case errors.As(err, new(*model.CameraAlreadyRunningError)):
-			writeAPIError(w, http.StatusConflict, err)
-		default:
-			logger.Error("failed to start camera", "camera_id", id, "error", err, "path", r.URL.Path)
-			WriteError(w, http.StatusInternalServerError, "failed to start camera")
-		}
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "started"})
-}
-
-// handleActivateCamera transitions a pending_activation camera to active by
-// applying credentials and starting the recorder. Used by the auto-discover
-// flow: an authenticated ONVIF device discovered without valid credentials is
-// persisted as pending_activation; the user supplies credentials via this
-// endpoint to bring it live.
-func (h *Handler) handleActivateCamera(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	var body struct {
-		Username string `json:"username"`
-		Password string `json:"password"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		WriteError(w, http.StatusBadRequest, "invalid JSON body")
-		return
-	}
-	if h.camMgr == nil {
-		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
-		return
-	}
-	if err := h.camMgr.ActivateCamera(r.Context(), id, body.Username, body.Password); err != nil {
-		switch {
-		case errors.As(err, new(*model.CameraNotFoundError)):
-			writeAPIError(w, http.StatusNotFound, err)
-		case errors.As(err, new(*model.CameraAlreadyRunningError)):
-			// Idempotent: the recorder auto-restored (e.g. on NVR restart) and raced
-			// with this request. Mirrors handleStartCamera's 409 — the camera is
-			// already in the desired state, not a server error.
-			writeAPIError(w, http.StatusConflict, err)
-		default:
-			logger.Error("failed to activate camera", "camera_id", id, "error", err, "path", r.URL.Path)
-			WriteError(w, http.StatusInternalServerError, "failed to activate camera")
-		}
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "activated"})
-}
-
-func (h *Handler) handleStopCamera(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	if h.camMgr == nil {
-		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
-		return
-	}
-	if err := h.camMgr.StopCamera(r.Context(), id); err != nil {
-		var cnf *model.CameraNotFoundError
-		if errors.As(err, &cnf) {
-			writeAPIError(w, http.StatusNotFound, err)
-		} else {
-			logger.Error("failed to stop camera", "camera_id", id, "error", err, "path", r.URL.Path)
-			WriteError(w, http.StatusInternalServerError, "failed to stop camera")
-		}
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
-}
-
-// handleRediscoverCamera manually triggers IP self-healing for a camera whose
-// network address may have changed (e.g. after an AP reboot across per-subnet
-// DHCP). It scans candidate subnets for a device whose ONVIF serial matches the
-// camera's StableID and, if found, updates the config and reconnects.
-func (h *Handler) handleRediscoverCamera(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	if h.camMgr == nil {
-		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
-		return
-	}
-	// The unicast scan can take up to MaxDuration (default 30s) on a wide subnet
-	// hint list, so do not bind it to the request's lifetime.
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	found, err := h.camMgr.RediscoverAndReconnect(ctx, id)
-	if err != nil {
-		var cnf *model.CameraNotFoundError
-		switch {
-		case errors.As(err, &cnf):
-			writeAPIError(w, http.StatusNotFound, err)
-		default:
-			logger.Error("rediscover camera failed", "camera_id", id, "error", err, "path", r.URL.Path)
-			WriteError(w, http.StatusInternalServerError, "rediscovery failed")
-		}
-		return
-	}
-	if !found {
-		// Not an error: camera may be unsupported (non-ONVIF), have no stable_id,
-		// or simply not be online in any candidate subnet yet.
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"found":  false,
-			"reason": "camera not found in candidate subnets (is it powered on? consider adding subnet_hints)",
-		})
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"found":  true,
-		"status": "reconnected",
-	})
-}
-
-// handleTestConnection attempts to connect to a camera URL with a short timeout.
-// Returns success/failure, a human-readable message, and the latency in milliseconds.
-func (h *Handler) handleTestConnection(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Protocol      string `json:"protocol"`
-		URL           string `json:"url"`
-		Username      string `json:"username"`
-		Password      string `json:"password"`
-		Encoding      string `json:"encoding"`
-		ONVIFEndpoint string `json:"onvif_endpoint"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		WriteError(w, http.StatusBadRequest, "invalid request body")
-		return
-	}
-	if body.URL == "" && body.ONVIFEndpoint == "" {
-		WriteError(w, http.StatusBadRequest, "url is required")
-		return
-	}
-
-	target := body.URL
-	if body.Protocol == "onvif" && body.ONVIFEndpoint != "" {
-		target = body.ONVIFEndpoint
-	}
-
-	startTime := time.Now()
-
-	// ONVIF cameras get a real stream-access probe: the old HTTP-HEAD check could
-	// report success while the RTSP stream was unreachable or credentials were
-	// wrong for GetStreamUri — the root of the "test passes but no image" reports
-	// (issues #29/#30). The probe distinguishes reachable / stream-ok / codec-lie.
-	if body.Protocol == "onvif" {
-		probe := probeONVIFStream(r.Context(), target, body.Username, body.Password)
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success":    probe.StreamOK,
-			"reachable":  probe.Reachable,
-			"stream_ok":  probe.StreamOK,
-			"encoding":   probe.Encoding,
-			"codec_lie":  probe.CodecLie,
-			"message":    probe.reasonOrOK(),
-			"latency_ms": time.Since(startTime).Milliseconds(),
-		})
-		return
-	}
-
-	switch {
-	case strings.HasPrefix(target, "rtsp://"):
-		// RTSP: try TCP connection to the host:port
-		conn, err := net.DialTimeout("tcp", stripScheme(target), 3*time.Second)
-		if err != nil {
-			writeJSON(w, http.StatusOK, map[string]any{
-				"success":    false,
-				"message":    fmt.Sprintf("connection refused: %v", err),
-				"latency_ms": time.Since(startTime).Milliseconds(),
-			})
-			return
-		}
-		conn.Close()
-
-	default:
-		// HTTP/ONVIF: try HEAD/GET request with timeout
-		client := &http.Client{Timeout: 3 * time.Second}
-		// For URLs with credentials, inject them
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodHead, target, nil)
-		if err != nil {
-			writeJSON(w, http.StatusOK, map[string]any{
-				"success":    false,
-				"message":    fmt.Sprintf("invalid URL: %v", err),
-				"latency_ms": time.Since(startTime).Milliseconds(),
-			})
-			return
-		}
-		if body.Username != "" {
-			req.SetBasicAuth(body.Username, body.Password)
-		} else {
-			// Extract credentials from URL if present (e.g., http://admin:pass@host)
-			if parsed, err := url.Parse(target); err == nil && parsed.User != nil {
-				if u := parsed.User.Username(); u != "" {
-					p, _ := parsed.User.Password()
-					req.SetBasicAuth(u, p)
-				}
-			}
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			writeJSON(w, http.StatusOK, map[string]any{
-				"success":    false,
-				"message":    fmt.Sprintf("connection failed: %v", err),
-				"latency_ms": time.Since(startTime).Milliseconds(),
-			})
-			return
-		}
-		resp.Body.Close()
-	}
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"success":    true,
-		"message":    "connection successful",
-		"latency_ms": time.Since(startTime).Milliseconds(),
-	})
-}
-
-// stripScheme extracts host:port from a URL string for TCP dialing.
-// Handles URLs with credentials (user:pass@host) by stripping userinfo.
-func stripScheme(rawURL string) string {
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return rawURL // fallback
-	}
-	host := parsed.Hostname()
-	port := parsed.Port()
-	if port == "" {
-		switch parsed.Scheme {
-		case "rtsp":
-			port = "554"
-		case "http":
-			port = "80"
-		case "https":
-			port = "443"
-		default:
-			port = "554"
-		}
-	}
-	return net.JoinHostPort(host, port)
-}
-
-// probeONVIFEncoding connects to an ONVIF device and retrieves the encoding
-// from the first media profile. Returns "H264" or "H265", or empty string on failure.
-// A bounded timeout is applied so a stuck device (e.g. ESP32 MiBeeCam with very
-// limited concurrent HTTP capacity) cannot block the camera-create request — the
-// caller context may outlive both the user's patience and the frontend fetch timeout.
-// probeONVIFEncoding returns the best-known video encoding ("H264" or "H265") for
-// an ONVIF device. It starts from the ONVIF profile declaration but verifies it
-// against the actual RTSP stream, because some HiSilicon-OEM cameras advertise H264
-// in their ONVIF profile while streaming H.265 (see ONVIFRecorder.detectEncoding).
-// If the RTSP DESCRIBE probe succeeds, its result is authoritative; otherwise the
-// ONVIF-declared encoding is returned as-is.
-// onvifStreamProbe is the structured result of probing an ONVIF device for real
-// stream access. It distinguishes "device reachable" from "stream actually
-// playable" — the old test-connection endpoint conflated the two (an HTTP HEAD
-// to the device_service URL can return 200 while the RTSP stream is unreachable
-// or the credentials are wrong for GetStreamUri), producing the "test passes but
-// no image" reports in issues #29/#30.
-type onvifStreamProbe struct {
-	Reachable bool   // ONVIF device_service responded to GetDeviceInformation/GetProfiles
-	StreamOK  bool   // an RTSP stream URI was resolved AND a DESCRIBE succeeded
-	Encoding  string // the REAL codec (RTSP DESCRIBE is authoritative; may differ from declared)
-	CodecLie  bool   // the ONVIF-declared codec disagrees with the real stream
-	Reason    string // human-readable explanation when Reachable/StreamOK is false
-}
-
-// onvifLooksLikeAuthError reports whether an ONVIF error smells like a
-// WS-Security rejection (the trigger for running the time-skew diagnosis).
-// Mirrors the onvif package's internal isAuthError but lives here to avoid
-// widening the onvif package's API surface.
-func onvifLooksLikeAuthError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := err.Error()
-	return strings.Contains(s, "NotAuthorized") ||
-		strings.Contains(s, "status 401") ||
-		strings.Contains(s, "status 403") ||
-		strings.Contains(s, "status 400")
-}
-
-// reasonOrOK returns the failure reason, or a success message when the stream
-// is healthy (used by the test-connection response so the frontend always has a
-// sensible message to show).
-func (p onvifStreamProbe) reasonOrOK() string {
-	if p.StreamOK {
-		if p.CodecLie {
-			return "stream accessible (declared codec corrected by RTSP probe)"
-		}
-		return "connection successful"
-	}
-	return p.Reason
-}
-
-// probeONVIFStream connects to an ONVIF device, resolves the stream URI, and
-// verifies the stream actually plays via an RTSP DESCRIBE. This is the
-// "does it really work?" check that the test-connection flow needs. It is also
-// the engine behind probeONVIFEncoding (which discards everything but encoding).
-func probeONVIFStream(ctx context.Context, endpoint, username, password string) onvifStreamProbe {
-	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
-	defer cancel()
-
-	client := onvif.NewClient(endpoint, username, password)
-	if err := client.Connect(ctx); err != nil {
-		reason := fmt.Sprintf("could not connect to ONVIF service: %v", err)
-		// If it looks like an auth rejection, run the time-skew diagnosis so the
-		// user gets an actionable "sync the camera's clock" hint instead of a
-		// generic failure (Hikvision cameras reject digest auth on clock skew).
-		if onvifLooksLikeAuthError(err) {
-			if diag := client.DiagnoseAuth(ctx); diag.SkewDetected {
-				reason = diag.Diagnosis
-			}
-		}
-		return onvifStreamProbe{Reason: reason}
-	}
-	profiles, err := client.GetProfiles(ctx)
-	if err != nil {
-		reason := fmt.Sprintf("device responded but GetProfiles failed (credentials may be wrong, or ONVIF may be limited): %v", err)
-		if onvifLooksLikeAuthError(err) {
-			if diag := client.DiagnoseAuth(ctx); diag.SkewDetected {
-				reason = diag.Diagnosis
-			}
-		}
-		return onvifStreamProbe{
-			Reachable: true,
-			Reason:    reason,
-		}
-	}
-	if len(profiles) == 0 {
-		return onvifStreamProbe{
-			Reachable: true,
-			Reason:    "device responded but exposed no media profiles — check the camera's ONVIF/stream configuration",
-		}
-	}
-	declared := profiles[0].Encoding
-
-	si, err := client.GetStreamURI(ctx, profiles[0].Token)
-	if err != nil || si.URI == "" {
-		return onvifStreamProbe{
-			Reachable: true,
-			Reason:    "device responded but GetStreamUri failed — credentials may lack stream access, or the camera does not expose RTSP",
-		}
-	}
-
-	// RTSP DESCRIBE is authoritative for the codec (corrects cameras that lie —
-	// e.g. HiSilicon OEMs advertising H264 while streaming H265) AND confirms the
-	// stream is actually playable with the supplied credentials.
-	actual := recorder.ProbeRTSPEncoding(si.URI, username, password)
-	if actual == "" {
-		return onvifStreamProbe{
-			Reachable: true,
-			Reason:    "stream URI resolved but RTSP DESCRIBE failed — check that the RTSP port is reachable and credentials are correct",
-		}
-	}
-	codecLie := declared != "" && !strings.EqualFold(actual, declared)
-	if codecLie {
-		logger.Info("ONVIF-declared encoding corrected by RTSP probe",
-			"endpoint", endpoint, "declared", declared, "actual", actual)
-	}
-	return onvifStreamProbe{
-		Reachable: true,
-		StreamOK:  true,
-		Encoding:  actual,
-		CodecLie:  codecLie,
-	}
-}
-
-// probeONVIFEncoding returns just the resolved encoding (empty on failure),
-// preserving the original contract of the create-camera path. It now delegates
-// to probeONVIFStream so both paths share one probing implementation.
-func probeONVIFEncoding(ctx context.Context, endpoint, username, password string) string {
-	return probeONVIFStream(ctx, endpoint, username, password).Encoding
-}
-
-// registerCameraRoutes registers all /api/cameras* routes (including nested
-// stream, ONVIF, PTZ, snapshot, merge-config, timelapse config, events, and
-// Xiaomi sub-routes) on the given (already auth-protected) router.
-// handleAdaptiveTrigger handles POST /api/cameras/{id}/adaptive/trigger
-// (issue #478): an external audio-activity event (e.g. a semantic classifier
-// running outside the NVR) forces the camera's adaptive gate out of timelapse
-// with the same GOP + pre-trigger back-fill as a loud window. Body:
-// {"source": "...", "hold": "10s", "dbfs": -23.4} — source/dbfs are
-// diagnostics only; hold (optional duration, 0–10m) extends how long
-// timelapse entry stays deferred after the event.
-func (h *Handler) handleAdaptiveTrigger(w http.ResponseWriter, r *http.Request) {
-	if h.camMgr == nil {
-		WriteError(w, http.StatusInternalServerError, "camera manager not available")
-		return
-	}
-	id := chi.URLParam(r, "id")
-	var body struct {
-		Source string  `json:"source"`
-		Hold   string  `json:"hold"`
-		DBFS   float64 `json:"dbfs"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		WriteError(w, http.StatusBadRequest, "invalid request body")
-		return
-	}
-	var hold time.Duration
-	if body.Hold != "" {
-		d, err := time.ParseDuration(body.Hold)
-		if err != nil || d < 0 || d > 10*time.Minute {
-			WriteError(w, http.StatusBadRequest, "hold must be a duration between 0 and 10m")
-			return
-		}
-		hold = d
-	}
-	rec := h.camMgr.GetRecorder(id)
-	if rec == nil {
-		WriteError(w, http.StatusNotFound, "camera not found")
-		return
-	}
-	trig, ok := rec.(interface {
-		AudioTriggerEvent(at time.Time, hold time.Duration) error
-	})
-	if !ok {
-		WriteError(w, http.StatusBadRequest, "camera does not support adaptive triggers")
-		return
-	}
-	if err := trig.AudioTriggerEvent(time.Now(), hold); err != nil {
-		writeAPIError(w, http.StatusBadRequest, err)
-		return
-	}
-	logger.Info("external adaptive trigger",
-		"camera_id", id, "source", body.Source,
-		"hold", hold.String(), "dbfs", body.DBFS)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "triggered"})
 }
 
 func (h *Handler) registerCameraRoutes(r chi.Router) {

--- a/internal/api/handlers_camera_create.go
+++ b/internal/api/handlers_camera_create.go
@@ -1,0 +1,379 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+)
+
+// gb28181ChannelPayload is the API shape of a camera's GB28181 binding.
+type gb28181ChannelPayload struct {
+	DeviceID     string `json:"device_id"`
+	ChannelID    string `json:"channel_id"`
+	Manufacturer string `json:"manufacturer,omitempty"`
+}
+
+// createBodyHost extracts the host IP from a create-camera body's URL or
+// ONVIF endpoint ("" when neither carries one). Feeds the cross-protocol
+// dedup against registered GB28181 devices.
+
+// createBodyHost extracts the host IP from a create-camera body's URL or
+// ONVIF endpoint ("" when neither carries one). Feeds the cross-protocol
+// dedup against registered GB28181 devices.
+func createBodyHost(rawURL, onvifEndpoint string) string {
+	for _, raw := range []string{strings.TrimSpace(rawURL), strings.TrimSpace(onvifEndpoint)} {
+		if raw == "" {
+			continue
+		}
+		if u, err := url.Parse(raw); err == nil && u.Hostname() != "" {
+			return u.Hostname()
+		}
+		if host, _, err := net.SplitHostPort(raw); err == nil && host != "" {
+			return host
+		}
+	}
+	return ""
+}
+
+func (p *gb28181ChannelPayload) toConfig() config.GB28181ChannelConfig {
+	return config.GB28181ChannelConfig{
+		DeviceID:     p.DeviceID,
+		ChannelID:    p.ChannelID,
+		Manufacturer: p.Manufacturer,
+	}
+}
+
+func (p *gb28181ChannelPayload) toConfigPtr() *config.GB28181ChannelConfig {
+	if p == nil {
+		return nil
+	}
+	cfg := p.toConfig()
+	return &cfg
+}
+
+func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name          string `json:"name"`
+		Protocol      string `json:"protocol"`
+		URL           string `json:"url"`
+		Username      string `json:"username"`
+		Password      string `json:"password"`
+		Enabled       *bool  `json:"enabled"`
+		Description   string `json:"description"`
+		Location      string `json:"location"`
+		Brand         string `json:"brand"`
+		Model         string `json:"model"`
+		SerialNumber  string `json:"serial_number"`
+		ONVIFEndpoint string `json:"onvif_endpoint"`
+		ProfileToken  string `json:"profile_token"`
+		// Sub-stream (#512): manual sub profile token + manual sub stream URL.
+		SubProfileToken string                        `json:"sub_profile_token"`
+		SubStreamURL    string                        `json:"sub_stream_url"`
+		StreamEncoding  string                        `json:"stream_encoding"`
+		Encoding        string                        `json:"encoding"`
+		Timelapse       *config.CameraTimelapseConfig `json:"timelapse"`
+		Channel         string                        `json:"channel"`
+		AudioEnabled    *bool                         `json:"audio_enabled"`
+		// Keep the camera's real audio track in recorded segments (default off).
+		AudioInRecordings *bool `json:"audio_in_recordings"`
+		// Recording gate: false = live-only (no segments written). nil = record.
+		RecordingEnabled *bool `json:"recording_enabled"`
+		// Cascade gate: false = hidden from the GB28181 cascade catalog and
+		// INVITEs refused. nil = default (exposed).
+		CascadeEnabled *bool `json:"cascade_enabled"`
+		// Cascade tier: forward the sub-stream instead of main (#512).
+		CascadeSubStream bool `json:"cascade_sub_stream"`
+		// Recording mode (#435): ""/"continuous" or "adaptive" (+ tuning).
+		RecordingMode string                          `json:"recording_mode"`
+		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
+		// Audio trigger (#478): loudness input for adaptive recording.
+		AudioTrigger *config.CameraAudioTriggerConfig `json:"audio_trigger"`
+		// Push/ingest fields (SRT/RTMP)
+		StreamKey     string `json:"stream_key"`
+		SRTPassphrase string `json:"srt_passphrase"`
+		SRTStreamID   string `json:"srt_stream_id"`
+		// Push-out relay targets + retention
+		PushTargets       []config.PushTargetConfig `json:"push_targets"`
+		PushRetentionDays *int                      `json:"push_retention_days"`
+		// IP self-healing: stable hardware ID (ONVIF serial) + candidate subnets.
+		StableID    string   `json:"stable_id"`
+		SubnetHints []string `json:"subnet_hints"`
+		// GB28181 SIP device/channel binding (protocol "gb28181")
+		GB28181 *gb28181ChannelPayload `json:"gb28181"`
+		// AllowDuplicate opts in to adding a pull camera (onvif/rtsp/http)
+		// whose host IP already belongs to a registered GB28181 device.
+		// Default false: one camera per physical device.
+		AllowDuplicate bool `json:"allow_duplicate"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.Name == "" {
+		WriteError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if isGBCamera := body.Protocol == "gb28181"; isGBCamera {
+		if body.GB28181 == nil || strings.TrimSpace(body.GB28181.DeviceID) == "" || strings.TrimSpace(body.GB28181.ChannelID) == "" {
+			WriteError(w, http.StatusBadRequest, "gb28181 device_id and channel_id are required for gb28181 cameras")
+			return
+		}
+	}
+	if body.Protocol == "" {
+		WriteError(w, http.StatusBadRequest, "protocol is required")
+		return
+	}
+	if !validProtocols[body.Protocol] {
+		WriteError(w, http.StatusBadRequest, fmt.Sprintf("invalid protocol %q, must be one of: rtsp, http, onvif, srt, rtmp, whip, xiaomi, timelapse, gb28181", body.Protocol))
+		return
+	}
+	// Push/ingest cameras (srt/rtmp/whip): no URL — the publisher connects to us.
+	isPush := body.Protocol == "srt" || body.Protocol == "rtmp" || body.Protocol == "whip"
+	// GB28181 cameras: no URL — identified by SIP DeviceID/ChannelID.
+	isGB28181 := body.Protocol == "gb28181"
+	// Cross-protocol dedup: a pull camera (onvif/rtsp/http) whose host IP
+	// matches a registered GB28181 device is the same physical camera — the
+	// GB28181 auto-enroll skips it symmetrically. Refuse unless the caller
+	// explicitly opts in (dual-protocol setups) with allow_duplicate.
+	if !isPush && !isGB28181 && h.gb28181DeviceMgr != nil {
+		if host := createBodyHost(body.URL, body.ONVIFEndpoint); host != "" {
+			conflict := ""
+			for _, d := range h.gb28181DeviceMgr.AllDevices() {
+				d.Mu.RLock()
+				netAddr := d.NetAddr
+				d.Mu.RUnlock()
+				devHost := netAddr
+				if h2, _, err := net.SplitHostPort(netAddr); err == nil && h2 != "" {
+					devHost = h2
+				}
+				if devHost == host {
+					conflict = fmt.Sprintf("a GB28181 device (%s) is already connected from %s", d.ID, host)
+					break
+				}
+			}
+			// L2: dual-NIC devices register GB28181 from a different interface
+			// IP than the ONVIF endpoint. Probe the create-host's ONVIF serial
+			// and match it against cached GB28181 device fingerprints. Skipped
+			// entirely when no fingerprints exist (no dual-protocol device has
+			// ever registered) so normal setups pay no probe latency.
+			if conflict == "" && h.db != nil {
+				if fps, err := h.db.ListGB28181Fingerprints(r.Context()); err == nil && len(fps) > 0 {
+					if serial, ok := onvif.ProbeSerial(r.Context(), host); ok {
+						for _, fp := range fps {
+							if fp.Serial == serial {
+								conflict = fmt.Sprintf("a GB28181 device (%s) with the same hardware serial (%s) is already connected", fp.DeviceID, serial)
+								break
+							}
+						}
+					}
+				}
+			}
+			if conflict != "" {
+				if !body.AllowDuplicate {
+					logger.Warn("create camera refused: same physical camera already connected via GB28181", "host", host)
+					WriteError(w, http.StatusConflict, conflict+
+						" — this looks like the same physical camera. Use it as-is, remove/archive it first, or pass allow_duplicate=true to keep both")
+					return
+				}
+				logger.Info("create camera: allow_duplicate set despite GB28181 dedup match", "host", host)
+			}
+		}
+	}
+	// ONVIF cameras: accept url OR onvif_endpoint
+	if body.Protocol == "onvif" {
+		endpoint := body.ONVIFEndpoint
+		if endpoint == "" {
+			endpoint = body.URL
+		}
+		if endpoint == "" {
+			WriteError(w, http.StatusBadRequest, "url or onvif_endpoint is required for ONVIF cameras")
+			return
+		}
+		body.ONVIFEndpoint = endpoint
+		body.URL = "" // Don't store in url field for ONVIF
+		// Check for duplicate ONVIF endpoint
+		if h.db != nil {
+			existingCams, _ := h.db.ListCameras(r.Context())
+			for _, ec := range existingCams {
+				if ec.Protocol == "onvif" && ec.ONVIFEndpoint == body.ONVIFEndpoint {
+					WriteError(w, http.StatusConflict, "ONVIF camera with this endpoint already exists")
+					return
+				}
+			}
+		}
+	} else if !isPush && !isGB28181 && body.URL == "" {
+		WriteError(w, http.StatusBadRequest, "url is required")
+		return
+	}
+	// Validate URL format for cameras that have one (not ONVIF, not push, not gb28181)
+	if body.Protocol != "onvif" && !isPush && !isGB28181 && body.URL != "" && !validateURL(body.URL) {
+		WriteError(w, http.StatusBadRequest, "invalid URL format")
+		return
+	}
+	// Sub-stream URL must be RTSP when provided (#512).
+	if body.SubStreamURL != "" && !strings.HasPrefix(body.SubStreamURL, "rtsp://") && !strings.HasPrefix(body.SubStreamURL, "rtsps://") {
+		WriteError(w, http.StatusBadRequest, "sub_stream_url must be an rtsp:// or rtsps:// URL")
+		return
+	}
+	// 0.10.0+: combined protocol strings are no longer accepted.
+	proto := body.Protocol
+	enc := body.Encoding
+	if strings.Contains(proto, "_") {
+		WriteError(w, http.StatusBadRequest,
+			fmt.Sprintf("protocol %q: combined format is no longer supported; use separate protocol and encoding fields", proto))
+		return
+	}
+	// Set default encoding if still empty
+	if enc == "" {
+		switch proto {
+		case "rtsp":
+			enc = "h264"
+		case "http":
+			enc = "jpeg"
+		case "srt", "rtmp", "whip":
+			// Push cameras: encoding derived from the published stream (H.264 default).
+			enc = "h264"
+		case "gb28181":
+			// Hint only — the recorder detects the real codec from PS stream NALUs.
+			enc = "h264"
+		case "xiaomi":
+			// Hint only — the Xiaomi recorder probes H264/H265 from the MISS
+			// stream at runtime; the list/get probe backfill corrects the label
+			// for H.265 devices. Without this default the UI's deliberate
+			// encoding omission (auto-detect protocols send none) persisted an
+			// empty encoding that failed startup validation fatally (#402).
+			enc = "h264"
+		case "onvif":
+			// Auto-detect encoding from ONVIF device profiles
+			if body.StreamEncoding == "" {
+				if detected := probeONVIFEncoding(r.Context(), body.ONVIFEndpoint, body.Username, body.Password); detected != "" {
+					body.StreamEncoding = detected
+					enc = strings.ToLower(detected)
+					logger.Info("auto-detected ONVIF encoding", "camera", body.Name, "encoding", enc)
+				}
+			} else {
+				enc = strings.ToLower(body.StreamEncoding)
+			}
+		}
+	}
+	// Guard the API write boundary with the same protocol+encoding validation
+	// the startup path enforces: an invalid combo saved here (e.g. http+h264
+	// from a non-UI client) bricks the NEXT restart with a fatal config
+	// validation error (#402 bug class).
+	if err := model.ValidateProtocolEncoding(proto, enc); err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Same boundary validation for the recording mode (#435, #402 class).
+	if err := config.ValidateCameraRecordingMode(config.CameraConfig{
+		ID:            body.Name,
+		Encoding:      enc,
+		RecordingMode: body.RecordingMode,
+		Adaptive:      body.Adaptive,
+	}); err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	cam := config.CameraConfig{
+		Name:              body.Name,
+		Protocol:          proto,
+		Encoding:          enc,
+		URL:               body.URL,
+		Username:          body.Username,
+		Password:          body.Password,
+		ONVIFEndpoint:     body.ONVIFEndpoint,
+		ProfileToken:      body.ProfileToken,
+		SubProfileToken:   body.SubProfileToken,
+		SubStreamURL:      body.SubStreamURL,
+		StreamEncoding:    body.StreamEncoding,
+		Timelapse:         body.Timelapse,
+		Channel:           body.Channel,
+		AudioEnabled:      body.AudioEnabled != nil && *body.AudioEnabled,
+		AudioInRecordings: body.AudioInRecordings != nil && *body.AudioInRecordings,
+		RecordingEnabled:  body.RecordingEnabled,
+		CascadeEnabled:    body.CascadeEnabled,
+		CascadeSubStream:  body.CascadeSubStream,
+		RecordingMode:     body.RecordingMode,
+		Adaptive:          body.Adaptive,
+		AudioTrigger:      body.AudioTrigger,
+		StreamKey:         body.StreamKey,
+		SRTPassphrase:     body.SRTPassphrase,
+		SRTStreamID:       body.SRTStreamID,
+		PushTargets:       body.PushTargets,
+		PushRetentionDays: body.PushRetentionDays,
+		StableID:          body.StableID,
+		SubnetHints:       body.SubnetHints,
+	}
+	if body.GB28181 != nil {
+		cam.GB28181 = body.GB28181.toConfig()
+	}
+
+	// Reject a dirty stable_id at the API boundary so it can't be frozen as the
+	// camera's permanent identity (which would break rediscovery — see #216).
+	// An empty stable_id is allowed (ONVIF cameras auto-populate it later).
+	if strings.TrimSpace(cam.StableID) != "" && !config.IsValidStableID(cam.StableID) {
+		WriteError(w, http.StatusBadRequest, fmt.Sprintf("stable_id %q is not a valid hardware identity (must be 3–64 chars of [A-Za-z0-9:_-], not all-same-character; rejects IPs, URLs, all-zero MACs)", cam.StableID))
+		return
+	}
+
+	if h.camMgr == nil {
+		WriteError(w, http.StatusInternalServerError, "camera manager not available")
+		return
+	}
+	id, err := h.camMgr.AddCamera(r.Context(), cam)
+	if err != nil {
+		var cae *model.CameraAlreadyExistsError
+		if errors.As(err, &cae) {
+			writeAPIError(w, http.StatusConflict, err)
+		} else {
+			logger.Error("failed to add camera", "camera_id", id, "error", err, "path", r.URL.Path)
+			WriteError(w, http.StatusInternalServerError, "failed to add camera")
+		}
+		return
+	}
+
+	// Notify merge scheduler if camera has timelapse config
+	if body.Timelapse != nil && body.Timelapse.MergeDuration != "" && h.mergeScheduler != nil {
+		if dur, err := config.ParseMergeDuration(body.Timelapse.MergeDuration); err == nil {
+			h.mergeScheduler.AddOrUpdate(id, dur)
+		}
+	}
+	// Persist DB-only metadata fields
+	if body.Description != "" || body.Location != "" || body.Brand != "" || body.Model != "" || body.SerialNumber != "" {
+		if err := h.db.UpdateCameraMetadata(r.Context(), id, body.Description, body.Location, body.Brand, body.Model, body.SerialNumber, 0); err != nil {
+			logger.Warn("failed to set camera metadata", "camera_id", id, "error", err)
+		}
+	}
+	// Persist push/ingest fields for srt/rtmp cameras.
+	if isPush {
+		if err := h.db.UpsertCameraIngest(r.Context(), id, body.StreamKey, body.SRTPassphrase, body.SRTStreamID); err != nil {
+			logger.Warn("failed to set camera ingest fields", "camera_id", id, "error", err)
+		}
+	}
+	// Return CameraRow with status
+	row, _ := h.db.GetCamera(r.Context(), id)
+	if row != nil {
+		if h.camMgr != nil {
+			row.Status = h.camMgr.CameraStatus(id)
+		}
+		// Inject last_seen from DB
+		lastSeen, err := h.db.GetLastRecordingTime(r.Context(), id)
+		if err == nil {
+			row.LastSeen = lastSeen
+		}
+		cameraRowForAPI(row)
+		writeJSON(w, http.StatusCreated, row)
+	} else {
+		cam.ID = id
+		writeJSON(w, http.StatusCreated, cam)
+	}
+}

--- a/internal/api/handlers_camera_lifecycle.go
+++ b/internal/api/handlers_camera_lifecycle.go
@@ -1,0 +1,211 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/go-chi/chi/v5"
+)
+
+func (h *Handler) handleCameraRecordingStats(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	count, totalSize, err := h.db.GetCameraRecordingStats(r.Context(), id)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "failed to get camera stats")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"recording_count": count, "total_size": totalSize})
+}
+
+func (h *Handler) handleStartCamera(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if h.camMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
+		return
+	}
+	if err := h.camMgr.StartCamera(r.Context(), id); err != nil {
+		switch {
+		case errors.As(err, new(*model.CameraNotFoundError)):
+			writeAPIError(w, http.StatusNotFound, err)
+		case errors.As(err, new(*model.CameraAlreadyRunningError)):
+			writeAPIError(w, http.StatusConflict, err)
+		default:
+			logger.Error("failed to start camera", "camera_id", id, "error", err, "path", r.URL.Path)
+			WriteError(w, http.StatusInternalServerError, "failed to start camera")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "started"})
+}
+
+// handleActivateCamera transitions a pending_activation camera to active by
+// applying credentials and starting the recorder. Used by the auto-discover
+// flow: an authenticated ONVIF device discovered without valid credentials is
+// persisted as pending_activation; the user supplies credentials via this
+// endpoint to bring it live.
+
+// handleActivateCamera transitions a pending_activation camera to active by
+// applying credentials and starting the recorder. Used by the auto-discover
+// flow: an authenticated ONVIF device discovered without valid credentials is
+// persisted as pending_activation; the user supplies credentials via this
+// endpoint to bring it live.
+func (h *Handler) handleActivateCamera(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if h.camMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
+		return
+	}
+	if err := h.camMgr.ActivateCamera(r.Context(), id, body.Username, body.Password); err != nil {
+		switch {
+		case errors.As(err, new(*model.CameraNotFoundError)):
+			writeAPIError(w, http.StatusNotFound, err)
+		case errors.As(err, new(*model.CameraAlreadyRunningError)):
+			// Idempotent: the recorder auto-restored (e.g. on NVR restart) and raced
+			// with this request. Mirrors handleStartCamera's 409 — the camera is
+			// already in the desired state, not a server error.
+			writeAPIError(w, http.StatusConflict, err)
+		default:
+			logger.Error("failed to activate camera", "camera_id", id, "error", err, "path", r.URL.Path)
+			WriteError(w, http.StatusInternalServerError, "failed to activate camera")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "activated"})
+}
+
+func (h *Handler) handleStopCamera(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if h.camMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
+		return
+	}
+	if err := h.camMgr.StopCamera(r.Context(), id); err != nil {
+		var cnf *model.CameraNotFoundError
+		if errors.As(err, &cnf) {
+			writeAPIError(w, http.StatusNotFound, err)
+		} else {
+			logger.Error("failed to stop camera", "camera_id", id, "error", err, "path", r.URL.Path)
+			WriteError(w, http.StatusInternalServerError, "failed to stop camera")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+}
+
+// handleRediscoverCamera manually triggers IP self-healing for a camera whose
+// network address may have changed (e.g. after an AP reboot across per-subnet
+// DHCP). It scans candidate subnets for a device whose ONVIF serial matches the
+// camera's StableID and, if found, updates the config and reconnects.
+
+// handleRediscoverCamera manually triggers IP self-healing for a camera whose
+// network address may have changed (e.g. after an AP reboot across per-subnet
+// DHCP). It scans candidate subnets for a device whose ONVIF serial matches the
+// camera's StableID and, if found, updates the config and reconnects.
+func (h *Handler) handleRediscoverCamera(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if h.camMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "camera manager not available")
+		return
+	}
+	// The unicast scan can take up to MaxDuration (default 30s) on a wide subnet
+	// hint list, so do not bind it to the request's lifetime.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	found, err := h.camMgr.RediscoverAndReconnect(ctx, id)
+	if err != nil {
+		var cnf *model.CameraNotFoundError
+		switch {
+		case errors.As(err, &cnf):
+			writeAPIError(w, http.StatusNotFound, err)
+		default:
+			logger.Error("rediscover camera failed", "camera_id", id, "error", err, "path", r.URL.Path)
+			WriteError(w, http.StatusInternalServerError, "rediscovery failed")
+		}
+		return
+	}
+	if !found {
+		// Not an error: camera may be unsupported (non-ONVIF), have no stable_id,
+		// or simply not be online in any candidate subnet yet.
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"found":  false,
+			"reason": "camera not found in candidate subnets (is it powered on? consider adding subnet_hints)",
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"found":  true,
+		"status": "reconnected",
+	})
+}
+
+// handleTestConnection attempts to connect to a camera URL with a short timeout.
+// Returns success/failure, a human-readable message, and the latency in milliseconds.
+
+// registerCameraRoutes registers all /api/cameras* routes (including nested
+// stream, ONVIF, PTZ, snapshot, merge-config, timelapse config, events, and
+// Xiaomi sub-routes) on the given (already auth-protected) router.
+// handleAdaptiveTrigger handles POST /api/cameras/{id}/adaptive/trigger
+// (issue #478): an external audio-activity event (e.g. a semantic classifier
+// running outside the NVR) forces the camera's adaptive gate out of timelapse
+// with the same GOP + pre-trigger back-fill as a loud window. Body:
+// {"source": "...", "hold": "10s", "dbfs": -23.4} — source/dbfs are
+// diagnostics only; hold (optional duration, 0–10m) extends how long
+// timelapse entry stays deferred after the event.
+func (h *Handler) handleAdaptiveTrigger(w http.ResponseWriter, r *http.Request) {
+	if h.camMgr == nil {
+		WriteError(w, http.StatusInternalServerError, "camera manager not available")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Source string  `json:"source"`
+		Hold   string  `json:"hold"`
+		DBFS   float64 `json:"dbfs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	var hold time.Duration
+	if body.Hold != "" {
+		d, err := time.ParseDuration(body.Hold)
+		if err != nil || d < 0 || d > 10*time.Minute {
+			WriteError(w, http.StatusBadRequest, "hold must be a duration between 0 and 10m")
+			return
+		}
+		hold = d
+	}
+	rec := h.camMgr.GetRecorder(id)
+	if rec == nil {
+		WriteError(w, http.StatusNotFound, "camera not found")
+		return
+	}
+	trig, ok := rec.(interface {
+		AudioTriggerEvent(at time.Time, hold time.Duration) error
+	})
+	if !ok {
+		WriteError(w, http.StatusBadRequest, "camera does not support adaptive triggers")
+		return
+	}
+	if err := trig.AudioTriggerEvent(time.Now(), hold); err != nil {
+		writeAPIError(w, http.StatusBadRequest, err)
+		return
+	}
+	logger.Info("external adaptive trigger",
+		"camera_id", id, "source", body.Source,
+		"hold", hold.String(), "dbfs", body.DBFS)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "triggered"})
+}

--- a/internal/api/handlers_camera_probe.go
+++ b/internal/api/handlers_camera_probe.go
@@ -1,0 +1,324 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
+)
+
+// handleTestConnection attempts to connect to a camera URL with a short timeout.
+// Returns success/failure, a human-readable message, and the latency in milliseconds.
+func (h *Handler) handleTestConnection(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Protocol      string `json:"protocol"`
+		URL           string `json:"url"`
+		Username      string `json:"username"`
+		Password      string `json:"password"`
+		Encoding      string `json:"encoding"`
+		ONVIFEndpoint string `json:"onvif_endpoint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.URL == "" && body.ONVIFEndpoint == "" {
+		WriteError(w, http.StatusBadRequest, "url is required")
+		return
+	}
+
+	target := body.URL
+	if body.Protocol == "onvif" && body.ONVIFEndpoint != "" {
+		target = body.ONVIFEndpoint
+	}
+
+	startTime := time.Now()
+
+	// ONVIF cameras get a real stream-access probe: the old HTTP-HEAD check could
+	// report success while the RTSP stream was unreachable or credentials were
+	// wrong for GetStreamUri — the root of the "test passes but no image" reports
+	// (issues #29/#30). The probe distinguishes reachable / stream-ok / codec-lie.
+	if body.Protocol == "onvif" {
+		probe := probeONVIFStream(r.Context(), target, body.Username, body.Password)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"success":    probe.StreamOK,
+			"reachable":  probe.Reachable,
+			"stream_ok":  probe.StreamOK,
+			"encoding":   probe.Encoding,
+			"codec_lie":  probe.CodecLie,
+			"message":    probe.reasonOrOK(),
+			"latency_ms": time.Since(startTime).Milliseconds(),
+		})
+		return
+	}
+
+	switch {
+	case strings.HasPrefix(target, "rtsp://"):
+		// RTSP: try TCP connection to the host:port
+		conn, err := net.DialTimeout("tcp", stripScheme(target), 3*time.Second)
+		if err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"success":    false,
+				"message":    fmt.Sprintf("connection refused: %v", err),
+				"latency_ms": time.Since(startTime).Milliseconds(),
+			})
+			return
+		}
+		conn.Close()
+
+	default:
+		// HTTP/ONVIF: try HEAD/GET request with timeout
+		client := &http.Client{Timeout: 3 * time.Second}
+		// For URLs with credentials, inject them
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodHead, target, nil)
+		if err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"success":    false,
+				"message":    fmt.Sprintf("invalid URL: %v", err),
+				"latency_ms": time.Since(startTime).Milliseconds(),
+			})
+			return
+		}
+		if body.Username != "" {
+			req.SetBasicAuth(body.Username, body.Password)
+		} else {
+			// Extract credentials from URL if present (e.g., http://admin:pass@host)
+			if parsed, err := url.Parse(target); err == nil && parsed.User != nil {
+				if u := parsed.User.Username(); u != "" {
+					p, _ := parsed.User.Password()
+					req.SetBasicAuth(u, p)
+				}
+			}
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"success":    false,
+				"message":    fmt.Sprintf("connection failed: %v", err),
+				"latency_ms": time.Since(startTime).Milliseconds(),
+			})
+			return
+		}
+		resp.Body.Close()
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success":    true,
+		"message":    "connection successful",
+		"latency_ms": time.Since(startTime).Milliseconds(),
+	})
+}
+
+// stripScheme extracts host:port from a URL string for TCP dialing.
+// Handles URLs with credentials (user:pass@host) by stripping userinfo.
+
+// stripScheme extracts host:port from a URL string for TCP dialing.
+// Handles URLs with credentials (user:pass@host) by stripping userinfo.
+func stripScheme(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL // fallback
+	}
+	host := parsed.Hostname()
+	port := parsed.Port()
+	if port == "" {
+		switch parsed.Scheme {
+		case "rtsp":
+			port = "554"
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			port = "554"
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// probeONVIFEncoding connects to an ONVIF device and retrieves the encoding
+// from the first media profile. Returns "H264" or "H265", or empty string on failure.
+// A bounded timeout is applied so a stuck device (e.g. ESP32 MiBeeCam with very
+// limited concurrent HTTP capacity) cannot block the camera-create request — the
+// caller context may outlive both the user's patience and the frontend fetch timeout.
+// probeONVIFEncoding returns the best-known video encoding ("H264" or "H265") for
+// an ONVIF device. It starts from the ONVIF profile declaration but verifies it
+// against the actual RTSP stream, because some HiSilicon-OEM cameras advertise H264
+// in their ONVIF profile while streaming H.265 (see ONVIFRecorder.detectEncoding).
+// If the RTSP DESCRIBE probe succeeds, its result is authoritative; otherwise the
+// ONVIF-declared encoding is returned as-is.
+// onvifStreamProbe is the structured result of probing an ONVIF device for real
+// stream access. It distinguishes "device reachable" from "stream actually
+// playable" — the old test-connection endpoint conflated the two (an HTTP HEAD
+// to the device_service URL can return 200 while the RTSP stream is unreachable
+// or the credentials are wrong for GetStreamUri), producing the "test passes but
+// no image" reports in issues #29/#30.
+
+// probeONVIFEncoding connects to an ONVIF device and retrieves the encoding
+// from the first media profile. Returns "H264" or "H265", or empty string on failure.
+// A bounded timeout is applied so a stuck device (e.g. ESP32 MiBeeCam with very
+// limited concurrent HTTP capacity) cannot block the camera-create request — the
+// caller context may outlive both the user's patience and the frontend fetch timeout.
+// probeONVIFEncoding returns the best-known video encoding ("H264" or "H265") for
+// an ONVIF device. It starts from the ONVIF profile declaration but verifies it
+// against the actual RTSP stream, because some HiSilicon-OEM cameras advertise H264
+// in their ONVIF profile while streaming H.265 (see ONVIFRecorder.detectEncoding).
+// If the RTSP DESCRIBE probe succeeds, its result is authoritative; otherwise the
+// ONVIF-declared encoding is returned as-is.
+// onvifStreamProbe is the structured result of probing an ONVIF device for real
+// stream access. It distinguishes "device reachable" from "stream actually
+// playable" — the old test-connection endpoint conflated the two (an HTTP HEAD
+// to the device_service URL can return 200 while the RTSP stream is unreachable
+// or the credentials are wrong for GetStreamUri), producing the "test passes but
+// no image" reports in issues #29/#30.
+type onvifStreamProbe struct {
+	Reachable bool   // ONVIF device_service responded to GetDeviceInformation/GetProfiles
+	StreamOK  bool   // an RTSP stream URI was resolved AND a DESCRIBE succeeded
+	Encoding  string // the REAL codec (RTSP DESCRIBE is authoritative; may differ from declared)
+	CodecLie  bool   // the ONVIF-declared codec disagrees with the real stream
+	Reason    string // human-readable explanation when Reachable/StreamOK is false
+}
+
+// onvifLooksLikeAuthError reports whether an ONVIF error smells like a
+// WS-Security rejection (the trigger for running the time-skew diagnosis).
+// Mirrors the onvif package's internal isAuthError but lives here to avoid
+// widening the onvif package's API surface.
+
+// onvifLooksLikeAuthError reports whether an ONVIF error smells like a
+// WS-Security rejection (the trigger for running the time-skew diagnosis).
+// Mirrors the onvif package's internal isAuthError but lives here to avoid
+// widening the onvif package's API surface.
+func onvifLooksLikeAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "NotAuthorized") ||
+		strings.Contains(s, "status 401") ||
+		strings.Contains(s, "status 403") ||
+		strings.Contains(s, "status 400")
+}
+
+// reasonOrOK returns the failure reason, or a success message when the stream
+// is healthy (used by the test-connection response so the frontend always has a
+// sensible message to show).
+
+// reasonOrOK returns the failure reason, or a success message when the stream
+// is healthy (used by the test-connection response so the frontend always has a
+// sensible message to show).
+func (p onvifStreamProbe) reasonOrOK() string {
+	if p.StreamOK {
+		if p.CodecLie {
+			return "stream accessible (declared codec corrected by RTSP probe)"
+		}
+		return "connection successful"
+	}
+	return p.Reason
+}
+
+// probeONVIFStream connects to an ONVIF device, resolves the stream URI, and
+// verifies the stream actually plays via an RTSP DESCRIBE. This is the
+// "does it really work?" check that the test-connection flow needs. It is also
+// the engine behind probeONVIFEncoding (which discards everything but encoding).
+
+// probeONVIFStream connects to an ONVIF device, resolves the stream URI, and
+// verifies the stream actually plays via an RTSP DESCRIBE. This is the
+// "does it really work?" check that the test-connection flow needs. It is also
+// the engine behind probeONVIFEncoding (which discards everything but encoding).
+func probeONVIFStream(ctx context.Context, endpoint, username, password string) onvifStreamProbe {
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	client := onvif.NewClient(endpoint, username, password)
+	if err := client.Connect(ctx); err != nil {
+		reason := fmt.Sprintf("could not connect to ONVIF service: %v", err)
+		// If it looks like an auth rejection, run the time-skew diagnosis so the
+		// user gets an actionable "sync the camera's clock" hint instead of a
+		// generic failure (Hikvision cameras reject digest auth on clock skew).
+		if onvifLooksLikeAuthError(err) {
+			if diag := client.DiagnoseAuth(ctx); diag.SkewDetected {
+				reason = diag.Diagnosis
+			}
+		}
+		return onvifStreamProbe{Reason: reason}
+	}
+	profiles, err := client.GetProfiles(ctx)
+	if err != nil {
+		reason := fmt.Sprintf("device responded but GetProfiles failed (credentials may be wrong, or ONVIF may be limited): %v", err)
+		if onvifLooksLikeAuthError(err) {
+			if diag := client.DiagnoseAuth(ctx); diag.SkewDetected {
+				reason = diag.Diagnosis
+			}
+		}
+		return onvifStreamProbe{
+			Reachable: true,
+			Reason:    reason,
+		}
+	}
+	if len(profiles) == 0 {
+		return onvifStreamProbe{
+			Reachable: true,
+			Reason:    "device responded but exposed no media profiles — check the camera's ONVIF/stream configuration",
+		}
+	}
+	declared := profiles[0].Encoding
+
+	si, err := client.GetStreamURI(ctx, profiles[0].Token)
+	if err != nil || si.URI == "" {
+		return onvifStreamProbe{
+			Reachable: true,
+			Reason:    "device responded but GetStreamUri failed — credentials may lack stream access, or the camera does not expose RTSP",
+		}
+	}
+
+	// RTSP DESCRIBE is authoritative for the codec (corrects cameras that lie —
+	// e.g. HiSilicon OEMs advertising H264 while streaming H265) AND confirms the
+	// stream is actually playable with the supplied credentials.
+	actual := recorder.ProbeRTSPEncoding(si.URI, username, password)
+	if actual == "" {
+		return onvifStreamProbe{
+			Reachable: true,
+			Reason:    "stream URI resolved but RTSP DESCRIBE failed — check that the RTSP port is reachable and credentials are correct",
+		}
+	}
+	codecLie := declared != "" && !strings.EqualFold(actual, declared)
+	if codecLie {
+		logger.Info("ONVIF-declared encoding corrected by RTSP probe",
+			"endpoint", endpoint, "declared", declared, "actual", actual)
+	}
+	return onvifStreamProbe{
+		Reachable: true,
+		StreamOK:  true,
+		Encoding:  actual,
+		CodecLie:  codecLie,
+	}
+}
+
+// probeONVIFEncoding returns just the resolved encoding (empty on failure),
+// preserving the original contract of the create-camera path. It now delegates
+// to probeONVIFStream so both paths share one probing implementation.
+
+// probeONVIFEncoding returns just the resolved encoding (empty on failure),
+// preserving the original contract of the create-camera path. It now delegates
+// to probeONVIFStream so both paths share one probing implementation.
+func probeONVIFEncoding(ctx context.Context, endpoint, username, password string) string {
+	return probeONVIFStream(ctx, endpoint, username, password).Encoding
+}
+
+// registerCameraRoutes registers all /api/cameras* routes (including nested
+// stream, ONVIF, PTZ, snapshot, merge-config, timelapse config, events, and
+// Xiaomi sub-routes) on the given (already auth-protected) router.
+// handleAdaptiveTrigger handles POST /api/cameras/{id}/adaptive/trigger
+// (issue #478): an external audio-activity event (e.g. a semantic classifier
+// running outside the NVR) forces the camera's adaptive gate out of timelapse
+// with the same GOP + pre-trigger back-fill as a loud window. Body:
+// {"source": "...", "hold": "10s", "dbfs": -23.4} — source/dbfs are
+// diagnostics only; hold (optional duration, 0–10m) extends how long
+// timelapse entry stays deferred after the event.


### PR DESCRIPTION
## 概要
issue #611 大文件拆分第二批（继 #615 repair 拆分）：\`internal/api/handlers_camera.go\` 按域拆为同包多文件，**纯移动、零逻辑变化**。

## 拆分结果
| 文件 | 行数 | 内容 |
|---|---|---|
| handlers_camera.go | 772 | cameraRowForAPI/injectYAMLConfigFields、List/Get/PushStatus/Update/Delete、probeCodec/resolveEncoding、registerCameraRoutes |
| handlers_camera_create.go | 379 | handleCreateCamera + validProtocols + gb28181ChannelPayload（GB 通道绑定 payload） |
| handlers_camera_lifecycle.go | 211 | RecordingStats/Start/Activate/Stop/Rediscover/AdaptiveTrigger |
| handlers_camera_probe.go | 324 | handleTestConnection + stripScheme + ONVIF 流探测族（probeONVIFStream/probeONVIFEncoding/onvifStreamProbe） |

## 验证
- \`go test -race ./internal/api/\` — 796 passed；\`make lint\` — 0 issues

Part of #611