### PR TITLE
fix(gb28181): cascade codec mis-detection on PSM-less mid-GOP joins (#625)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 )
 
 require (
-	github.com/mickeyzzc/gb28181-go v0.2.1
+	github.com/mickeyzzc/gb28181-go v0.2.2
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -95,10 +95,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mickeyzzc/gb28181-go v0.0.0-20260828151933-7d7a314ddf3a h1:rPfS1DoDgV8KlGUZEUMZrms2Z1nG06lJ8VaWCvNVp3w=
-github.com/mickeyzzc/gb28181-go v0.0.0-20260828151933-7d7a314ddf3a/go.mod h1:iBdMyROOcouMICmXo4lhHWGpopr7AX1B8RAFkoupx5A=
-github.com/mickeyzzc/gb28181-go v0.2.1 h1:ckyg8QGr804UY72CWXZtCti5jflnha4VHMKNEpF1HsQ=
-github.com/mickeyzzc/gb28181-go v0.2.1/go.mod h1:0OCiIGFWsdx6HXEysdaWcGk+JD+fURhwQIwIsNH9/cQ=
+github.com/mickeyzzc/gb28181-go v0.2.2 h1:Lq0sW++Nn2hmNGjiT3uvKjADrwgTx9CFTzMKa42HyGo=
+github.com/mickeyzzc/gb28181-go v0.2.2/go.mod h1:0OCiIGFWsdx6HXEysdaWcGk+JD+fURhwQIwIsNH9/cQ=
 github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2 h1:mbHQKNzFOWrSamcEuMEvqgSEUa79nMUntCFaW8XamvE=
 github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -46,21 +46,21 @@ type GB28181Config struct {
 type GB28181Recorder struct {
 	cfg GB28181Config
 	// Hub is set by camera.initStreamHub (same pattern as H264Recorder.Hub).
-	Hub            *streamhub.StreamHub
-	mu             sync.Mutex
-	status         model.RecorderStatus
-	sps, pps, vps  []byte
-	codecType      string
+	Hub             *streamhub.StreamHub
+	mu              sync.Mutex
+	status          model.RecorderStatus
+	sps, pps, vps   []byte
+	codecType       string
 	codecDefinitive bool // codecType came from a parameter-set NALU, not the encoding fallback
-	muxer         *muxer.MP4Muxer
-	trackID       int
-	curTemp       string
-	curFinal      string
-	segStart      time.Time
-	lastFrameTime time.Time
-	frameCount    int
-	ptsBase       int64 // first AU's RTP timestamp (90kHz), PTS origin
-	lastPtsTicks  int64 // last written AU's RTP timestamp (monotonic guard)
+	muxer           *muxer.MP4Muxer
+	trackID         int
+	curTemp         string
+	curFinal        string
+	segStart        time.Time
+	lastFrameTime   time.Time
+	frameCount      int
+	ptsBase         int64 // first AU's RTP timestamp (90kHz), PTS origin
+	lastPtsTicks    int64 // last written AU's RTP timestamp (monotonic guard)
 
 	// Audio state (PS audio demux, #340). The audio track is added lazily on
 	// the first frame — GB28181 streams may start video-only and interleave

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -46,11 +46,12 @@ type GB28181Config struct {
 type GB28181Recorder struct {
 	cfg GB28181Config
 	// Hub is set by camera.initStreamHub (same pattern as H264Recorder.Hub).
-	Hub           *streamhub.StreamHub
-	mu            sync.Mutex
-	status        model.RecorderStatus
-	sps, pps, vps []byte
-	codecType     string
+	Hub            *streamhub.StreamHub
+	mu             sync.Mutex
+	status         model.RecorderStatus
+	sps, pps, vps  []byte
+	codecType      string
+	codecDefinitive bool // codecType came from a parameter-set NALU, not the encoding fallback
 	muxer         *muxer.MP4Muxer
 	trackID       int
 	curTemp       string
@@ -181,8 +182,22 @@ func (r *GB28181Recorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 		r.mu.Unlock()
 		return
 	}
-	if r.codecType == "" && len(au) > 0 {
-		r.codecType = detectCodec(au, r.cfg.Encoding)
+	if r.codecType == "" || !r.codecDefinitive {
+		if c, definitive := detectCodecDetailed(au, r.cfg.Encoding); c != "" {
+			// A definitive parameter-set detection overrides an earlier
+			// encoding fallback: a session whose first AUs were P-frames
+			// mid-GOP latches the configured guess (default h264) and would
+			// otherwise wait for the wrong parameter sets forever when the
+			// real stream is the other codec (MiBeeNvr #625 — FLV/WS 503
+			// on H.265 cascade channels).
+			if r.codecType == "" || definitive {
+				if r.codecType != "" && r.codecType != c {
+					r.closeCurrentSegmentLocked()
+				}
+				r.codecType = c
+			}
+			r.codecDefinitive = r.codecDefinitive || definitive
+		}
 	}
 	if r.codecType == "h264" {
 		newSPS, newPPS, changed := updateParamSetsH264(au, r.sps, r.pps)

--- a/internal/recorder/gb28181_codec_latch_test.go
+++ b/internal/recorder/gb28181_codec_latch_test.go
@@ -1,0 +1,78 @@
+package recorder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+)
+
+// A mid-GOP session start delivers P-frames first: the recorder latches the
+// configured encoding guess (builder default h264 when the camera row is
+// empty). When the first real parameter-set NALUs arrive and reveal the other
+// codec, the definitive detection must OVERRIDE the guess — otherwise the
+// recorder waits for the wrong parameter sets forever (MiBeeNvr #625: H.265
+// cascade channel mis-latched as h264 → FLV/WS 503 "waiting for video
+// stream" on the upper platform).
+func TestGB28181Recorder_DefinitiveCodecOverridesFallback(t *testing.T) {
+	store, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+	rec := NewGB28181Recorder(GB28181Config{
+		CameraID:      "latch-cam",
+		Encoding:      "h264", // the fallback guess (actual stream is H.265)
+		SegmentDur:    time.Hour,
+		Store:         store,
+		RecordEnabled: true,
+	}, nil)
+	rec.Hub = streamhub.New()
+	rec.Hub.SetCameraID("latch-cam")
+	require.NoError(t, rec.Start(context.Background()))
+	defer rec.Stop()
+
+	// 1) P-frame first (H.265 TRAIL_R): latches the h264 fallback.
+	rec.WriteNALU([][]byte{{0x02, 0x01, 0x02, 0x03}}, 90000, false)
+	codec0, sps, _, _ := rec.CodecParams()
+	require.Equal(t, "h264", string(codec0))
+	require.Nil(t, sps)
+
+	// 2) The stream's real IDR arrives with H.265 parameter sets → override.
+	h265IDR := [][]byte{
+		{0x40, 0x01, 0x0c, 0x01}, // VPS
+		{0x42, 0x01, 0x01, 0x90}, // SPS
+		{0x44, 0x01, 0xc0, 0xac}, // PPS
+		{0x26, 0x01, 0xaf, 0x06}, // IDR_W_RADL slice
+	}
+	rec.WriteNALU(h265IDR, 93600, true)
+
+	codec, sps2, _, vps2 := rec.CodecParams()
+	require.Equal(t, "h265", string(codec), "definitive param sets must override the fallback guess")
+	require.NotNil(t, vps2, "H.265 VPS must be captured after the override")
+	require.NotNil(t, sps2, "H.265 SPS must be captured after the override")
+}
+
+// Once decided definitively, later AUs must not flip the codec again.
+func TestGB28181Recorder_DefinitiveCodecIsSticky(t *testing.T) {
+	store, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+	rec := NewGB28181Recorder(GB28181Config{
+		CameraID:      "sticky-cam",
+		Encoding:      "",
+		SegmentDur:    time.Hour,
+		Store:         store,
+		RecordEnabled: true,
+	}, nil)
+	rec.Hub = streamhub.New()
+	rec.Hub.SetCameraID("sticky-cam")
+	require.NoError(t, rec.Start(context.Background()))
+	defer rec.Stop()
+
+	h264AU := [][]byte{{0x67, 0x42, 0x00, 0x1e}, {0x68, 0xce, 0x38, 0x80}, {0x65, 0x88, 0x84}}
+	rec.WriteNALU(h264AU, 90000, true)
+	rec.WriteNALU([][]byte{{0x40, 0x01, 0x0c}}, 93600, false) // stray H.265-looking byte
+	codec, _, _, _ := rec.CodecParams()
+	require.Equal(t, "h264", string(codec), "definitive decision must be sticky")
+}

--- a/internal/recorder/gb28181_helpers.go
+++ b/internal/recorder/gb28181_helpers.go
@@ -12,6 +12,15 @@ import (
 // forever for VPS/SPS/PPS that never came and never opened a segment. AUs
 // without parameter sets defer to the configured encoding hint.
 func detectCodec(au [][]byte, encoding string) string {
+	c, _ := detectCodecDetailed(au, encoding)
+	return c
+}
+
+// detectCodecDetailed is detectCodec with definitiveness: definitive=true
+// means the codec was decided from a parameter-set NALU (reliable);
+// definitive=false means it fell back to the configured encoding hint — a
+// later definitive observation must be allowed to override it (#625).
+func detectCodecDetailed(au [][]byte, encoding string) (codec string, definitive bool) {
 	for _, nalu := range au {
 		if len(nalu) == 0 {
 			continue
@@ -22,7 +31,7 @@ func detectCodec(au [][]byte, encoding string) string {
 		}
 		t264 := firstByte & 0x1F
 		if t264 == 7 || t264 == 8 || t264 == 9 { // SPS / PPS / AUD — definitive
-			return "h264"
+			return "h264", true
 		}
 		if t264 == 1 || t264 == 5 {
 			// H.264 slices collide with H.265 param-set slots under the
@@ -32,13 +41,13 @@ func detectCodec(au [][]byte, encoding string) string {
 		}
 		t265 := (firstByte >> 1) & 0x3F
 		if t265 == 32 || t265 == 33 || t265 == 34 { // VPS / SPS / PPS — definitive
-			return "h265"
+			return "h265", true
 		}
 	}
 	if encoding != "" {
-		return encoding
+		return encoding, false
 	}
-	return ""
+	return "", false
 }
 
 func updateParamSetsH264(au [][]byte, currentSPS, currentPPS []byte) (newSPS, newPPS []byte, changed bool) {


### PR DESCRIPTION
Closes #625. Found during the v0.12.0 pre-release test pass; A/B-verified on the field box (old receiver binary correct, new receiver broken, same sender).

## Root cause (three stacked weaknesses)

1. **Sender — no PSM on mid-GOP session start**: the cascade muxer only attaches the PSM to IDR-flagged bursts, and the lib's content-based `auIsIDR` stays false until the next real IDR. Wire capture of channel …004 on M5: 3MB of cascade stream, **zero PSM**.
2. **Receiver demuxer — codec unknown without PSM**: psdemux reports "", so AU splitting and IDR tracking run generic → the upper's keyframe watchdog never confirms → 17s re-INVITE recycle loop.
3. **Recorder — fallback latch is final**: the first P-only AUs latch the encoding fallback (builder default h264); the `codecType != ""` guard then never re-detects, so the recorder waits for H.264 parameter sets that never arrive on an H.265 stream → FLV/WS 503 `waiting for video stream` forever.

## Fixes (two ends, three layers)

- **gb28181-go v0.2.1 → v0.2.2** (lib PR mickeyzzc/gb28181-go#22, CI green, tag pushed):
  - cascade: the session's FIRST burst always carries the PSM (`psStarted` latch); later bursts keep following auIsIDR;
  - psdemux: with no PSM seen, latch the codec from definitive parameter-set NALUs (0x67/0x68 vs 0x40/0x42/0x44 — unambiguous across syntaxes); a later PSM still wins.
- **recorder**: a definitive parameter-set detection overrides a non-definitive encoding fallback (`codecDefinitive` latch + defensive segment close on codec change). Slice-only AUs still defer.

## Tests

- Library: first-burst PSM presence (and second burst NOT re-sending), PSM-less h264/h265 latch, slice-only no-latch, stickiness — full lib suite green on Linux.
- NVR: `TestGB28181Recorder_DefinitiveCodecOverridesFallback` / `...IsSticky`; full `go test ./...` green on Linux against the official v0.2.2 tag.

Deploy-verification (M5 sender + fnOS receiver, both patched) follows in #625 before tagging v0.12.0.