### PR TITLE
test(upload): error-path coverage 61.9% → 77% (#611 weak areas)

### DIFF
--- a/internal/upload/handler_test.go
+++ b/internal/upload/handler_test.go
@@ -310,3 +310,154 @@ func TestUploadVideoWritesFile(t *testing.T) {
 	assert.False(t, info.IsDir(), "H264 segment should be a file")
 	assert.Equal(t, int64(len(videoData)), info.Size())
 }
+
+// errReader fails every Read — exercises the readBody error path.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, assert.AnError }
+
+// TestUploadBatch_BadContentType: non-multipart content type is rejected.
+func TestUploadBatch_BadContentType(t *testing.T) {
+	t.Parallel()
+	h, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam1/batch", bytes.NewReader(testJPEG))
+	req.Header.Set("Content-Type", "image/jpeg")
+	rec := httptest.NewRecorder()
+	newRouter(h).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "multipart/form-data")
+}
+
+// TestUploadBatch_GarbageMultipart: multipart content type with a body that
+// does not parse as multipart fails ParseMultipartForm.
+func TestUploadBatch_GarbageMultipart(t *testing.T) {
+	t.Parallel()
+	h, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam1/batch", bytes.NewReader([]byte("definitely not multipart")))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=x")
+	rec := httptest.NewRecorder()
+	newRouter(h).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to parse multipart form")
+}
+
+// TestUploadBatch_NoFramesField: a valid multipart form without any "frames"
+// parts is rejected.
+func TestUploadBatch_NoFramesField(t *testing.T) {
+	t.Parallel()
+	h, cleanup := setupTestEnv(t)
+	defer cleanup()
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("other", "note.txt")
+	require.NoError(t, err)
+	_, err = fw.Write([]byte("hi"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam1/batch", &buf)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	rec := httptest.NewRecorder()
+	newRouter(h).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no frames found")
+}
+
+// TestUploadVideo_Oversized: a video body past the limit is rejected 413.
+func TestUploadVideo_Oversized(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	mgr, err := storage.NewManager(filepath.Join(tmpDir, "storage"))
+	require.NoError(t, err)
+	db, err := storage.New(filepath.Join(tmpDir, "test.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	require.NoError(t, db.UpsertCamera(context.Background(), "cam2", "Cam", "rtsp", "h264", "rtsp://x", "", "", "", "", "", ""))
+	t.Cleanup(func() { _ = db.Close() })
+
+	h := NewHandler(mgr, db, 8)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam2/video", bytes.NewReader([]byte("0123456789ABCDEF")))
+	req.Header.Set("Content-Type", "video/mp4")
+	rec := httptest.NewRecorder()
+	newRouter(h).ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "maximum size")
+}
+
+// TestUploadBodyReadError: a failing request body surfaces as 500 on both
+// single-frame and video endpoints.
+func TestUploadBodyReadError(t *testing.T) {
+	t.Parallel()
+	h, cleanup := setupTestEnv(t)
+	defer cleanup()
+	r := newRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam1", errReader{})
+	req.Header.Set("Content-Type", "image/jpeg")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/api/upload/cam2/video", errReader{})
+	req2.Header.Set("Content-Type", "video/mp4")
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusInternalServerError, rec2.Code)
+}
+
+// TestUploadStorageFailure: a storage manager whose root is a regular file
+// cannot create segments — every upload endpoint answers 500.
+func TestUploadStorageFailure(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// A regular file planted at <root>/cam1 makes CreateSegment's camera-dir
+	// mkdir fail — every endpoint must answer 500 without touching the DB row.
+	mgr, err := storage.NewManager(filepath.Join(tmpDir, "storage"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "storage", "cam1"), []byte("x"), 0o644))
+
+	db, err := storage.New(filepath.Join(tmpDir, "test.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	require.NoError(t, db.UpsertCamera(context.Background(), "cam1", "Cam", "http", "jpeg", "http://x", "", "", "", "", "", ""))
+	t.Cleanup(func() { _ = db.Close() })
+
+	h := NewHandler(mgr, db, 1024*1024)
+	r := newRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload/cam1", bytes.NewReader(testJPEG))
+	req.Header.Set("Content-Type", "image/jpeg")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile("frames", "f.jpg")
+	require.NoError(t, err)
+	_, err = fw.Write(testJPEG)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	req2 := httptest.NewRequest(http.MethodPost, "/api/upload/cam1/batch", &buf)
+	req2.Header.Set("Content-Type", w.FormDataContentType())
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusInternalServerError, rec2.Code)
+
+	req3 := httptest.NewRequest(http.MethodPost, "/api/upload/cam1/video", bytes.NewReader([]byte("mp4")))
+	req3.Header.Set("Content-Type", "video/mp4")
+	rec3 := httptest.NewRecorder()
+	r.ServeHTTP(rec3, req3)
+	assert.Equal(t, http.StatusInternalServerError, rec3.Code)
+}


### PR DESCRIPTION
Second batch of the #611 weak-area backfill. `internal/upload` was the weakest remaining package (61.9%; rtsp 84.8% / whip 79.9% / rediscovery 83.5% already pass the bar).

Added error-branch tests:
- batch endpoint: non-multipart content type (400), garbage multipart body (400), multipart without `frames` parts (400)
- video endpoint: oversized body (413), failing body reader → readBody error (500)
- storage failure: file planted at `<root>/<camID>` makes CreateSegment mkdir fail → 500 on JPEG/batch/video

No production code touched.