### PR TITLE
fix(substream): re-resolve target after repeated pull failures

### DIFF
--- a/internal/substream/pull.go
+++ b/internal/substream/pull.go
@@ -28,6 +28,13 @@ var errNoVideo = errors.New("no H.264/H.265 video track in sub-stream SDP")
 // or collapsing timestamp (see pullOnce).
 const sessionGapPTS = 90000
 
+// reresolveFails is the number of consecutive pull failures after which the
+// pull loop re-runs the target resolver: a target resolved at Acquire time
+// can go stale when the camera's address changes (ONVIF rediscovery updates
+// the camera record, but this loop would otherwise keep dialing the old
+// host forever while references keep the entry alive).
+const reresolveFails = 6
+
 // pull runs the reconnect loop for one source until the entry is cancelled.
 // Exits when ctx is done, or after a permanent failure (leaving the source in
 // StateFailed and scheduling a self-recycle so a later Acquire re-resolves
@@ -37,6 +44,7 @@ func (m *Manager) pull(ctx context.Context, e *entry) {
 
 	cameraID := e.src.cameraID
 	backoff := time.Second
+	fails := 0
 	for {
 		if ctx.Err() != nil {
 			return
@@ -45,7 +53,7 @@ func (m *Manager) pull(ctx context.Context, e *entry) {
 		if e.target.Kind == KindGB28181 {
 			err = m.pullGBOnce(ctx, e, &backoff)
 		} else {
-			err = m.pullOnce(ctx, e, &backoff)
+			err = m.pullOnce(ctx, e, &backoff, &fails)
 		}
 		if ctx.Err() != nil {
 			return
@@ -65,6 +73,18 @@ func (m *Manager) pull(ctx context.Context, e *entry) {
 		e.src.state.Store(StateReconnecting)
 		subLogger.Warn("sub-stream pull error, reconnecting", "camera_id", cameraID,
 			"error", err, "backoff", backoff.String())
+		fails++
+		if fails%reresolveFails == 0 && e.target.Kind != KindGB28181 && m.cfg.Resolver != nil {
+			rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			t, ok, rerr := m.cfg.Resolver(rctx, cameraID)
+			cancel()
+			if rerr == nil && ok && t.URL != "" && t.URL != e.target.URL {
+				subLogger.Info("sub-stream target re-resolved after failures", "camera_id", cameraID,
+					"old", redactURL(e.target.URL), "new", redactURL(t.URL))
+				e.target = t
+				backoff = time.Second
+			}
+		}
 		select {
 		case <-ctx.Done():
 			return
@@ -78,13 +98,13 @@ func (m *Manager) pull(ctx context.Context, e *entry) {
 
 // pullOnce dials the target, plays the video track, and blocks until the
 // session fails, stalls, or ctx is done. backoff is reset once the session
-// reaches PLAY.
+// reaches PLAY (fails likewise — consecutive-failure counting restarts).
 //
 // RTP timestamps are per-session random bases; downstream muxers
 // (FLV/HLS/WS) require a monotonic timeline, so each session is REBASED to
 // continue 1s after the previous session's high-water mark (entry.lastPTS —
 // same failure class as #506's dts collapse otherwise).
-func (m *Manager) pullOnce(ctx context.Context, e *entry, backoff *time.Duration) error {
+func (m *Manager) pullOnce(ctx context.Context, e *entry, backoff *time.Duration, fails *int) error {
 	rawURL := e.target.URL
 	if e.target.Username != "" {
 		rawURL = injectCredentials(rawURL, e.target.Username, e.target.Password)
@@ -243,6 +263,7 @@ func (m *Manager) pullOnce(ctx context.Context, e *entry, backoff *time.Duration
 	}
 	setupTimer.Stop()
 	*backoff = time.Second
+	*fails = 0
 	src.state.Store(StateLive)
 	subLogger.Info("sub-stream live", "camera_id", src.cameraID, "codec", string(codec), "url", redactURL(rawURL))
 

--- a/internal/substream/substream_test.go
+++ b/internal/substream/substream_test.go
@@ -512,3 +512,65 @@ func TestStatusAndHubPerCamera(t *testing.T) {
 	require.Eventually(t, func() bool { return m.Status("cam-1") == nil }, 3*time.Second, 50*time.Millisecond)
 	require.Nil(t, m.Hub("cam-1"))
 }
+
+// TestPullReresolvesStaleTarget reproduces the camera-address-change trap:
+// the target resolved at Acquire time (a dead address) goes stale once the
+// camera record points elsewhere (ONVIF rediscovery). The pull loop must
+// re-resolve after consecutive failures and follow the camera to its new
+// address instead of dialing the old host forever — provided a reference
+// keeps the entry alive, exactly like a cascade INVITE session does.
+func TestPullReresolvesStaleTarget(t *testing.T) {
+	_, liveURL := newTestSource(t, model.FormatH264)
+
+	// An address that refuses connections instantly (the old camera host).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	deadURL := "rtsp://" + ln.Addr().String() + "/sub"
+	ln.Close()
+
+	var cur atomic.Value
+	cur.Store(deadURL)
+	m := newTestManager(t, deadURL, func(c *Config) {
+		c.Resolver = func(context.Context, string) (Target, bool, error) {
+			return Target{URL: cur.Load().(string)}, true, nil
+		}
+		// The caller outlives the stale-target phase, like a live INVITE.
+		c.ReadyTimeout = 40 * time.Second
+	})
+
+	type acquireRes struct {
+		src *Source
+		err error
+	}
+	ch := make(chan acquireRes, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+	go func() {
+		src, err := m.Acquire(ctx, "cam-move")
+		ch <- acquireRes{src, err}
+	}()
+
+	// The entry exists and is retrying the stale target.
+	require.Eventually(t, func() bool {
+		st := m.Status("cam-move")
+		return st != nil && (st.State == StateReconnecting || st.State == StateStarting)
+	}, 3*time.Second, 50*time.Millisecond)
+
+	// The camera record now points at the new address (rediscovery moment).
+	cur.Store(liveURL)
+
+	// The pull loop must re-resolve within a few backoff cycles and the
+	// blocked acquire must come back live on the new target.
+	select {
+	case r := <-ch:
+		require.NoError(t, r.err)
+		require.NotNil(t, r.src)
+	case <-time.After(35 * time.Second):
+		t.Fatal("acquire did not recover after the target was re-resolved")
+	}
+	// ready closes on the first AU (RTP callback) which can precede the
+	// pullOnce state transition to live — poll for the terminal state.
+	require.Eventually(t, func() bool {
+		return m.Status("cam-move").State == StateLive
+	}, 3*time.Second, 20*time.Millisecond)
+}


### PR DESCRIPTION
## Problem

A sub-stream target is resolved **once** at `Acquire` time and cached on the entry. If the camera's address changes afterwards (DHCP lease flip, camera reboot onto a new IP), the main recorder follows via ONVIF rediscovery — but the sub-stream pull loop keeps dialing the **old host forever**:

- `pull()` retries `e.target.URL` indefinitely; only `errNoVideo` triggers recycle+re-resolve.
- While any reference holds the entry (e.g. an active cascade INVITE session, per #512), the idle recycle never fires → the loop hammers a dead address with no exit.

Observed live on the test NVR: camera IP changed `.201 → `.200`; rediscovery updated the endpoint and the main stream recovered at 04:05, while the sub-stream puller kept dialing `rtsp://…201:554/12` for **2h+** (every 8s, `no route to host`), and the cascade channel downstream served a frozen GOP cache from 03:44.

## Fix

Every 6th **consecutive** pull failure, the loop re-runs `cfg.Resolver` (outside the manager lock, 10s-bounded) and swaps `e.target` when the resolved URL changed (backoff resets on swap). The failure counter resets once a session reaches PLAY. GB28181-kind targets are unaffected (URL ignored).

## Test

`TestPullReresolvesStaleTarget` reproduces the exact production sequence: a blocked `Acquire` (long ctx, holding a reference like an INVITE session) over a dead address; the resolver then flips to a live source; the pull follows within a few backoff cycles and the blocked acquire returns live. Full package suite green (15/15).
