### PR TITLE
fix(dashboard): 存储占用卡瞬时拉取失败不清空已有数据

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1788165282972';
+const CACHE_VERSION = 'mibee-nvr-1788166977820';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -286,7 +286,10 @@
       cameraStorageError = false;
     } catch (e) {
       console.warn('Failed to load camera storage stats:', e);
-      cameraStorageError = true;
+      // Keep the previous rows — a transient failure (e.g. the retention
+      // sweep contending with the GROUP BY) must not blank the card; the
+      // 30s poll retries. Only surface the error before the first load.
+      if (cameraStorage.length === 0) cameraStorageError = true;
     }
   }
 


### PR DESCRIPTION
#631 的跟进小修。

M5 实测时发现整点清理批量删除旧录像期间，`GET /api/stats/cameras` 的 GROUP BY 会与删除事务竞争出现瞬时 500 —— 原实现会把已渲染的占用列表整个替换成错误行，30s 后才恢复。改为**保留失败前的旧数据**，仅首次加载（尚无数据）失败才显示错误态；30s 轮询自然重试。

实机复现日志（a023b5a1 部署后 17:00 整点清理窗口，随后 3 次重试全部 200）。