### PR TITLE
fix(mqtt): wire trigger actions to camera lifecycle

### DIFF
--- a/internal/mqtt/actions.go
+++ b/internal/mqtt/actions.go
@@ -1,0 +1,75 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// CameraLifecycle is the camera-manager surface the MQTT trigger dispatcher
+// needs. Satisfied by *camera.CameraManager; narrow interface keeps the
+// dispatcher testable without the full manager.
+type CameraLifecycle interface {
+	StartCamera(ctx context.Context, cameraID string) error
+	StopCamera(ctx context.Context, cameraID string) error
+}
+
+// Trigger actions accepted on {prefix}/trigger/{camera_id}.
+const (
+	actionRecord   = "record"
+	actionStop     = "stop"
+	actionSnapshot = "snapshot"
+)
+
+// actionTimeout bounds one triggered lifecycle call (camera dial + recorder
+// start can legitimately take seconds; 30s leaves room for slow devices).
+const actionTimeout = 30 * time.Second
+
+var actionLogger = slog.Default().With("component", "mqtt-trigger")
+
+// NewActionDispatcher maps MQTT trigger actions to camera lifecycle
+// operations and returns the onAction callback for NewClient. Each action
+// runs on its own goroutine: the paho message handler must never block
+// (internal/mqtt anti-pattern), and StartCamera dials the camera.
+func NewActionDispatcher(lifecycle CameraLifecycle) func(cameraID, action string) {
+	return func(cameraID, action string) {
+		if action != actionRecord && action != actionStop {
+			switch action {
+			case actionSnapshot:
+				// TODO(#656): capture a frame and persist it to storage.
+				actionLogger.Warn("mqtt snapshot trigger is not implemented yet", "camera_id", cameraID)
+			default:
+				actionLogger.Warn("unknown mqtt trigger action ignored", "camera_id", cameraID, "action", action)
+			}
+			return
+		}
+		if lifecycle == nil {
+			actionLogger.Error("mqtt trigger dropped: no camera lifecycle wired", "camera_id", cameraID, "action", action)
+			return
+		}
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+			defer cancel()
+
+			var err error
+			if action == actionRecord {
+				err = lifecycle.StartCamera(ctx, cameraID)
+			} else {
+				err = lifecycle.StopCamera(ctx, cameraID)
+			}
+			if err != nil {
+				var running *model.CameraAlreadyRunningError
+				if errors.As(err, &running) {
+					actionLogger.Info("mqtt trigger: camera already recording", "camera_id", cameraID, "action", action)
+					return
+				}
+				actionLogger.Warn("mqtt trigger action failed", "camera_id", cameraID, "action", action, "error", err)
+				return
+			}
+			actionLogger.Info("mqtt trigger applied", "camera_id", cameraID, "action", action)
+		}()
+	}
+}

--- a/internal/mqtt/actions_test.go
+++ b/internal/mqtt/actions_test.go
@@ -1,0 +1,162 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLifecycle records lifecycle calls; blockFor simulates a slow camera dial.
+type fakeLifecycle struct {
+	mu       sync.Mutex
+	starts   []string
+	stops    []string
+	startErr error
+	stopErr  error
+	blockFor time.Duration
+}
+
+func (f *fakeLifecycle) StartCamera(_ context.Context, cameraID string) error {
+	if f.blockFor > 0 {
+		time.Sleep(f.blockFor)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.starts = append(f.starts, cameraID)
+	return f.startErr
+}
+
+func (f *fakeLifecycle) StopCamera(_ context.Context, cameraID string) error {
+	if f.blockFor > 0 {
+		time.Sleep(f.blockFor)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stops = append(f.stops, cameraID)
+	return f.stopErr
+}
+
+func (f *fakeLifecycle) started() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.starts...)
+}
+
+func (f *fakeLifecycle) stopped() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.stops...)
+}
+
+func TestActionDispatcher_Record_StartsCamera(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "record")
+
+	require.Eventually(t, func() bool {
+		return len(fake.started()) == 1
+	}, 15*time.Second, 50*time.Millisecond, "StartCamera should be called for the record action")
+	assert.Equal(t, []string{"cam-1"}, fake.started())
+	assert.Empty(t, fake.stopped())
+}
+
+func TestActionDispatcher_Stop_StopsCamera(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "stop")
+
+	require.Eventually(t, func() bool {
+		return len(fake.stopped()) == 1
+	}, 15*time.Second, 50*time.Millisecond, "StopCamera should be called for the stop action")
+	assert.Equal(t, []string{"cam-1"}, fake.stopped())
+	assert.Empty(t, fake.started())
+}
+
+func TestActionDispatcher_UnknownAction_NoCalls(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "reboot")
+
+	assert.Never(t, func() bool {
+		return len(fake.started())+len(fake.stopped()) > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "unknown actions must not touch the lifecycle")
+}
+
+func TestActionDispatcher_Snapshot_LogsOnly(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "snapshot")
+
+	assert.Never(t, func() bool {
+		return len(fake.started())+len(fake.stopped()) > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "snapshot is not wired to the lifecycle yet")
+}
+
+func TestActionDispatcher_AlreadyRunning_Idempotent(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{startErr: &model.CameraAlreadyRunningError{CameraID: "cam-1"}}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "record")
+
+	require.Eventually(t, func() bool {
+		return len(fake.started()) == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	// A duplicate trigger must not retry in a loop: the call count stays at 1.
+	assert.Never(t, func() bool {
+		return len(fake.started()) > 1
+	}, 500*time.Millisecond, 50*time.Millisecond)
+}
+
+func TestActionDispatcher_StartError_NotFatal(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{startErr: errors.New("dial timeout")}
+	dispatch := NewActionDispatcher(fake)
+
+	dispatch("cam-1", "record")
+	require.Eventually(t, func() bool {
+		return len(fake.started()) == 1
+	}, 15*time.Second, 50*time.Millisecond)
+
+	// The dispatcher keeps working after a failed action.
+	dispatch("cam-1", "stop")
+	require.Eventually(t, func() bool {
+		return len(fake.stopped()) == 1
+	}, 15*time.Second, 50*time.Millisecond)
+}
+
+func TestActionDispatcher_NonBlocking(t *testing.T) {
+	t.Helper()
+	fake := &fakeLifecycle{blockFor: 300 * time.Millisecond}
+	dispatch := NewActionDispatcher(fake)
+
+	start := time.Now()
+	dispatch("cam-1", "record")
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 50*time.Millisecond, "dispatcher must not block the paho handler goroutine")
+}
+
+func TestActionDispatcher_NilLifecycle_Noop(t *testing.T) {
+	t.Helper()
+	dispatch := NewActionDispatcher(nil)
+
+	dispatch("cam-1", "record")
+	dispatch("cam-1", "stop")
+	dispatch("cam-1", "snapshot")
+	dispatch("cam-1", "bogus")
+}

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -57,6 +57,13 @@ func (c *Client) IsConfigured() bool {
 	return c.brokerURL != ""
 }
 
+// HasActionHandler reports whether trigger messages are dispatched to an
+// action callback. Production wiring must pass a non-nil onAction; this lets
+// assembly tests assert the trigger path is actually connected.
+func (c *Client) HasActionHandler() bool {
+	return c != nil && c.onAction != nil
+}
+
 // Start connects to the MQTT broker and subscribes to trigger events.
 // It blocks until ctx is cancelled. If MQTT is not configured, it returns immediately.
 func (c *Client) Start(ctx context.Context) error {

--- a/internal/mqtt/client_test.go
+++ b/internal/mqtt/client_test.go
@@ -89,6 +89,16 @@ func TestIsConfigured(t *testing.T) {
 	assert.True(t, c.IsConfigured())
 }
 
+func TestHasActionHandler(t *testing.T) {
+	t.Helper()
+	cb := &mockCallback{}
+	withHandler := NewClient("tcp://localhost:1883", "test", "mibee-nvr", "", "", cb.callback)
+	assert.True(t, withHandler.HasActionHandler())
+
+	withoutHandler := NewClient("tcp://localhost:1883", "test", "mibee-nvr", "", "", nil)
+	assert.False(t, withoutHandler.HasActionHandler())
+}
+
 func TestNotConfiguredNoOp(t *testing.T) {
 	t.Helper()
 	c := NewClient("", "test", "mibee-nvr", "", "", nil)

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -805,9 +805,10 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	deps.cleanupMgr = cleanupMgr
 	deps.archiveDeleter = cleanup.NewArchiveDeleter(db, store)
 
-	// Step 9: Optional MQTT client
+	// Step 9: Optional MQTT client. The trigger dispatcher wires
+	// record/stop actions to the camera manager (camMgr is built at Step 5.6).
 	if cfg.MQTT.Enabled {
-		deps.mqttClient = mqtt.NewClient(cfg.MQTT.Broker, cfg.MQTT.ClientID, cfg.MQTT.Topic, cfg.MQTT.Username, cfg.MQTT.Password, nil)
+		deps.mqttClient = mqtt.NewClient(cfg.MQTT.Broker, cfg.MQTT.ClientID, cfg.MQTT.Topic, cfg.MQTT.Username, cfg.MQTT.Password, mqtt.NewActionDispatcher(deps.camMgr))
 	}
 
 	// Wire MQTT client into health manager for event publishing

--- a/pkg/app/mqtt_wiring_test.go
+++ b/pkg/app/mqtt_wiring_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"testing"
+)
+
+// TestBuildAppDeps_MQTTTriggerWired guards the production wiring: the MQTT
+// client must be constructed with a real action dispatcher so record/stop
+// trigger messages reach the camera manager (the subscription itself is
+// useless without it — regression guard for the onAction=nil wiring bug).
+func TestBuildAppDeps_MQTTTriggerWired(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+	cfg.MQTT.Enabled = true
+	cfg.MQTT.Broker = "tcp://127.0.0.1:1" // unreachable is fine: connect happens in Start, not build
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if deps.mqttClient == nil {
+		t.Fatal("deps.mqttClient is nil with mqtt.enabled=true")
+	}
+	if !deps.mqttClient.HasActionHandler() {
+		t.Fatal("deps.mqttClient has no action handler: MQTT trigger messages would be silently dropped")
+	}
+}
+
+func TestBuildAppDeps_MQTTDisabled_NoClient(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+	cfg.MQTT.Enabled = false
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if deps.mqttClient != nil {
+		t.Fatal("deps.mqttClient should be nil with mqtt.enabled=false")
+	}
+}


### PR DESCRIPTION
## Problem

The MQTT client subscribes to `{prefix}/trigger/+` and parses `{"action":...}` payloads, but production wiring passed a **nil** `onAction` callback (`pkg/app/builders.go` Step 9). Every `record`/`stop` trigger message was parsed and silently dropped — the trigger feature documented in `docs/{zh,en}/mqtt-integration.md` never worked in production.

## Changes

- `internal/mqtt/actions.go` — `NewActionDispatcher(CameraLifecycle)` maps `record`→`StartCamera`, `stop`→`StopCamera`:
  - each action runs on its own goroutine with a 30s timeout (paho handler goroutine must never block)
  - `CameraAlreadyRunningError` treated as idempotent success (info log, no retry storm)
  - `snapshot` action logs "not implemented yet" (persistence is a follow-up issue)
  - unknown actions log a warning, touch nothing
- `internal/mqtt/client.go` — `HasActionHandler()` so assembly tests can assert the trigger path is wired
- `pkg/app/builders.go` — construct the client with `mqtt.NewActionDispatcher(deps.camMgr)` (camMgr built at Step 5.6, before Step 9)

## Tests (TDD: red → green per behavior)

- 8 dispatcher tests (`actions_test.go`): record/stop mapping, unknown-action no-op, snapshot log-only, already-running idempotence, error-not-fatal, non-blocking (<50ms with 300ms lifecycle), nil-lifecycle no-op
- `TestHasActionHandler` (`client_test.go`)
- `TestBuildAppDeps_MQTTTriggerWired` / `_MQTTDisabled_NoClient` (`pkg/app/mqtt_wiring_test.go`) — regression guard against re-introducing nil

`go test -race ./internal/mqtt/ ./pkg/app/` clean; `golangci-lint` 0 issues.