### PR TITLE
feat(mqtt): opt-in event-bus status forwarding to MQTT

### DIFF
--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -208,6 +208,10 @@ type MQTTConfig struct {
 	ClientID string `yaml:"client_id"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+	// StatusEvents forwards whitelisted event-bus topics (segment completed,
+	// camera added/quality, storage health) to `{topic}/event/<event-topic>`.
+	// Opt-in, matching health.alerts.mqtt's posture. default false
+	StatusEvents bool `yaml:"status_events"`
 }
 
 // ObservabilityConfig defines observability settings

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1772,3 +1772,31 @@ func TestValidate_CameraRingBufCap(t *testing.T) {
 	err = Validate(base(10001))
 	require.ErrorContains(t, err, "ring_buf_cap")
 }
+
+func TestMQTTStatusEventsConfig(t *testing.T) {
+	t.Helper()
+
+	// Round-trip: status_events survives Save/Load.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mibee-nvr.yaml")
+	original := &Config{
+		MQTT: MQTTConfig{
+			Enabled:      true,
+			Broker:       "tcp://mqtt.local:1883",
+			Topic:        "mibee",
+			ClientID:     "mibee-nvr",
+			StatusEvents: true,
+		},
+	}
+	original.ApplyDefaults()
+	require.NoError(t, Save(path, original))
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	require.True(t, loaded.MQTT.StatusEvents, "status_events=true should round-trip")
+
+	// Default: opt-in, off unless explicitly enabled.
+	cfg := &Config{}
+	cfg.ApplyDefaults()
+	require.False(t, cfg.MQTT.StatusEvents, "default mqtt.status_events should be false")
+}

--- a/internal/mqtt/status_publisher.go
+++ b/internal/mqtt/status_publisher.go
@@ -1,0 +1,129 @@
+package mqtt
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+)
+
+// MQTTPublisher is the publish surface the status publisher needs.
+// Satisfied by *mqtt.Client; narrow interface keeps the publisher testable
+// without a broker (same duck-typing as health.AlertPipeline).
+type MQTTPublisher interface {
+	Publish(topic string, payload any) error
+}
+
+// statusTopics is the whitelist of event-bus topics forwarded to MQTT.
+// Published as `{topicPrefix}/event/<event-topic>` with the event payload
+// passed through unchanged (JSON-marshaled by Client.Publish). High-frequency
+// topics (ai.detection.*) stay off the whitelist on purpose.
+var statusTopics = []string{
+	event.TopicSegmentCompleted,
+	event.TopicCameraAdded,
+	event.TopicCameraQuality,
+	event.TopicStorageHealthChanged,
+}
+
+var statusLogger = slog.Default().With("component", "mqtt-status")
+
+// StatusPublisher forwards whitelisted event-bus topics to MQTT so smart-home
+// platforms (Home Assistant etc.) can consume NVR state without REST polling
+// or an SSE bridge. Implements the pkg/app Service interface.
+type StatusPublisher struct {
+	bus  *event.EventBus
+	mqtt MQTTPublisher
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+	subCh  chan event.Event
+}
+
+// NewStatusPublisher builds the publisher. mqtt may be nil until the broker
+// client connects — events observed before then are dropped with a warning.
+func NewStatusPublisher(bus *event.EventBus, mqtt MQTTPublisher) *StatusPublisher {
+	return &StatusPublisher{bus: bus, mqtt: mqtt}
+}
+
+// Name implements pkg/app.Service.
+func (p *StatusPublisher) Name() string { return "mqtt-status" }
+
+// Start subscribes to the whitelisted topics and launches the drain loop.
+func (p *StatusPublisher) Start(ctx context.Context) error {
+	p.mu.Lock()
+	if p.cancel != nil {
+		p.mu.Unlock()
+		return nil // already running
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	subCh := make(chan event.Event, 64)
+	p.cancel = cancel
+	p.subCh = subCh
+	done := make(chan struct{})
+	p.done = done
+	p.mu.Unlock()
+
+	for _, topic := range statusTopics {
+		if err := p.bus.Subscribe(topic, subCh, 64); err != nil {
+			p.stopLocked()
+			return err
+		}
+	}
+
+	go func() {
+		defer close(done)
+		p.run(runCtx, subCh)
+	}()
+	return nil
+}
+
+// Stop unsubscribes and joins the drain goroutine.
+func (p *StatusPublisher) Stop() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.stopLocked()
+	return nil
+}
+
+func (p *StatusPublisher) stopLocked() {
+	cancel, done, subCh := p.cancel, p.done, p.subCh
+	p.cancel, p.done, p.subCh = nil, nil, nil
+
+	if cancel != nil {
+		cancel()
+	}
+	if subCh != nil {
+		for _, topic := range statusTopics {
+			p.bus.Unsubscribe(topic, subCh)
+		}
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+// run drains events until ctx is cancelled. A slow broker can block here —
+// that is intentional backpressure: the bus drops the oldest event when the
+// channel is full, so recorders are never blocked.
+func (p *StatusPublisher) run(ctx context.Context, ch <-chan event.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt := <-ch:
+			p.forward(evt)
+		}
+	}
+}
+
+func (p *StatusPublisher) forward(evt event.Event) {
+	if p.mqtt == nil {
+		return
+	}
+	topic := "event/" + evt.Topic
+	if err := p.mqtt.Publish(topic, evt.Data); err != nil {
+		statusLogger.Warn("failed to forward event to MQTT", "topic", topic, "error", err)
+	}
+}

--- a/internal/mqtt/status_publisher_test.go
+++ b/internal/mqtt/status_publisher_test.go
@@ -1,0 +1,186 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStatusMQTT records Publish calls; err (when set) fails every publish.
+// attempts counts every call (failed ones included) so tests can observe the
+// drain loop's progress even while publishes fail.
+type mockStatusMQTT struct {
+	mu       sync.Mutex
+	topics   []string
+	payloads []any
+	attempts int
+	err      error
+}
+
+func (m *mockStatusMQTT) Publish(topic string, payload any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.attempts++
+	if m.err != nil {
+		return m.err
+	}
+	m.topics = append(m.topics, topic)
+	m.payloads = append(m.payloads, payload)
+	return nil
+}
+
+func (m *mockStatusMQTT) attemptCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.attempts
+}
+
+func (m *mockStatusMQTT) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.topics)
+}
+
+func (m *mockStatusMQTT) last() (string, any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.topics) == 0 {
+		return "", nil
+	}
+	return m.topics[len(m.topics)-1], m.payloads[len(m.payloads)-1]
+}
+
+func (m *mockStatusMQTT) setErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func newStatusTestBus(t *testing.T) *event.EventBus {
+	t.Helper()
+	return event.NewEventBus(64)
+}
+
+func TestStatusPublisher_ForwardsSegmentCompleted(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { require.NoError(t, p.Stop()) }()
+
+	seg := event.SegmentCompleted{
+		CameraID:    "cam-1",
+		FilePath:    "cam-1/2026/rec.mp4",
+		Format:      "mp4",
+		Encoding:    "h264",
+		RecordingID: "rec-42",
+	}
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, seg)
+
+	require.Eventually(t, func() bool {
+		return mock.calls() == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	topic, payload := mock.last()
+	assert.Equal(t, "event/segment.completed", topic)
+	assert.Equal(t, seg, payload)
+}
+
+func TestStatusPublisher_ForwardsCameraAdded(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { require.NoError(t, p.Stop()) }()
+
+	payload := map[string]any{"camera_id": "front-door", "name": "前门"}
+	bus.Publish(context.Background(), event.TopicCameraAdded, payload)
+
+	require.Eventually(t, func() bool {
+		return mock.calls() == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	topic, got := mock.last()
+	assert.Equal(t, "event/camera.added", topic)
+	assert.Equal(t, payload, got)
+}
+
+func TestStatusPublisher_IgnoresOtherTopics(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { require.NoError(t, p.Stop()) }()
+
+	bus.Publish(context.Background(), event.TopicAIDetection, map[string]any{"camera_id": "cam-1"})
+
+	assert.Never(t, func() bool {
+		return mock.calls() > 0
+	}, 300*time.Millisecond, 50*time.Millisecond, "non-whitelisted topics must not be forwarded")
+}
+
+func TestStatusPublisher_StopUnsubscribes(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{CameraID: "cam-1"})
+	require.Eventually(t, func() bool {
+		return mock.calls() == 1
+	}, 15*time.Second, 50*time.Millisecond)
+
+	require.NoError(t, p.Stop())
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{CameraID: "cam-1"})
+	assert.Never(t, func() bool {
+		return mock.calls() > 1
+	}, 300*time.Millisecond, 50*time.Millisecond, "events after Stop must not be forwarded")
+}
+
+func TestStatusPublisher_PublishErrorNotFatal(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{err: errors.New("broker down")}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { require.NoError(t, p.Stop()) }()
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{CameraID: "cam-1"})
+	// Wait until the drain loop has processed (and failed) the first event
+	// before clearing the error, so exactly one publish can succeed.
+	require.Eventually(t, func() bool {
+		return mock.attemptCount() == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	mock.setErr(nil)
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{CameraID: "cam-2"})
+
+	require.Eventually(t, func() bool {
+		return mock.calls() == 1
+	}, 15*time.Second, 50*time.Millisecond, "the second event must still be forwarded after a failed publish")
+}
+
+func TestStatusPublisher_NilMQTT_Noop(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	p := NewStatusPublisher(bus, nil)
+	require.NoError(t, p.Start(context.Background()))
+
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{CameraID: "cam-1"})
+
+	require.NoError(t, p.Stop())
+}
+
+func TestStatusPublisher_Name(t *testing.T) {
+	t.Helper()
+	p := NewStatusPublisher(newStatusTestBus(t), &mockStatusMQTT{})
+	assert.Equal(t, "mqtt-status", p.Name())
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -816,6 +816,13 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		healthMgr.SetMQTTClient(deps.mqttClient)
 	}
 
+	// Opt-in event-bus → MQTT forwarding (`{prefix}/event/<topic>`) so
+	// smart-home platforms consume NVR state without REST polling or an
+	// SSE bridge. mqtt.status_events must be explicitly enabled.
+	if cfg.MQTT.Enabled && cfg.MQTT.StatusEvents {
+		deps.mqttStatusPub = mqtt.NewStatusPublisher(deps.eventBus, deps.mqttClient)
+	}
+
 	// Step 10: Optional FTP server
 	if cfg.FTP.Enabled != nil && *cfg.FTP.Enabled {
 		ftpAddr := fmt.Sprintf(":%d", cfg.FTP.Port)

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -82,6 +82,7 @@ type appDeps struct {
 
 	// Ingest listeners (optional)
 	mqttClient        *mqtt.Client
+	mqttStatusPub     *mqtt.StatusPublisher
 	ftpServer         *ftp.Server
 	rtmpServer        *rtmp.Server
 	srtListener       *srt.Listener

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -337,6 +337,21 @@ func registerServices(a *App, deps *appDeps) error {
 		}
 	}
 
+	// 8.5 mqtt-status (optional): event-bus → MQTT forwarding
+	if deps.mqttStatusPub != nil {
+		if err := a.Register(&serviceFunc{
+			name: "mqtt-status",
+			startFunc: func(ctx context.Context) error {
+				return deps.mqttStatusPub.Start(ctx)
+			},
+			stopFunc: func() error {
+				return deps.mqttStatusPub.Stop()
+			},
+		}); err != nil {
+			return fmt.Errorf("register mqtt-status: %w", err)
+		}
+	}
+
 	// 9. ftp (optional)
 	if deps.ftpServer != nil {
 		if err := a.Register(&serviceFunc{

--- a/pkg/app/run_test.go
+++ b/pkg/app/run_test.go
@@ -464,3 +464,59 @@ func TestRunFree_DoesNotBlockOnStorageScan(t *testing.T) {
 	}
 	t.Logf("RunFree returned in %v with seeded storage tree", elapsed)
 }
+
+// TestRunFree_ServiceOrder_MQTTStatusEvents asserts the mqtt and mqtt-status
+// services register in their slots (after archive-deleter, before rtsp) when
+// mqtt.enabled + mqtt.status_events are both on.
+func TestRunFree_ServiceOrder_MQTTStatusEvents(t *testing.T) {
+	t.Helper()
+	cfg, _ := minimalConfig(t)
+
+	cfg.MQTT.Enabled = true
+	cfg.MQTT.Broker = "tcp://127.0.0.1:1" // unreachable: connect happens in Start, not registration
+	cfg.MQTT.StatusEvents = true
+
+	a, err := RunFree(cfg, filepath.Join(cfg.Storage.RootDir, "mibee-nvr.yaml"))
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+
+	svcs := a.Services()
+	t.Logf("observed Services() = %v", svcs)
+
+	expected := []string{"storage-migrator", "db", "startup-bg", "camera", "health", "recording-auditor", "merge", "rolling-merge", "motion-score", "mergeScheduler", "cleanup", "archive-deleter", "mqtt", "mqtt-status", "rtsp", "ws", "hls", "api-handler", "pprof-loopback"}
+	if len(svcs) != len(expected) {
+		t.Errorf("Services() count = %d, want %d", len(svcs), len(expected))
+	}
+	for i, want := range expected {
+		if i >= len(svcs) {
+			t.Errorf("Services()[%d] missing, want %q", i, want)
+			continue
+		}
+		if svcs[i] != want {
+			t.Errorf("Services()[%d] = %q, want %q", i, svcs[i], want)
+		}
+	}
+}
+
+// TestRunFree_ServiceOrder_MQTTStatusEventsDisabled asserts mqtt-status stays
+// absent when status_events is off (opt-in), even with mqtt.enabled=true.
+func TestRunFree_ServiceOrder_MQTTStatusEventsDisabled(t *testing.T) {
+	t.Helper()
+	cfg, _ := minimalConfig(t)
+
+	cfg.MQTT.Enabled = true
+	cfg.MQTT.Broker = "tcp://127.0.0.1:1"
+	cfg.MQTT.StatusEvents = false
+
+	a, err := RunFree(cfg, filepath.Join(cfg.Storage.RootDir, "mibee-nvr.yaml"))
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+
+	for _, name := range a.Services() {
+		if name == "mqtt-status" {
+			t.Errorf("Services() contains %q, want absent when mqtt.status_events=false", name)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

For smart-home integration (Home Assistant etc.), NVR state currently requires REST polling or an SSE→MQTT bridge (Node-RED/AppDaemon). The event bus already carries the interesting state; this forwards a whitelist of it to MQTT.

## Changes

- `mqtt.status_events` config flag (**default false**, opt-in — same posture as `health.alerts.mqtt`); round-trip + default covered by `TestMQTTStatusEventsConfig`
- `internal/mqtt/status_publisher.go` — `StatusPublisher` service (`mqtt-status`, registered right after `mqtt`):
  - whitelist: `segment.completed`, `camera.added`, `camera.quality`, `storage.health.changed`
  - published to `{prefix}/event/<event-topic>` with the payload passed through unchanged
  - one channel + drain goroutine (motion.Analyzer pattern); slow broker = intentional backpressure, bus drops on overflow so recorders never block
  - publish errors are logged and never kill the drain loop
- Wiring: `builders.go` (construct when `mqtt.enabled && mqtt.status_events`), `register.go` slot 8.5, `deps.go`

## Tests (TDD)

- 8 publisher tests (`status_publisher_test.go`): segment/camera.added forwarding, non-whitelisted topic ignored, Stop unsubscribes, publish-error not fatal, nil-MQTT noop, name
- `TestRunFree_ServiceOrder_MQTTStatusEvents` (+ disabled variant) — exact service-order slice with the new slot
- `go test -race ./internal/mqtt/ ./internal/config/ ./pkg/app/` clean; golangci-lint 0 issues

Docs (mqtt-integration.md 状态发布 section + Home Assistant guide) follow in a separate docs PR.