### PR TITLE
chore(storage): statfs 跨平台化——解禁 Windows 宿主本地测试

### DIFF
--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -161,12 +160,10 @@ func (m *Manager) Roots() []string {
 // GetRootUsage returns total/free bytes of the filesystem containing root —
 // the capacity gate for per-camera migrations.
 func (m *Manager) GetRootUsage(root string) (total, free int64, err error) {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(root, &stat); err != nil {
+	total, free, err = statfsFree(root)
+	if err != nil {
 		return 0, 0, fmt.Errorf("storage: failed to stat %q: %w", root, err)
 	}
-	total = int64(stat.Blocks * uint64(stat.Bsize))
-	free = int64(stat.Bfree * uint64(stat.Bsize))
 	return total, free, nil
 }
 
@@ -552,16 +549,11 @@ func (m *Manager) DeleteCameraDir(cameraID string) error {
 
 // GetDiskUsage returns total and used disk space for the filesystem containing rootDir.
 func (m *Manager) GetDiskUsage() (total int64, used int64, err error) {
-	var stat syscall.Statfs_t
-
-	if err := syscall.Statfs(m.currentRoot(), &stat); err != nil {
+	var free int64
+	total, free, err = statfsFree(m.currentRoot())
+	if err != nil {
 		return 0, 0, fmt.Errorf("storage: failed to stat filesystem: %w", err)
 	}
-
-	// Total space in bytes
-	total = int64(stat.Blocks * uint64(stat.Bsize))
-	// Free space in bytes
-	free := int64(stat.Bfree * uint64(stat.Bsize))
 	// Used = total - free
 	used = total - free
 

--- a/internal/storage/statfs_linux.go
+++ b/internal/storage/statfs_linux.go
@@ -1,0 +1,18 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd
+
+package storage
+
+import "syscall"
+
+// statfsFree reports total and free bytes of the filesystem containing path.
+// Unix variant (Statfs; darwin/bsd share the API with a different stat
+// layout, both expose Blocks/Bsize/Bfree as uint64-compatible fields).
+func statfsFree(path string) (total, free int64, err error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, 0, err
+	}
+	total = int64(stat.Blocks * uint64(stat.Bsize))
+	free = int64(stat.Bfree * uint64(stat.Bsize))
+	return total, free, nil
+}

--- a/internal/storage/statfs_windows.go
+++ b/internal/storage/statfs_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package storage
+
+import "golang.org/x/sys/windows"
+
+// statfsFree reports total and free bytes of the filesystem containing path.
+// Windows variant via GetDiskFreeSpaceEx — keeps the package compilable (and
+// unit-testable) on dev Windows boxes; the NVR itself targets Linux.
+func statfsFree(path string) (total, free int64, err error) {
+	var (
+		freeCaller, totalC, freeC uint64
+	)
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := windows.GetDiskFreeSpaceEx(p, &freeCaller, &totalC, &freeC); err != nil {
+		return 0, 0, err
+	}
+	return int64(totalC), int64(freeC), nil
+}


### PR DESCRIPTION
GetRootUsage / GetDiskUsage 的 syscall.Statfs 抽成 statfsFree (statfs_linux.go / statfs_windows.go build tags; Windows 用 x/sys GetDiskFreeSpaceEx)。

此前 storage 包在 Windows 开发机上无法编译,本地 go test 不可用;抽层后除 transcoding(Setpgid/Setpriority 系 Linux-only)外全仓可在宿主构建。纯重构,行为不变,两平台各走各的实现。