### PR TITLE
fix(health): suppress false restart announcement for blacklisted cameras (#645)

### DIFF
--- a/internal/health/auto_remediate.go
+++ b/internal/health/auto_remediate.go
@@ -154,9 +154,16 @@ func (r *AutoRemediator) Check(cameraID string, status string) error {
 		if offline < timeout {
 			return nil // brief reconnect blip — let the recorder's own backoff handle it
 		}
-		// Stuck in reconnect long enough — fall through to restart logic.
-		slog.Info("auto-remediate: recorder stuck in reconnecting, triggering restart",
-			"camera_id", cameraID, "offline_duration", offline, "threshold", timeout)
+		// Stuck in reconnect long enough — fall through to restart logic. A
+		// blacklisted camera cannot be restarted (the blacklist gate below will
+		// skip it), so don't announce a restart that will never happen; the
+		// skip stays visible as CheckAll's single "skipped" line with the
+		// blacklist expiry. The blacklist branch itself (periodic rediscovery
+		// rescan) still runs — only the log is suppressed (#645).
+		if !r.IsBlacklisted(cameraID) {
+			slog.Info("auto-remediate: recorder stuck in reconnecting, triggering restart",
+				"camera_id", cameraID, "offline_duration", offline, "threshold", timeout)
+		}
 	} else if status != string(model.StatusError) {
 		return nil
 	}

--- a/internal/health/auto_remediate_test.go
+++ b/internal/health/auto_remediate_test.go
@@ -1,7 +1,10 @@
 package health
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -149,6 +152,51 @@ func TestAutoRemediator_ReconnectingBelowTimeoutIgnored(t *testing.T) {
 	}
 	if got := mock.callCount(t); got != 0 {
 		t.Fatalf("expected 0 restart calls for brief reconnecting, got %d", got)
+	}
+}
+
+// TestAutoRemediator_BlacklistedReconnectingNoFalseRestartAnnouncement covers
+// #645: a blacklisted camera stuck in reconnecting must NOT log "triggering
+// restart" — the blacklist gate below blocks the restart moments later, so on
+// the 10s health tick the announcement is a false claim spammed forever
+// (production: 303 log lines/hour, all no-ops). The skip stays observable as
+// exactly one line per tick: CheckAll's "auto-remediate skipped" WARN carrying
+// the blacklist expiry. The periodic blacklist rescan must still dispatch.
+//
+// Sequential (no t.Parallel): swaps the global default slog logger.
+func TestAutoRemediator_BlacklistedReconnectingNoFalseRestartAnnouncement(t *testing.T) {
+	cfg := config.HealthAutoRemediationConfig{
+		Enabled:            true,
+		MaxRestartsPerHour: 3,
+		CooldownMinutes:    0,
+		BlacklistHours:     1,
+		GlobalMaxPerMin:    100,
+	}
+	r, mock, _ := newTestRemediatorWithConfig(t, cfg)
+	r.SetOfflineDurationFn(func(string) time.Duration { return 15 * time.Minute }) // > 10min default
+	blacklistCamera(t, r, "cam-1")
+	restartsBefore := mock.callCount(t)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	// One health tick for a blacklisted, reconnecting camera — the exact
+	// production scenario from the issue.
+	r.CheckAll(map[string]string{"cam-1": string(model.StatusReconnecting)})
+
+	if got := mock.callCount(t); got != restartsBefore {
+		t.Fatalf("blacklist must still block restarts: %d calls before, %d after", restartsBefore, got)
+	}
+	if strings.Contains(buf.String(), "triggering restart") {
+		t.Fatalf("blacklisted camera must not announce a restart that cannot happen; log:\n%s", buf.String())
+	}
+	if n := strings.Count(buf.String(), "auto-remediate skipped"); n != 1 {
+		t.Fatalf("expected exactly 1 skip line per tick, got %d; log:\n%s", n, buf.String())
+	}
+	if !strings.Contains(buf.String(), "blacklisted until") {
+		t.Fatalf("skip line must carry the blacklist expiry; log:\n%s", buf.String())
 	}
 }
 


### PR DESCRIPTION
## 问题 (#645)

M5 生产观测:处于 reconnecting 且已被 blacklist 的相机,健康检查每个 tick(10s)打两条日志:

```
INFO  auto-remediate: recorder stuck in reconnecting, triggering restart
WARN  auto-remediate skipped error="camera ... is blacklisted until ..."
```

一小时 303 条,动作全部被 blacklist 拦下——"triggering restart" 是无效宣告。根因:`Check()` 在 reconnecting 分支先打 INFO 宣告(`internal/health/auto_remediate.go:158`),blacklist 检查(safety check 3)发生在其后。

## 修复

blacklist 判断前置到宣告处:被 blacklist 时不再打 "triggering restart"。每 tick 只剩一条明确的 skip 日志(`CheckAll` 的 WARN,带 blacklist 截止时间),即 issue 建议的两条合一。

**注意**:不是提前 return——blacklist 分支内的周期性 rediscovery rescan 逻辑不受影响,只压制日志。重连退避本身(`internal/recorder/reconnect.go`)无需改动。

## 测试 (TDD)

- RED 先行:`TestAutoRemediator_BlacklistedReconnectingNoFalseRestartAnnouncement` 复现 issue 场景(blacklisted + reconnecting + offline>timeout + CheckAll 单 tick),断言无 "triggering restart"、恰 1 条 skip、带 "blacklisted until"
- GREEN:`internal/health/` 全套 127 项通过,`-race` 干净,`golangci-lint` 0 issues

Closes #645