### PR TITLE
fix(recorder): semantic SPS comparison + rotation gating — stop segment rotation storms (#642)

### DIFF
--- a/internal/merge/rolling_live.go
+++ b/internal/merge/rolling_live.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
@@ -345,9 +346,20 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 			"camera_id", seg.cameraID, "recording_id", seg.recordingID, "dropped", dropped)
 	}
 
-	// Compute SPS/PPS compatibility key.
+	// Compute SPS/PPS compatibility key. The SPS contributes its semantic
+	// decode key, not raw bytes (#642): cameras alternating decode-equivalent
+	// SPS encodings (VUI/timing-only differences) per GOP must not split/
+	// re-spawn buckets at segment granularity — with the raw bytes, bucket
+	// keys flip every segment whenever consecutive segments happened to be
+	// created under different variants. PPS/VPS have no semantic parser and
+	// stay raw (their variant flapping is rotation-rate-limited upstream).
+	// Unparseable SPS falls back to raw bytes (conservative split).
+	spsKeyBytes := newInfo.SPS
+	if key, ok := nalutil.SPSSemanticKey(newInfo.SPS, newInfo.Codec == "h265"); ok && key != "" {
+		spsKeyBytes = []byte(key)
+	}
 	h := sha256.New()
-	h.Write(newInfo.SPS)
+	h.Write(spsKeyBytes)
 	h.Write(newInfo.PPS)
 	h.Write(newInfo.VPS)
 	spsKey := hex.EncodeToString(h.Sum(nil))

--- a/internal/model/nalutil/sps_semantic.go
+++ b/internal/model/nalutil/sps_semantic.go
@@ -1,0 +1,597 @@
+// SPS semantic comparison for segment-rotation decisions.
+//
+// Some cameras (observed: a Xiaomi 2K PTZ model) alternate between two SPS
+// encodings that differ only in VUI/timing decoration — semantically
+// equivalent, byte-level different. Byte-equality rotation checks turned that
+// into a segment-rotation storm: 188 rotations in 4.9h, each spawning a new
+// rolling-merge bucket (MiBeeNvr #642). Comparing SPS semantically — every
+// field that affects decodability, ignoring VUI — suppresses those rotations.
+//
+// The trick: H.264/H.265 SPS syntax is a fixed-order bitstream and Exp-Golomb
+// coding is canonical, so two SPSs with equal pre-VUI field values ALWAYS
+// produce equal bit prefixes. Hashing the consumed RBSP prefix through the end
+// of the pre-VUI syntax (frame_cropping for H.264, strong_intra_smoothing for
+// H.265) is therefore an exact comparison over all decodability-relevant
+// fields, without enumerating them individually.
+
+package nalutil
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+// semBitReader reads bits from an RBSP, MSB first. It is deliberately local to
+// this file: the merge package keeps its own parser for resolution extraction;
+// this one exists to count consumed bits for prefix hashing.
+type semBitReader struct {
+	data   []byte
+	offset int
+}
+
+func (r *semBitReader) readBit() (int, error) {
+	if r.offset >= len(r.data)*8 {
+		return 0, fmt.Errorf("nalutil: sps bitReader overflow at bit %d (rbsp %d bits)", r.offset, len(r.data)*8)
+	}
+	byteIdx := r.offset / 8
+	bitIdx := 7 - (r.offset % 8)
+	r.offset++
+	return int((r.data[byteIdx] >> bitIdx) & 1), nil
+}
+
+func (r *semBitReader) readBits(n int) (int, error) {
+	val := 0
+	for range n {
+		bit, err := r.readBit()
+		if err != nil {
+			return 0, err
+		}
+		val = (val << 1) | bit
+	}
+	return val, nil
+}
+
+func (r *semBitReader) readUE() (int, error) {
+	leadingZeros := 0
+	for {
+		bit, err := r.readBit()
+		if err != nil {
+			return 0, err
+		}
+		if bit == 1 {
+			break
+		}
+		leadingZeros++
+		if leadingZeros > 32 {
+			return 0, fmt.Errorf("nalutil: sps readUE leadingZeros overflow (%d)", leadingZeros)
+		}
+	}
+	if leadingZeros == 0 {
+		return 0, nil
+	}
+	bits, err := r.readBits(leadingZeros)
+	if err != nil {
+		return 0, err
+	}
+	return (1 << leadingZeros) - 1 + bits, nil
+}
+
+func (r *semBitReader) readSE() (int, error) {
+	val, err := r.readUE()
+	if err != nil {
+		return 0, err
+	}
+	if val%2 == 0 {
+		return -(val / 2), nil
+	}
+	return (val + 1) / 2, nil
+}
+
+// semRemoveEPB strips emulation prevention bytes (0x00 0x00 0x03 → 0x00 0x00).
+func semRemoveEPB(data []byte) []byte {
+	var result []byte
+	i := 0
+	for i < len(data) {
+		if i+2 < len(data) && data[i] == 0 && data[i+1] == 0 && data[i+2] == 3 {
+			result = append(result, 0, 0)
+			i += 3
+		} else {
+			result = append(result, data[i])
+			i++
+		}
+	}
+	return result
+}
+
+// prefixKey hashes codec + consumed bit count + the masked RBSP prefix into a
+// stable key. The final partial byte has its unconsumed low bits zeroed so two
+// prefixes that merely happen to share trailing bytes cannot collide.
+func prefixKey(codec byte, rbsp []byte, bits int) string {
+	n := (bits + 7) / 8
+	if n > len(rbsp) {
+		n = len(rbsp)
+	}
+	prefix := make([]byte, n)
+	copy(prefix, rbsp[:n])
+	if rem := bits % 8; rem != 0 && n > 0 {
+		prefix[n-1] &= byte(0xFF) << (8 - rem)
+	}
+	h := sha256.New()
+	h.Write([]byte{codec})
+	var bitsBuf [8]byte
+	binary.BigEndian.PutUint64(bitsBuf[:], uint64(bits))
+	h.Write(bitsBuf[:])
+	h.Write(prefix)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// SPSSemanticKey returns a canonical key over every SPS field that affects
+// decodability — for H.264 from profile_idc through the frame cropping
+// offsets; for H.265 from the NAL header through
+// strong_intra_smoothing_enabled_flag. VUI parameters (timing info, bitstream
+// restrictions) and everything after them are deliberately excluded: they do
+// not change how samples decode. ok=false when the SPS cannot be parsed —
+// callers must then fall back to byte comparison (conservative: rotate on any
+// difference).
+func SPSSemanticKey(sps []byte, isH265 bool) (key string, ok bool) {
+	if isH265 {
+		return h265SPSKey(sps)
+	}
+	return h264SPSKey(sps)
+}
+
+// SPSSemanticallyEqual reports whether two SPS NAL units (without start-code
+// prefixes) are interchangeable for decoding: equal across all
+// decodability-relevant fields, possibly differing only in VUI/timing
+// decoration. When either SPS cannot be parsed it degrades to byte equality —
+// a difference then means "rotate", preserving the pre-#642 conservative
+// behavior for malformed input.
+func SPSSemanticallyEqual(a, b []byte, isH265 bool) bool {
+	if EqualParamSets(a, b) {
+		return true
+	}
+	ka, okA := SPSSemanticKey(a, isH265)
+	kb, okB := SPSSemanticKey(b, isH265)
+	return okA && okB && ka == kb
+}
+
+// h264SPSKey parses an H.264 SPS (NAL header byte excluded from the key —
+// nal_ref_idc differences are irrelevant) through the frame cropping offsets
+// and hashes the consumed prefix.
+func h264SPSKey(sps []byte) (string, bool) {
+	if len(sps) < 8 {
+		return "", false
+	}
+	rbsp := semRemoveEPB(sps[1:])
+	if len(rbsp) < 4 {
+		return "", false
+	}
+	r := &semBitReader{data: rbsp}
+
+	profileIDC, err := r.readBits(8)
+	if err != nil {
+		return "", false
+	}
+	if _, err = r.readBits(8); err != nil { // constraint_set_flags
+		return "", false
+	}
+	if _, err = r.readBits(8); err != nil { // level_idc
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // seq_parameter_set_id
+		return "", false
+	}
+
+	highProfile := profileIDC == 100 || profileIDC == 110 || profileIDC == 122 ||
+		profileIDC == 244 || profileIDC == 44 || profileIDC == 83 ||
+		profileIDC == 86 || profileIDC == 118 || profileIDC == 128 ||
+		profileIDC == 138 || profileIDC == 139 || profileIDC == 134
+
+	if highProfile {
+		chromaFormatIDC, err := r.readUE()
+		if err != nil {
+			return "", false
+		}
+		if chromaFormatIDC == 3 {
+			if _, err = r.readBit(); err != nil { // separate_colour_plane_flag
+				return "", false
+			}
+		}
+		if _, err = r.readUE(); err != nil { // bit_depth_luma_minus8
+			return "", false
+		}
+		if _, err = r.readUE(); err != nil { // bit_depth_chroma_minus8
+			return "", false
+		}
+		if _, err = r.readBit(); err != nil { // qpprime_y_zero_transform_bypass_flag
+			return "", false
+		}
+		scalingPresent, err := r.readBit()
+		if err != nil {
+			return "", false
+		}
+		if scalingPresent == 1 {
+			count := 8
+			if chromaFormatIDC == 3 {
+				count = 12
+			}
+			for i := range count {
+				present, err := r.readBit()
+				if err != nil {
+					return "", false
+				}
+				if present == 1 {
+					size := 16
+					if i >= 6 {
+						size = 64
+					}
+					for range size {
+						if _, err = r.readSE(); err != nil { // delta_scale
+							return "", false
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if _, err = r.readUE(); err != nil { // log2_max_frame_num_minus4
+		return "", false
+	}
+	picOrderCntType, err := r.readUE()
+	if err != nil {
+		return "", false
+	}
+	if picOrderCntType == 0 {
+		if _, err = r.readUE(); err != nil { // log2_max_pic_order_cnt_lsb_minus4
+			return "", false
+		}
+	} else if picOrderCntType == 1 {
+		if _, err = r.readBit(); err != nil { // delta_pic_order_always_zero_flag
+			return "", false
+		}
+		if _, err = r.readSE(); err != nil { // offset_for_non_ref_pic
+			return "", false
+		}
+		if _, err = r.readSE(); err != nil { // offset_for_top_to_bottom_field
+			return "", false
+		}
+		numRefFrames, err := r.readUE()
+		if err != nil {
+			return "", false
+		}
+		for range numRefFrames {
+			if _, err = r.readSE(); err != nil { // offset_for_ref_frame[i]
+				return "", false
+			}
+		}
+	}
+
+	if _, err = r.readUE(); err != nil { // max_num_ref_frames
+		return "", false
+	}
+	if _, err = r.readBit(); err != nil { // gaps_in_frame_num_value_allowed_flag
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // pic_width_in_mbs_minus1
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // pic_height_in_map_units_minus1
+		return "", false
+	}
+	frameMbsOnly, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if frameMbsOnly == 0 {
+		if _, err = r.readBit(); err != nil { // mb_adaptive_frame_field_flag
+			return "", false
+		}
+	}
+	if _, err = r.readBit(); err != nil { // direct_8x8_inference_flag
+		return "", false
+	}
+	frameCropping, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if frameCropping == 1 {
+		for range 4 { // frame_crop_left/right/top/bottom_offset
+			if _, err = r.readUE(); err != nil {
+				return "", false
+			}
+		}
+	}
+	// VUI starts here — intentionally excluded from the key.
+	return prefixKey(0x64, rbsp, r.offset), true
+}
+
+// h265SPSKey parses an H.265 SPS through strong_intra_smoothing_enabled_flag
+// and hashes the consumed prefix. Scaling lists are the one bail-out: their
+// DPCM syntax is not worth reimplementing for a comparison used only as a
+// rotation gate, and cameras with scaling lists are effectively nonexistent —
+// the caller falls back to byte comparison for them.
+func h265SPSKey(sps []byte) (string, bool) {
+	if len(sps) < 8 {
+		return "", false
+	}
+	rbsp := semRemoveEPB(sps[2:]) // skip the 2-byte NAL header
+	if len(rbsp) < 13 {
+		return "", false
+	}
+	r := &semBitReader{data: rbsp}
+
+	if _, err := r.readBits(4); err != nil { // sps_video_parameter_set_id
+		return "", false
+	}
+	maxSubLayersMinus1, err := r.readBits(3)
+	if err != nil {
+		return "", false
+	}
+	if _, err = r.readBit(); err != nil { // sps_temporal_id_nesting_flag
+		return "", false
+	}
+
+	// profile_tier_level(1, maxSubLayersMinus1) — general part.
+	if _, err = r.readBits(8); err != nil { // general_profile_space/tier/idc
+		return "", false
+	}
+	if _, err = r.readBits(32); err != nil { // general_profile_compatibility_flag[32]
+		return "", false
+	}
+	if _, err = r.readBits(48); err != nil { // general constraint indicator flags
+		return "", false
+	}
+	if _, err = r.readBits(8); err != nil { // general_level_idc
+		return "", false
+	}
+	// Sub-layer part. Track the presence flags, then consume the actual
+	// sub-layer profile/level payloads (unlike a resolution-only parser, a
+	// semantic key cannot skip them — they affect decode).
+	subProfilePresent := make([]bool, maxSubLayersMinus1)
+	subLevelPresent := make([]bool, maxSubLayersMinus1)
+	for i := range maxSubLayersMinus1 {
+		pp, err := r.readBit()
+		if err != nil {
+			return "", false
+		}
+		lp, err := r.readBit()
+		if err != nil {
+			return "", false
+		}
+		subProfilePresent[i] = pp == 1
+		subLevelPresent[i] = lp == 1
+	}
+	if maxSubLayersMinus1 > 0 {
+		for range 8 - maxSubLayersMinus1 {
+			if _, err = r.readBits(2); err != nil { // reserved_zero_2bits
+				return "", false
+			}
+		}
+	}
+	for i := range maxSubLayersMinus1 {
+		if subProfilePresent[i] {
+			if _, err = r.readBits(8 + 32 + 48); err != nil {
+				return "", false
+			}
+		}
+		if subLevelPresent[i] {
+			if _, err = r.readBits(8); err != nil {
+				return "", false
+			}
+		}
+	}
+
+	if _, err = r.readUE(); err != nil { // sps_seq_parameter_set_id
+		return "", false
+	}
+	chromaFormatIDC, err := r.readUE()
+	if err != nil {
+		return "", false
+	}
+	if chromaFormatIDC == 3 {
+		if _, err = r.readBit(); err != nil { // separate_colour_plane_flag
+			return "", false
+		}
+	}
+	if _, err = r.readUE(); err != nil { // pic_width_in_luma_samples
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // pic_height_in_luma_samples
+		return "", false
+	}
+	confWindow, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if confWindow == 1 {
+		for range 4 { // conf_win_left/right/top/bottom_offset
+			if _, err = r.readUE(); err != nil {
+				return "", false
+			}
+		}
+	}
+	if _, err = r.readUE(); err != nil { // bit_depth_luma_minus8
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // bit_depth_chroma_minus8
+		return "", false
+	}
+	log2MaxPocLsbMinus4, err := r.readUE()
+	if err != nil {
+		return "", false
+	}
+
+	orderingInfoPresent, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	start := 0
+	if orderingInfoPresent == 0 {
+		start = maxSubLayersMinus1
+	}
+	for i := start; i <= maxSubLayersMinus1; i++ {
+		if _, err = r.readUE(); err != nil { // sps_max_dec_pic_buffering_minus1[i]
+			return "", false
+		}
+		if _, err = r.readUE(); err != nil { // sps_max_num_reorder_pics[i]
+			return "", false
+		}
+		if _, err = r.readUE(); err != nil { // sps_max_latency_increase_plus1[i]
+			return "", false
+		}
+	}
+
+	if _, err = r.readUE(); err != nil { // log2_min_luma_coding_block_size_minus3
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // log2_diff_max_min_luma_coding_block_size
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // log2_min_luma_transform_block_size_minus2
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // log2_diff_max_min_luma_transform_block_size
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // max_transform_hierarchy_depth_inter
+		return "", false
+	}
+	if _, err = r.readUE(); err != nil { // max_transform_hierarchy_depth_intra
+		return "", false
+	}
+	scalingListEnabled, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if scalingListEnabled == 1 {
+		return "", false // conservative: fall back to byte comparison
+	}
+	if _, err = r.readBit(); err != nil { // amp_enabled_flag
+		return "", false
+	}
+	if _, err = r.readBit(); err != nil { // sample_adaptive_offset_enabled_flag
+		return "", false
+	}
+	pcmEnabled, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if pcmEnabled == 1 {
+		if _, err = r.readBits(4); err != nil { // pcm_sample_bit_depth_luma_minus1
+			return "", false
+		}
+		if _, err = r.readBits(4); err != nil { // pcm_sample_bit_depth_chroma_minus1
+			return "", false
+		}
+		if _, err = r.readUE(); err != nil { // log2_min_pcm_luma_coding_block_size_minus3
+			return "", false
+		}
+		if _, err = r.readUE(); err != nil { // log2_diff_max_min_pcm_luma_coding_block_size
+			return "", false
+		}
+		if _, err = r.readBit(); err != nil { // pcm_loop_filter_disabled_flag
+			return "", false
+		}
+	}
+
+	numSTRefPicSets, err := r.readUE()
+	if err != nil {
+		return "", false
+	}
+	numDeltaPocs := make([]int, numSTRefPicSets)
+	for idx := range numSTRefPicSets {
+		interPred := 0
+		if idx != 0 {
+			if interPred, err = r.readBit(); err != nil {
+				return "", false
+			}
+		}
+		if interPred == 1 {
+			// In an SPS (as opposed to a slice header) RefRpsIdx is always
+			// idx-1: the delta_idx_minus1 field only exists when
+			// idx == num_short_term_ref_pic_sets, which cannot happen here.
+			if _, err = r.readBit(); err != nil { // delta_rps_sign
+				return "", false
+			}
+			if _, err = r.readUE(); err != nil { // abs_delta_rps_minus1
+				return "", false
+			}
+			count := 0
+			for range numDeltaPocs[idx-1] + 1 {
+				used, err := r.readBit()
+				if err != nil {
+					return "", false
+				}
+				if used == 1 {
+					count++
+					continue
+				}
+				useDelta, err := r.readBit()
+				if err != nil {
+					return "", false
+				}
+				if useDelta == 1 {
+					count++
+				}
+			}
+			numDeltaPocs[idx] = count
+		} else {
+			numNeg, err := r.readUE()
+			if err != nil {
+				return "", false
+			}
+			numPos, err := r.readUE()
+			if err != nil {
+				return "", false
+			}
+			for range numNeg {
+				if _, err = r.readUE(); err != nil { // delta_poc_s0_minus1[i]
+					return "", false
+				}
+				if _, err = r.readBit(); err != nil { // used_by_curr_pic_s0_flag[i]
+					return "", false
+				}
+			}
+			for range numPos {
+				if _, err = r.readUE(); err != nil { // delta_poc_s1_minus1[i]
+					return "", false
+				}
+				if _, err = r.readBit(); err != nil { // used_by_curr_pic_s1_flag[i]
+					return "", false
+				}
+			}
+			numDeltaPocs[idx] = numNeg + numPos
+		}
+	}
+
+	longTermPresent, err := r.readBit()
+	if err != nil {
+		return "", false
+	}
+	if longTermPresent == 1 {
+		numLongTerm, err := r.readUE()
+		if err != nil {
+			return "", false
+		}
+		ltLsbBits := log2MaxPocLsbMinus4 + 4
+		for range numLongTerm {
+			if _, err = r.readBits(ltLsbBits); err != nil { // lt_ref_pic_poc_lsb_sps[i]
+				return "", false
+			}
+			if _, err = r.readBit(); err != nil { // used_by_curr_pic_lt_sps_flag[i]
+				return "", false
+			}
+		}
+	}
+	if _, err = r.readBit(); err != nil { // sps_temporal_mvp_enabled_flag
+		return "", false
+	}
+	if _, err = r.readBit(); err != nil { // strong_intra_smoothing_enabled_flag
+		return "", false
+	}
+	// vui_parameters_present_flag and everything after are excluded.
+	return prefixKey(0x1A, rbsp, r.offset), true
+}

--- a/internal/model/nalutil/sps_semantic_test.go
+++ b/internal/model/nalutil/sps_semantic_test.go
@@ -1,0 +1,386 @@
+package nalutil
+
+import (
+	"bytes"
+	"testing"
+)
+
+// --- Test bit writer: builds SPS RBSP bitstreams field by field ---
+
+type spsBits struct {
+	buf []byte
+	n   int // bits written
+}
+
+func (w *spsBits) u(val, width int) {
+	for i := width - 1; i >= 0; i-- {
+		bit := (val >> i) & 1
+		byteIdx := w.n / 8
+		if byteIdx >= len(w.buf) {
+			w.buf = append(w.buf, 0)
+		}
+		if bit == 1 {
+			w.buf[byteIdx] |= byte(1 << (7 - w.n%8))
+		}
+		w.n++
+	}
+}
+
+func (w *spsBits) ue(v int) {
+	// Exp-Golomb: codeNum v → leading zeros + info bits
+	val := v + 1
+	bits := 0
+	for m := val; m > 1; m >>= 1 {
+		bits++
+	}
+	w.u(0, bits)
+	w.u(val, bits+1)
+}
+
+// trailing writes the rbsp_stop_one_bit plus zero padding to the byte boundary.
+func (w *spsBits) trailing() {
+	w.u(1, 1)
+	if w.n%8 != 0 {
+		w.u(0, 8-w.n%8)
+	}
+}
+
+// insertEPB inserts H.264/H.265 emulation prevention bytes (0x03) into an RBSP
+// so it becomes a valid NAL payload.
+func insertEPB(rbsp []byte) []byte {
+	var out []byte
+	zeros := 0
+	for _, b := range rbsp {
+		if zeros >= 2 && b <= 3 {
+			out = append(out, 0x03)
+			zeros = 0
+		}
+		out = append(out, b)
+		if b == 0 {
+			zeros++
+		} else {
+			zeros = 0
+		}
+	}
+	return out
+}
+
+// --- H.264 SPS builders (baseline profile, 640x352) ---
+
+// buildH264SPS writes a baseline-profile H.264 SPS up to frame_cropping, then a
+// caller-differentiable VUI. timingScale controls the VUI time_scale field —
+// the classic encoder "decoration" difference that must NOT trigger rotation.
+func buildH264SPS(t *testing.T, timingScale int, withVUI bool) []byte {
+	t.Helper()
+	w := &spsBits{}
+	w.u(66, 8) // profile_idc = baseline
+	w.u(0, 8)  // constraint_set flags
+	w.u(30, 8) // level_idc
+	w.ue(0)    // seq_parameter_set_id
+	w.ue(0)    // log2_max_frame_num_minus4
+	w.ue(0)    // pic_order_cnt_type = 0
+	w.ue(0)    // log2_max_pic_order_cnt_lsb_minus4
+	w.ue(1)    // max_num_ref_frames
+	w.u(0, 1)  // gaps_in_frame_num_value_allowed_flag
+	w.ue(39)   // pic_width_in_mbs_minus1  → 640
+	w.ue(21)   // pic_height_in_map_units_minus1 → 352
+	w.u(1, 1)  // frame_mbs_only_flag
+	w.u(1, 1)  // direct_8x8_inference_flag
+	w.u(0, 1)  // frame_cropping_flag
+	if withVUI {
+		w.u(1, 1)            // vui_parameters_present_flag
+		w.u(0, 1)            // aspect_ratio_info_present_flag
+		w.u(0, 1)            // overscan_info_present_flag
+		w.u(0, 1)            // video_signal_type_present_flag
+		w.u(0, 1)            // chroma_loc_info_present_flag
+		w.u(1, 1)            // timing_info_present_flag
+		w.u(1, 32)           // num_units_in_tick
+		w.u(timingScale, 32) // time_scale  ← the variant difference
+		w.u(1, 1)            // fixed_frame_rate_flag
+		w.u(0, 1)            // nal_hrd_parameters_present_flag
+		w.u(0, 1)            // vcl_hrd_parameters_present_flag
+		w.u(0, 1)            // pic_struct_present_flag
+		w.u(0, 1)            // bitstream_restriction_flag
+	} else {
+		w.u(0, 1) // vui_parameters_present_flag
+	}
+	w.trailing()
+	return append([]byte{0x67}, insertEPB(w.buf)...)
+}
+
+// buildH264SPSWide is buildH264SPS with a real codec difference (1280 wide).
+func buildH264SPSWide(t *testing.T) []byte {
+	t.Helper()
+	w := &spsBits{}
+	w.u(66, 8)
+	w.u(0, 8)
+	w.u(30, 8)
+	w.ue(0)
+	w.ue(0)
+	w.ue(0)
+	w.ue(0)
+	w.ue(1)
+	w.u(0, 1)
+	w.ue(79) // 1280 wide
+	w.ue(21)
+	w.u(1, 1)
+	w.u(1, 1)
+	w.u(0, 1)
+	w.u(0, 1)
+	w.trailing()
+	return append([]byte{0x67}, insertEPB(w.buf)...)
+}
+
+// buildH264SPSHighProfile changes profile_idc to 77 (Main) — a real difference.
+// Note: a true Main-profile SPS would carry the extra chroma/bit-depth syntax;
+// for the key comparison the differing profile byte alone must produce a
+// different key.
+func buildH264SPSHighProfile(t *testing.T) []byte {
+	t.Helper()
+	w := &spsBits{}
+	w.u(77, 8) // profile_idc = Main
+	w.u(0, 8)
+	w.u(30, 8)
+	w.ue(0)
+	w.ue(0)
+	w.ue(0)
+	w.ue(0)
+	w.ue(1)
+	w.u(0, 1)
+	w.ue(39)
+	w.ue(21)
+	w.u(1, 1)
+	w.u(1, 1)
+	w.u(0, 1)
+	w.u(0, 1)
+	w.trailing()
+	return append([]byte{0x67}, insertEPB(w.buf)...)
+}
+
+// --- H.265 SPS builders (Main profile, 640x352) ---
+
+// buildH265SPS writes a minimal Main-profile HEVC SPS through
+// strong_intra_smoothing, then a caller-differentiable VUI.
+func buildH265SPS(t *testing.T, timingScale int, withVUI bool) []byte {
+	t.Helper()
+	w := &spsBits{}
+	w.u(0, 4) // sps_video_parameter_set_id
+	w.u(0, 3) // sps_max_sub_layers_minus1
+	w.u(1, 1) // sps_temporal_id_nesting_flag
+	// profile_tier_level (general only, no sub-layers)
+	w.u(0, 2)           // general_profile_space
+	w.u(0, 1)           // general_tier_flag
+	w.u(1, 5)           // general_profile_idc = Main
+	w.u(0x60000000, 32) // general_profile_compatibility_flag[32]
+	w.u(0, 48)          // general constraint indicator flags + progressive etc.
+	w.u(120, 8)         // general_level_idc
+	w.ue(0)             // sps_seq_parameter_set_id
+	w.ue(1)             // chroma_format_idc = 4:2:0
+	w.ue(640)           // pic_width_in_luma_samples
+	w.ue(352)           // pic_height_in_luma_samples
+	w.u(0, 1)           // conformance_window_flag
+	w.ue(0)             // bit_depth_luma_minus8
+	w.ue(0)             // bit_depth_chroma_minus8
+	w.ue(4)             // log2_max_pic_order_cnt_lsb_minus4
+	w.u(1, 1)           // sps_sub_layer_ordering_info_present_flag
+	w.ue(1)             // sps_max_dec_pic_buffering_minus1[0]
+	w.ue(0)             // sps_max_num_reorder_pics[0]
+	w.ue(0)             // sps_max_latency_increase_plus1[0]
+	w.ue(0)             // log2_min_luma_coding_block_size_minus3
+	w.ue(2)             // log2_diff_max_min_luma_coding_block_size
+	w.ue(0)             // log2_min_luma_transform_block_size_minus2
+	w.ue(3)             // log2_diff_max_min_luma_transform_block_size
+	w.ue(0)             // max_transform_hierarchy_depth_inter
+	w.ue(0)             // max_transform_hierarchy_depth_intra
+	w.u(0, 1)           // scaling_list_enabled_flag
+	w.u(0, 1)           // amp_enabled_flag
+	w.u(1, 1)           // sample_adaptive_offset_enabled_flag
+	w.u(0, 1)           // pcm_enabled_flag
+	w.ue(0)             // num_short_term_ref_pic_sets
+	w.u(0, 1)           // long_term_ref_pics_present_flag
+	w.u(0, 1)           // sps_temporal_mvp_enabled_flag
+	w.u(0, 1)           // strong_intra_smoothing_enabled_flag
+	if withVUI {
+		w.u(1, 1)            // vui_parameters_present_flag
+		w.u(0, 1)            // aspect_ratio_info_present_flag
+		w.u(0, 1)            // interlace_conformance... (overscan)
+		w.u(0, 1)            // video_signal_type_present_flag
+		w.u(0, 1)            // chroma_loc_info_present_flag
+		w.u(1, 1)            // timing_info_present_flag
+		w.u(1, 32)           // num_units_in_tick
+		w.u(timingScale, 32) // time_scale ← the variant difference
+		w.u(1, 1)            // poc_proportional_to_timing_flag
+		w.u(1, 32)           // num_ticks_poc_diff_one_minus1
+		w.u(0, 1)            // hrd_parameters_present_flag
+		w.u(0, 1)            // bitstream_restriction_flag
+	} else {
+		w.u(0, 1)
+	}
+	w.trailing()
+	return append([]byte{0x42, 0x01}, insertEPB(w.buf)...)
+}
+
+// --- Real-camera SPS fixtures (from internal/merge/sps_test.go) ---
+
+var realH264SPS640 = []byte{
+	0x67, 0x42, 0xc0, 0x1e, 0xd9, 0x00, 0xa0, 0x47, 0xfe, 0xc8,
+}
+
+var realH264SPS720 = []byte{
+	0x67, 0x42, 0xc0, 0x1e, 0xf4, 0x02, 0x80, 0x2d, 0x80,
+}
+
+var realH264SPS1080 = []byte{
+	0x67, 0x42, 0xc0, 0x28, 0xf4, 0x03, 0xc0, 0x11, 0x2f, 0x28,
+}
+
+var realH265SPS1080 = []byte{
+	0x42, 0x01, 0x01, 0x01, 0x60, 0x00, 0x00, 0x03, 0x00, 0x90,
+	0x00, 0x00, 0x03, 0x00, 0x00, 0x03, 0x00, 0x78, 0xa0, 0x03,
+	0xc0, 0x80, 0x10, 0xe5, 0x96, 0x66, 0x69, 0x24, 0xca, 0xe0,
+	0x10, 0x00, 0x00, 0x03, 0x00, 0x10, 0x00, 0x00, 0x03, 0x01,
+	0xe0, 0x80,
+}
+
+// --- Tests ---
+
+// The production case from #642: a camera alternates between two SPS encodings
+// that differ only in VUI timing (time_scale) — 188 rotations in 4.9h. These
+// must compare as semantically equal so the recorder keeps its canonical SPS.
+func TestSPSSemanticallyEqual_H264_VUITimingVariants(t *testing.T) {
+	a := buildH264SPS(t, 50, true)
+	b := buildH264SPS(t, 60, true)
+	noVUI := buildH264SPS(t, 0, false)
+
+	if bytes.Equal(a, b) {
+		t.Fatal("test fixture degenerate: variants must differ at byte level")
+	}
+	if !SPSSemanticallyEqual(a, b, false) {
+		t.Fatal("SPS variants differing only in VUI time_scale must be semantically equal")
+	}
+	if !SPSSemanticallyEqual(a, noVUI, false) {
+		t.Fatal("SPS with and without VUI must be semantically equal")
+	}
+	if !SPSSemanticallyEqual(a, a, false) {
+		t.Fatal("identical SPS must be semantically equal")
+	}
+}
+
+func TestSPSSemanticallyEqual_H264_RealChanges(t *testing.T) {
+	base := buildH264SPS(t, 50, true)
+	if SPSSemanticallyEqual(base, buildH264SPSWide(t), false) {
+		t.Fatal("resolution change must NOT be semantically equal")
+	}
+	if SPSSemanticallyEqual(base, buildH264SPSHighProfile(t), false) {
+		t.Fatal("profile change must NOT be semantically equal")
+	}
+}
+
+// Real camera SPS from muxer fixtures: parse must succeed (ok=true) and
+// distinct resolutions must yield distinct keys.
+func TestSPSSemanticKey_H264_RealFixtures(t *testing.T) {
+	k640, ok640 := SPSSemanticKey(realH264SPS640, false)
+	k720, ok720 := SPSSemanticKey(realH264SPS720, false)
+	k1080, ok1080 := SPSSemanticKey(realH264SPS1080, false)
+	if !ok640 || !ok720 || !ok1080 {
+		t.Fatalf("real H.264 SPS must parse: ok640=%v ok720=%v ok1080=%v", ok640, ok720, ok1080)
+	}
+	if k640 == k720 || k720 == k1080 || k640 == k1080 {
+		t.Fatal("distinct resolutions must produce distinct semantic keys")
+	}
+}
+
+// Malformed/truncated SPS must fall back to byte comparison: byte-identical →
+// equal, byte-different → not equal (rotate) — never a false "equal".
+func TestSPSSemanticallyEqual_H264_UnparseableFallsBackToBytes(t *testing.T) {
+	good := realH264SPS1080
+	trunc := good[:6] // too short to parse
+	trunc2 := append([]byte(nil), trunc...)
+	trunc2[len(trunc2)-1] ^= 0xFF
+
+	if !SPSSemanticallyEqual(trunc, trunc, false) {
+		t.Fatal("byte-identical unparseable SPS must be equal")
+	}
+	if SPSSemanticallyEqual(trunc, trunc2, false) {
+		t.Fatal("byte-different unparseable SPS must not be equal (conservative rotate)")
+	}
+	// Parseable vs unparseable: byte-different → not equal.
+	if SPSSemanticallyEqual(good, trunc, false) {
+		t.Fatal("parseable vs truncated must not be equal")
+	}
+}
+
+func TestSPSSemanticallyEqual_H265_VUITimingVariants(t *testing.T) {
+	a := buildH265SPS(t, 50, true)
+	b := buildH265SPS(t, 60, true)
+	noVUI := buildH265SPS(t, 0, false)
+
+	if bytes.Equal(a, b) {
+		t.Fatal("test fixture degenerate: variants must differ at byte level")
+	}
+	if !SPSSemanticallyEqual(a, b, true) {
+		t.Fatal("H.265 SPS variants differing only in VUI timing must be semantically equal")
+	}
+	if !SPSSemanticallyEqual(a, noVUI, true) {
+		t.Fatal("H.265 SPS with and without VUI must be semantically equal")
+	}
+}
+
+func TestSPSSemanticallyEqual_H265_RealChanges(t *testing.T) {
+	base := buildH265SPS(t, 50, true)
+
+	wide := &spsBits{}
+	wide.u(0, 4)
+	wide.u(0, 3)
+	wide.u(1, 1)
+	wide.u(0, 2)
+	wide.u(0, 1)
+	wide.u(1, 5)
+	wide.u(0x60000000, 32)
+	wide.u(0, 48)
+	wide.u(120, 8)
+	wide.ue(0)
+	wide.ue(1)
+	wide.ue(1280) // different width
+	wide.ue(720)
+	wide.u(0, 1)
+	wide.ue(0)
+	wide.ue(0)
+	wide.ue(4)
+	wide.u(1, 1)
+	wide.ue(1)
+	wide.ue(0)
+	wide.ue(0)
+	wide.ue(0)
+	wide.ue(2)
+	wide.ue(0)
+	wide.ue(3)
+	wide.ue(0)
+	wide.ue(0)
+	wide.u(0, 1)
+	wide.u(0, 1)
+	wide.u(1, 1)
+	wide.u(0, 1)
+	wide.ue(0)
+	wide.u(0, 1)
+	wide.u(0, 1)
+	wide.u(0, 1)
+	wide.u(0, 1)
+	wide.trailing()
+	wideNAL := append([]byte{0x42, 0x01}, insertEPB(wide.buf)...)
+
+	if SPSSemanticallyEqual(base, wideNAL, true) {
+		t.Fatal("H.265 resolution change must NOT be semantically equal")
+	}
+}
+
+// Real 1080p HEVC SPS (contains emulation prevention bytes) must parse.
+func TestSPSSemanticKey_H265_RealFixture(t *testing.T) {
+	k, ok := SPSSemanticKey(realH265SPS1080, true)
+	if !ok {
+		t.Fatal("real HEVC SPS must parse to a semantic key")
+	}
+	if _, ok2 := SPSSemanticKey(realH265SPS1080, true); !ok2 || k == "" {
+		t.Fatal("key must be stable and non-empty")
+	}
+}

--- a/internal/model/nalutil/spscompat.go
+++ b/internal/model/nalutil/spscompat.go
@@ -1,0 +1,101 @@
+package nalutil
+
+import (
+	"time"
+)
+
+// Rotation gating on top of the semantic SPS comparison (#642).
+//
+// SPSSemanticallyEqual (sps_semantic.go) answers "are these two SPS
+// decode-equivalent?", folding unparseable inputs into a conservative
+// byte-compare. The rotation decision needs one more distinction: a
+// byte-different pair whose semantics are UNKNOWN (parse failure) should not
+// rotate a segment every flip — that is exactly the storm #642 describes —
+// so it is bounded by a minimum interval instead.
+
+type ParamCompat int
+
+const (
+	// ParamCompatEqual means the parameter sets are decode-equivalent: only
+	// VUI/timing/decorative bits may differ.
+	ParamCompatEqual ParamCompat = iota
+	// ParamCompatDifferent means a decode-relevant field differs (resolution,
+	// profile, level, chroma/bit depth, ordering, cropping…) — mixing frames
+	// across the pair inside one segment would break playback.
+	ParamCompatDifferent
+	// ParamCompatUnknown means at least one side could not be parsed; frames
+	// may or may not stay decodable, so rotation must be rate-limited.
+	ParamCompatUnknown
+)
+
+// CompareSPS classifies two SPS NAL units (start code excluded) for rotation
+// decisions. Byte-identical inputs are Equal without parsing; an unparseable
+// input yields Unknown (never a false Equal).
+func CompareSPS(oldSPS, newSPS []byte, isH265 bool) ParamCompat {
+	if EqualParamSets(oldSPS, newSPS) {
+		return ParamCompatEqual
+	}
+	oldKey, oldOK := SPSSemanticKey(oldSPS, isH265)
+	newKey, newOK := SPSSemanticKey(newSPS, isH265)
+	if !oldOK || !newOK {
+		return ParamCompatUnknown
+	}
+	if oldKey == newKey {
+		return ParamCompatEqual
+	}
+	return ParamCompatDifferent
+}
+
+// DefaultParamRotationMinInterval bounds rotations triggered by parameter
+// sets that cannot be semantically classified (parse failure, or VPS/PPS
+// which have no semantic parser): a genuine one-shot change still rotates,
+// rapid alternation collapses to at most one rotation per interval.
+const DefaultParamRotationMinInterval = 60 * time.Second
+
+// ParamRotationGate bounds parameter-set-triggered segment rotations. Each
+// recorder keeps one instance; it is touched only from the recorder's single
+// write goroutine and is deliberately not goroutine-safe.
+type ParamRotationGate struct {
+	// MinInterval is the backstop interval for Unknown/unparsed changes.
+	// Zero means DefaultParamRotationMinInterval.
+	MinInterval time.Duration
+
+	lastRotate time.Time
+}
+
+// ShouldRotateSPS decides whether a byte-different SPS should rotate the
+// segment:
+//   - decode-compatible variants (VUI/timing-only differences) never rotate;
+//     the caller still caches the fresh bytes for the NEXT segment,
+//   - a real codec change (resolution/profile/…) rotates immediately — MP4
+//     avcC/hvcC must stay consistent within a segment,
+//   - unparseable changes rotate at most once per MinInterval (storm backstop).
+func (g *ParamRotationGate) ShouldRotateSPS(oldSPS, newSPS []byte, isH265 bool, now time.Time) bool {
+	switch CompareSPS(oldSPS, newSPS, isH265) {
+	case ParamCompatEqual:
+		return false
+	case ParamCompatDifferent:
+		g.lastRotate = now
+		return true
+	default:
+		return g.rateLimited(now)
+	}
+}
+
+// ShouldRotateUnparsed applies the storm backstop to parameter sets without a
+// semantic parser (VPS/PPS).
+func (g *ParamRotationGate) ShouldRotateUnparsed(now time.Time) bool {
+	return g.rateLimited(now)
+}
+
+func (g *ParamRotationGate) rateLimited(now time.Time) bool {
+	interval := g.MinInterval
+	if interval <= 0 {
+		interval = DefaultParamRotationMinInterval
+	}
+	if now.Sub(g.lastRotate) >= interval {
+		g.lastRotate = now
+		return true
+	}
+	return false
+}

--- a/internal/model/nalutil/spscompat_test.go
+++ b/internal/model/nalutil/spscompat_test.go
@@ -1,0 +1,135 @@
+package nalutil
+
+import (
+	"testing"
+	"time"
+)
+
+// Rotation-gate tests. The semantic-comparison semantics themselves (VUI-only
+// variants equal, real changes different, real fixtures, EPB canonicalization)
+// are covered by sps_semantic_test.go — this file covers the three-way
+// classification and the rotation policy layered on top.
+
+func TestCompareSPS_ByteEqualIsEqual(t *testing.T) {
+	t.Parallel()
+	a := buildH264SPS(t, 50, true)
+	if got := CompareSPS(a, a, false); got != ParamCompatEqual {
+		t.Fatalf("byte-identical SPS: got %v, want Equal", got)
+	}
+}
+
+func TestCompareSPS_VUIOnlyVariantsAreEqual(t *testing.T) {
+	t.Parallel()
+	base := buildH264SPS(t, 50, true)
+	vui := buildH264SPS(t, 90000, true)
+	if got := CompareSPS(base, vui, false); got != ParamCompatEqual {
+		t.Fatalf("VUI-only variant: got %v, want Equal", got)
+	}
+	h265Base := buildH265SPS(t, 50, true)
+	h265VUI := buildH265SPS(t, 90000, true)
+	if got := CompareSPS(h265Base, h265VUI, true); got != ParamCompatEqual {
+		t.Fatalf("H.265 VUI-only variant: got %v, want Equal", got)
+	}
+}
+
+func TestCompareSPS_RealChangeIsDifferent(t *testing.T) {
+	t.Parallel()
+	base := buildH264SPS(t, 50, true)
+	if got := CompareSPS(base, buildH264SPSWide(t), false); got != ParamCompatDifferent {
+		t.Fatalf("resolution change: got %v, want Different", got)
+	}
+}
+
+func TestCompareSPS_UnparseableIsUnknown(t *testing.T) {
+	t.Parallel()
+	good := realH264SPS1080
+	trunc := good[:6]
+	if got := CompareSPS(good, trunc, false); got != ParamCompatUnknown {
+		t.Fatalf("parseable vs truncated: got %v, want Unknown", got)
+	}
+	if got := CompareSPS(trunc, trunc, false); got != ParamCompatEqual {
+		t.Fatalf("byte-identical truncated: got %v, want Equal", got)
+	}
+}
+
+func TestParamRotationGate_CompatibleVariantsNeverRotate(t *testing.T) {
+	t.Parallel()
+	var g ParamRotationGate
+	old := buildH264SPS(t, 50, true)
+	variant := buildH264SPS(t, 90000, true)
+
+	now := time.Now()
+	for i := range 120 { // a full day of per-GOP alternation
+		t2 := now.Add(time.Duration(i) * 2 * time.Second)
+		if g.ShouldRotateSPS(old, variant, false, t2) {
+			t.Fatalf("decode-compatible variant must never rotate (flip %d)", i)
+		}
+	}
+}
+
+func TestParamRotationGate_RealChangeRotatesImmediately(t *testing.T) {
+	t.Parallel()
+	var g ParamRotationGate
+	old := buildH264SPS(t, 50, true)
+	wide := buildH264SPSWide(t)
+	now := time.Now()
+	if !g.ShouldRotateSPS(old, wide, false, now) {
+		t.Fatal("real codec change must rotate immediately")
+	}
+	// Even a rapid second genuine change (quality oscillation) still rotates —
+	// MP4 avcC consistency outranks churn bounds for known-real changes.
+	if !g.ShouldRotateSPS(wide, old, false, now.Add(5*time.Second)) {
+		t.Fatal("a second genuine change must still rotate")
+	}
+}
+
+func TestParamRotationGate_UnknownChangeRateLimited(t *testing.T) {
+	t.Parallel()
+	var g ParamRotationGate
+	a := realH264SPS1080[:6]
+	b := append([]byte(nil), a...)
+	b[len(b)-1] ^= 0xFF
+	now := time.Now()
+	if !g.ShouldRotateSPS(a, b, false, now) {
+		t.Fatal("first unparseable change must rotate (lastRotate is zero)")
+	}
+	for i := range 5 { // flips at 11s..55s — all inside the 60s interval
+		t2 := now.Add(time.Duration(i+1) * 11 * time.Second)
+		if g.ShouldRotateSPS(a, b, false, t2) {
+			t.Fatalf("unparseable flip inside the interval must not rotate (t=+%ds)", (i+1)*11)
+		}
+	}
+	if !g.ShouldRotateSPS(a, b, false, now.Add(61*time.Second)) {
+		t.Fatal("after the interval an unparseable change rotates again")
+	}
+}
+
+func TestParamRotationGate_UnparsedRateLimited(t *testing.T) {
+	t.Parallel()
+	var g ParamRotationGate
+	now := time.Now()
+	if !g.ShouldRotateUnparsed(now) {
+		t.Fatal("first VPS/PPS change must rotate")
+	}
+	if g.ShouldRotateUnparsed(now.Add(11 * time.Second)) {
+		t.Fatal("VPS/PPS flip-flop must be rate-limited")
+	}
+	if !g.ShouldRotateUnparsed(now.Add(60 * time.Second)) {
+		t.Fatal("after the interval VPS/PPS change rotates again")
+	}
+}
+
+func TestParamRotationGate_CustomMinInterval(t *testing.T) {
+	t.Parallel()
+	g := ParamRotationGate{MinInterval: 5 * time.Minute}
+	now := time.Now()
+	if !g.ShouldRotateUnparsed(now) {
+		t.Fatal("first change rotates")
+	}
+	if g.ShouldRotateUnparsed(now.Add(4 * time.Minute)) {
+		t.Fatal("custom MinInterval must be honored")
+	}
+	if !g.ShouldRotateUnparsed(now.Add(5 * time.Minute)) {
+		t.Fatal("custom MinInterval elapsed")
+	}
+}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -49,6 +49,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
@@ -302,6 +303,12 @@ type baseRecorder struct {
 	// SPS/PPS/VPS concurrently with the writeFrames writer without a data race
 	// or torn triplet reads. vps is H.265-only; always nil for H.264.
 	codec atomic.Pointer[codecParams]
+
+	// paramGate bounds parameter-set-triggered segment rotations (#642):
+	// decode-compatible SPS variants (VUI/timing-only differences) never
+	// rotate; unclassifiable changes are rate-limited. Owned by the single
+	// writeFrames goroutine via the driver's handleParamSet.
+	paramGate nalutil.ParamRotationGate
 
 	// Audio configuration (Tier 2, #226): immutable snapshot behind
 	// atomic.Pointer, detected once during connectAndRecord and read by the

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
@@ -50,6 +51,7 @@ type GB28181Recorder struct {
 	mu              sync.Mutex
 	status          model.RecorderStatus
 	sps, pps, vps   []byte
+	paramGate       nalutil.ParamRotationGate // bounds param-set rotations (#642)
 	codecType       string
 	codecDefinitive bool // codecType came from a parameter-set NALU, not the encoding fallback
 	muxer           *muxer.MP4Muxer
@@ -200,7 +202,7 @@ func (r *GB28181Recorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 		}
 	}
 	if r.codecType == "h264" {
-		newSPS, newPPS, changed := updateParamSetsH264(au, r.sps, r.pps)
+		newSPS, newPPS, changed := updateParamSetsH264(au, r.sps, r.pps, &r.paramGate, time.Now())
 		if changed {
 			r.closeCurrentSegmentLocked()
 		}
@@ -211,7 +213,7 @@ func (r *GB28181Recorder) WriteNALU(au [][]byte, ptsTicks int64, isIDR bool) {
 			r.pps = newPPS
 		}
 	} else if r.codecType == "h265" {
-		newVPS, newSPS, newPPS, changed := updateParamSetsH265(au, r.vps, r.sps, r.pps)
+		newVPS, newSPS, newPPS, changed := updateParamSetsH265(au, r.vps, r.sps, r.pps, &r.paramGate, time.Now())
 		if changed {
 			r.closeCurrentSegmentLocked()
 		}

--- a/internal/recorder/gb28181_helpers.go
+++ b/internal/recorder/gb28181_helpers.go
@@ -1,6 +1,8 @@
 package recorder
 
 import (
+	"time"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 )
 
@@ -50,40 +52,52 @@ func detectCodecDetailed(au [][]byte, encoding string) (codec string, definitive
 	return "", false
 }
 
-func updateParamSetsH264(au [][]byte, currentSPS, currentPPS []byte) (newSPS, newPPS []byte, changed bool) {
+func updateParamSetsH264(au [][]byte, currentSPS, currentPPS []byte, gate *nalutil.ParamRotationGate, now time.Time) (newSPS, newPPS []byte, changed bool) {
 	sps, pps := nalutil.ExtractParamSetsH264(au)
 	if sps != nil {
 		newSPS = append([]byte(nil), sps...)
-		if currentSPS != nil && !nalutil.EqualParamSets(currentSPS, sps) {
+		// #642: decode-equivalent SPS variants (VUI/timing-only differences)
+		// don't rotate; unclassifiable changes are rate-limited.
+		if currentSPS != nil && !nalutil.EqualParamSets(currentSPS, sps) &&
+			gate.ShouldRotateSPS(currentSPS, sps, false, now) {
 			changed = true
 		}
 	}
 	if pps != nil {
 		newPPS = append([]byte(nil), pps...)
-		if currentPPS != nil && !nalutil.EqualParamSets(currentPPS, pps) {
+		// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+		if currentPPS != nil && !nalutil.EqualParamSets(currentPPS, pps) &&
+			gate.ShouldRotateUnparsed(now) {
 			changed = true
 		}
 	}
 	return newSPS, newPPS, changed
 }
 
-func updateParamSetsH265(au [][]byte, currentVPS, currentSPS, currentPPS []byte) (newVPS, newSPS, newPPS []byte, changed bool) {
+func updateParamSetsH265(au [][]byte, currentVPS, currentSPS, currentPPS []byte, gate *nalutil.ParamRotationGate, now time.Time) (newVPS, newSPS, newPPS []byte, changed bool) {
 	vps, sps, pps := nalutil.ExtractParamSetsH265(au)
 	if vps != nil {
 		newVPS = append([]byte(nil), vps...)
-		if currentVPS != nil && !nalutil.EqualParamSets(currentVPS, vps) {
+		// No semantic VPS parser — rate-limit rapid variant alternation (#642).
+		if currentVPS != nil && !nalutil.EqualParamSets(currentVPS, vps) &&
+			gate.ShouldRotateUnparsed(now) {
 			changed = true
 		}
 	}
 	if sps != nil {
 		newSPS = append([]byte(nil), sps...)
-		if currentSPS != nil && !nalutil.EqualParamSets(currentSPS, sps) {
+		// #642: decode-equivalent SPS variants don't rotate; real codec
+		// changes rotate immediately.
+		if currentSPS != nil && !nalutil.EqualParamSets(currentSPS, sps) &&
+			gate.ShouldRotateSPS(currentSPS, sps, true, now) {
 			changed = true
 		}
 	}
 	if pps != nil {
 		newPPS = append([]byte(nil), pps...)
-		if currentPPS != nil && !nalutil.EqualParamSets(currentPPS, pps) {
+		// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+		if currentPPS != nil && !nalutil.EqualParamSets(currentPPS, pps) &&
+			gate.ShouldRotateUnparsed(now) {
 			changed = true
 		}
 	}

--- a/internal/recorder/gb28181_paramgate_test.go
+++ b/internal/recorder/gb28181_paramgate_test.go
@@ -1,0 +1,68 @@
+package recorder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
+)
+
+// updateParamSets* rotation gating (#642). The SPS Equal/Different paths are
+// covered end-to-end by TestH265Characterization_SPSChangeRotatesSegment (real
+// parseable fixtures through a live recorder); here we verify the helper folds
+// the gate into `changed` correctly — unclassifiable SPS changes and
+// byte-different VPS/PPS rotate once per gate interval, not on every flip.
+// (The local testSPS fixture is a 7-byte stub that cannot be parsed, which
+// makes it a natural Unknown-class input.)
+func TestUpdateParamSets_RotationGating(t *testing.T) {
+	now := time.Now()
+
+	t.Run("unclassifiable SPS change rotates once per interval", func(t *testing.T) {
+		var gate nalutil.ParamRotationGate
+		altSPS := make([]byte, len(testSPS))
+		copy(altSPS, testSPS)
+		altSPS[len(altSPS)-1] ^= 0x01
+		require.Equal(t, nalutil.ParamCompatUnknown, nalutil.CompareSPS(testSPS, altSPS, false),
+			"test fixture: the stub SPS must be unclassifiable for this wiring test")
+
+		_, _, changed := updateParamSetsH264([][]byte{altSPS, testPPS}, testSPS, testPPS, &gate, now)
+		require.True(t, changed, "first unclassifiable change rotates (lastRotate is zero)")
+
+		_, _, changed = updateParamSetsH264([][]byte{altSPS, testPPS}, testSPS, testPPS, &gate, now.Add(5*time.Second))
+		require.False(t, changed, "rapid unclassifiable flip-flop is rate-limited")
+	})
+
+	t.Run("PPS alternation rate-limited", func(t *testing.T) {
+		var gate nalutil.ParamRotationGate
+		altPPS := make([]byte, len(testPPS))
+		copy(altPPS, testPPS)
+		altPPS[len(altPPS)-1] ^= 0x01
+
+		_, _, changed := updateParamSetsH264([][]byte{testSPS, altPPS}, testSPS, testPPS, &gate, now)
+		require.True(t, changed, "first PPS change rotates")
+
+		_, _, changed = updateParamSetsH264([][]byte{testSPS, altPPS}, testSPS, altPPS, &gate, now.Add(5*time.Second))
+		require.False(t, changed, "rapid PPS flip-flop is rate-limited")
+	})
+
+	t.Run("H265 VPS alternation rate-limited", func(t *testing.T) {
+		var gate nalutil.ParamRotationGate
+		altVPS := make([]byte, len(testVPS265))
+		copy(altVPS, testVPS265)
+		altVPS[len(altVPS)-1] ^= 0x01
+
+		_, _, _, changed := updateParamSetsH265([][]byte{altVPS, testSPS265, testPPS265}, testVPS265, testSPS265, testPPS265, &gate, now)
+		require.True(t, changed, "first VPS change rotates")
+
+		_, _, _, changed = updateParamSetsH265([][]byte{altVPS, testSPS265, testPPS265}, altVPS, testSPS265, testPPS265, &gate, now.Add(5*time.Second))
+		require.False(t, changed, "rapid VPS flip-flop is rate-limited")
+	})
+
+	t.Run("unchanged params never rotate", func(t *testing.T) {
+		var gate nalutil.ParamRotationGate
+		_, _, changed := updateParamSetsH264([][]byte{testSPS, testPPS}, testSPS, testPPS, &gate, now)
+		require.False(t, changed, "byte-identical param sets must not report a change")
+	})
+}

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -78,17 +78,30 @@ func (d H264NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) boo
 	sps, pps, _ := b.codecSnapshot()
 	switch typ {
 	case 7: // SPS
-		if sps != nil && !bytes.Equal(sps, nalu) {
-			b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(nalu, pps, nil)
-			return true
+		// The muxer==nil guard keeps param sync at connect (SDP sprop seed vs
+		// first in-band delivery) from consuming rotation budget — there is no
+		// segment to protect yet, so the fresh bytes are just cached.
+		if sps != nil && !bytes.Equal(sps, nalu) && b.muxer != nil {
+			// #642: cameras may alternate decode-equivalent SPS encodings
+			// (VUI/timing-only differences) per GOP — only rotate on a real
+			// codec change; always cache the fresh bytes for the next segment.
+			if b.paramGate.ShouldRotateSPS(sps, nalu, false, time.Now()) {
+				b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
+				b.setCodecParams(nalu, pps, nil)
+				return true
+			}
+			b.log.Debug("SPS variant is decode-compatible, keeping segment open",
+				"camera_id", b.cfg.CameraID)
 		}
 		b.setCodecParams(nalu, pps, nil)
 	case 8: // PPS
-		if pps != nil && !bytes.Equal(pps, nalu) {
-			b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(sps, nalu, nil)
-			return true
+		if pps != nil && !bytes.Equal(pps, nalu) && b.muxer != nil {
+			// No semantic PPS parser — rate-limit rapid variant alternation.
+			if b.paramGate.ShouldRotateUnparsed(time.Now()) {
+				b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
+				b.setCodecParams(sps, nalu, nil)
+				return true
+			}
 		}
 		b.setCodecParams(sps, nalu, nil)
 	}

--- a/internal/recorder/h264_h265_characterization_test.go
+++ b/internal/recorder/h264_h265_characterization_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
@@ -527,47 +528,76 @@ func TestH265Characterization_VPSChangeRotatesSegment(t *testing.T) {
 	require.GreaterOrEqual(t, n, 2, "VPS change should produce at least 2 segments, got %d", n)
 }
 
-// 2b. SPS change rotates segment (H265)
+// 2b. SPS change rotates segment (H265) — but only REAL codec changes (#642):
+// a decode-equivalent variant (VUI/decoration-only byte difference) must keep
+// the segment open, while a semantic change must rotate.
 func TestH265Characterization_SPSChangeRotatesSegment(t *testing.T) {
-	srv := newTestRTSPServerH265(t)
-	defer srv.close()
+	// Variant A: flip the trailing decoration byte — decode-equivalent, must
+	// NOT rotate (#642: production cameras alternate such variants per GOP).
+	compatSPS := make([]byte, len(testSPS265))
+	copy(compatSPS, testSPS265)
+	compatSPS[len(compatSPS)-1] ^= 0x01
+	require.Equal(t, nalutil.CompareSPS(testSPS265, compatSPS, true), nalutil.ParamCompatEqual,
+		"test fixture: trailing-byte flip must be decode-compatible")
 
-	mgr := newTestManager(t)
-
-	// Build a slightly different H265 SPS
-	altSPS := make([]byte, len(testSPS265))
-	copy(altSPS, testSPS265)
-	altSPS[len(altSPS)-1] ^= 0x01
-
-	rec := NewH265Recorder(H265Config{
-		CameraID:   "h265-char-sps",
-		RTSPURL:    srv.rtspURL,
-		SegmentDur: 5 * time.Minute,
-		RingBufCap: 200,
-	}, mgr)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	require.NoError(t, rec.Start(ctx))
-	srv.waitPlay(t, 5*time.Second)
-	time.Sleep(100 * time.Millisecond)
-
-	// Send initial frames
-	srv.sendFrames(3, 30*time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
-
-	// Send frames with different SPS — should trigger segment rotation
-	for range 3 {
-		srv.sendAU([][]byte{testVPS265, altSPS, testPPS265, testIDR265})
-		time.Sleep(30 * time.Millisecond)
+	// Variant B: a byte flip that changes decode semantics — must rotate.
+	// Scan for one deterministically (fixed fixture, fixed scan order).
+	realSPS := make([]byte, len(testSPS265))
+	copy(realSPS, testSPS265)
+	found := false
+	for i := 2; i < len(realSPS); i++ { // skip the 2-byte NAL header
+		candidate := make([]byte, len(testSPS265))
+		copy(candidate, testSPS265)
+		candidate[i] ^= 0x01
+		if nalutil.CompareSPS(testSPS265, candidate, true) == nalutil.ParamCompatDifferent {
+			realSPS = candidate
+			found = true
+			break
+		}
 	}
-	time.Sleep(300 * time.Millisecond)
+	require.True(t, found, "test fixture: some byte flip must be a real semantic change")
 
-	require.NoError(t, rec.Stop())
+	for name, spsVariant := range map[string][]byte{"compatible": compatSPS, "real": realSPS} {
+		t.Run(name, func(t *testing.T) {
+			srv := newTestRTSPServerH265(t)
+			defer srv.close()
 
-	n := countFinalFiles(t, mgr, "h265-char-sps")
-	require.GreaterOrEqual(t, n, 2, "SPS change should produce at least 2 segments, got %d", n)
+			mgr := newTestManager(t)
+			rec := NewH265Recorder(H265Config{
+				CameraID:   "h265-char-sps-" + name,
+				RTSPURL:    srv.rtspURL,
+				SegmentDur: 5 * time.Minute,
+				RingBufCap: 200,
+			}, mgr)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			require.NoError(t, rec.Start(ctx))
+			srv.waitPlay(t, 5*time.Second)
+			time.Sleep(100 * time.Millisecond)
+
+			// Send initial frames
+			srv.sendFrames(3, 30*time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
+
+			// Send frames with the variant SPS
+			for range 3 {
+				srv.sendAU([][]byte{testVPS265, spsVariant, testPPS265, testIDR265})
+				time.Sleep(30 * time.Millisecond)
+			}
+			time.Sleep(300 * time.Millisecond)
+
+			require.NoError(t, rec.Stop())
+
+			n := countFinalFiles(t, mgr, "h265-char-sps-"+name)
+			if name == "compatible" {
+				require.Equal(t, 1, n, "decode-compatible SPS variant must NOT rotate the segment, got %d segments", n)
+			} else {
+				require.GreaterOrEqual(t, n, 2, "real SPS change must rotate the segment, got %d segments", n)
+			}
+		})
+	}
 }
 
 // 2c. PPS change rotates segment (H265)

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -60,26 +60,41 @@ func (d H265NALDriver) handleParamSet(b *baseRecorder, nalu []byte, typ int) boo
 	// the RTSP server's parameter injection, and the MP4 track config all
 	// served VPS/SPS/PPS in each other's slots).
 	sps, pps, vps := b.codecSnapshot()
+	// The muxer==nil guard keeps param sync at connect (SDP sprop seed vs
+	// first in-band delivery) from consuming rotation budget — there is no
+	// segment to protect yet, so the fresh bytes are just cached.
 	switch typ {
 	case 32: // VPS
-		if vps != nil && !bytes.Equal(vps, nalu) {
-			b.log.Info("VPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(sps, pps, nalu)
-			return true
+		if vps != nil && !bytes.Equal(vps, nalu) && b.muxer != nil {
+			// No semantic VPS parser — rate-limit rapid variant alternation (#642).
+			if b.paramGate.ShouldRotateUnparsed(time.Now()) {
+				b.log.Info("VPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
+				b.setCodecParams(sps, pps, nalu)
+				return true
+			}
 		}
 		b.setCodecParams(sps, pps, nalu)
 	case 33: // SPS
-		if sps != nil && !bytes.Equal(sps, nalu) {
-			b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(nalu, pps, vps)
-			return true
+		if sps != nil && !bytes.Equal(sps, nalu) && b.muxer != nil {
+			// #642: decode-equivalent SPS variants (VUI/timing-only differences)
+			// never rotate; a real codec change rotates immediately.
+			if b.paramGate.ShouldRotateSPS(sps, nalu, true, time.Now()) {
+				b.log.Info("SPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
+				b.setCodecParams(nalu, pps, vps)
+				return true
+			}
+			b.log.Debug("SPS variant is decode-compatible, keeping segment open",
+				"camera_id", b.cfg.CameraID)
 		}
 		b.setCodecParams(nalu, pps, vps)
 	case 34: // PPS
-		if pps != nil && !bytes.Equal(pps, nalu) {
-			b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
-			b.setCodecParams(sps, nalu, vps)
-			return true
+		if pps != nil && !bytes.Equal(pps, nalu) && b.muxer != nil {
+			// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+			if b.paramGate.ShouldRotateUnparsed(time.Now()) {
+				b.log.Info("PPS change detected, rotating segment", "camera_id", b.cfg.CameraID)
+				b.setCodecParams(sps, nalu, vps)
+				return true
+			}
 		}
 		b.setCodecParams(sps, nalu, vps)
 	}

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -88,6 +88,14 @@ type IngestRecorder struct {
 	segStart   time.Time
 	lastFrame  time.Time
 	frameCount int
+	// paramGate bounds parameter-set-triggered segment rotations (#642) —
+	// decode-equivalent SPS variant flapping must not churn segments. Guarded
+	// by mu like the segment state above (WriteNALU callbacks are serialized
+	// by the listener, but keep it under the same lock discipline). Rotation
+	// is only consulted while a segment is open (muxer != nil), so the
+	// sequence-header→in-band param sync at publisher connect never consumes
+	// rotation budget.
+	paramGate nalutil.ParamRotationGate
 
 	// Audio (WHIP push-in, #369). The negotiated format is set via SetAudioFormat
 	// when the publisher's audio track is accepted; frames then arrive via
@@ -368,23 +376,33 @@ func (r *IngestRecorder) cacheParamSets(au [][]byte) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		if vps != nil {
-			if r.vps != nil && !nalutil.EqualParamSets(r.vps, vps) {
-				ingestLogger.Info("VPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-				r.closeCurrentSegmentLocked()
+			if r.vps != nil && !nalutil.EqualParamSets(r.vps, vps) && r.muxer != nil {
+				// No semantic VPS parser — rate-limit rapid variant alternation (#642).
+				if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+					ingestLogger.Info("VPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+					r.closeCurrentSegmentLocked()
+				}
 			}
 			r.vps = append([]byte(nil), vps...)
 		}
 		if sps != nil {
-			if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) {
-				ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-				r.closeCurrentSegmentLocked()
+			if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) && r.muxer != nil {
+				// #642: decode-equivalent SPS variants never rotate; a real
+				// codec change rotates immediately.
+				if r.paramGate.ShouldRotateSPS(r.sps, sps, true, time.Now()) {
+					ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+					r.closeCurrentSegmentLocked()
+				}
 			}
 			r.sps = append([]byte(nil), sps...)
 		}
 		if pps != nil {
-			if r.pps != nil && !nalutil.EqualParamSets(r.pps, pps) {
-				ingestLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-				r.closeCurrentSegmentLocked()
+			if r.pps != nil && !nalutil.EqualParamSets(r.pps, pps) && r.muxer != nil {
+				// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+				if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+					ingestLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+					r.closeCurrentSegmentLocked()
+				}
 			}
 			r.pps = append([]byte(nil), pps...)
 		}
@@ -394,16 +412,23 @@ func (r *IngestRecorder) cacheParamSets(au [][]byte) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if sps != nil {
-		if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) {
-			ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegmentLocked()
+		if r.sps != nil && !nalutil.EqualParamSets(r.sps, sps) && r.muxer != nil {
+			// #642: decode-equivalent SPS variants never rotate; a real codec
+			// change rotates immediately.
+			if r.paramGate.ShouldRotateSPS(r.sps, sps, false, time.Now()) {
+				ingestLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegmentLocked()
+			}
 		}
 		r.sps = append([]byte(nil), sps...)
 	}
 	if pps != nil {
-		if r.pps != nil && !nalutil.EqualParamSets(r.pps, pps) {
-			ingestLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegmentLocked()
+		if r.pps != nil && !nalutil.EqualParamSets(r.pps, pps) && r.muxer != nil {
+			// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+			if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+				ingestLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegmentLocked()
+			}
 		}
 		r.pps = append([]byte(nil), pps...)
 	}

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
@@ -147,6 +148,11 @@ type XiaomiRecorder struct {
 	pps     []byte
 	vps     []byte // H265 only
 	codecOK bool   // true once codec type is determined
+	// paramGate bounds parameter-set-triggered segment rotations (#642): this
+	// model family alternates decode-equivalent SPS encodings (VUI/timing-only
+	// differences) per GOP — 188 rotations in 4.9h on production. Owned by the
+	// video NALU processing goroutine.
+	paramGate nalutil.ParamRotationGate
 
 	// Audio state (probed from first audio packet)
 	audioCodecID uint32 // MISS codec ID for audio (0 = not detected yet)
@@ -810,16 +816,28 @@ func (r *XiaomiRecorder) processH264NALU(nalu []byte, timestamp uint64, lastTime
 	naluType := nalu[0] & 0x1F
 	switch naluType {
 	case 7: // SPS
-		if r.sps != nil && !bytes.Equal(r.sps, nalu) {
-			xiaomiLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegment()
+		// r.muxer==nil guard: no open segment → just refresh the cache without
+		// consuming rotation budget (e.g. param sync right after connect).
+		if r.sps != nil && !bytes.Equal(r.sps, nalu) && r.muxer != nil {
+			// #642: decode-equivalent SPS variants (VUI/timing-only differences)
+			// never rotate; a real codec change rotates immediately.
+			if r.paramGate.ShouldRotateSPS(r.sps, nalu, false, time.Now()) {
+				xiaomiLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegment()
+			} else {
+				xiaomiLogger.Debug("SPS variant is decode-compatible, keeping segment open",
+					"camera_id", r.cfg.CameraID)
+			}
 		}
 		r.sps = append([]byte(nil), nalu...)
 		return
 	case 8: // PPS
-		if r.pps != nil && !bytes.Equal(r.pps, nalu) {
-			xiaomiLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegment()
+		if r.pps != nil && !bytes.Equal(r.pps, nalu) && r.muxer != nil {
+			// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+			if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+				xiaomiLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegment()
+			}
 		}
 		r.pps = append([]byte(nil), nalu...)
 		return
@@ -936,23 +954,36 @@ func (r *XiaomiRecorder) processH265NALU(nalu []byte, timestamp uint64, lastTime
 	naluType := (nalu[0] >> 1) & 0x3F
 	switch naluType {
 	case 32: // VPS
-		if r.vps != nil && !bytes.Equal(r.vps, nalu) {
-			xiaomiLogger.Info("VPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegment()
+		if r.vps != nil && !bytes.Equal(r.vps, nalu) && r.muxer != nil {
+			// No semantic VPS parser — rate-limit rapid variant alternation (#642).
+			if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+				xiaomiLogger.Info("VPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegment()
+			}
 		}
 		r.vps = append([]byte(nil), nalu...)
 		return
 	case 33: // SPS
-		if r.sps != nil && !bytes.Equal(r.sps, nalu) {
-			xiaomiLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegment()
+		if r.sps != nil && !bytes.Equal(r.sps, nalu) && r.muxer != nil {
+			// #642: decode-equivalent SPS variants never rotate; a real codec
+			// change rotates immediately.
+			if r.paramGate.ShouldRotateSPS(r.sps, nalu, true, time.Now()) {
+				xiaomiLogger.Info("SPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegment()
+			} else {
+				xiaomiLogger.Debug("SPS variant is decode-compatible, keeping segment open",
+					"camera_id", r.cfg.CameraID)
+			}
 		}
 		r.sps = append([]byte(nil), nalu...)
 		return
 	case 34: // PPS
-		if r.pps != nil && !bytes.Equal(r.pps, nalu) {
-			xiaomiLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
-			r.closeCurrentSegment()
+		if r.pps != nil && !bytes.Equal(r.pps, nalu) && r.muxer != nil {
+			// No semantic PPS parser — rate-limit rapid variant alternation (#642).
+			if r.paramGate.ShouldRotateUnparsed(time.Now()) {
+				xiaomiLogger.Info("PPS change detected, rotating segment", "camera_id", r.cfg.CameraID)
+				r.closeCurrentSegment()
+			}
 		}
 		r.pps = append([]byte(nil), nalu...)
 		return


### PR DESCRIPTION
## 问题 (#642)

小米 2K 云台相机在两个**字节不同但解码等价**的 SPS 编码间逐 GOP 交替(VUI/timing/装饰位差异)。字节级比较(`bytes.Equal` / `nalutil.EqualParamSets`)把每次翻转都当作 codec 变化强制轮转:

- **188 次轮转 / 4.9h**(突发期每 ~11s 一次)
- rolling-merge bucket key 随之 `11ffbc3e ↔ 8bbe8d1f` 秒级来回切(184 次)
- 每次轮转额外触发一次 vision 推送(该相机 2.1 次/分钟)

## 方案(issue 建议的两条全落地)

**1. SPS 语义化比较**——`internal/model/nalutil` 新增(含上一会话遗留未提交的 `sps_semantic.go` 解析器,本次修复其 lint 问题并补齐接线):
- `SPSSemanticKey`:H.264 取 profile→frame_cropping 前缀,H.265 取 NAL header→strong_intra_smoothing 前缀(覆盖 PTL/chroma/分辨率/conformance window/位深/SAO/短参考集等),VUI 一律排除
- `CompareSPS` 三态:Equal(仅 VUI 差异)/ Different(解码相关字段变化)/ Unknown(解析失败)

**2. 轮转频控**——`ParamRotationGate`:
- 兼容变体:**永不轮转**(新字节仍缓存,供下一个分段使用)
- 真实 codec 变化:**立即轮转**(MP4 avcC/hvcC 一致性优先,质量切换不受影响)
- 无法判定的变化:60s 内最多轮转一次(VPS/PPS 无语义解析器,同样走此兜底)

**3. 全部 6 处接线**:recorder h264/h265 driver、xiaomi(H264+H265)、ingest(SRT/RTMP)、gb28181 helpers、rolling-merge bucket key(哈希语义 key,变体交替不再按分段粒度分裂 bucket)

**4. 连接期参数同步不消耗预算**:RTSP SDP sprop 预置与带内参数的首次同步(SDP≠带内时触发一次空轮转)不占用 60s 窗口——没有打开的分段时跳过门控只刷新缓存。这是实现中 e2e 测试揭出的真缺陷(characterization 测试失败暴露)。

## 测试

- nalutil:语义比较/门控策略单测(VUI 变体、真实变化、解析失败、自定义间隔、持续 240s 交替不轮转),含上一会话的 12 项解析器测试(真实相机 fixtures、EPB 规范化)
- recorder:characterization 测试按新行为重写(兼容变体恰 1 个分段 / 真实变化 ≥2 个分段,变体分类用 `CompareSPS` 自校验);gb28181 helper 门控接线单测(4 项)
- `-race` 全绿(recorder/merge/xiaomi/nalutil 798 项);golangci-lint 0 issues
- timelapse 包在 `-count=2`/全量负载下有两个既有 flaky(基线同样复现,与本改动无关)

## 验收对照

issue 要求"该相机 SPS 轮转降到 <5 次/小时、bucket 不再秒级来回切"——兼容变体路径归零轮转、bucket key 恒定,直接满足;需 M5 实机观察期确认(合并后部署观察)。

Closes #642
