### PR TITLE
fix(pixgate,substream): 采样停滞重生 + 半开会话回归定性（09-02 事故硬化）

### DIFF
--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -80,10 +81,15 @@ type Config struct {
 	FFmpegPath string
 	// FFmpegArgs allows tests to substitute a fake frame source binary.
 	FFmpegArgs func(url string, fps float64) []string
-	Resolver   Resolver
-	Trigger    Trigger
-	Bus        Publisher
-	Log        *slog.Logger
+	// FrameStallTimeout aborts a sampler whose ffmpeg produces no decoded
+	// frame for this long — a wedged network read inside ffmpeg never exits
+	// on its own (2026-09-02 incident: pixgate silent from 02:01 until the
+	// 05:09 service restart). <=0 → 30s.
+	FrameStallTimeout time.Duration
+	Resolver          Resolver
+	Trigger           Trigger
+	Bus               Publisher
+	Log               *slog.Logger
 	// Cameras is the enabled set, refreshed via SetCameras.
 	Cameras map[string]CameraConfig
 }
@@ -468,11 +474,18 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 }
 
 // sampleFrames runs one ffmpeg process to completion, feeding each decoded
-// gray frame to fn (return false stops early). Returns frames consumed.
+// gray frame to fn (return false stops early). Returns frames consumed. A
+// source that stops producing frames without exiting (wedged network read)
+// is killed after the stall timeout and reported as an error so the caller's
+// backoff loop respawns it.
 func sampleFrames(ctx context.Context, cfg Config, target Target, fps float64, fn func([]byte) bool, frame []byte) (int, error) {
 	args := ffmpegArgs(target, fps)
 	if cfg.FFmpegArgs != nil {
 		args = cfg.FFmpegArgs(target.URL, fps)
+	}
+	stall := cfg.FrameStallTimeout
+	if stall <= 0 {
+		stall = 30 * time.Second
 	}
 	cmd := exec.CommandContext(ctx, cfg.FFmpegPath, args...)
 	stdout, err := cmd.StdoutPipe()
@@ -486,11 +499,46 @@ func sampleFrames(ctx context.Context, cfg Config, target Target, fps float64, f
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()
 	}()
+
+	// Stall watchdog (2026-09-02 incident): a wedged source — ffmpeg blocked
+	// in a network read — never exits and never writes. Pipe read deadlines
+	// are not portable across the exec implementations, so the watchdog
+	// KILLS the process instead: the pipe closes and the pending ReadFull
+	// below returns on every platform. stalled distinguishes that kill from
+	// a source that died on its own.
+	var lastFrameNS atomic.Int64
+	var stalled atomic.Bool
+	lastFrameNS.Store(time.Now().UnixNano())
+	watchStop := make(chan struct{})
+	defer close(watchStop)
+	go func() {
+		t := time.NewTicker(stall / 3)
+		defer t.Stop()
+		for {
+			select {
+			case <-watchStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if time.Since(time.Unix(0, lastFrameNS.Load())) > stall {
+					stalled.Store(true)
+					_ = cmd.Process.Kill()
+					return
+				}
+			}
+		}
+	}()
+
 	n := 0
 	for {
 		if _, err := io.ReadFull(stdout, frame); err != nil {
+			if stalled.Load() {
+				return n, fmt.Errorf("no frame for %s — sampler source stalled", stall)
+			}
 			return n, err
 		}
+		lastFrameNS.Store(time.Now().UnixNano())
 		n++
 		if !fn(frame) {
 			return n, nil
@@ -512,6 +560,10 @@ func ffmpegArgs(target Target, fps float64) []string {
 	return []string{
 		"-hide_banner", "-loglevel", "error", "-nostdin",
 		"-rtsp_transport", "tcp",
+		// Socket-level read timeout (µs): a dead RTSP connection must fail
+		// inside ffmpeg, not hang the sampler process forever. Paired with
+		// the per-frame stall deadline in sampleFrames (belt and suspenders).
+		"-rw_timeout", "15000000", // 15s
 		"-i", u,
 		"-vf", fmt.Sprintf("fps=%.3f,scale=%d:%d", fps, GridW, GridH),
 		"-f", "rawvideo", "-pix_fmt", "gray",

--- a/internal/pixgate/pixgate_test.go
+++ b/internal/pixgate/pixgate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -234,5 +235,77 @@ func TestManager_SuppressBlindsGate(t *testing.T) {
 	}
 	if st.Valid != 0 {
 		t.Fatalf("suppressed samples must be invalid, got %d valid of %d", st.Valid, st.Samples)
+	}
+}
+
+// TestHelperStallProcess is not a real test: it is spawned as the fake ffmpeg
+// by TestSampleFramesStallKillsWedgedSource. It emits exactly one frame, then
+// blocks forever — the shape of an ffmpeg wedged in a network read.
+func TestHelperStallProcess(t *testing.T) {
+	if os.Getenv("GO_PIXGATE_HELPER") != "stall" {
+		return
+	}
+	if _, err := os.Stdout.Write(make([]byte, GridW*GridH)); err != nil {
+		os.Exit(1)
+	}
+	// Sleep-loop rather than select{}: without a pending timer the runtime's
+	// deadlock detector kills the process (panic → EOF on the pipe), which is
+	// the exited-source shape, not the wedged-source shape under test.
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+// TestSampleFramesStallKillsWedgedSource (2026-09-02 incident, 05:01 network
+// blip): a sampler source that emits one frame and then goes silent WITHOUT
+// exiting must be aborted after FrameStallTimeout instead of blocking
+// io.ReadFull forever (field shape: pixgate silent from 02:01 EOF-respawn
+// until the 05:09 service restart). Before the fix this test hangs.
+func TestSampleFramesStallKillsWedgedSource(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GO_PIXGATE_HELPER", "stall")
+	cfg := Config{
+		FFmpegPath: exe,
+		FFmpegArgs: func(string, float64) []string {
+			return []string{"-test.run=TestHelperStallProcess"}
+		},
+		FrameStallTimeout: 300 * time.Millisecond,
+	}
+	fr := make([]byte, GridW*GridH)
+	n, serr := sampleFrames(context.Background(), cfg, Target{URL: "rtsp://example/stream"}, 10,
+		func([]byte) bool { return true }, fr)
+	if n != 1 {
+		t.Fatalf("frames = %d, want 1 (the first frame must arrive before the stall)", n)
+	}
+	if serr == nil || !strings.Contains(serr.Error(), "stall") {
+		t.Fatalf("want a stall error, got %v", serr)
+	}
+}
+
+// TestFFmpegArgsSocketReadTimeout: the ffmpeg invocation must carry a socket
+// read timeout (-rw_timeout) ahead of -i so a dead RTSP connection fails
+// inside ffmpeg instead of hanging the sampler process forever.
+func TestFFmpegArgsSocketReadTimeout(t *testing.T) {
+	args := ffmpegArgs(Target{URL: "rtsp://example/stream"}, 1)
+	iIdx, rwIdx := -1, -1
+	for k, a := range args {
+		if a == "-i" {
+			iIdx = k
+		}
+		if a == "-rw_timeout" {
+			rwIdx = k
+		}
+	}
+	if iIdx < 0 {
+		t.Fatal("args missing -i")
+	}
+	if rwIdx < 0 || rwIdx > iIdx {
+		t.Fatal("-rw_timeout must precede -i (it scopes the input socket)")
+	}
+	if rwIdx+1 >= len(args) {
+		t.Fatal("-rw_timeout has no value")
 	}
 }

--- a/internal/substream/substream_test.go
+++ b/internal/substream/substream_test.go
@@ -10,6 +10,7 @@ package substream
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -61,6 +62,13 @@ type testSource struct {
 	done     chan struct{}
 	url      string
 	lastConn atomic.Pointer[gortsplib.ServerConn]
+	// connCount counts accepted connections — the reconnect assertion anchor
+	// for the silent-server test (a teardown + redial shows up as +1).
+	connCount atomic.Int32
+	// silent makes the writer stop emitting RTP while keeping the connection
+	// and the stream open — the half-open shape (no FIN, no data) a network
+	// blip leaves behind.
+	silent atomic.Bool
 
 	// streamReady gates the writer until the ServerStream exists. The stream
 	// is created lazily on the first DESCRIBE — ServerStream.Initialize
@@ -72,6 +80,7 @@ type testSource struct {
 
 func (s *testSource) OnConnOpen(ctx *gortsplib.ServerHandlerOnConnOpenCtx) {
 	s.lastConn.Store(ctx.Conn)
+	s.connCount.Add(1)
 }
 
 // ensureStream builds the ServerStream on the first request.
@@ -102,6 +111,15 @@ func (s *testSource) OnPlay(*gortsplib.ServerHandlerOnPlayCtx) (*base.Response, 
 	return &base.Response{StatusCode: base.StatusOK}, nil
 }
 
+// GoSilent stops emitting RTP while keeping the accepted connection and the
+// ServerStream alive — from the client this is indistinguishable from a
+// half-open TCP connection after a network blip. SetSilent(false) resumes.
+func (s *testSource) GoSilent()        { s.silent.Store(true) }
+func (s *testSource) SetSilent(v bool) { s.silent.Store(v) }
+
+// ConnCount reports how many client connections the server has accepted.
+func (s *testSource) ConnCount() int { return int(s.connCount.Load()) }
+
 // writeLoop alternates IDR (with in-band parameter sets) and P frames at
 // ~40ms cadence — a plausible low-res sub-stream.
 func (s *testSource) writeLoop() {
@@ -125,11 +143,13 @@ func (s *testSource) writeLoop() {
 		} else {
 			au = [][]byte{s.pSl}
 		}
-		pkts, err := s.enc.Encode(au)
-		if err == nil {
-			for _, p := range pkts {
-				p.Timestamp = ts
-				_ = s.stream.WritePacketRTP(s.media, p)
+		if !s.silent.Load() {
+			pkts, err := s.enc.Encode(au)
+			if err == nil {
+				for _, p := range pkts {
+					p.Timestamp = ts
+					_ = s.stream.WritePacketRTP(s.media, p)
+				}
 			}
 		}
 		ts += 3600 // 40ms @ 90kHz
@@ -278,18 +298,23 @@ func newTestManager(t *testing.T, url string, mut func(*Config)) *Manager {
 	return m
 }
 
+// recvFrameSeq disambiguates hub consumer names so a test can call recvFrame
+// more than once (the unsubscribe rides t.Cleanup, which runs only at the end).
+var recvFrameSeq atomic.Int64
+
 // recvFrame subscribes to the hub and returns the first frame matching pred
 // (timeout 5s).
 func recvFrame(t *testing.T, src *Source, pred func(model.FrameMsg) bool) model.FrameMsg {
 	t.Helper()
+	name := fmt.Sprintf("test-%d", recvFrameSeq.Add(1))
 	frames := make(chan model.FrameMsg, 64)
-	require.NoError(t, src.Hub().SubscribeMsg("test", func(m model.FrameMsg) {
+	require.NoError(t, src.Hub().SubscribeMsg(name, func(m model.FrameMsg) {
 		select {
 		case frames <- m:
 		default:
 		}
 	}))
-	t.Cleanup(func() { src.Hub().Unsubscribe("test") })
+	t.Cleanup(func() { src.Hub().Unsubscribe(name) })
 	deadline := time.After(5 * time.Second)
 	for {
 		select {
@@ -343,6 +368,40 @@ func TestAcquireH265ReadyAndFrames(t *testing.T) {
 	mf := recvFrame(t, src, func(m model.FrameMsg) bool { return m.IsKeyframe })
 	require.NotEmpty(t, mf.AU)
 
+	m.Release("cam-1")
+}
+
+// TestPullSilentServerTornDownAndRedialed is the N1 regression test (incident
+// 2026-09-02 05:01): a live session whose server goes silent WITHOUT closing
+// the TCP connection — the half-open shape a network blip leaves behind — must
+// be torn down promptly (gortsplib's own TCP inactivity timeout via
+// ReadTimeout=DialTimeout, backed by the manager's FrameStallTimeout watchdog)
+// and redialed. The pull loop must never park in client.Wait() forever while
+// consumers starve. Teardown is observable as a fresh accepted connection; the
+// same Source/hub then recovers once data flows again.
+func TestPullSilentServerTornDownAndRedialed(t *testing.T) {
+	src, url := newTestSource(t, model.FormatH264)
+	m := newTestManager(t, url, func(c *Config) {
+		c.DialTimeout = 500 * time.Millisecond // → client ReadTimeout
+		c.FrameStallTimeout = 2 * time.Second
+		c.IdleTimeout = 30 * time.Second // keep the entry alive across the redial
+	})
+
+	s, err := m.Acquire(context.Background(), "cam-1")
+	require.NoError(t, err)
+	_ = recvFrame(t, s, func(fm model.FrameMsg) bool { return fm.IsKeyframe })
+	before := src.ConnCount()
+
+	src.GoSilent()
+
+	require.Eventually(t, func() bool { return src.ConnCount() >= before+1 },
+		10*time.Second, 100*time.Millisecond,
+		"silent half-open session was not torn down and redialed")
+
+	// Resume writing: the redialed session must deliver frames again on the
+	// SAME source (hub survives reconnection).
+	src.SetSilent(false)
+	_ = recvFrame(t, s, func(fm model.FrameMsg) bool { return fm.IsKeyframe })
 	m.Release("cam-1")
 }
 


### PR DESCRIPTION
Closes #667

## pixgate 采样器停滞重生（bug）

- **现场形态**：09-02 05:01 网络闪断后采样器静默死亡（02:01 EOF 重生后日志归零），05:09 重启才恢复——ffmpeg 悬死在网络读上，`io.ReadFull` 永久阻塞。
- **修复**：停滞看门狗（`FrameStallTimeout` 默认 30s，可注入）超时 Kill → 管道关闭 → `runCamera` 退避重生；`ffmpegArgs` 加 `-rw_timeout 15s` 双保险。
- **测试**：`TestSampleFramesStallKillsWedgedSource`（TestHelperProcess 模式：假 ffmpeg 输出一帧后挂死 → 300ms 内杀掉并返回 stall 错误）、`TestFFmpegArgsSocketReadTimeout`。

## substream 半开会话回归定性（test/evidence）

- `TestPullSilentServerTornDownAndRedialed`：服务器静默不关连接（无 FIN 无数据 = 半开形态）→ gortsplib TCP 空闲超时（`ReadTimeout=DialTimeout`）秒级拆除 → 重拨 → 同一 Source 恢复出帧。
- **事故定性结论**：journal（闪断窗口零 sub-stream 错误、子层 tierrec 每分钟出段）+ DB（视通/H80 主流 60s 段无缺口）证明 09-02 05:01 事故 NVR 侧无冻结——「看门狗失效」为巡检误判（UTC 时间戳误读），消费端（外部 AI 后端）才是卡死方。
- 测试基建：`testSource` 加 `GoSilent/SetSilent/ConnCount`；`recvFrame` 消费者名唯一化（支持同测试多次订阅）。

## 验证

- `go test -race ./internal/pixgate/ ./internal/substream/` 本地全绿（pixgate 5.4s / substream 27.2s）。
- 不改任何生产路径行为（仅 pixgate 新增防御 + 测试）。