### PR TITLE
ci(release): artifact checksums + ed25519 signature (#646)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,33 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -trimpath -ldflags="$LDFLAGS" -o mibee-nvr-armv7 ./cmd/mibee-nvr/ &
           wait
 
+      # ---- Artifact integrity (#646) ------------------------------------------
+      # checksums.txt (sha256sum format) + a raw 64-byte ed25519 signature over
+      # it, verified in-process by internal/update (pure Go, stdlib ed25519 —
+      # the interop contract is locked by TestVerifyChecksumsSignature_OpenSSLInterop).
+      # The matching public key is embedded in internal/update/verify.go and
+      # shipped as PEM in deploy/keys/release-signing.pub.pem.
+      # If RELEASE_SIGNING_KEY is unset the checksums still upload, unsigned —
+      # a missing secret must never block a release (same policy as the ACR
+      # mirror job).
+      - name: Generate checksums and signature
+        env:
+          SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          sha256sum mibee-nvr-amd64 mibee-nvr-arm64 mibee-nvr-armv7 > checksums.txt
+          cat checksums.txt
+          if [ -n "${SIGNING_KEY}" ]; then
+            printf '%s' "$SIGNING_KEY" | base64 -d > "$RUNNER_TEMP/release-signing.key"
+            openssl pkeyutl -sign -inkey "$RUNNER_TEMP/release-signing.key" \
+              -rawin -in checksums.txt -out checksums.txt.sig
+            rm -f "$RUNNER_TEMP/release-signing.key"
+            echo "SIGNED=true" >> "$GITHUB_ENV"
+            echo "checksums.txt.sig created"
+          else
+            echo "::warning::RELEASE_SIGNING_KEY secret not set — checksums.txt uploaded WITHOUT ed25519 signature"
+          fi
+
       - name: Update release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -62,6 +89,14 @@ jobs:
             mibee-nvr-amd64
             mibee-nvr-arm64
             mibee-nvr-armv7
+            checksums.txt
+
+      - name: Attach release signature
+        if: env.SIGNED == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: checksums.txt.sig
+          append_body: false
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3

--- a/deploy/keys/release-signing.pub.pem
+++ b/deploy/keys/release-signing.pub.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA8NQQQl1tSJAZZ/t2n3qzMmdzxoYqAcNEXfF4v05bmyw=
+-----END PUBLIC KEY-----

--- a/docs/en/deployment-autoupdate.md
+++ b/docs/en/deployment-autoupdate.md
@@ -86,3 +86,24 @@ Watchtower supports [Shoutrrr](https://containrrr.dev/shoutrrr/) notification UR
 | QNAP QTS | Container Station: rebuild, or Watchtower |
 
 See the per-platform deployment docs for specifics.
+
+## Verifying bare-metal release artifacts (#646)
+
+Every GitHub Release ships `checksums.txt` (SHA-256 over the bare binaries, `sha256sum` format) and `checksums.txt.sig` (a 64-byte raw ed25519 signature over checksums.txt). The signing private key lives in the repository secret; the public key is embedded in the binary (`internal/update/verify.go`) and distributed as PEM in the repo (`deploy/keys/release-signing.pub.pem`). Until the bare-metal auto-updater (#647) lands, verify manually:
+
+```bash
+# 1. Integrity: the downloaded mibee-nvr-<arch> matches checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+
+# 2. (Optional) Provenance: prove checksums.txt was produced by this project
+curl -fsSL -o release-signing.pub.pem \
+  https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/keys/release-signing.pub.pem
+openssl pkeyutl -verify -pubin -inkey release-signing.pub.pem \
+  -rawin -in checksums.txt -sigfile checksums.txt.sig
+```
+
+Notes:
+
+- `checksums.txt` covers the three bare binaries (amd64/arm64/armv7). The fnOS `.fpk` is distributed through the fnOS store channel; Docker images are integrity-protected by registry digests.
+- If a Release has no `checksums.txt.sig`, the signing secret was not configured (that release is unsigned) — step 1 alone still checks integrity.
+- A key rotation means newer Releases are signed with a new key; always take the public key from the repo's main branch.

--- a/docs/zh/deployment-autoupdate.md
+++ b/docs/zh/deployment-autoupdate.md
@@ -86,3 +86,24 @@ Watchtower 支持 [Shoutrrr](https://containrrr.dev/shoutrrr/) 通知 URL。在 
 | 威联通 QTS | Container Station：重建，或 Watchtower |
 
 详见各平台部署文档。
+
+## 裸机安装的产物校验（#646）
+
+每次 GitHub Release 附带 `checksums.txt`(裸二进制的 SHA-256,`sha256sum` 格式)与 `checksums.txt.sig`(对 checksums.txt 的 ed25519 签名,64 字节原始签名)。签名私钥保存在仓库 Secret 中,公钥内嵌于程序内(`internal/update/verify.go`)并以 PEM 形式随仓库分发(`deploy/keys/release-signing.pub.pem`)。裸机自动升级(#647)落地前,可手动校验:
+
+```bash
+# 1. 校验完整性:下载的 mibee-nvr-<arch> 与 checksums.txt 对应
+sha256sum -c checksums.txt --ignore-missing
+
+# 2. (可选)校验来源:证明 checksums.txt 出自本项目,未被篡改
+curl -fsSL -o release-signing.pub.pem \
+  https://raw.githubusercontent.com/Mi-Bee-Studio/MiBeeNvr/main/deploy/keys/release-signing.pub.pem
+openssl pkeyutl -verify -pubin -inkey release-signing.pub.pem \
+  -rawin -in checksums.txt -sigfile checksums.txt.sig
+```
+
+注意:
+
+- `checksums.txt` 覆盖三个裸二进制(amd64/arm64/armv7);fnOS `.fpk` 由飞牛商店渠道分发,不在其列;Docker 镜像由 registry 摘要保证完整性。
+- 若某次 Release 没有 `checksums.txt.sig`,说明签名 Secret 未配置(该 Release 未签名),只做第 1 步完整性校验。
+- 密钥轮换意味着新 Release 用新公钥签发;以仓库 main 分支上的公钥为准。

--- a/internal/update/verify.go
+++ b/internal/update/verify.go
@@ -1,0 +1,95 @@
+package update
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Release artifact verification (#646).
+//
+// release.yml attaches checksums.txt (sha256sum format over the bare
+// binaries) and checksums.txt.sig (raw 64-byte ed25519 signature over
+// checksums.txt, produced from the RELEASE_SIGNING_KEY GitHub secret) to
+// every release. This file carries the matching public key and the pure-Go
+// verification the future self-update pipeline (#647) — and manual users —
+// use to prove a downloaded binary is the exact artifact this project
+// released: verify the signature over checksums.txt, then match the binary's
+// sha256 against its line.
+
+// releaseSigningPubKeyB64 is the raw 32-byte ed25519 public key (base64)
+// corresponding to the RELEASE_SIGNING_KEY secret. The PEM form for manual
+// openssl verification ships in deploy/keys/release-signing.pub.pem.
+// Rotating the key means regenerating the pair, updating this const (and the
+// PEM), and replacing the secret — releases signed by the old key will then
+// fail verification, which is the intended fail-closed behavior.
+const releaseSigningPubKeyB64 = "8NQQQl1tSJAZZ/t2n3qzMmdzxoYqAcNEXfF4v05bmyw="
+
+// VerifyChecksumsSignature checks an ed25519 signature (raw 64 bytes, as
+// produced by `openssl pkeyutl -sign -rawin`) over the full checksums.txt
+// bytes, using the embedded release signing key.
+func VerifyChecksumsSignature(checksums, sig []byte) error {
+	raw, err := base64.StdEncoding.DecodeString(releaseSigningPubKeyB64)
+	if err != nil {
+		return fmt.Errorf("update: embedded release signing key is malformed: %w", err)
+	}
+	return verifyWithKey(ed25519.PublicKey(raw), checksums, sig)
+}
+
+// verifyWithKey is VerifyChecksumsSignature with an injected key (tests sign
+// with their own throwaway pairs).
+func verifyWithKey(pub ed25519.PublicKey, checksums, sig []byte) error {
+	if len(pub) != ed25519.PublicKeySize {
+		return fmt.Errorf("update: bad public key size %d (want %d)", len(pub), ed25519.PublicKeySize)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		return fmt.Errorf("update: bad signature size %d (want %d)", len(sig), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(pub, checksums, sig) {
+		return errors.New("update: checksums.txt signature verification failed — the artifact may be corrupted or tampered with")
+	}
+	return nil
+}
+
+// VerifyBinaryChecksum matches data's sha256 against filename's line in a
+// sha256sum-format checksums.txt ("<64 hex chars>  <filename>" per line).
+// This is the second half of the chain: a valid signature over checksums.txt
+// plus a matching digest proves the downloaded bytes are the released ones.
+func VerifyBinaryChecksum(checksums []byte, filename string, data []byte) error {
+	want, err := digestFor(checksums, filename)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+	if got != want {
+		return fmt.Errorf("update: %s checksum mismatch: got %s, release says %s", filename, got, want)
+	}
+	return nil
+}
+
+func digestFor(checksums []byte, filename string) (string, error) {
+	for line := range strings.Lines(string(checksums)) {
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 || parts[1] != filename {
+			continue
+		}
+		digest := parts[0]
+		if len(digest) != 64 {
+			return "", fmt.Errorf("update: malformed digest for %s in checksums.txt", filename)
+		}
+		if _, err := hex.DecodeString(digest); err != nil {
+			return "", fmt.Errorf("update: non-hex digest for %s in checksums.txt", filename)
+		}
+		return digest, nil
+	}
+	return "", fmt.Errorf("update: %s not listed in checksums.txt", filename)
+}

--- a/internal/update/verify_test.go
+++ b/internal/update/verify_test.go
@@ -1,0 +1,160 @@
+package update
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testChecksums mirrors the sha256sum format produced by release.yml.
+const testChecksums = `3f79bb7b435b05321651daefd374cdc681dc06faa65e374e38337b88ca046dea  mibee-nvr-amd64
+9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08  mibee-nvr-arm64
+b17ef6d19c7a5b1e83b9895f5d4b9a1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f70  mibee-nvr-armv7
+`
+
+func signForTest(t *testing.T, priv ed25519.PrivateKey, data []byte) []byte {
+	t.Helper()
+	return ed25519.Sign(priv, data)
+}
+
+func TestVerifyChecksumsSignature_ValidAndTampered(t *testing.T) {
+	t.Parallel()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig := signForTest(t, priv, []byte(testChecksums))
+
+	if err := verifyWithKey(pub, []byte(testChecksums), sig); err != nil {
+		t.Fatalf("valid signature must verify: %v", err)
+	}
+
+	// Flip ONE byte in the checksums (the forged-binary scenario) — must fail.
+	forged := []byte(testChecksums)
+	forged[0] ^= 0x01
+	if err := verifyWithKey(pub, forged, sig); err == nil {
+		t.Fatal("tampered checksums must fail signature verification")
+	}
+
+	// Flip one byte in the signature itself.
+	badSig := append([]byte(nil), sig...)
+	badSig[7] ^= 0x01
+	if err := verifyWithKey(pub, []byte(testChecksums), badSig); err == nil {
+		t.Fatal("tampered signature must fail")
+	}
+
+	// Wrong key entirely.
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyWithKey(otherPub, []byte(testChecksums), sig); err == nil {
+		t.Fatal("signature by a different key must fail")
+	}
+
+	// Malformed key sizes.
+	if err := verifyWithKey(ed25519.PublicKey(make([]byte, 10)), []byte(testChecksums), sig); err == nil {
+		t.Fatal("undersized public key must fail")
+	}
+	if err := verifyWithKey(pub, []byte(testChecksums), sig[:32]); err == nil {
+		t.Fatal("undersized signature must fail")
+	}
+}
+
+func TestEmbeddedReleaseSigningKeyWellFormed(t *testing.T) {
+	t.Parallel()
+	raw, err := base64.StdEncoding.DecodeString(releaseSigningPubKeyB64)
+	if err != nil {
+		t.Fatalf("embedded key must be valid base64: %v", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		t.Fatalf("embedded key must be %d raw bytes (ed25519), got %d", ed25519.PublicKeySize, len(raw))
+	}
+}
+
+func TestVerifyBinaryChecksum(t *testing.T) {
+	t.Parallel()
+	payload := []byte("fake binary bytes")
+	sum := sha256.Sum256(payload)
+	checksums := fmt.Sprintf("%s  mibee-nvr-amd64\n%s  mibee-nvr-arm64\n",
+		hex.EncodeToString(sum[:]), strings.Repeat("a", 64))
+
+	if err := VerifyBinaryChecksum([]byte(checksums), "mibee-nvr-amd64", payload); err != nil {
+		t.Fatalf("correct hash must verify: %v", err)
+	}
+
+	// One flipped payload byte — the forged-binary scenario (#646 acceptance).
+	forged := append([]byte(nil), payload...)
+	forged[0] ^= 0x01
+	if err := VerifyBinaryChecksum([]byte(checksums), "mibee-nvr-amd64", forged); err == nil {
+		t.Fatal("modified binary must fail checksum verification")
+	}
+
+	if err := VerifyBinaryChecksum([]byte(checksums), "mibee-nvr-armv7", payload); err == nil {
+		t.Fatal("file missing from checksums.txt must fail")
+	}
+
+	binaryLine := strings.Repeat("z", 64)
+	if err := VerifyBinaryChecksum([]byte(binaryLine+"  mibee-nvr-x\n"), "mibee-nvr-x", payload); err == nil {
+		t.Fatal("malformed hex digest must fail")
+	}
+}
+
+// TestVerifyChecksumsSignature_OpenSSLInterop locks the exact signature
+// format release.yml produces (`openssl pkeyutl -sign -rawin` over
+// checksums.txt with a PKCS#8 DER ed25519 key) to what verifyWithKey accepts:
+// a throwaway keypair is signed by the openssl binary and verified in-process.
+// Skips when openssl is unavailable (hermetic-by-default per repo test rules).
+func TestVerifyChecksumsSignature_OpenSSLInterop(t *testing.T) {
+	if _, err := exec.LookPath("openssl"); err != nil {
+		t.Skip("openssl not installed")
+	}
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "test.key")
+	if err := exec.Command("openssl", "genpkey", "-algorithm", "ed25519", "-outform", "DER", "-out", keyPath).Run(); err != nil {
+		t.Fatalf("genpkey: %v", err)
+	}
+	dataPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(dataPath, []byte(testChecksums), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sigPath := filepath.Join(dir, "checksums.txt.sig")
+	sign := exec.Command("openssl", "pkeyutl", "-sign", "-inkey", keyPath, "-rawin", "-in", dataPath, "-out", sigPath)
+	if out, err := sign.CombinedOutput(); err != nil {
+		t.Fatalf("pkeyutl -sign: %v\n%s", err, out)
+	}
+
+	// Extract the raw 32-byte public key from the SPKI DER (last 32 bytes).
+	pubSPKI, err := exec.Command("openssl", "pkey", "-in", keyPath, "-inform", "DER", "-pubout", "-outform", "DER").Output()
+	if err != nil {
+		t.Fatalf("pkey -pubout: %v", err)
+	}
+	if len(pubSPKI) < ed25519.PublicKeySize {
+		t.Fatalf("unexpected SPKI size %d", len(pubSPKI))
+	}
+	pub := ed25519.PublicKey(pubSPKI[len(pubSPKI)-ed25519.PublicKeySize:])
+
+	sig, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("openssl produced a %d-byte signature, want %d", len(sig), ed25519.SignatureSize)
+	}
+	if err := verifyWithKey(pub, []byte(testChecksums), sig); err != nil {
+		t.Fatalf("openssl-signed checksums must verify in-process: %v", err)
+	}
+	forged := []byte(testChecksums)
+	forged[0] ^= 0x01
+	if err := verifyWithKey(pub, forged, sig); err == nil {
+		t.Fatal("tampered checksums must fail against the openssl signature")
+	}
+}


### PR DESCRIPTION
## 背景 (#646)

裸机自动升级(#647)的硬前置:当前 Release 只上传裸二进制,没有任何完整性/来源校验手段——升级客户端下载后无从验证文件是否损坏、是否被篡改。

## 改动

**1. `release.yml`(release job,构建后)**
- `checksums.txt`:三个裸二进制(amd64/arm64/armv7)的 SHA-256,`sha256sum` 格式(浏览器用户可直接 `sha256sum -c`,未来客户端用 `VerifyBinaryChecksum` 解析同一格式)
- `checksums.txt.sig`:对 checksums.txt 的 **ed25519 签名**(64 字节原始签名,`openssl pkeyutl -sign -rawin`,私钥来自 Secret `RELEASE_SIGNING_KEY`,base64 PKCS#8 DER)
- **优雅降级**:Secret 未配置时 checksums.txt 照常上传(无签名 + warning 注解),绝不阻塞发版——与 ACR 镜像 job 同一策略;首个用上签名的发版自然携带 .sig
- 选型说明:ed25519(进程内纯 Go 验签,贴合静态二进制无外部依赖约束)优于 Artifact Attestations(设备端验证需 gh/cosign,嵌入式不现实)

**2. `internal/update/verify.go`(为 #647 准备的客户端侧)**
- 内嵌发布公钥 const(裸 32 字节 ed25519,base64)
- `VerifyChecksumsSignature`(验签)+ `VerifyBinaryChecksum`(sha256 匹配)——完整信任链:签名证明 checksums 出自本项目,摘要证明下载的字节与发布一致
- **openssl ↔ Go 互操作契约由测试锁定**:`TestVerifyChecksumsSignature_OpenSSLInterop` 用 openssl 二进制按 workflow 完全相同的命令签名、Go 进程内验签(openssl 缺失自动 skip,符合轻量夹具规约)
- 验收项"改动任意 1 字节的伪造二进制验签失败":篡改 checksums/签名/二进制字节的负向用例全覆盖

**3. 密钥操作(已执行)**
- 密钥对本会话生成:私钥经管道直接写入 GitHub Secret `RELEASE_SIGNING_KEY`(**未经过任何上下文/未落库**,本地临时文件已删);公钥内嵌 const + `deploy/keys/release-signing.pub.pem`
- 密钥轮换 = 重新生成对 + 更新 const/PEM/Secret,旧签名的 Release 验证失败属预期 fail-closed

**4. 文档**(`docs/{zh,en}/deployment-autoupdate.md` 追加章节,既有页面无需官网注册)
- 手动校验两步:`sha256sum -c` 完整性 + `openssl pkeyutl -verify` 来源
- 说明 .fpk(商店渠道)与 Docker 镜像(registry 摘要)不在 checksums 覆盖范围的原因

## 验证

- `internal/update` 26 项测试全绿(含 -race);golangci-lint 0 issues;workflow YAML 解析通过
- 真实密钥端到端(私钥签名→公钥验签)将在下一次实际发版时自然验证——互操作格式已由测试在等效密钥对上证明

Closes #646
