### PR TITLE
fix(pixgate): 移除 -rw_timeout —— M5 ffmpeg 4.4 拒识该参数，采样器 EOF 死循环

### DIFF
--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -560,10 +560,10 @@ func ffmpegArgs(target Target, fps float64) []string {
 	return []string{
 		"-hide_banner", "-loglevel", "error", "-nostdin",
 		"-rtsp_transport", "tcp",
-		// Socket-level read timeout (µs): a dead RTSP connection must fail
-		// inside ffmpeg, not hang the sampler process forever. Paired with
-		// the per-frame stall deadline in sampleFrames (belt and suspenders).
-		"-rw_timeout", "15000000", // 15s
+		// NOTE: no -rw_timeout here — M5's ffmpeg 4.4 rejects the option
+		// outright ("Option rw_timeout not found"), killing the sampler with
+		// zero frames. Wedged network reads are handled portably by the stall
+		// watchdog in sampleFrames (kill + respawn).
 		"-i", u,
 		"-vf", fmt.Sprintf("fps=%.3f,scale=%d:%d", fps, GridW, GridH),
 		"-f", "rawvideo", "-pix_fmt", "gray",

--- a/internal/pixgate/pixgate_test.go
+++ b/internal/pixgate/pixgate_test.go
@@ -285,27 +285,25 @@ func TestSampleFramesStallKillsWedgedSource(t *testing.T) {
 	}
 }
 
-// TestFFmpegArgsSocketReadTimeout: the ffmpeg invocation must carry a socket
-// read timeout (-rw_timeout) ahead of -i so a dead RTSP connection fails
-// inside ffmpeg instead of hanging the sampler process forever.
-func TestFFmpegArgsSocketReadTimeout(t *testing.T) {
+// TestFFmpegArgsNoUnsupportedOptions: the sampler args must only use options
+// portable across the fleet's ffmpeg builds. -rw_timeout looked like a second
+// line of defense against wedged RTSP reads, but M5's ffmpeg 4.4 rejects it
+// outright ("Option rw_timeout not found" → Error opening input → sampler
+// EOF-loop with zero frames, deployed 2026-09-02 11:56 and caught live) — the
+// stall watchdog in sampleFrames is the portable defense.
+func TestFFmpegArgsNoUnsupportedOptions(t *testing.T) {
 	args := ffmpegArgs(Target{URL: "rtsp://example/stream"}, 1)
-	iIdx, rwIdx := -1, -1
-	for k, a := range args {
-		if a == "-i" {
-			iIdx = k
-		}
-		if a == "-rw_timeout" {
-			rwIdx = k
+	for _, banned := range []string{"-rw_timeout", "-stimeout", "-timeout"} {
+		for _, a := range args {
+			if a == banned {
+				t.Fatalf("ffmpegArgs must not use %s (rejected by ffmpeg 4.4 on M5): %v", banned, args)
+			}
 		}
 	}
-	if iIdx < 0 {
-		t.Fatal("args missing -i")
-	}
-	if rwIdx < 0 || rwIdx > iIdx {
-		t.Fatal("-rw_timeout must precede -i (it scopes the input socket)")
-	}
-	if rwIdx+1 >= len(args) {
-		t.Fatal("-rw_timeout has no value")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-rtsp_transport tcp", "-i rtsp://example/stream", "-f rawvideo", "-pix_fmt gray"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("args missing %q: %v", want, args)
+		}
 	}
 }


### PR DESCRIPTION
#668 部署后 15 分钟内抓到的回归热修。

## 现场

- #668 于 11:56 部署 M5 → 视通 pixgate 采样器立即 `frames=0 error=EOF` 重试死循环。
- 机器复现：M5 的 /usr/bin/ffmpeg 4.4 解析期直接报 `Option rw_timeout not found` → `Error opening input`，每次重生在首帧前退出；同一命令去掉该参数后灰帧流正常（已在 M5 实测对比）。

## 修复

- `ffmpegArgs` 移除 `-rw_timeout`；停滞看门狗（sampleFrames Kill+重生）本就是跨版本的唯一可移植防线，保留不变。
- `TestFFmpegArgsSocketReadTimeout` 反转为 `TestFFmpegArgsNoUnsupportedOptions`：参数表钉死不得使用 -rw_timeout/-stimeout/-timeout（车队最老 ffmpeg 4.4 兼容性），并断言管道要素齐全。