### PR TITLE
feat(vision): heartbeat protocol v2 — queue-drop accounting, runtime metrics, 'skipped' recording status

### DIFF
--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -384,12 +384,9 @@ func (h *Handler) handleUpdateRecording(w http.ResponseWriter, r *http.Request) 
 // handleUpdateRecordingAIStatus allows MiBeeVision to update the AI processing
 // status of a recording. Requires API Key authentication.
 // PATCH /api/recordings/{id}/ai-status  body: {"ai_status":"completed", "ai_error":""}
-// Valid ai_status values: pending, processing, completed, failed.
-
-// handleUpdateRecordingAIStatus allows MiBeeVision to update the AI processing
-// status of a recording. Requires API Key authentication.
-// PATCH /api/recordings/{id}/ai-status  body: {"ai_status":"completed", "ai_error":""}
-// Valid ai_status values: pending, processing, completed, failed.
+// Valid ai_status values: pending, processing, completed, failed, skipped.
+// 'skipped' (#671) = consumer-reported queue drop: terminal, stamps
+// ai_processed_at, reason goes in ai_error.
 func (h *Handler) handleUpdateRecordingAIStatus(w http.ResponseWriter, r *http.Request) {
 	if !middleware.IsAPIKeyAuthenticated(r.Context()) {
 		WriteError(w, http.StatusUnauthorized, "API key required")
@@ -412,10 +409,10 @@ func (h *Handler) handleUpdateRecordingAIStatus(w http.ResponseWriter, r *http.R
 
 	// Validate ai_status value.
 	switch body.AIStatus {
-	case "pending", "processing", "completed", "failed":
+	case "pending", "processing", "completed", "failed", "skipped":
 		// ok
 	default:
-		WriteError(w, http.StatusBadRequest, "invalid ai_status; must be one of: pending, processing, completed, failed")
+		WriteError(w, http.StatusBadRequest, "invalid ai_status; must be one of: pending, processing, completed, failed, skipped")
 		return
 	}
 

--- a/internal/api/handlers_recording_extra_test.go
+++ b/internal/api/handlers_recording_extra_test.go
@@ -149,6 +149,26 @@ func TestRecordingCRUD_VisionPaths(t *testing.T) {
 	require.Equal(t, "completed", rec.AIStatus)
 }
 
+func TestRecordingAIStatus_SkippedAccepted(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	routes := withAPIKey("vision", h.Routes())
+	seedRecording(t, db, makeRecording("skip-1", "cam-1", "mp4", time.Now(), false))
+
+	// 'skipped' = consumer-reported queue drop (#671): terminal, stamps
+	// ai_processed_at, carries the reason in ai_error.
+	rr := doRequest(t, routes, http.MethodPatch, "/api/recordings/skip-1/ai-status",
+		strings.NewReader(`{"ai_status":"skipped","ai_error":"vision drop:queue_full"}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	rec, err := db.GetRecording(context.Background(), "skip-1")
+	require.NoError(t, err)
+	require.Equal(t, "skipped", rec.AIStatus)
+	require.Equal(t, "vision drop:queue_full", rec.AIError)
+	require.NotNil(t, rec.AIProcessedAt)
+}
+
 func TestTimelineSeekEvent(t *testing.T) {
 	t.Parallel()
 	db, store := setupTestDB(t)

--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -120,8 +120,8 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) handleVisionMetrics(w http.ResponseWriter, r *http.Request) {
 	if h.visionCoordinator == nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"enabled":     false,
-			"points":      []vision.VisionSample{},
+			"enabled":      false,
+			"points":       []vision.VisionSample{},
 			"marked_total": 0,
 		})
 		return

--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/go-chi/chi/v5"
@@ -17,11 +19,17 @@ func (h *Handler) registerVisionPublicRoutes(r chi.Router) {
 // registerVisionRoutes 注册需要认证的 Vision 端点(在 protected 组,Web UI 用)。
 func (h *Handler) registerVisionRoutes(r chi.Router) {
 	r.Get("/api/vision/status", h.handleVisionStatus)
+	r.Get("/api/vision/metrics", h.handleVisionMetrics)
 }
 
 // handleVisionHeartbeat 接收 MiBeeVision 的心跳报告。
 // Vision 每 30 秒 POST 一次,NVR 据此判断 Vision 是否健康。
 // 只有健康的 Vision 才会收到段推送。
+//
+// 心跳 v2 (#671) 增加两个可选块(旧版本消费者不带,完全向后兼容):
+//   - drops:批量丢弃报告(压缩范围)。收到即把受影响录像标记
+//     ai_status='skipped',并在响应回 ack_drops=seq 让消费者清空暂存。
+//   - metrics:运行指标快照,进内存历史环供仪表盘查询。
 func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if h.visionCoordinator == nil {
 		WriteError(w, http.StatusServiceUnavailable, "vision integration not enabled")
@@ -38,6 +46,9 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		// SkipCameras(#515): 消费者声明不处理的相机,NVR 停推(含离线补偿)。
 		// 缺省/为空 = 全推(向后兼容)。
 		SkipCameras []string `json:"skip_cameras"`
+		// 心跳 v2 (#671) 可选块。
+		Drops   *vision.VisionDrops   `json:"drops"`
+		Metrics *vision.VisionMetrics `json:"metrics"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
@@ -50,12 +61,25 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		QueueDepth:     body.QueueDepth,
 		ProcessedCount: body.ProcessedCount,
 		SkipCameras:    body.SkipCameras,
+		Drops:          body.Drops,
+		Metrics:        body.Metrics,
 	})
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"ok":           true,
 		"push_enabled": h.visionCoordinator.Health().IsHealthy(),
-	})
+	}
+	if body.Drops != nil {
+		if h.db != nil {
+			if marked := vision.ApplyDrops(r.Context(), h.db, body.Drops); marked > 0 {
+				h.visionCoordinator.Health().NoteMarkedDrops(marked)
+			}
+		}
+		// ack = "已收到并消费这份报告"。即使个别范围数据坏掉被跳过,
+		// 也回 ack——不让消费者对一份注定无法生效的报告无限重试。
+		resp["ack_drops"] = body.Drops.Seq
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleVisionStatus 返回 Vision 集成的当前状态(供 NVR Web UI 展示)。
@@ -77,10 +101,48 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 		"processed":    status.ProcessedCount,
 		"skip_cameras": status.SkipCameras, // #515: 消费者声明的跳单(空=nil=全推)
 	}
+	if status.Metrics != nil {
+		resp["metrics"] = status.Metrics
+	}
+	if n := h.visionCoordinator.Health().MarkedDropTotal(); n > 0 {
+		resp["drops_marked_total"] = n
+	}
 	// Omit the zero time — no heartbeat has ever been received. Rendering it
 	// would surface "0001-01-01" in the UI (#328).
 	if !lastSeen.IsZero() {
 		resp["last_seen"] = lastSeen
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleVisionMetrics 返回心跳历史采样环(内存,约 24h @ 30s),供仪表盘
+// 趋势图。?hours=1..168(默认 24)。
+func (h *Handler) handleVisionMetrics(w http.ResponseWriter, r *http.Request) {
+	if h.visionCoordinator == nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"enabled":     false,
+			"points":      []vision.VisionSample{},
+			"marked_total": 0,
+		})
+		return
+	}
+
+	hours := 24
+	if v := r.URL.Query().Get("hours"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			hours = parsed
+		}
+	}
+	if hours < 1 {
+		hours = 1
+	}
+	if hours > 168 {
+		hours = 168
+	}
+	since := time.Now().Add(-time.Duration(hours) * time.Hour)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled":      true,
+		"points":       h.visionCoordinator.Health().MetricsHistory(since),
+		"marked_total": h.visionCoordinator.Health().MarkedDropTotal(),
+	})
 }

--- a/internal/api/handlers_vision_test.go
+++ b/internal/api/handlers_vision_test.go
@@ -5,9 +5,11 @@ package api
 // values — only the health tracker matters here).
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -68,4 +70,114 @@ func TestVision_HeartbeatAndStatus(t *testing.T) {
 	require.Contains(t, rr.Body.String(), `"device":"vision-1"`)
 	require.Contains(t, rr.Body.String(), `"last_seen"`)
 	require.Contains(t, rr.Body.String(), "cam-x")
+}
+
+func TestVision_HeartbeatV2DropsAndMetrics(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	h.SetVisionCoordinator(vision.NewCoordinator(
+		func() config.VisionConfig { return config.VisionConfig{HeartbeatTimeoutSecs: 30} },
+		func() string { return store.RootDir() },
+		event.NewEventBus(4),
+		nil, nil,
+	))
+	routes := h.Routes()
+
+	// Seed recordings: precise-id drop target (sub-layer join), range-fallback
+	// target, and a terminal-status row that must stay untouched.
+	base := time.Date(2026, 9, 2, 4, 0, 0, 0, time.UTC)
+	seedRecording(t, db, makeRecording("drop-precise", "cam-1", "mp4", base, false))
+	seedRecording(t, db, makeRecording("drop-range", "cam-1", "mp4", base.Add(10*time.Minute), false))
+	seedRecording(t, db, makeRecording("keep-done", "cam-1", "mp4", base.Add(11*time.Minute), false))
+	require.NoError(t, db.UpdateRecordingAIStatus(t.Context(), "keep-done", "completed", ""))
+
+	body := `{
+		"protocol": 2,
+		"status": "healthy",
+		"device": "cuda",
+		"queue_depth": 12,
+		"processed_count": 1024,
+		"skip_cameras": ["cam-x"],
+		"drops": {
+			"seq": 7,
+			"ranges": [
+				{"camera_id":"cam-1","reason":"queue_full","count":2,
+				 "from":"2026-09-02T04:00:01Z","to":"2026-09-02T04:01:00Z",
+				 "ids":["drop-precise","1786611799700038099#1756742400000000000"]},
+				{"camera_id":"cam-1","reason":"ttl_expired","count":1,
+				 "from":"2026-09-02T04:09:00Z","to":"2026-09-02T04:12:00Z"}
+			]
+		},
+		"metrics": {
+			"queue_capacity": 64, "decode_workers": 2, "workers_busy": 1,
+			"received_total": 2049, "dropped_total": 1045,
+			"dropped_queue_full": 1040, "dropped_ttl": 5,
+			"events_emitted": 88, "seg_ms_p50": 16600, "seg_ms_p90": 76400,
+			"decoded_queue_depth": 1, "mem_available_mb": 620, "load1": 2.1
+		}
+	}`
+	rr := doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat", strings.NewReader(body), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"ack_drops":7`)
+
+	// Marking: precise id marked; the non-existent joined sub-id is a no-op;
+	// the id-less range covers drop-range; keep-done stays completed.
+	for id, want := range map[string]string{
+		"drop-precise": "skipped",
+		"drop-range":   "skipped",
+		"keep-done":    "completed",
+	} {
+		rec, err := db.GetRecording(t.Context(), id)
+		require.NoError(t, err)
+		require.Equal(t, want, rec.AIStatus, id)
+	}
+
+	// Status now carries metrics + the marked-drop counter.
+	rr = doRequest(t, routes, http.MethodGet, "/api/vision/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"metrics"`)
+	require.Contains(t, rr.Body.String(), `"decode_workers":2`)
+	require.Contains(t, rr.Body.String(), `"drops_marked_total":2`)
+
+	// Metrics history endpoint returns the recorded samples.
+	rr = doRequest(t, routes, http.MethodGet, "/api/vision/metrics", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Points []vision.VisionSample `json:"points"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Points, 1)
+	require.Equal(t, 12, resp.Points[0].QueueDepth)
+	require.Equal(t, int64(1045), resp.Points[0].DroppedTotal)
+
+	// A v1 (legacy) heartbeat after a v2 one keeps working and does not
+	// produce an ack field for a report that wasn't sent.
+	rr = doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat",
+		strings.NewReader(`{"status":"healthy","device":"cuda","queue_depth":0,"processed_count":1025}`), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.NotContains(t, rr.Body.String(), "ack_drops")
+}
+
+func TestVision_HeartbeatV2UnparseableRangeTimesStill200(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	h.SetVisionCoordinator(vision.NewCoordinator(
+		func() config.VisionConfig { return config.VisionConfig{HeartbeatTimeoutSecs: 30} },
+		func() string { return store.RootDir() },
+		event.NewEventBus(4),
+		nil, nil,
+	))
+	routes := h.Routes()
+
+	// Garbage range (no ids, bad times): marking is skipped, heartbeat still
+	// succeeds and is acked — the consumer must not retry forever.
+	body := `{"status":"healthy","drops":{"seq":9,"ranges":[
+		{"camera_id":"cam-9","reason":"queue_full","count":1,"from":"garbage","to":"garbage"}]}}`
+	rr := doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat", strings.NewReader(body), "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"ack_drops":9`)
 }

--- a/internal/storage/db_dropmark_test.go
+++ b/internal/storage/db_dropmark_test.go
@@ -1,0 +1,109 @@
+package storage
+
+// Tests for queue-drop marking (#671): recordings reported dropped by the AI
+// consumer get ai_status='skipped' — never overwriting terminal statuses —
+// and are excluded from offline-compensation repush.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func seedDropRecording(t *testing.T, db *DB, id, cameraID, aiStatus string, startedAt time.Time) {
+	t.Helper()
+	r := &model.Recording{
+		ID: id, CameraID: cameraID, FilePath: "/data/" + id + ".mp4",
+		Format: model.Format("mp4"), StartedAt: startedAt, EndedAt: startedAt.Add(time.Minute),
+		FileSize: 100, FrameCount: 10,
+	}
+	require.NoError(t, db.InsertRecording(context.Background(), r))
+	if aiStatus != "" {
+		require.NoError(t, db.UpdateRecordingAIStatus(context.Background(), id, aiStatus, ""))
+	}
+}
+
+func TestMarkRecordingsSkippedByIDs(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 9, 2, 4, 0, 0, 0, time.UTC)
+
+	seedDropRecording(t, db, "drop-blank", "cam-1", "", base)
+	seedDropRecording(t, db, "drop-pending", "cam-1", "pending", base.Add(time.Minute))
+	seedDropRecording(t, db, "drop-processing", "cam-1", "processing", base.Add(2*time.Minute))
+	seedDropRecording(t, db, "keep-completed", "cam-1", "completed", base.Add(3*time.Minute))
+	seedDropRecording(t, db, "keep-failed", "cam-1", "failed", base.Add(4*time.Minute))
+	seedDropRecording(t, db, "keep-skipped-old", "cam-1", "skipped", base.Add(5*time.Minute))
+
+	marked, err := db.MarkRecordingsSkippedByIDs(ctx,
+		[]string{"drop-blank", "drop-pending", "drop-processing", "keep-completed", "keep-failed", "keep-skipped-old", "ghost-id"},
+		"vision drop:queue_full")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), marked, "only non-terminal rows are marked")
+
+	for _, id := range []string{"drop-blank", "drop-pending", "drop-processing"} {
+		rec, err := db.GetRecording(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "skipped", rec.AIStatus, id)
+		require.Equal(t, "vision drop:queue_full", rec.AIError, id)
+		require.NotNil(t, rec.AIProcessedAt, "skipped stamps ai_processed_at (%s)", id)
+	}
+	for _, id := range []string{"keep-completed", "keep-failed"} {
+		rec, err := db.GetRecording(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, id == "keep-completed", rec.AIStatus == "completed")
+		require.Equal(t, id == "keep-failed", rec.AIStatus == "failed")
+	}
+}
+
+func TestMarkRecordingsSkippedByRange(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2026, 9, 2, 4, 0, 0, 0, time.UTC)
+
+	seedDropRecording(t, db, "in-win-cam1", "cam-1", "", base.Add(10*time.Minute))
+	seedDropRecording(t, db, "in-win-cam2", "cam-2", "", base.Add(11*time.Minute))
+	seedDropRecording(t, db, "out-win-cam1", "cam-1", "", base.Add(5*time.Hour))
+	seedDropRecording(t, db, "in-win-done", "cam-1", "completed", base.Add(12*time.Minute))
+
+	marked, err := db.MarkRecordingsSkippedByRange(ctx, "cam-1",
+		base.Add(5*time.Minute), base.Add(3*time.Hour), "vision drop:ttl_expired")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), marked, "camera + time window + non-terminal filter")
+
+	rec, err := db.GetRecording(ctx, "in-win-cam1")
+	require.NoError(t, err)
+	require.Equal(t, "skipped", rec.AIStatus)
+	require.Equal(t, "vision drop:ttl_expired", rec.AIError)
+
+	rec, _ = db.GetRecording(ctx, "in-win-cam2")
+	require.Equal(t, "", rec.AIStatus, "other cameras untouched")
+	rec, _ = db.GetRecording(ctx, "out-win-cam1")
+	require.Equal(t, "", rec.AIStatus, "outside the time window untouched")
+	rec, _ = db.GetRecording(ctx, "in-win-done")
+	require.Equal(t, "completed", rec.AIStatus, "terminal status untouched")
+}
+
+func TestRepushExcludesSkipped(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	seedDropRecording(t, db, "repush-eligible", "cam-1", "", now.Add(-20*time.Minute))
+	seedDropRecording(t, db, "repush-skipped", "cam-1", "", now.Add(-18*time.Minute))
+	// Mark one as skipped via the drop path (not the generic status updater).
+	_, err := db.MarkRecordingsSkippedByIDs(ctx, []string{"repush-skipped"}, "vision drop:queue_full")
+	require.NoError(t, err)
+
+	recs, err := db.ListRecordingsForVisionRepush(ctx, now.Add(-2*time.Hour), now, 500)
+	require.NoError(t, err)
+	ids := make([]string, 0, len(recs))
+	for _, r := range recs {
+		ids = append(ids, r.ID)
+	}
+	require.ElementsMatch(t, []string{"repush-eligible"}, ids,
+		"dropped-and-marked recordings must not be re-pushed during offline compensation")
+}

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -1101,7 +1101,7 @@ func (d *DB) GetRecordingAIStatus(ctx context.Context, id string) (status string
 
 // MarkRecordingsSkippedByIDs marks the given recordings ai_status='skipped'
 // with the drop reason in ai_error (#671 — consumer-reported queue drops).
-// Only rows still in a non-terminal AI state ('', pending, processing) are
+// Only rows still in a non-terminal AI state (”, pending, processing) are
 // touched; completed/failed/skipped stay as-is. Returns rows marked.
 func (d *DB) MarkRecordingsSkippedByIDs(ctx context.Context, ids []string, aiErr string) (int64, error) {
 	defer d.observeQuery("MarkRecordingsSkippedByIDs", time.Now())

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -1099,6 +1099,54 @@ func (d *DB) GetRecordingAIStatus(ctx context.Context, id string) (status string
 	return
 }
 
+// MarkRecordingsSkippedByIDs marks the given recordings ai_status='skipped'
+// with the drop reason in ai_error (#671 — consumer-reported queue drops).
+// Only rows still in a non-terminal AI state ('', pending, processing) are
+// touched; completed/failed/skipped stay as-is. Returns rows marked.
+func (d *DB) MarkRecordingsSkippedByIDs(ctx context.Context, ids []string, aiErr string) (int64, error) {
+	defer d.observeQuery("MarkRecordingsSkippedByIDs", time.Now())
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	var sb strings.Builder
+	sb.WriteString(`UPDATE recordings SET ai_status='skipped', ai_error=?, ai_processed_at=? WHERE id IN (`)
+	for range ids {
+		sb.WriteString("?,")
+	}
+	sbString := sb.String()
+	sbString = sbString[:len(sbString)-1] + `) AND COALESCE(ai_status,'') IN ('','pending','processing');`
+
+	args := make([]any, 0, len(ids)+2)
+	args = append(args, aiErr, time.Now().UTC().Format("2006-01-02 15:04:05.999999999"))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	res, err := d.db.ExecContext(ctx, sbString, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// MarkRecordingsSkippedByRange is the id-less fallback of
+// MarkRecordingsSkippedByIDs: mark every non-terminal recording of the given
+// camera whose started_at falls inside [from, to] (#671). Returns rows marked.
+func (d *DB) MarkRecordingsSkippedByRange(ctx context.Context, cameraID string, from, to time.Time, aiErr string) (int64, error) {
+	defer d.observeQuery("MarkRecordingsSkippedByRange", time.Now())
+	if cameraID == "" || to.Before(from) {
+		return 0, nil
+	}
+	res, err := d.db.ExecContext(ctx,
+		`UPDATE recordings SET ai_status='skipped', ai_error=?, ai_processed_at=? WHERE camera_id=? AND started_at >= ? AND started_at <= ? AND COALESCE(ai_status,'') IN ('','pending','processing');`,
+		aiErr, time.Now().UTC().Format("2006-01-02 15:04:05.999999999"), cameraID, timeToDB(from), timeToDB(to))
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
 // UpdateRecordingMotionScore persists the compressed-domain activity score,
 // absolute-size confidence (issue #634) and activity flags for a recording
 // (issue #435). Written by the offline motion analyzer after a segment

--- a/internal/vision/dropmarker.go
+++ b/internal/vision/dropmarker.go
@@ -1,0 +1,125 @@
+package vision
+
+// dropmarker.go (#671): 解读消费者心跳 v2 的批量丢弃报告,把受影响的录像
+// 标记为 ai_status='skipped'(ai_error 携带原因)。被丢弃的段同时被排除在
+// 离线补偿重推之外(ListRecordingsForVisionRepush 只取 ''/pending/processing)
+// ——不会把消费者刚刚丢掉的东西再灌回去。
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// DropMarkerDB abstracts the recording-marking queries used by ApplyDrops.
+// Production wiring passes *storage.DB; tests use fakes.
+type DropMarkerDB interface {
+	MarkRecordingsSkippedByIDs(ctx context.Context, ids []string, aiErr string) (int64, error)
+	MarkRecordingsSkippedByRange(ctx context.Context, cameraID string, from, to time.Time, aiErr string) (int64, error)
+}
+
+// stripSubLayerSuffix 去掉子码流推送在录像 ID 后拼接的 "#<纳秒>" 后缀
+// (#514 的 joinRecordingID),与 AI 事件回写路径的剥壳规则一致。
+func stripSubLayerSuffix(id string) string {
+	if i := strings.LastIndexByte(id, '#'); i > 0 {
+		suffix := id[i+1:]
+		if suffix != "" && isAllDigits(suffix) {
+			return id[:i]
+		}
+	}
+	return id
+}
+
+func isAllDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitizeReason 清洗外部上报的丢弃原因:截取开头连续的 [a-z0-9_] 小写段,
+// 最长 32 字符,空则 unknown。该值会写进 ai_error 展示给用户。
+func sanitizeReason(reason string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(reason) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+		} else {
+			break
+		}
+	}
+	out := b.String()
+	if len(out) > 32 {
+		out = out[:32]
+	}
+	if out == "" {
+		out = "unknown"
+	}
+	return out
+}
+
+// ApplyDrops 按报告逐个范围标记录像,返回累计标记行数。
+//
+// 规则:
+//   - 范围带 ids → 精确按 ID 标记(id 先剥 "#nano" 子层后缀、去重)——
+//     时间字段此时仅作参考,解析失败不影响精确标记。
+//   - 范围无 ids → 相机 + [from,to] 时间窗批量标记;时间或相机不可用则
+//     跳过该范围(记 Warn,不让一条坏数据拖垮整份报告)。
+//   - 标记永远不覆盖终态(completed/failed/skipped),由 DB 层的状态卫兵保证。
+//
+// db 为 nil(测试/降级部署)时直接返回 0。
+func ApplyDrops(ctx context.Context, db DropMarkerDB, drops *VisionDrops) int64 {
+	if db == nil || drops == nil {
+		return 0
+	}
+	var total int64
+	for _, r := range drops.Ranges {
+		errMsg := "vision drop:" + sanitizeReason(r.Reason)
+
+		if ids := normalizeIDs(r.IDs); len(ids) > 0 {
+			n, err := db.MarkRecordingsSkippedByIDs(ctx, ids, errMsg)
+			if err != nil {
+				slog.Warn("vision drop report: mark by ids failed", "error", err, "count", len(ids))
+				continue
+			}
+			total += n
+			continue
+		}
+
+		from, errFrom := time.Parse(time.RFC3339, r.From)
+		to, errTo := time.Parse(time.RFC3339, r.To)
+		if errFrom != nil || errTo != nil || r.CameraID == "" || to.Before(from) {
+			slog.Warn("vision drop report: unusable range skipped",
+				"camera_id", r.CameraID, "reason", r.Reason, "count", r.Count)
+			continue
+		}
+		n, err := db.MarkRecordingsSkippedByRange(ctx, r.CameraID, from, to, errMsg)
+		if err != nil {
+			slog.Warn("vision drop report: mark by range failed", "error", err, "camera_id", r.CameraID)
+			continue
+		}
+		total += n
+	}
+	return total
+}
+
+// normalizeIDs 剥子层后缀 + 去重,保持首次出现顺序。
+func normalizeIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		norm := stripSubLayerSuffix(id)
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	return out
+}

--- a/internal/vision/dropmarker_test.go
+++ b/internal/vision/dropmarker_test.go
@@ -1,0 +1,116 @@
+package vision
+
+// Tests for dropmarker.go (#671): interpreting the consumer's batched drop
+// report and marking the affected recordings ai_status='skipped'.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMarkerDB struct {
+	byIDsCalls  []idCall
+	rangeCalls  []rangeCall
+	idsResult   int64
+	rangeResult int64
+}
+
+type idCall struct {
+	ids    []string
+	aiErr  string
+}
+
+type rangeCall struct {
+	cameraID string
+	from, to time.Time
+	aiErr    string
+}
+
+func (f *fakeMarkerDB) MarkRecordingsSkippedByIDs(ctx context.Context, ids []string, aiErr string) (int64, error) {
+	f.byIDsCalls = append(f.byIDsCalls, idCall{ids: append([]string(nil), ids...), aiErr: aiErr})
+	return f.idsResult, nil
+}
+
+func (f *fakeMarkerDB) MarkRecordingsSkippedByRange(ctx context.Context, cameraID string, from, to time.Time, aiErr string) (int64, error) {
+	f.rangeCalls = append(f.rangeCalls, rangeCall{cameraID: cameraID, from: from, to: to, aiErr: aiErr})
+	return f.rangeResult, nil
+}
+
+func TestStripSubLayerSuffix(t *testing.T) {
+	require.Equal(t, "1786611799700038099", stripSubLayerSuffix("1786611799700038099#1756742400000000000"))
+	require.Equal(t, "plain", stripSubLayerSuffix("plain"))
+	require.Equal(t, "", stripSubLayerSuffix(""))
+	// Suffix stripping only applies to the sub-layer "#<nano>" join; an id
+	// containing '#' earlier in the string is untouched.
+	require.Equal(t, "a#b#c", stripSubLayerSuffix("a#b#c"))
+}
+
+func TestApplyDropsPreciseIDs(t *testing.T) {
+	fake := &fakeMarkerDB{idsResult: 2}
+	drops := &VisionDrops{Seq: 1, Ranges: []VisionDropRange{{
+		CameraID: "cam-1", Reason: "queue_full", Count: 2,
+		From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:01:00Z",
+		IDs: []string{"rec-1", "1786...#1756742400000000000", "rec-1"}, // dup + sub-layer join
+	}}}
+	marked := ApplyDrops(context.Background(), fake, drops)
+	require.Equal(t, int64(2), marked)
+	require.Len(t, fake.byIDsCalls, 1)
+	require.Equal(t, []string{"rec-1", "1786..."}, fake.byIDsCalls[0].ids, "dup removed, #nano stripped")
+	require.Equal(t, "vision drop:queue_full", fake.byIDsCalls[0].aiErr)
+	require.Empty(t, fake.rangeCalls, "precise ids win over the time-window fallback")
+}
+
+func TestApplyDropsRangeFallback(t *testing.T) {
+	fake := &fakeMarkerDB{rangeResult: 37}
+	drops := &VisionDrops{Seq: 2, Ranges: []VisionDropRange{{
+		CameraID: "cam-2", Reason: "ttl_expired", Count: 37,
+		From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:31:20Z",
+	}}}
+	marked := ApplyDrops(context.Background(), fake, drops)
+	require.Equal(t, int64(37), marked)
+	require.Len(t, fake.rangeCalls, 1)
+	call := fake.rangeCalls[0]
+	require.Equal(t, "cam-2", call.cameraID)
+	require.Equal(t, "vision drop:ttl_expired", call.aiErr)
+	wantFrom, _ := time.Parse(time.RFC3339, "2026-09-02T04:00:01Z")
+	wantTo, _ := time.Parse(time.RFC3339, "2026-09-02T04:31:20Z")
+	require.Equal(t, wantFrom, call.from)
+	require.Equal(t, wantTo, call.to)
+}
+
+func TestApplyDropsSanitizesReason(t *testing.T) {
+	fake := &fakeMarkerDB{idsResult: 1}
+	drops := &VisionDrops{Ranges: []VisionDropRange{{
+		CameraID: "cam-1", Reason: "Queue<FULL>; DROP TABLE", Count: 1,
+		From:     "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z",
+		IDs:      []string{"rec-x"},
+	}}}
+	ApplyDrops(context.Background(), fake, drops)
+	// Leading run of [a-z0-9_] only — injected characters can't ride along
+	// into ai_error.
+	require.Equal(t, "vision drop:queue", fake.byIDsCalls[0].aiErr)
+}
+
+func TestApplyDropsSkipsMalformedRanges(t *testing.T) {
+	fake := &fakeMarkerDB{}
+	drops := &VisionDrops{Ranges: []VisionDropRange{
+		{CameraID: "cam-1", Reason: "queue_full", Count: 1,
+			From: "not-a-time", To: "also-not", IDs: []string{"rec-1"}},
+		{CameraID: "", Reason: "queue_full", Count: 1,
+			From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z"}, // no camera, no ids
+	}}
+	marked := ApplyDrops(context.Background(), fake, drops)
+	// rec-1 still marked precisely (ids present, times unparseable);
+	// the camera-less range with bad semantics is skipped entirely.
+	require.Equal(t, int64(0), marked)
+	require.Len(t, fake.byIDsCalls, 1)
+	require.Empty(t, fake.rangeCalls)
+}
+
+func TestApplyDropsNilSafe(t *testing.T) {
+	require.Zero(t, ApplyDrops(context.Background(), &fakeMarkerDB{}, nil))
+	require.Zero(t, ApplyDrops(context.Background(), &fakeMarkerDB{}, &VisionDrops{}))
+}

--- a/internal/vision/dropmarker_test.go
+++ b/internal/vision/dropmarker_test.go
@@ -19,8 +19,8 @@ type fakeMarkerDB struct {
 }
 
 type idCall struct {
-	ids    []string
-	aiErr  string
+	ids   []string
+	aiErr string
 }
 
 type rangeCall struct {
@@ -85,8 +85,8 @@ func TestApplyDropsSanitizesReason(t *testing.T) {
 	fake := &fakeMarkerDB{idsResult: 1}
 	drops := &VisionDrops{Ranges: []VisionDropRange{{
 		CameraID: "cam-1", Reason: "Queue<FULL>; DROP TABLE", Count: 1,
-		From:     "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z",
-		IDs:      []string{"rec-x"},
+		From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z",
+		IDs: []string{"rec-x"},
 	}}}
 	ApplyDrops(context.Background(), fake, drops)
 	// Leading run of [a-z0-9_] only — injected characters can't ride along
@@ -97,10 +97,14 @@ func TestApplyDropsSanitizesReason(t *testing.T) {
 func TestApplyDropsSkipsMalformedRanges(t *testing.T) {
 	fake := &fakeMarkerDB{}
 	drops := &VisionDrops{Ranges: []VisionDropRange{
-		{CameraID: "cam-1", Reason: "queue_full", Count: 1,
-			From: "not-a-time", To: "also-not", IDs: []string{"rec-1"}},
-		{CameraID: "", Reason: "queue_full", Count: 1,
-			From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z"}, // no camera, no ids
+		{
+			CameraID: "cam-1", Reason: "queue_full", Count: 1,
+			From: "not-a-time", To: "also-not", IDs: []string{"rec-1"},
+		},
+		{
+			CameraID: "", Reason: "queue_full", Count: 1,
+			From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:00:30Z",
+		}, // no camera, no ids
 	}}
 	marked := ApplyDrops(context.Background(), fake, drops)
 	// rec-1 still marked precisely (ids present, times unparseable);

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// maxHistorySamples caps the in-memory heartbeat history ring: 24h at the
+// 30s heartbeat interval. Lightweight by design — no DB persistence; history
+// resets on NVR restart.
+const maxHistorySamples = 2880
+
 // HeartbeatStatus 是 Vision 心跳报告中携带的状态信息。
 type HeartbeatStatus struct {
 	Status         string `json:"status"`          // "healthy"
@@ -15,6 +20,60 @@ type HeartbeatStatus struct {
 	// 或处理容量取舍。NVR 对这些相机停推(含离线补偿),省下纯浪费的上传带宽。
 	// 字段缺省/为空 = 不跳过任何相机(向后兼容旧版本消费者)。
 	SkipCameras []string `json:"skip_cameras,omitempty"`
+	// Drops 是心跳 v2(#671)携带的批量丢弃报告(压缩范围)。nil = 本次心跳
+	// 没有丢弃要回报(旧版本消费者永远为 nil)。
+	Drops *VisionDrops `json:"drops,omitempty"`
+	// Metrics 是心跳 v2(#671)携带的运行指标(队列/worker/吞吐/资源)。
+	Metrics *VisionMetrics `json:"metrics,omitempty"`
+}
+
+// VisionDropRange 是一个压缩后的丢弃范围:同一相机同一原因、时间上相邻的
+// 连续丢弃合并为一条(消费者侧负责压缩),count 是该范围内的丢弃段数。
+// ids 为有限条精确录像 ID(消费者上限截断);只带范围不带 ids 时 NVR 用
+// 相机 + 时间窗批量标记。
+type VisionDropRange struct {
+	CameraID string   `json:"camera_id"`
+	Reason   string   `json:"reason"` // queue_full / ttl_expired / ...
+	Count    int      `json:"count"`
+	From     string   `json:"from"` // RFC3339
+	To       string   `json:"to"`   // RFC3339
+	IDs      []string `json:"ids,omitempty"`
+}
+
+// VisionDrops 是一次心跳携带的完整丢弃报告。seq 单调递增,NVR 在响应里
+// 回 ack_drops=seq,消费者据此清空已确认的暂存。
+type VisionDrops struct {
+	Seq    int64             `json:"seq"`
+	Ranges []VisionDropRange `json:"ranges"`
+}
+
+// VisionMetrics 是消费者上报的运行指标快照(#671)。全部字段可选——
+// 旧版本消费者的心跳没有这个块。
+type VisionMetrics struct {
+	QueueCapacity     int     `json:"queue_capacity"`
+	DecodeWorkers     int     `json:"decode_workers"`
+	WorkersBusy       int     `json:"workers_busy"`
+	ReceivedTotal     int64   `json:"received_total"`
+	DroppedTotal      int64   `json:"dropped_total"`
+	DroppedQueueFull  int64   `json:"dropped_queue_full"`
+	DroppedTTL        int64   `json:"dropped_ttl"`
+	EventsEmitted     int64   `json:"events_emitted"`
+	SegMsP50          int64   `json:"seg_ms_p50"`
+	SegMsP90          int64   `json:"seg_ms_p90"`
+	DecodedQueueDepth int     `json:"decoded_queue_depth"`
+	MemAvailableMB    int64   `json:"mem_available_mb"`
+	Load1             float64 `json:"load1"`
+}
+
+// VisionSample 是历史环里的一次心跳采样(供仪表盘趋势图)。
+type VisionSample struct {
+	TS             time.Time `json:"ts"`
+	QueueDepth     int       `json:"queue_depth"`
+	ProcessedCount int64     `json:"processed_count"`
+	DroppedTotal   int64     `json:"dropped_total"`
+	DecodeWorkers  int       `json:"decode_workers"`
+	WorkersBusy    int       `json:"workers_busy"`
+	EventsEmitted  int64     `json:"events_emitted"`
 }
 
 // HealthTracker 追踪 Vision 的心跳健康状态。
@@ -22,11 +81,13 @@ type HeartbeatStatus struct {
 // NVR 的推送协调器在推送段之前检查 IsHealthy()——只在 Vision 健康时推送,
 // 避免向不可用的 Vision 发请求。Vision 恢复后,心跳恢复,推送自动续上。
 type HealthTracker struct {
-	mu         sync.RWMutex
-	lastSeen   time.Time
-	status     HeartbeatStatus
-	timeout    time.Duration
-	onRecovery func()
+	mu          sync.RWMutex
+	lastSeen    time.Time
+	status      HeartbeatStatus
+	timeout     time.Duration
+	onRecovery  func()
+	samples     []VisionSample // 心跳历史环(≤maxHistorySamples)
+	markedDrops int64          // 累计按丢弃报告标记为 skipped 的录像数
 }
 
 // NewHealthTracker 创建健康追踪器。timeoutSecs ≤ 0 时默认 60 秒。
@@ -53,8 +114,28 @@ func (h *HealthTracker) RecordHeartbeat(status HeartbeatStatus) {
 	h.mu.Lock()
 	wasHealthy := !h.lastSeen.IsZero() && time.Since(h.lastSeen) < h.timeout &&
 		h.status.Status != "degraded"
-	h.lastSeen = time.Now()
+	now := time.Now()
+	if !h.lastSeen.IsZero() && now.Before(h.lastSeen) {
+		now = h.lastSeen // 保证历史环时间戳单调不减
+	}
+	h.lastSeen = now
 	h.status = status
+
+	sample := VisionSample{
+		TS:             now,
+		QueueDepth:     status.QueueDepth,
+		ProcessedCount: int64(status.ProcessedCount),
+	}
+	if status.Metrics != nil {
+		sample.DroppedTotal = status.Metrics.DroppedTotal
+		sample.DecodeWorkers = status.Metrics.DecodeWorkers
+		sample.WorkersBusy = status.Metrics.WorkersBusy
+		sample.EventsEmitted = status.Metrics.EventsEmitted
+	}
+	if len(h.samples) >= maxHistorySamples {
+		h.samples = h.samples[1:]
+	}
+	h.samples = append(h.samples, sample)
 	cb := h.onRecovery
 	h.mu.Unlock()
 	if !wasHealthy && cb != nil {
@@ -62,6 +143,36 @@ func (h *HealthTracker) RecordHeartbeat(status HeartbeatStatus) {
 		// block on compensation work.
 		go cb()
 	}
+}
+
+// MetricsHistory 返回 since 之后(含)的心跳采样,按到达顺序。
+func (h *HealthTracker) MetricsHistory(since time.Time) []VisionSample {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]VisionSample, 0, len(h.samples))
+	for _, s := range h.samples {
+		if !s.TS.Before(since) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// NoteMarkedDrops 累加按丢弃报告标记的录像数(心跳处理路径调用)。
+func (h *HealthTracker) NoteMarkedDrops(n int64) {
+	if n <= 0 {
+		return
+	}
+	h.mu.Lock()
+	h.markedDrops += n
+	h.mu.Unlock()
+}
+
+// MarkedDropTotal 返回累计标记数。
+func (h *HealthTracker) MarkedDropTotal() int64 {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.markedDrops
 }
 
 // IsHealthy 返回 Vision 是否健康(最近 timeout 内收到过非 degraded 心跳)。

--- a/internal/vision/health_test.go
+++ b/internal/vision/health_test.go
@@ -56,7 +56,7 @@ func TestHealthTracker_MetricsHistoryRing(t *testing.T) {
 	require.Len(t, h.MetricsHistory(since), 1)
 
 	// Ring cap: only the newest maxHistorySamples survive.
-	for i := 0; i < maxHistorySamples+10; i++ {
+	for i := range maxHistorySamples + 10 {
 		h.RecordHeartbeat(HeartbeatStatus{Status: "healthy", ProcessedCount: i})
 	}
 	all := h.MetricsHistory(time.Time{})

--- a/internal/vision/health_test.go
+++ b/internal/vision/health_test.go
@@ -1,0 +1,89 @@
+package vision
+
+// Tests for the heartbeat v2 extensions on HealthTracker (#671):
+// optional drop reports + runtime metrics, and the in-memory history ring
+// that backs GET /api/vision/metrics.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthTracker_MetricsHistoryRing(t *testing.T) {
+	h := NewHealthTracker(60)
+
+	// Old-format heartbeat (no metrics) still yields a sample with zeroed
+	// metrics fields — the ring must not skip legacy consumers.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy", QueueDepth: 1, ProcessedCount: 5})
+
+	// v2 heartbeat with metrics.
+	h.RecordHeartbeat(HeartbeatStatus{
+		Status:         "healthy",
+		QueueDepth:     3,
+		ProcessedCount: 7,
+		Metrics: &VisionMetrics{
+			QueueCapacity:    64,
+			DecodeWorkers:    2,
+			WorkersBusy:      1,
+			ReceivedTotal:    100,
+			DroppedTotal:     10,
+			DroppedQueueFull: 9,
+			DroppedTTL:       1,
+			EventsEmitted:    42,
+			SegMsP50:         16000,
+			SegMsP90:         76000,
+			MemAvailableMB:   620,
+			Load1:            2.5,
+		},
+	})
+
+	samples := h.MetricsHistory(time.Time{})
+	require.Len(t, samples, 2)
+	require.Equal(t, 1, samples[0].QueueDepth)
+	require.Equal(t, int64(5), samples[0].ProcessedCount)
+	require.Equal(t, 0, samples[0].DecodeWorkers, "legacy heartbeat has no worker info")
+	require.Equal(t, 3, samples[1].QueueDepth)
+	require.Equal(t, 2, samples[1].DecodeWorkers)
+	require.Equal(t, 1, samples[1].WorkersBusy)
+	require.Equal(t, int64(10), samples[1].DroppedTotal)
+	require.Equal(t, int64(42), samples[1].EventsEmitted)
+	require.False(t, samples[0].TS.After(samples[1].TS), "samples are in arrival order")
+
+	// since-filter drops older samples.
+	since := samples[1].TS
+	require.Len(t, h.MetricsHistory(since), 1)
+
+	// Ring cap: only the newest maxHistorySamples survive.
+	for i := 0; i < maxHistorySamples+10; i++ {
+		h.RecordHeartbeat(HeartbeatStatus{Status: "healthy", ProcessedCount: i})
+	}
+	all := h.MetricsHistory(time.Time{})
+	require.Len(t, all, maxHistorySamples)
+	require.Equal(t, int64(maxHistorySamples+9), all[len(all)-1].ProcessedCount,
+		"newest sample kept after overflow")
+}
+
+func TestHealthTracker_MarkedDropCounter(t *testing.T) {
+	h := NewHealthTracker(60)
+	require.Zero(t, h.MarkedDropTotal())
+	h.NoteMarkedDrops(3)
+	h.NoteMarkedDrops(2)
+	require.Equal(t, int64(5), h.MarkedDropTotal())
+}
+
+func TestHealthTracker_DropsCarriedInSnapshot(t *testing.T) {
+	h := NewHealthTracker(60)
+	drops := &VisionDrops{Seq: 7, Ranges: []VisionDropRange{{
+		CameraID: "cam-1", Reason: "queue_full", Count: 3,
+		From: "2026-09-02T04:00:01Z", To: "2026-09-02T04:31:20Z",
+	}}}
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy", Drops: drops})
+
+	_, _, status := h.Snapshot()
+	require.NotNil(t, status.Drops)
+	require.Equal(t, int64(7), status.Drops.Seq)
+	require.Len(t, status.Drops.Ranges, 1)
+	require.Equal(t, "queue_full", status.Drops.Ranges[0].Reason)
+}


### PR DESCRIPTION
Closes #671.

Extends the AI-consumer heartbeat with **optional, backward-compatible** fields:

## Changes
- **Heartbeat v2**: optional `drops` (compressed queue-drop ranges: camera + reason + count + time window + bounded id list) and `metrics` (queue capacity/depth, worker counts, cumulative counters, latency percentiles, host memory/load). Response gains `ack_drops` so the consumer can clear its pending buffer. Old consumers (no new fields) behave exactly as before.
- **Drop marking** (`internal/vision/dropmarker.go`): on a drop report, affected recordings get the new terminal `ai_status='skipped'` with the reason in `ai_error` — precise ids first (sub-layer `#nano` suffix stripped, like the AI-event path), id-less ranges fall back to a camera+time-window UPDATE. A DB-layer status guard never overwrites `completed`/`failed`.
- **Repush exclusion**: `ListRecordingsForVisionRepush` only picks up `''/pending/processing`, so dropped segments are never re-pushed during offline compensation (pinned by test).
- **PATCH /api/recordings/{id}/ai-status** now accepts `skipped` (the SQL layer already stamped `ai_processed_at` for it).
- **API**: `GET /api/vision/status` gains `metrics` + `drops_marked_total`; new `GET /api/vision/metrics?hours=1..168` serves an in-memory 24h heartbeat history ring (2880 samples @ 30s) for dashboard charts.
- Zero DB migration — reuses existing `ai_status`/`ai_error`/`ai_processed_at` columns.

## Tests
heartbeat v2 parse + v1 compat + ack response; drop-marker precision (suffix strip/dedup), status guard, reason sanitization, range SQL; repush excludes `skipped`; PATCH accepts `skipped`; history-ring cap. Frontend panel follows in a separate PR.

Note: `TestTestConnection_RTSPConnectionRefused` fails only in the local WSL sandbox (verified failing on clean `main` there); expecting CI Linux runners to be unaffected as before.