### PR TITLE
feat(update): bare-metal auto-update execution layer (#647)

### DIFF
--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -314,6 +314,8 @@ func dispatchSubcommand(args []string) {
 		cmdMergeCameras()
 	case "eval-replay":
 		cmdEvalReplay()
+	case "update":
+		cmdUpdate()
 	case "cleanup":
 		cmdCleanup()
 	}

--- a/cmd/mibee-nvr/main.go
+++ b/cmd/mibee-nvr/main.go
@@ -159,15 +159,26 @@ func main() {
 	}
 	defer cancel()
 
-	// In-app version check (sensing layer only — never executes an upgrade).
-	// Polls GitHub Releases with ETag conditional requests (304s do not count
-	// against the unauth rate limit) and exposes the result at /api/update/check.
+	// In-app version check (sensing layer). Polls GitHub Releases with ETag
+	// conditional requests (304s do not count against the unauth rate limit)
+	// and exposes the result at /api/update/check.
 	if cfg.Update.IsEnabled() {
 		interval, err := time.ParseDuration(cfg.Update.CheckInterval)
 		if err != nil || interval < time.Minute {
 			interval = time.Hour
 		}
 		upd := update.New(appVersion, cfg.Update.Repo, cfg.Update.Channel, interval)
+		// Opt-in bare-metal auto-apply (#647): on the first sighting of a newer
+		// stable release, hand off to the root helper unit (polkit-authorized).
+		// Best-effort — trigger failures are logged, never fatal.
+		if cfg.Update.IsAutoApply() {
+			upd.SetOnAvailable(func(st update.Status) {
+				if err := update.TriggerAutoApply(appVersion, st, update.Deployment(),
+					cfg.Storage.RootDir, update.StartHelperUnit); err != nil {
+					slog.Warn("update: auto-apply trigger failed", "error", err)
+				}
+			})
+		}
 		upd.Start(ctx)
 		defer upd.Stop()
 		api.SetUpdateChecker(upd)

--- a/cmd/mibee-nvr/update_cmd.go
+++ b/cmd/mibee-nvr/update_cmd.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/update"
+)
+
+// cmdUpdate implements `mibee-nvr update` — the bare-metal upgrade execution
+// layer (#647). Two entry paths share one pipeline:
+//
+//	manual:      sudo mibee-nvr update [--version vX.Y.Z]
+//	root helper: mibee-nvr update --apply-request /var/lib/mibee-nvr/update-request.json
+//	             (ExecStart of mibee-nvr-update.service; the file is written by
+//	             the app and consumed exactly once)
+//
+//	--check prints the sensing-layer status without touching anything.
+func cmdUpdate() {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	cfgPath := fs.String("config", "mibee-nvr.yaml", "path to configuration file")
+	version := fs.String("version", "", "target release tag (default: latest stable)")
+	checkOnly := fs.Bool("check", false, "only show the update status, change nothing")
+	applyRequest := fs.String("apply-request", "", "run the request file written by the app (helper entry)")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if err := runUpdate(runUpdateArgs{
+		cfgPath:      *cfgPath,
+		version:      *version,
+		checkOnly:    *checkOnly,
+		applyRequest: *applyRequest,
+	}, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runUpdateArgs is the parsed `update` invocation (kept as a struct so tests
+// can call runUpdate without argv games).
+type runUpdateArgs struct {
+	cfgPath      string
+	version      string
+	checkOnly    bool
+	applyRequest string
+}
+
+// applyFn is overridable in tests (the real one runs the full root pipeline).
+var applyFn = func(req update.Request) error {
+	return (&update.Applier{}).Apply(context.Background(), req)
+}
+
+// healthFn resolves the health-probe URL for the running config (tests).
+var healthFn = healthURLForConfig
+
+func runUpdate(args runUpdateArgs, out io.Writer) error {
+	cfg, err := config.Load(args.cfgPath)
+	if err != nil {
+		return fmt.Errorf("update: load config %s: %w", args.cfgPath, err)
+	}
+	repo := cfg.Update.Repo
+	if repo == "" {
+		repo = "Mi-Bee-Studio/MiBeeNvr"
+	}
+
+	// Sensing only: print what the checker knows right now.
+	if args.checkOnly {
+		st, err := updateCheckFn(context.Background(), repo)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "current:    %s\nlatest:     %s\navailable:  %v\ndeployment: %s\n",
+			appVersion, st.Latest, st.UpdateAvailable, update.Deployment())
+		return nil
+	}
+
+	// Root-helper entry: consume the request file exactly once.
+	target := args.version
+	if args.applyRequest != "" {
+		reqFile, err := update.ReadRequest(args.applyRequest)
+		if err != nil {
+			return fmt.Errorf("update: read request file: %w", err)
+		}
+		target = reqFile.TargetTag
+		defer func() {
+			// Remove on ANY outcome (success or failure): a failed attempt is
+			// logged in the history file; a stale request must never re-run
+			// on the next manual `systemctl start`.
+			if err := update.RemoveRequest(args.applyRequest); err != nil {
+				slog.Warn("update: remove request file", "path", args.applyRequest, "error", err)
+			}
+		}()
+	}
+
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("update: must run as root — use `sudo mibee-nvr update` or the mibee-nvr-update.service helper")
+	}
+
+	if target == "" {
+		st, err := updateCheckFn(context.Background(), repo)
+		if err != nil {
+			return fmt.Errorf("update: resolve latest release: %w", err)
+		}
+		if !st.UpdateAvailable {
+			fmt.Fprintf(out, "already up to date (%s)\n", appVersion)
+			return nil
+		}
+		target = st.Latest
+	}
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("update: resolve running binary path: %w", err)
+	}
+	binPath, err = resolveBinaryPath(binPath)
+	if err != nil {
+		return err
+	}
+	dataDir := cfg.Storage.RootDir
+	if dataDir == "" {
+		dataDir = "/var/lib/mibee-nvr"
+	}
+
+	fmt.Fprintf(out, "upgrading %s → %s (binary %s)\n", appVersion, target, binPath)
+	req := update.Request{
+		Current:    appVersion,
+		TargetTag:  target,
+		Repo:       repo,
+		BinaryPath: binPath,
+		DataDir:    dataDir,
+		HealthURL:  healthFn(cfg),
+	}
+	if err := applyFn(req); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "upgraded to %s — health gate passed\n", target)
+	return nil
+}
+
+// resolveBinaryPath follows a symlinked binary to its real location so the
+// .prev backup and replace target the file systemd actually executes.
+func resolveBinaryPath(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", fmt.Errorf("update: resolve binary symlinks: %w", err)
+	}
+	if !strings.HasPrefix(resolved, "/") {
+		abs, err := os.Getwd()
+		if err == nil {
+			resolved = abs + "/" + resolved
+		}
+	}
+	return resolved, nil
+}
+
+// healthURLForConfig maps the config's server.listen to a loopback health URL
+// (":9090" → "http://127.0.0.1:9090/api/health"; an explicit host is kept,
+// IPv6 literals bracketed).
+func healthURLForConfig(cfg *config.Config) string {
+	listen := cfg.Server.Listen
+	if listen == "" {
+		listen = ":9090"
+	}
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		host, port = listen, ""
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if strings.Contains(host, ":") { // IPv6 literal
+		host = "[" + host + "]"
+	}
+	return "http://" + host + ":" + port + "/api/health"
+}
+
+// updateCheckFn resolves the CURRENT release status (tests stub the network).
+var updateCheckFn = func(ctx context.Context, repo string) (update.Status, error) {
+	c := update.New(appVersion, repo, "stable", time.Hour)
+	return c.Refresh(ctx)
+}

--- a/cmd/mibee-nvr/update_cmd_test.go
+++ b/cmd/mibee-nvr/update_cmd_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/update"
+)
+
+func TestHealthURLForConfig(t *testing.T) {
+	cases := []struct {
+		listen string
+		want   string
+	}{
+		{":9090", "http://127.0.0.1:9090/api/health"},
+		{"0.0.0.0:9191", "http://0.0.0.0:9191/api/health"},
+		{"192.168.1.5:80", "http://192.168.1.5:80/api/health"},
+		{"[::]:9090", "http://[::]:9090/api/health"},
+		{"", "http://127.0.0.1:9090/api/health"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.listen, func(t *testing.T) {
+			cfg := &config.Config{Server: config.ServerConfig{Listen: tc.listen}}
+			if got := healthURLForConfig(cfg); got != tc.want {
+				t.Fatalf("healthURLForConfig(%q) = %q, want %q", tc.listen, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunUpdate_CheckOnly(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "mibee-nvr.yaml")
+	cfg := &config.Config{}
+	cfg.ApplyDefaults()
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := updateCheckFn
+	updateCheckFn = func(context.Context, string) (update.Status, error) {
+		return update.Status{Current: "v1.0.0", Latest: "v9.9.9", UpdateAvailable: true}, nil
+	}
+	t.Cleanup(func() { updateCheckFn = prev })
+
+	var out strings.Builder
+	err := runUpdate(runUpdateArgs{cfgPath: cfgPath, checkOnly: true}, &out)
+	if err != nil {
+		t.Fatalf("--check must not fail: %v", err)
+	}
+	if !strings.Contains(out.String(), "v9.9.9") || !strings.Contains(out.String(), "true") {
+		t.Fatalf("check output missing status:\n%s", out.String())
+	}
+}
+
+// The apply path enforces root. When tests themselves run as root (CI
+// containers do), the pipeline seam is stubbed and driven instead.
+func TestRunUpdate_ApplyPath(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	cfg := &config.Config{}
+	cfg.Server.Listen = ":19090"
+	cfg.Storage.RootDir = dir
+	cfg.ApplyDefaults()
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	prevCheck := updateCheckFn
+	updateCheckFn = func(context.Context, string) (update.Status, error) {
+		return update.Status{Current: "v1.0.0", Latest: "v9.9.9", UpdateAvailable: true}, nil
+	}
+	t.Cleanup(func() { updateCheckFn = prevCheck })
+
+	if os.Geteuid() != 0 {
+		err := runUpdate(runUpdateArgs{cfgPath: cfgPath, version: "v9.9.9"}, os.Stderr)
+		if err == nil || !strings.Contains(err.Error(), "root") {
+			t.Fatalf("non-root apply must be refused: %v", err)
+		}
+		return
+	}
+
+	prevApply := applyFn
+	var applied []update.Request
+	applyFn = func(req update.Request) error {
+		applied = append(applied, req)
+		return nil
+	}
+	t.Cleanup(func() { applyFn = prevApply })
+
+	var out strings.Builder
+	if err := runUpdate(runUpdateArgs{cfgPath: cfgPath, version: "v9.9.9"}, &out); err != nil {
+		t.Fatalf("root apply (stubbed) failed: %v", err)
+	}
+	if len(applied) != 1 || applied[0].TargetTag != "v9.9.9" {
+		t.Fatalf("pipeline request wrong: %+v", applied)
+	}
+	if applied[0].HealthURL != "http://127.0.0.1:19090/api/health" {
+		t.Fatalf("health URL derivation failed: %q", applied[0].HealthURL)
+	}
+	if !strings.Contains(out.String(), "v9.9.9") {
+		t.Fatalf("output missing upgrade summary:\n%s", out.String())
+	}
+}
+
+// The root-helper entry consumes the request file exactly once — it must be
+// removed even when the pipeline fails, so a stale request can never re-run.
+func TestRunUpdate_ApplyRequestConsumedExactlyOnce(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("request-file lifecycle on the apply path requires root in this environment")
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "mibee-nvr.yaml")
+	cfg := &config.Config{}
+	cfg.Storage.RootDir = dir
+	cfg.ApplyDefaults()
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	reqPath, err := update.WriteRequest(dir, "v9.9.9", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevApply := applyFn
+	applyFn = func(update.Request) error { return errPipelineFailureForTest }
+	t.Cleanup(func() { applyFn = prevApply })
+
+	err = runUpdate(runUpdateArgs{cfgPath: cfgPath, applyRequest: reqPath}, os.Stderr)
+	if err == nil || !strings.Contains(err.Error(), "pipeline") {
+		t.Fatalf("pipeline failure must propagate: %v", err)
+	}
+	if _, statErr := os.Stat(reqPath); !os.IsNotExist(statErr) {
+		t.Fatalf("request file must be removed after a failed run: %v", statErr)
+	}
+}
+
+var errPipelineFailureForTest = errors.New("pipeline failed for test")

--- a/deploy/mibee-nvr-update-polkit.rules
+++ b/deploy/mibee-nvr-update-polkit.rules
@@ -1,0 +1,17 @@
+// MiBee NVR self-update authorization (#647).
+// Install to /etc/polkit-1/rules.d/60-mibee-nvr-update.rules.
+//
+// Allows exactly ONE privileged action for the sandboxed app user: starting
+// the mibee-nvr-update.service one-shot helper. The helper itself is
+// mibee-nvr's own `update --apply-request` subcommand running as root — it
+// verifies sha256+ed25519 signatures before replacing anything, keeps a .prev
+// rollback binary, and rolls back automatically if the upgraded service fails
+// its health gate. Everything else (arbitrary units, stopping the NVR,
+// editing units) stays unauthorized for the nvr user.
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.systemd1.manage-units" &&
+        subject.user == "nvr" &&
+        action.lookup("unit") == "mibee-nvr-update.service") {
+        return polkit.Result.YES;
+    }
+});

--- a/deploy/mibee-nvr-update.service
+++ b/deploy/mibee-nvr-update.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=MiBee NVR one-shot self-update (root helper, triggered by the app via polkit)
+# Only meaningful when the app wrote a request file; a manual `systemctl
+# start` without one exits immediately instead of re-running a stale upgrade.
+ConditionPathExists=/var/lib/mibee-nvr/update-request.json
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# The binary is its own helper: this subcommand runs the full #647 pipeline
+# (guards → download → sha256+ed25519 verify → atomic replace with .prev
+# backup → restart mibee-nvr → health gate → rollback on failure) and
+# consumes the request file exactly once.
+ExecStart=/usr/local/bin/mibee-nvr update --apply-request /var/lib/mibee-nvr/update-request.json
+# Download + verify + health gate can legitimately take minutes on a slow
+# ARM box; don't let the default 90s kill a healthy upgrade.
+TimeoutStartSec=15min

--- a/docs/en/deployment-autoupdate.md
+++ b/docs/en/deployment-autoupdate.md
@@ -112,7 +112,7 @@ Notes:
 
 Outside Docker, bare-metal installs (via install.sh) are the last online scenario that can be automated. The architecture deliberately avoids in-process self-replacement — the `mibee-nvr.service` sandbox (`User=nvr` + `ProtectSystem=strict`) already forbids the app from writing `/usr/local/bin`:
 
-```
+```text
 app (nvr user, sandboxed)              root helper (mibee-nvr-update.service)
   sensing layer sees a new release
   AND update.auto_apply: true

--- a/docs/en/deployment-autoupdate.md
+++ b/docs/en/deployment-autoupdate.md
@@ -107,3 +107,58 @@ Notes:
 - `checksums.txt` covers the three bare binaries (amd64/arm64/armv7). The fnOS `.fpk` is distributed through the fnOS store channel; Docker images are integrity-protected by registry digests.
 - If a Release has no `checksums.txt.sig`, the signing secret was not configured (that release is unsigned) — step 1 alone still checks integrity.
 - A key rotation means newer Releases are signed with a new key; always take the public key from the repo's main branch.
+
+## Bare-metal auto-update (#647, systemd installs)
+
+Outside Docker, bare-metal installs (via install.sh) are the last online scenario that can be automated. The architecture deliberately avoids in-process self-replacement — the `mibee-nvr.service` sandbox (`User=nvr` + `ProtectSystem=strict`) already forbids the app from writing `/usr/local/bin`:
+
+```
+app (nvr user, sandboxed)              root helper (mibee-nvr-update.service)
+  sensing layer sees a new release
+  AND update.auto_apply: true
+  ├─ write /var/lib/mibee-nvr/update-request.json
+  └─ systemctl start mibee-nvr-update.service  →  mibee-nvr update --apply-request …
+                                                    ① prechecks (non-docker, strict semver step, disk ≥ 3× artifact)
+                                                    ② stream-download checksums + ed25519 sig + binary
+                                                    ③ sha256 + signature verify (any failure aborts, zero changes)
+                                                    ④ keep .prev → atomic binary replace
+                                                    ⑤ systemctl restart mibee-nvr
+                                                    ⑥ health gate: /api/health readiness probe
+                                                    ⑦ automatic .prev rollback + restart on failure
+                                                    ⑧ append to update-history.jsonl
+```
+
+A polkit rule (`/etc/polkit-1/rules.d/60-mibee-nvr-update.rules`, installed by the installer) authorizes the nvr user to start exactly this ONE unit — minimal privilege surface.
+
+### Enable
+
+```yaml
+update:
+  auto_apply: true   # default false: announce only, never execute
+```
+
+Permanently disabled conditions (even when enabled): `dev` builds, non-stable channels, candidate ≤ current (never downgrades), Docker deployments.
+
+### Manual upgrade (no polkit needed)
+
+```bash
+sudo mibee-nvr update              # upgrade to latest stable
+sudo mibee-nvr update --version v0.12.1
+mibee-nvr update --check           # status only, changes nothing
+```
+
+### Rollback
+
+The previous version is kept as `<binary>.prev`; the health gate rolls back automatically on failure. Manual rollback:
+
+```bash
+sudo systemctl stop mibee-nvr
+sudo cp /usr/local/bin/mibee-nvr.prev /usr/local/bin/mibee-nvr
+sudo systemctl start mibee-nvr
+```
+
+Upgrade history lives in `<data-dir>/update-history.jsonl` (time, from/to, result, failure reason).
+
+### Scope
+
+Only install.sh/systemd bare-metal installs. Docker belongs to Watchtower; fnOS/unRAID store installs belong to the platform's upgrade mechanism; offline environments should download manually (see the verification section above). On distros without polkit the automatic trigger is unavailable, but the `sudo mibee-nvr update` manual path still works.

--- a/docs/zh/deployment-autoupdate.md
+++ b/docs/zh/deployment-autoupdate.md
@@ -107,3 +107,57 @@ openssl pkeyutl -verify -pubin -inkey release-signing.pub.pem \
 - `checksums.txt` 覆盖三个裸二进制(amd64/arm64/armv7);fnOS `.fpk` 由飞牛商店渠道分发,不在其列;Docker 镜像由 registry 摘要保证完整性。
 - 若某次 Release 没有 `checksums.txt.sig`,说明签名 Secret 未配置(该 Release 未签名),只做第 1 步完整性校验。
 - 密钥轮换意味着新 Release 用新公钥签发;以仓库 main 分支上的公钥为准。
+
+## 裸机自动升级(#647,systemd 安装)
+
+Docker 之外,`install.sh` 安装的裸机环境是最后一个可自动化的在线场景。架构刻意绕开进程内自我替换——`mibee-nvr.service` 的沙箱(`User=nvr` + `ProtectSystem=strict`)本来就禁止应用写 `/usr/local/bin`:
+
+```
+应用(nvr 用户,沙箱内)                root helper(mibee-nvr-update.service)
+  感知层发现新版 + update.auto_apply: true
+  ├─ 写请求文件 /var/lib/mibee-nvr/update-request.json
+  └─ systemctl start mibee-nvr-update.service   →  mibee-nvr update --apply-request …
+                                                    ① 前置检查(非 docker、semver 严格更新、磁盘 ≥ 产物×3)
+                                                    ② 流式下载校验和 + ed25519 签名 + 二进制
+                                                    ③ sha256 + 签名验证(失败即中止,系统零改动)
+                                                    ④ 保留 .prev → 原子替换二进制
+                                                    ⑤ systemctl restart mibee-nvr
+                                                    ⑥ 健康门禁:/api/health 就绪探针
+                                                    ⑦ 失败自动回滚 .prev 并重启
+                                                    ⑧ 升级历史落盘 update-history.jsonl
+```
+
+polkit 规则(`/etc/polkit-1/rules.d/60-mibee-nvr-update.rules`,installer 自动安装)只放行 nvr 用户**启动这一个 unit**,特权面最小。
+
+### 开启
+
+```yaml
+update:
+  auto_apply: true   # 默认 false,仅提示不执行
+```
+
+恒禁用条件(开了也不会执行):`dev` 构建、非 stable channel、候选版本 ≤ 当前(永不降级)、Docker 部署。
+
+### 手动升级(无需 polkit)
+
+```bash
+sudo mibee-nvr update              # 升级到最新 stable
+sudo mibee-nvr update --version v0.12.1
+mibee-nvr update --check           # 只看状态,零改动
+```
+
+### 回滚
+
+升级前自动保留上一版为 `<二进制>.prev`;健康门禁失败会**自动**回滚并重启。手动回滚:
+
+```bash
+sudo systemctl stop mibee-nvr
+sudo cp /usr/local/bin/mibee-nvr.prev /usr/local/bin/mibee-nvr
+sudo systemctl start mibee-nvr
+```
+
+升级记录在 `<数据目录>/update-history.jsonl`(时间、from/to、结果、失败原因)。
+
+### 适用边界
+
+仅适用 `install.sh`/systemd 裸机安装。Docker 归 Watchtower;fnOS/unRAID 等商店渠道归平台的升级机制;离线环境请手动下载(校验方法见上一节)。无 polkit 的老发行版上自动触发不可用,但 `sudo mibee-nvr update` 手动路径不受影响。

--- a/docs/zh/deployment-autoupdate.md
+++ b/docs/zh/deployment-autoupdate.md
@@ -112,7 +112,7 @@ openssl pkeyutl -verify -pubin -inkey release-signing.pub.pem \
 
 Docker 之外,`install.sh` 安装的裸机环境是最后一个可自动化的在线场景。架构刻意绕开进程内自我替换——`mibee-nvr.service` 的沙箱(`User=nvr` + `ProtectSystem=strict`)本来就禁止应用写 `/usr/local/bin`:
 
-```
+```text
 应用(nvr 用户,沙箱内)                root helper(mibee-nvr-update.service)
   感知层发现新版 + update.auto_apply: true
   ├─ 写请求文件 /var/lib/mibee-nvr/update-request.json

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,39 @@ install_service() {
     info "Installed systemd service to ${SERVICE_FILE}."
 }
 
+# install_update_helper deploys the #647 self-update root helper: the one-shot
+# mibee-nvr-update.service unit plus the polkit rule authorizing the nvr user
+# to start exactly that unit. Best-effort — failures downgrade to a warning
+# (manual `sudo mibee-nvr update` still works without them), never abort the
+# install.
+install_update_helper() {
+    local helper_service="/etc/systemd/system/mibee-nvr-update.service"
+    local helper_url="https://raw.githubusercontent.com/${REPO}/main/deploy/mibee-nvr-update.service"
+    local polkit_rules="/etc/polkit-1/rules.d/60-mibee-nvr-update.rules"
+    local polkit_url="https://raw.githubusercontent.com/${REPO}/main/deploy/mibee-nvr-update-polkit.rules"
+
+    if ! download "$helper_url" "$helper_service"; then
+        warn "Failed to download mibee-nvr-update.service — auto-apply (update.auto_apply) unavailable."
+        warn "Manual upgrades via 'sudo mibee-nvr update' still work."
+        return 0
+    fi
+    chmod 644 "$helper_service"
+
+    if [[ -d /etc/polkit-1/rules.d ]]; then
+        if download "$polkit_url" "$polkit_rules"; then
+            chmod 644 "$polkit_rules"
+            # Some distros need a polkit restart to pick up new rules.
+            systemctl reload polkit 2>/dev/null || systemctl restart polkit 2>/dev/null || true
+            info "Installed self-update helper + polkit rule (opt-in auto-apply ready)."
+        else
+            warn "Polkit rule install failed — enable with: sudo systemctl start mibee-nvr-update.service (manual)."
+        fi
+    else
+        warn "No polkit rules dir (/etc/polkit-1/rules.d) — auto-apply trigger unavailable on this distro;"
+        warn "upgrade manually with: sudo mibee-nvr update"
+    fi
+}
+
 install_optional_ffmpeg() {
     # FFmpeg is OPTIONAL — only needed for H.265↔H.264 transcoding (storage
     # optimization + live relay transcode). All other features work without it.
@@ -280,6 +313,11 @@ do_uninstall() {
         info "Removed service file."
     fi
 
+    # Self-update helper artifacts (#647)
+    rm -f /etc/systemd/system/mibee-nvr-update.service
+    rm -f /etc/polkit-1/rules.d/60-mibee-nvr-update.rules
+    systemctl reload polkit 2>/dev/null || true
+
     if [[ -f "${BIN_PATH}" ]]; then
         rm -f "${BIN_PATH}"
         info "Removed binary."
@@ -352,6 +390,7 @@ do_install() {
     install_binary "$arch" "$version"
     init_config
     install_service
+    install_update_helper
     install_optional_ffmpeg
     enable_service
     wait_for_ready

--- a/internal/config/config_update.go
+++ b/internal/config/config_update.go
@@ -24,6 +24,14 @@ type UpdateConfig struct {
 	// Repo is the "owner/name" GitHub repository to check.
 	// Default "Mi-Bee-Studio/MiBeeNvr".
 	Repo string `yaml:"repo"`
+	// AutoApply opt-in EXECUTION of bare-metal upgrades (#647). Default false:
+	// the sensing layer only announces updates. When true AND the deployment
+	// is bare-metal systemd (never docker/dev/beta), a newly detected stable
+	// release is installed via the mibee-nvr-update.service root helper
+	// (polkit-authorized), with sha256+ed25519 verification and automatic
+	// rollback to the previous binary if the upgraded service fails its
+	// health gate.
+	AutoApply *bool `yaml:"auto_apply"`
 }
 
 // IsEnabled returns whether the update check is enabled (default true).
@@ -32,4 +40,10 @@ func (c UpdateConfig) IsEnabled() bool {
 		return true
 	}
 	return *c.Enabled
+}
+
+// IsAutoApply returns whether bare-metal auto-apply is enabled (default
+// false — the sensing layer never executes upgrades unless explicitly opted in).
+func (c UpdateConfig) IsAutoApply() bool {
+	return c.AutoApply != nil && *c.AutoApply
 }

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -854,3 +854,10 @@ func (m *Manager) reconcileCameraDir(ctx context.Context, db *DB, dirName string
 
 	return reconciled, nil
 }
+
+// FreeSpace returns total and free bytes on the filesystem containing path.
+// Exported wrapper around the shared statfs helper so the self-update layer
+// (#647) can run its disk prechecks without constructing a Manager.
+func FreeSpace(path string) (total, free int64, err error) {
+	return statfsFree(path)
+}

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -1,0 +1,512 @@
+// Bare-metal upgrade execution layer (#647).
+//
+// The sandbox in deploy/mibee-nvr.service (User=nvr, ProtectSystem=strict)
+// prevents the running app from writing /usr/local/bin/mibee-nvr, so
+// in-process self-replacement is impossible by design. Instead the pipeline
+// below runs as ROOT inside the one-shot mibee-nvr-update.service helper
+// (allowed for the nvr user via a narrowly-scoped polkit rule), or manually
+// via `sudo mibee-nvr update`. The app side only writes a request file and
+// triggers the helper — it never touches the binary itself.
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+)
+
+// Request describes one upgrade run.
+type Request struct {
+	Current    string // running version (appVersion, e.g. "v0.11.0")
+	TargetTag  string // release tag to install (e.g. "v0.12.0")
+	Repo       string // "owner/name"
+	BinaryPath string // absolute path of the binary to replace
+	DataDir    string // writable data dir (request file, history)
+	HealthURL  string // e.g. http://127.0.0.1:9090/api/health
+}
+
+// Applier executes the upgrade pipeline with every external effect behind an
+// injectable seam (tests fake all of them; production defaults are the real
+// system operations). Not goroutine-safe — one run at a time.
+type Applier struct {
+	// ReleaseBase overrides the download base URL
+	// (https://github.com/{repo}/releases/download) — tests point it at an
+	// httptest server; a future mirror (#649) can point it at a CDN.
+	ReleaseBase string
+
+	// DeploymentOverride replaces Deployment() (tests).
+	DeploymentOverride string
+
+	// SignVerify checks the ed25519 signature over checksums.txt.
+	// Default: VerifyChecksumsSignature (embedded release key).
+	SignVerify func(checksums, sig []byte) error
+
+	// DigestVerify matches the downloaded artifact against its checksums.txt
+	// line. Default: VerifyBinaryChecksum.
+	DigestVerify func(checksums []byte, filename string, data []byte) error
+
+	// FreeSpace reports (total, free) bytes on the path's filesystem.
+	// Default: storage.FreeSpace (the shared statfs wrapper, #664).
+	FreeSpace func(path string) (total, free int64, err error)
+
+	// Restart restarts the mibee-nvr service. Default: systemctl restart.
+	Restart func(ctx context.Context) error
+
+	// HealthWait blocks until the upgraded service answers /api/health or the
+	// timeout elapses. Default: pollHealth.
+	HealthWait func(ctx context.Context, url string, timeout time.Duration) error
+
+	Now func() time.Time // default time.Now
+
+	HealthTimeout  time.Duration // default 120s
+	MinSpaceFactor int64         // free disk must exceed factor×artifact size (default 3)
+
+	log *slog.Logger
+}
+
+// historyRow is one update-history.jsonl entry (UI reads it via the API).
+type historyRow struct {
+	Time   string `json:"time"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Result string `json:"result"` // "ok" | "failed"
+	Error  string `json:"error,omitempty"`
+}
+
+// AutoRequest is the polkit handoff file: the app (nvr user) writes it, the
+// root helper (mibee-nvr-update.service) reads it and removes it after use.
+type AutoRequest struct {
+	TargetTag   string `json:"target_tag"`
+	RequestedAt string `json:"requested_at"`
+}
+
+const (
+	requestFile  = "update-request.json"
+	historyFile  = "update-history.jsonl"
+	maxMetaBytes = 1 << 16 // checksums.txt + .sig are tiny; 64KB is generous
+)
+
+// Apply runs the full pipeline: guards → download → verify → atomic replace
+// (with .prev backup) → restart → health gate (rollback on failure) → history.
+// Any pre-replace failure leaves the system untouched.
+func (a *Applier) Apply(ctx context.Context, req Request) error {
+	a.log = slog.Default().With("component", "update-apply", "to", req.TargetTag)
+	if err := a.guards(req); err != nil {
+		return err
+	}
+
+	base := a.releaseBase(req)
+	binaryURL, checksumsURL, sigURL := base+"/"+assetName(), base+"/checksums.txt", base+"/checksums.txt.sig"
+
+	size, err := a.artifactSize(ctx, binaryURL)
+	if err != nil {
+		return fmt.Errorf("update: resolve artifact size: %w", err)
+	}
+	if err := a.checkDisk(req.BinaryPath, size); err != nil {
+		return err
+	}
+
+	checksums, err := a.fetchMeta(ctx, checksumsURL)
+	if err != nil {
+		return fmt.Errorf("update: download checksums.txt: %w", err)
+	}
+	sig, err := a.fetchMeta(ctx, sigURL)
+	if err != nil {
+		return fmt.Errorf("update: download checksums.txt.sig: %w", err)
+	}
+	if err := a.signVerify()(checksums, sig); err != nil {
+		return fmt.Errorf("update: signature verification failed (artifact may be corrupted or tampered with): %w", err)
+	}
+
+	tmpPath := req.BinaryPath + ".new"
+	if err := a.downloadBinary(ctx, binaryURL, tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("update: download binary: %w", err)
+	}
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("update: read downloaded binary: %w", err)
+	}
+	if err := a.digestVerify()(checksums, assetName(), data); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("update: artifact verification failed, system left untouched: %w", err)
+	}
+
+	// Atomic replace with rollback anchor. The .new file already sits on the
+	// same filesystem, so rename cannot cross devices.
+	prevPath := req.BinaryPath + ".prev"
+	_ = os.Remove(prevPath)
+	if err := os.Rename(req.BinaryPath, prevPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("update: back up current binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, req.BinaryPath); err != nil {
+		// Put the old binary back — the service is still running the old code
+		// from memory, but a machine reboot in this window must find a bootable file.
+		_ = os.Rename(prevPath, req.BinaryPath)
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("update: replace binary: %w", err)
+	}
+
+	if err := a.restart()(ctx); err != nil {
+		a.rollback(req, prevPath)
+		return fmt.Errorf("update: restart service failed (rollback performed): %w", err)
+	}
+	if err := a.healthWait()(ctx, req.HealthURL, a.healthTimeout()); err != nil {
+		a.rollback(req, prevPath)
+		a.appendHistory(req, "failed", "health gate: "+err.Error())
+		return fmt.Errorf("update: health gate after upgrade failed — rollback to %s performed: %w", req.Current, err)
+	}
+
+	a.appendHistory(req, "ok", "")
+	a.log.Info("update applied", "from", req.Current, "to", req.TargetTag)
+	return nil
+}
+
+// guards enforces the恒禁用 conditions from #647: docker deployments, dev
+// builds, and non-strictly-newer targets never run.
+func (a *Applier) guards(req Request) error {
+	deployment := a.DeploymentOverride
+	if deployment == "" {
+		deployment = Deployment()
+	}
+	if deployment == "docker" {
+		return fmt.Errorf("update: auto-apply is permanently disabled for docker deployments (the container is immutable; use Watchtower or compose pull)")
+	}
+	if !isNewer(req.Current, req.TargetTag) {
+		if ensureV(strings.TrimSpace(req.Current)) == ensureV(strings.TrimSpace(req.TargetTag)) {
+			return fmt.Errorf("update: target %s is the running version — nothing to do", req.TargetTag)
+		}
+		if isSemver(req.Current) && isSemver(req.TargetTag) {
+			return fmt.Errorf("update: refusing downgrade %s → %s", req.Current, req.TargetTag)
+		}
+		return fmt.Errorf("update: running version %q is not a semver release build — self-update is disabled for dev builds", req.Current)
+	}
+	return nil
+}
+
+func (a *Applier) releaseBase(req Request) string {
+	if a.ReleaseBase != "" {
+		return strings.TrimRight(a.ReleaseBase, "/")
+	}
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s", req.Repo, req.TargetTag)
+}
+
+func assetName() string {
+	arch := runtime.GOARCH
+	if arch == "arm" {
+		arch = "armv7"
+	}
+	return "mibee-nvr-" + arch
+}
+
+func (a *Applier) artifactSize(ctx context.Context, url string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("HEAD %s: %s", url, resp.Status)
+	}
+	if resp.ContentLength <= 0 {
+		return 0, fmt.Errorf("HEAD %s: no content length", url)
+	}
+	return resp.ContentLength, nil
+}
+
+func (a *Applier) checkDisk(path string, artifactSize int64) error {
+	_, free, err := a.freeSpace()(filepath.Dir(path))
+	if err != nil {
+		// A failed space check fails CLOSED: without knowing the free space we
+		// cannot guarantee the replace won't fill the disk.
+		return fmt.Errorf("update: disk space precheck failed: %w", err)
+	}
+	factor := a.MinSpaceFactor
+	if factor <= 0 {
+		factor = 3
+	}
+	if free < artifactSize*factor {
+		return fmt.Errorf("update: insufficient disk space: %d bytes free, need %d (artifact %d × factor %d)",
+			free, artifactSize*factor, artifactSize, factor)
+	}
+	return nil
+}
+
+func (a *Applier) fetchMeta(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s", resp.Status)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxMetaBytes))
+}
+
+// downloadBinary streams the artifact to path — never buffered whole in memory
+// (512MB-class binaries must not blow the memory budget of a 1GB ARM box).
+func (a *Applier) downloadBinary(ctx context.Context, url, path string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s", resp.Status)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(f, resp.Body)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// rollback restores the .prev binary and restarts again. Best-effort: errors
+// are logged but do not mask the original failure.
+func (a *Applier) rollback(req Request, prevPath string) {
+	if _, err := os.Stat(prevPath); err != nil {
+		a.log.Error("rollback: no .prev binary to restore", "path", prevPath)
+		return
+	}
+	if err := os.Rename(prevPath, req.BinaryPath); err != nil {
+		a.log.Error("rollback: restore previous binary failed", "error", err)
+		return
+	}
+	if err := a.restart()(context.Background()); err != nil {
+		a.log.Error("rollback: restart after restore failed", "error", err)
+		return
+	}
+	a.log.Warn("rollback complete — previous version restored", "version", req.Current)
+}
+
+func (a *Applier) appendHistory(req Request, result, errMsg string) {
+	row := historyRow{
+		Time:   a.now().UTC().Format(time.RFC3339),
+		From:   req.Current,
+		To:     req.TargetTag,
+		Result: result,
+		Error:  errMsg,
+	}
+	b, err := json.Marshal(row)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(req.DataDir, historyFile),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		a.log.Warn("history: open failed", "error", err)
+		return
+	}
+	defer f.Close()
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		a.log.Warn("history: write failed", "error", err)
+	}
+}
+
+func (a *Applier) healthTimeout() time.Duration {
+	if a.HealthTimeout > 0 {
+		return a.HealthTimeout
+	}
+	return 120 * time.Second
+}
+
+func (a *Applier) signVerify() func([]byte, []byte) error {
+	if a.SignVerify != nil {
+		return a.SignVerify
+	}
+	return VerifyChecksumsSignature
+}
+
+func (a *Applier) digestVerify() func([]byte, string, []byte) error {
+	if a.DigestVerify != nil {
+		return a.DigestVerify
+	}
+	return VerifyBinaryChecksum
+}
+
+func (a *Applier) freeSpace() func(string) (int64, int64, error) {
+	if a.FreeSpace != nil {
+		return a.FreeSpace
+	}
+	return storage.FreeSpace
+}
+
+func (a *Applier) restart() func(context.Context) error {
+	if a.Restart != nil {
+		return a.Restart
+	}
+	return func(ctx context.Context) error {
+		return exec.CommandContext(ctx, "systemctl", "restart", "mibee-nvr").Run()
+	}
+}
+
+func (a *Applier) healthWait() func(context.Context, string, time.Duration) error {
+	if a.HealthWait != nil {
+		return a.HealthWait
+	}
+	return pollHealth
+}
+
+func (a *Applier) now() time.Time {
+	if a.Now != nil {
+		return a.Now()
+	}
+	return time.Now()
+}
+
+// pollHealth GETs url every 2s until it answers 200 or the timeout elapses.
+func pollHealth(ctx context.Context, url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("/api/health not ready within %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// --- Request file (polkit handoff) ---
+
+// WriteRequest atomically writes the auto-apply request into dataDir and
+// returns its path. The nvr user owns the data dir (ReadWritePaths), so this
+// is the ONE file the sandboxed app may use to ask root for an upgrade.
+func WriteRequest(dataDir, targetTag string, now time.Time) (string, error) {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return "", err
+	}
+	req := AutoRequest{TargetTag: targetTag, RequestedAt: now.UTC().Format(time.RFC3339)}
+	b, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dataDir, requestFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return "", err
+	}
+	return path, os.Rename(tmp, path)
+}
+
+// ReadRequest parses a request file.
+func ReadRequest(path string) (AutoRequest, error) {
+	var req AutoRequest
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return req, err
+	}
+	return req, json.Unmarshal(b, &req)
+}
+
+// RemoveRequest deletes the request file (called by the helper after use so a
+// later manual `systemctl start` doesn't re-run a stale upgrade).
+func RemoveRequest(path string) error {
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// RequestFilePath returns the conventional request-file path inside dataDir.
+func RequestFilePath(dataDir string) string { return filepath.Join(dataDir, requestFile) }
+
+// --- Auto-apply eligibility ---
+
+// ShouldAutoApply reports whether the sensing layer may trigger the root
+// helper for this status: stable channel, semver current build, binary
+// deployment, strictly newer candidate. Docker/dev/beta never auto-apply.
+func ShouldAutoApply(currentVersion string, st Status, deployment string) bool {
+	return st.UpdateAvailable &&
+		st.Latest != "" &&
+		deployment != "docker" &&
+		st.Channel == "stable" &&
+		isSemver(currentVersion) &&
+		isNewer(currentVersion, st.Latest)
+}
+
+// isSemver reports whether v is a canonical semver string (optionally
+// "v"-prefixed) — "dev" or "" are not.
+func isSemver(v string) bool {
+	return semver.IsValid(ensureV(strings.TrimSpace(v)))
+}
+
+// TriggerAutoApply is the app-side half of the #647 handoff: for an eligible
+// status it writes the request file (the one path the sandboxed nvr user may
+// write) and starts the root helper unit. startUnit is injectable — production
+// uses systemctl via polkit; trigger failures are returned so the caller can
+// log them (auto-apply is best-effort, never fatal).
+func TriggerAutoApply(currentVersion string, st Status, deployment, dataDir string, startUnit func(unit string) error) error {
+	if !ShouldAutoApply(currentVersion, st, deployment) {
+		return fmt.Errorf("update: auto-apply not eligible (deployment=%s channel=%s latest=%q current=%q)",
+			deployment, st.Channel, st.Latest, currentVersion)
+	}
+	if _, err := WriteRequest(dataDir, st.Latest, time.Now()); err != nil {
+		return fmt.Errorf("update: write auto-apply request: %w", err)
+	}
+	const helperUnit = "mibee-nvr-update.service"
+	if err := startUnit(helperUnit); err != nil {
+		return fmt.Errorf("update: start %s (polkit rule installed?): %w", helperUnit, err)
+	}
+	slog.Info("update: auto-apply triggered", "version", st.Latest, "helper", helperUnit)
+	return nil
+}
+
+// StartHelperUnit is the production startUnit: systemctl start via D-Bus
+// (polkit authorizes the nvr user for exactly this unit). Use `systemctl
+// start` (not `isolate`) so the request is one policy check.
+func StartHelperUnit(unit string) error {
+	return exec.Command("systemctl", "start", unit).Run()
+}

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -1,0 +1,429 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeArtifact wires a test HTTP server serving the binary, checksums.txt and
+// checksums.txt.sig, tracking what got requested.
+type fakeArtifact struct {
+	srv        *httptest.Server
+	binary     []byte
+	checksums  string
+	sig        []byte
+	binaryHits int
+}
+
+func newFakeArtifact(t *testing.T, binary []byte, withSig bool) *fakeArtifact {
+	t.Helper()
+	fa := &fakeArtifact{binary: binary}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/releases/download/v9.9.9/mibee-nvr-"+testArch()+"/", func(w http.ResponseWriter, r *http.Request) {
+		fa.binaryHits++
+		w.Header().Set("Content-Length", strconv.Itoa(len(fa.binary)))
+		w.Write(fa.binary)
+	})
+	mux.HandleFunc("/releases/download/v9.9.9/mibee-nvr-"+testArch(), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Length", strconv.Itoa(len(fa.binary)))
+			return
+		}
+		fa.binaryHits++
+		w.Write(fa.binary)
+	})
+	fa.checksums = sha256Line("mibee-nvr-"+testArch(), binary)
+	mux.HandleFunc("/releases/download/v9.9.9/checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fa.checksums))
+	})
+	if withSig {
+		fa.sig = []byte("fake-signature-material")
+		mux.HandleFunc("/releases/download/v9.9.9/checksums.txt.sig", func(w http.ResponseWriter, r *http.Request) {
+			w.Write(fa.sig)
+		})
+	}
+	fa.srv = httptest.NewServer(mux)
+	t.Cleanup(fa.srv.Close)
+	return fa
+}
+
+func testArch() string {
+	if runtime.GOARCH == "arm" {
+		return "armv7"
+	}
+	return runtime.GOARCH
+}
+
+// newTestApplier builds an Applier with every external seam faked: downloads
+// hit the test server, signature/digest checks are stubs, restart and health
+// are recorded callbacks. Verifications use the REAL digest logic (the same
+// VerifyBinaryChecksum production uses) over the fake server's bytes.
+func newTestApplier(t *testing.T, fa *fakeArtifact) (*Applier, *applyRecorder) {
+	t.Helper()
+	rec := &applyRecorder{}
+	a := &Applier{
+		SignVerify: func(checksums, sig []byte) error {
+			rec.sigVerified = true
+			if !withSig(fa) {
+				return errors.New("no sig")
+			}
+			return nil
+		},
+		DigestVerify: VerifyBinaryChecksum,
+		FreeSpace: func(string) (int64, int64, error) {
+			return 1 << 40, 1 << 35, nil // 1TB total, 32GB free
+		},
+		Restart: func(context.Context) error {
+			rec.restarts++
+			return nil
+		},
+		HealthWait: func(context.Context, string, time.Duration) error {
+			rec.healthProbes++
+			return nil
+		},
+		Now:           func() time.Time { return time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC) },
+		ReleaseBase:   fa.srv.URL + "/releases/download/v9.9.9",
+		HealthTimeout: 30 * time.Second,
+	}
+	return a, rec
+}
+
+func withSig(fa *fakeArtifact) bool { return fa.sig != nil }
+
+type applyRecorder struct {
+	restarts     int
+	healthProbes int
+	sigVerified  bool
+}
+
+func testRequest(t *testing.T, fa *fakeArtifact) Request {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "mibee-nvr")
+	oldBinary := []byte("#!/bin/sh\nold version")
+	if err := os.WriteFile(bin, oldBinary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return Request{
+		Current:    "v1.0.0",
+		TargetTag:  "v9.9.9",
+		Repo:       "Mi-Bee-Studio/MiBeeNvr",
+		BinaryPath: bin,
+		DataDir:    dir,
+		HealthURL:  "http://127.0.0.1:19090/api/health",
+	}
+}
+
+// The happy path: verified download → atomic replace (with .prev backup) →
+// restart → health gate → history row.
+func TestApplier_Apply_HappyPath(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("new binary bytes"), true)
+	a, rec := newTestApplier(t, fa)
+	req := testRequest(t, fa)
+
+	if err := a.Apply(context.Background(), req); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got, err := os.ReadFile(req.BinaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new binary bytes" {
+		t.Fatalf("binary not replaced: %q", got)
+	}
+	prev, err := os.ReadFile(req.BinaryPath + ".prev")
+	if err != nil {
+		t.Fatalf(".prev backup missing: %v", err)
+	}
+	if string(prev) != "#!/bin/sh\nold version" {
+		t.Fatalf(".prev content wrong: %q", prev)
+	}
+	if rec.restarts != 1 || rec.healthProbes != 1 || !rec.sigVerified {
+		t.Fatalf("pipeline steps wrong: restarts=%d health=%d sigVerified=%v", rec.restarts, rec.healthProbes, rec.sigVerified)
+	}
+	if fi, err := os.Stat(req.BinaryPath); err != nil || fi.Mode()&0o111 == 0 {
+		t.Fatalf("replaced binary must be executable: %v %v", fi, err)
+	}
+
+	// History row records from/to/result.
+	hist, err := os.ReadFile(filepath.Join(req.DataDir, "update-history.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row map[string]any
+	if err := json.Unmarshal([]byte(lastLine(string(hist))), &row); err != nil {
+		t.Fatalf("history row not JSON: %v\n%s", err, hist)
+	}
+	if row["from"] != "v1.0.0" || row["to"] != "v9.9.9" || row["result"] != "ok" {
+		t.Fatalf("history row wrong: %v", row)
+	}
+}
+
+// The #646 acceptance case in the pipeline context: a tampered binary must be
+// rejected BEFORE any system change — no replace, no restart, no history.
+func TestApplier_Apply_TamperedBinaryRejectedBeforeApply(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("forged binary bytes — digest will not match"), true)
+	a, rec := newTestApplier(t, fa)
+	// Real digest verification over checksums for a DIFFERENT binary.
+	fa.checksums = sha256Line("mibee-nvr-"+testArch(), []byte("the genuine artifact"))
+	req := testRequest(t, fa)
+
+	err := a.Apply(context.Background(), req)
+	if err == nil {
+		t.Fatal("digest mismatch must fail Apply")
+	}
+
+	got, readErr := os.ReadFile(req.BinaryPath)
+	if readErr != nil || string(got) != "#!/bin/sh\nold version" {
+		t.Fatalf("binary must be untouched on verification failure: %q %v", got, readErr)
+	}
+	if rec.restarts != 0 {
+		t.Fatalf("no restart may happen on verification failure, got %d", rec.restarts)
+	}
+	if _, err := os.Stat(req.BinaryPath + ".new"); !os.IsNotExist(err) {
+		t.Fatalf("temp file must be cleaned up: %v", err)
+	}
+	if _, err := os.Stat(req.BinaryPath + ".prev"); !os.IsNotExist(err) {
+		t.Fatal("no backup may exist when nothing was applied")
+	}
+}
+
+func TestApplier_Apply_MissingSignatureRejected(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("new binary"), false) // release without .sig
+	a, _ := newTestApplier(t, fa)
+	req := testRequest(t, fa)
+
+	if err := a.Apply(context.Background(), req); err == nil {
+		t.Fatal("unsigned release must be rejected by the pipeline")
+	}
+	if got, _ := os.ReadFile(req.BinaryPath); string(got) != "#!/bin/sh\nold version" {
+		t.Fatal("binary must be untouched")
+	}
+}
+
+// Health gate failure after a successful replace → automatic rollback to the
+// .prev binary + second restart.
+func TestApplier_Apply_HealthGateFailureRollsBack(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("new but broken binary"), true)
+	a, rec := newTestApplier(t, fa)
+	a.HealthWait = func(context.Context, string, time.Duration) error {
+		return errors.New("health gate: /api/health not ready in time")
+	}
+	req := testRequest(t, fa)
+
+	err := a.Apply(context.Background(), req)
+	if err == nil || !strings.Contains(err.Error(), "rollback") {
+		t.Fatalf("expected rollback error, got: %v", err)
+	}
+
+	got, readErr := os.ReadFile(req.BinaryPath)
+	if readErr != nil || string(got) != "#!/bin/sh\nold version" {
+		t.Fatalf("rollback must restore the previous binary: %q %v", got, readErr)
+	}
+	if rec.restarts != 2 {
+		t.Fatalf("rollback must restart again, restarts=%d", rec.restarts)
+	}
+	hist, _ := os.ReadFile(filepath.Join(req.DataDir, "update-history.jsonl"))
+	if !strings.Contains(string(hist), `"result":"failed"`) {
+		t.Fatalf("history must record the failure: %s", hist)
+	}
+}
+
+func TestApplier_Apply_Guards(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("new"), true)
+
+	cases := []struct {
+		name string
+		mut  func(*Request, *Applier)
+		want string
+	}{
+		{
+			name: "docker deployment refused",
+			mut: func(r *Request, a *Applier) {
+				a.DeploymentOverride = "docker"
+			},
+			want: "docker",
+		},
+		{
+			name: "dev build refused",
+			mut:  func(r *Request, a *Applier) { r.Current = "dev" },
+			want: "dev",
+		},
+		{
+			name: "downgrade refused",
+			mut:  func(r *Request, a *Applier) { r.TargetTag = "v0.0.1" },
+			want: "downgrade",
+		},
+		{
+			name: "insufficient disk space refused",
+			mut: func(r *Request, a *Applier) {
+				// Artifact is 3 bytes ("new"); 1 byte free < required 9.
+				a.FreeSpace = func(string) (int64, int64, error) { return 1 << 30, 1, nil }
+			},
+			want: "disk",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, rec := newTestApplier(t, fa)
+			req := testRequest(t, fa)
+			tc.mut(&req, a)
+			err := a.Apply(context.Background(), req)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got: %v", tc.want, err)
+			}
+			if rec.restarts != 0 {
+				t.Fatalf("guards must run before any system change, restarts=%d", rec.restarts)
+			}
+			if got, _ := os.ReadFile(req.BinaryPath); string(got) != "#!/bin/sh\nold version" {
+				t.Fatal("binary must be untouched")
+			}
+		})
+	}
+}
+
+// The polkit handoff file: the app (nvr user) writes a request, the root
+// helper reads it and deletes it after a successful run.
+func TestRequestFileRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteRequest(dir, "v9.9.9", time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Dir(path) != dir {
+		t.Fatalf("request file must live in the data dir, got %s", path)
+	}
+	got, err := ReadRequest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TargetTag != "v9.9.9" {
+		t.Fatalf("round trip lost the tag: %+v", got)
+	}
+	if got.RequestedAt == "" {
+		t.Fatal("requested_at must be recorded")
+	}
+	if err := RemoveRequest(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("request must be deletable")
+	}
+}
+
+// Auto-apply eligibility: only stable-channel, semver-current, non-docker
+// deployments with a strictly newer candidate may trigger the helper.
+func TestShouldAutoApply(t *testing.T) {
+	cases := []struct {
+		name        string
+		current     string
+		channel     string
+		deployment  string
+		updateAvail bool
+		latest      string
+		want        bool
+	}{
+		{"eligible", "v1.0.0", "stable", "binary", true, "v9.9.9", true},
+		{"docker never", "v1.0.0", "stable", "docker", true, "v9.9.9", false},
+		{"dev build never", "dev", "stable", "binary", true, "v9.9.9", false},
+		{"beta channel never", "v1.0.0", "beta", "binary", true, "v9.9.9", false},
+		{"no update available", "v1.0.0", "stable", "binary", false, "v1.0.0", false},
+		{"no latest known", "v1.0.0", "stable", "binary", false, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := Status{UpdateAvailable: tc.updateAvail, Latest: tc.latest, Channel: tc.channel}
+			if got := ShouldAutoApply(tc.current, st, tc.deployment); got != tc.want {
+				t.Fatalf("ShouldAutoApply(%q, %+v, %q) = %v, want %v", tc.current, st, tc.deployment, got, tc.want)
+			}
+		})
+	}
+}
+
+// sha256Line renders one sha256sum-format line for the digest verifier.
+func sha256Line(name string, data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]) + "  " + name + "\n"
+}
+
+// lastLine returns the final non-empty line of s.
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	return lines[len(lines)-1]
+}
+
+// SetOnAvailable fires once per distinct newer tag — the auto-apply hook
+// (#647). Repeated polls of the same tag must not re-trigger.
+func TestChecker_SetOnAvailable_FiresOncePerTag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"tag_name":"v9.9.9","html_url":"x"}`)
+	}))
+	defer srv.Close()
+
+	c := New("v1.0.0", "Mi-Bee-Studio/MiBeeNvr", "stable", time.Hour)
+	c.endpoint = srv.URL
+	var mu sync.Mutex
+	var tags []string
+	c.SetOnAvailable(func(st Status) {
+		mu.Lock()
+		tags = append(tags, st.Latest)
+		mu.Unlock()
+	})
+
+	for range 3 {
+		if _, err := c.fetchAndCache(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(tags) != 1 || tags[0] != "v9.9.9" {
+		t.Fatalf("callback must fire exactly once for the tag, got %v", tags)
+	}
+}
+
+// The auto-apply trigger: eligible status → request file written + helper
+// triggered; ineligible → nothing.
+func TestTriggerAutoApply(t *testing.T) {
+	dir := t.TempDir()
+	var started []string
+	trig := func(unit string) error {
+		started = append(started, unit)
+		return nil
+	}
+
+	st := Status{UpdateAvailable: true, Latest: "v9.9.9", Channel: "stable"}
+	if err := TriggerAutoApply("v1.0.0", st, "binary", dir, trig); err != nil {
+		t.Fatalf("eligible trigger: %v", err)
+	}
+	reqPath := RequestFilePath(dir)
+	got, err := ReadRequest(reqPath)
+	if err != nil || got.TargetTag != "v9.9.9" {
+		t.Fatalf("request file must carry the target tag: %+v %v", got, err)
+	}
+	if len(started) != 1 || started[0] != "mibee-nvr-update.service" {
+		t.Fatalf("helper must be started exactly once, got %v", started)
+	}
+
+	if err := TriggerAutoApply("v1.0.0", st, "docker", dir, trig); err == nil {
+		t.Fatal("docker deployment must refuse to trigger")
+	}
+	if len(started) != 1 {
+		t.Fatalf("ineligible status must not trigger the helper, got %v", started)
+	}
+}

--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -76,6 +76,11 @@ type Checker struct {
 	cached *Status // latest known status (nil before first successful check)
 	etag   string  // sent as If-None-Match on the next poll
 
+	// onAvailable is invoked once per distinct newer tag discovered by a poll
+	// (#647 auto-apply hook). Guarded by mu; nil = no hook.
+	onAvailable     func(Status)
+	lastNotifiedTag string
+
 	stop chan struct{} // closed by Stop to end the poll loop
 }
 
@@ -113,6 +118,17 @@ func (c *Checker) Stop() {
 	default:
 		close(c.stop)
 	}
+}
+
+// SetOnAvailable registers a callback fired (on the poll goroutine) once per
+// distinct newer release tag — the #647 auto-apply entry point. The callback
+// must be non-blocking or spawn its own goroutine: it runs inside the poll
+// loop, and a slow callback would delay subsequent checks. Safe to call
+// before Start; setting it again replaces the previous hook.
+func (c *Checker) SetOnAvailable(fn func(Status)) {
+	c.mu.Lock()
+	c.onAvailable = fn
+	c.mu.Unlock()
 }
 
 // Status returns a snapshot of the latest check. Before the first successful
@@ -227,6 +243,15 @@ func (c *Checker) fetchAndCache(ctx context.Context) (Status, error) {
 	c.mu.Lock()
 	c.cached = &status
 	c.etag = resp.Header.Get("ETag")
+	// Fire the auto-apply hook once per distinct newer tag: repeated polls of
+	// the same release (the normal case) must not re-trigger the helper.
+	if status.UpdateAvailable && status.Latest != c.lastNotifiedTag && c.onAvailable != nil {
+		c.lastNotifiedTag = status.Latest
+		cb := c.onAvailable
+		c.mu.Unlock()
+		cb(status)
+		return status, nil
+	}
 	c.mu.Unlock()
 	return status, nil
 }


### PR DESCRIPTION
## 背景 (#647)

裸机(install.sh/systemd)安装是最后一个无自动升级的在线场景(#204 两层设计的执行层缺口;Docker 已有 Watchtower)。硬约束:`mibee-nvr.service` 沙箱(`User=nvr` + `ProtectSystem=strict`)禁止进程写 `/usr/local/bin`,进程内 self-update 被挡死——本 PR 采用 issue 推荐的**方案 1:root oneshot helper unit + polkit**,沙箱不动、特权面最小。

## 架构

```
应用(nvr 用户,沙箱内)                root helper(mibee-nvr-update.service)
  感知层发现新版 + update.auto_apply: true
  ├─ 写请求文件 /var/lib/mibee-nvr/update-request.json(沙箱唯一可写的交接点)
  └─ systemctl start mibee-nvr-update.service(polkit 精确放行这一个 unit)
                                       →  mibee-nvr update --apply-request …(二进制自身就是 helper)
```

polkit 规则只放行 nvr 用户启动 `mibee-nvr-update.service`;unit 带 `ConditionPathExists` 请求文件,手动误触空跑无害。

## 升级流水线(安全护栏全落地)

`internal/update.Applier`,所有外部效应注入化(符合仓库可测性规约):

1. **前置检查**:docker/dev 构建/非严格更新(永不降级)拒绝;磁盘剩余 ≥ 产物×3(HEAD Content-Length 探得,statfs 经 #664 的共享封装导出 `storage.FreeSpace`)
2. **流式下载**:二进制 io.Copy 落盘(内存有界)+ checksums.txt/.sig(64KB 上限)
3. **验证**(#646 落地的能力):ed25519 签名 + sha256 摘要——**任何失败在系统改动前中止**,.new 临时文件清理
4. **原子替换**:temp→rename;先保留 `.prev`(同文件系统,断电安全,f.Sync)
5. **重启 + 健康门禁**:`systemctl restart` 后探 `/api/health`(120s,2s 间隔)
6. **自动回滚**:门禁失败恢复 `.prev` + 再重启,失败记入历史
7. **可观测**:全程 slog + `update-history.jsonl`(from/to/result/error,#648 的 UI 可直接读)

## 其他组件

- **Checker.SetOnAvailable**:每个新 tag 恰好触发一次(重复轮询不重触);`TriggerAutoApply` 判定资格(stable/semver/非 docker)后交接 helper,失败仅告警不致命
- **config** `update.auto_apply`(默认 false,纯 opt-in)
- **CLI**:`sudo mibee-nvr update`(手动路径,无 polkit 也可用)/ `--version` / `--check`(零改动)/ `--apply-request`(helper 入口,请求文件**无论成败都恰好消费一次**,杜绝陈旧请求重放)
- **install.sh**:部署 helper unit + polkit 规则(best-effort,失败降级为手动路径告警),uninstall 清理
- **docs zh/en**:裸机自动升级章节(流程图、开启、回滚、适用边界)

## 测试(TDD,hermetic)

- `internal/update` 45 项:管线全链(替换+备份+重启+健康+历史)、篡改二进制在改动前拒绝、缺签名拒绝、健康门禁失败自动回滚+失败历史、四类 guard、请求文件往返、auto-apply 资格矩阵、checker 每 tag 一次回调
- `cmd` 67 项:健康 URL 推导(含 IPv6)、--check、root 强制(CI root 环境下走注桩管线)、请求文件失败后清理
- `-race` 全绿;golangci-lint 0 issues

## 验收对照(issue 任务清单)

- [x] root oneshot helper + polkit(方案 1)
- [x] 升级流水线 6 道护栏
- [x] `mibee-nvr update` CLI(sudo 手动路径 + 无 polkit 兜底)
- [x] install.sh 部署 helper + polkit
- [x] docs 裸机自动升级章节
- [ ] 实机验收:建议在 Docker VM 用 systemd 装一套 + 手动触发一次完整升级/回滚(合并后跟进,测法见 docs)

依赖链:#646(#669,已合入)提供签名验证;后续 #648(API + Settings UI)消费 update-history + auto_apply 开关入口。

Closes #647
