### PR TITLE
feat(update): download mirror for release artifacts (#649)

### DIFF
--- a/cmd/mibee-nvr/update_cmd.go
+++ b/cmd/mibee-nvr/update_cmd.go
@@ -56,8 +56,10 @@ type runUpdateArgs struct {
 }
 
 // applyFn is overridable in tests (the real one runs the full root pipeline).
-var applyFn = func(req update.Request) error {
-	return (&update.Applier{}).Apply(context.Background(), req)
+// The download mirror from config (#649) applies to ALL artifacts; empty
+// mirror keeps GitHub official URLs.
+var applyFn = func(req update.Request, mirror string) error {
+	return (&update.Applier{Mirror: mirror}).Apply(context.Background(), req)
 }
 
 // healthFn resolves the health-probe URL for the running config (tests).
@@ -140,7 +142,7 @@ func runUpdate(args runUpdateArgs, out io.Writer) error {
 		DataDir:    dataDir,
 		HealthURL:  healthFn(cfg),
 	}
-	if err := applyFn(req); err != nil {
+	if err := applyFn(req, cfg.Update.DownloadMirror); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "upgraded to %s — health gate passed\n", target)

--- a/cmd/mibee-nvr/update_cmd_test.go
+++ b/cmd/mibee-nvr/update_cmd_test.go
@@ -87,8 +87,10 @@ func TestRunUpdate_ApplyPath(t *testing.T) {
 
 	prevApply := applyFn
 	var applied []update.Request
-	applyFn = func(req update.Request) error {
+	var mirrors []string
+	applyFn = func(req update.Request, mirror string) error {
 		applied = append(applied, req)
+		mirrors = append(mirrors, mirror)
 		return nil
 	}
 	t.Cleanup(func() { applyFn = prevApply })
@@ -129,7 +131,7 @@ func TestRunUpdate_ApplyRequestConsumedExactlyOnce(t *testing.T) {
 	}
 
 	prevApply := applyFn
-	applyFn = func(update.Request) error { return errPipelineFailureForTest }
+	applyFn = func(update.Request, string) error { return errPipelineFailureForTest }
 	t.Cleanup(func() { applyFn = prevApply })
 
 	err = runUpdate(runUpdateArgs{cfgPath: cfgPath, applyRequest: reqPath}, os.Stderr)

--- a/docs/en/deployment-autoupdate.md
+++ b/docs/en/deployment-autoupdate.md
@@ -159,6 +159,21 @@ sudo systemctl start mibee-nvr
 
 Upgrade history lives in `<data-dir>/update-history.jsonl` (time, from/to, result, failure reason).
 
+### Mainland-China networks: download mirror (#649)
+
+Both `api.github.com` and `github.com/releases/download` are frequently slow or unreachable from mainland-China networks. Configure a download mirror:
+
+```yaml
+update:
+  download_mirror: "https://your-mirror.example/https://github.com"   # prefix replacing https://github.com
+```
+
+Rules:
+
+- The mirror is a **prefix that replaces `https://github.com`** — the `{repo}/releases/download/...` path structure is preserved underneath it, so ghproxy-style prefix proxies and self-hosted path-preserving mirrors both fit. Version **checking** still goes to the GitHub API.
+- The binary, `checksums.txt` and the signature all download from the **same origin** — the trust chain is never spliced (official signature + mirror binary is a forbidden combination).
+- A mirror failure **fails the apply with a clear error** — never a fallback to GitHub. Empty (default) behaves exactly as before.
+
 ### Scope
 
 Only install.sh/systemd bare-metal installs. Docker belongs to Watchtower; fnOS/unRAID store installs belong to the platform's upgrade mechanism; offline environments should download manually (see the verification section above). On distros without polkit the automatic trigger is unavailable, but the `sudo mibee-nvr update` manual path still works.

--- a/docs/zh/deployment-autoupdate.md
+++ b/docs/zh/deployment-autoupdate.md
@@ -158,6 +158,21 @@ sudo systemctl start mibee-nvr
 
 升级记录在 `<数据目录>/update-history.jsonl`(时间、from/to、结果、失败原因)。
 
+### 国内网络:下载镜像源(#649)
+
+`api.github.com` 与 `github.com/releases/download` 在国内网络经常不可达或极慢,可配置下载镜像:
+
+```yaml
+update:
+  download_mirror: "https://your-mirror.example/https://github.com"   # 替换 https://github.com 的前缀
+```
+
+规则:
+
+- 镜像地址是**替换 `https://github.com` 的前缀**,其下保留 `{repo}/releases/download/...` 路径结构——ghproxy 类前缀代理与自建路径保持镜像都适用;版本**检测**仍走 GitHub API
+- 二进制、`checksums.txt`、签名**同源镜像**下载——信任链不拼接(官方签名 + 镜像二进制是被禁止的组合)
+- 镜像失败**直接报错拒绝安装**,不会回退官方源;留空(默认)行为与现状完全一致
+
 ### 适用边界
 
 仅适用 `install.sh`/systemd 裸机安装。Docker 归 Watchtower;fnOS/unRAID 等商店渠道归平台的升级机制;离线环境请手动下载(校验方法见上一节)。无 polkit 的老发行版上自动触发不可用,但 `sudo mibee-nvr update` 手动路径不受影响。

--- a/internal/config/config_update.go
+++ b/internal/config/config_update.go
@@ -32,6 +32,15 @@ type UpdateConfig struct {
 	// rollback to the previous binary if the upgraded service fails its
 	// health gate.
 	AutoApply *bool `yaml:"auto_apply"`
+	// DownloadMirror is a base URL that replaces "https://github.com" for
+	// release-artifact downloads (#649) — bare-metal auto-upgrade reliability
+	// on networks where GitHub is slow/unreachable. The
+	// {repo}/releases/download/... path is preserved underneath it, so a
+	// ghproxy-style prefix or a self-hosted path-preserving mirror both fit.
+	// The version CHECK still goes to the GitHub API. Empty (default) =
+	// GitHub official. All artifacts (binary + checksums + signature) come
+	// from the same origin; mirror failures never fall back to GitHub.
+	DownloadMirror string `yaml:"download_mirror"`
 }
 
 // IsEnabled returns whether the update check is enabled (default true).

--- a/internal/update/apply.go
+++ b/internal/update/apply.go
@@ -43,9 +43,19 @@ type Request struct {
 // injectable seam (tests fake all of them; production defaults are the real
 // system operations). Not goroutine-safe — one run at a time.
 type Applier struct {
-	// ReleaseBase overrides the download base URL
-	// (https://github.com/{repo}/releases/download) — tests point it at an
-	// httptest server; a future mirror (#649) can point it at a CDN.
+	// Mirror is a download-mirror base that replaces "https://github.com"
+	// (#649, config update.download_mirror) — the {repo}/releases/download
+	// path is preserved underneath it, so a ghproxy-style prefix mirror or a
+	// self-hosted path-preserving mirror both fit. Empty = GitHub official.
+	// ALL artifacts (binary, checksums.txt, signature) come from the SAME
+	// origin: mixing a mirror binary with officially-signed checksums would
+	// keep the signature valid while swapping the bytes it vouches for. A
+	// mirror failure therefore fails CLOSED — never a silent fallback to
+	// GitHub.
+	Mirror string
+
+	// ReleaseBase overrides the full download base URL (mirror/tag already
+	// resolved) — tests point it at an httptest server.
 	ReleaseBase string
 
 	// DeploymentOverride replaces Deployment() (tests).
@@ -203,6 +213,9 @@ func (a *Applier) guards(req Request) error {
 func (a *Applier) releaseBase(req Request) string {
 	if a.ReleaseBase != "" {
 		return strings.TrimRight(a.ReleaseBase, "/")
+	}
+	if m := strings.TrimRight(a.Mirror, "/"); m != "" {
+		return fmt.Sprintf("%s/%s/releases/download/%s", m, req.Repo, req.TargetTag)
 	}
 	return fmt.Sprintf("https://github.com/%s/releases/download/%s", req.Repo, req.TargetTag)
 }

--- a/internal/update/apply_test.go
+++ b/internal/update/apply_test.go
@@ -427,3 +427,66 @@ func TestTriggerAutoApply(t *testing.T) {
 		t.Fatalf("ineligible status must not trigger the helper, got %v", started)
 	}
 }
+
+// #649: a configured download mirror must serve ALL artifacts (binary,
+// checksums, signature) — the trust chain may never mix origins — and a
+// mirror failure must NOT silently fall back to GitHub.
+func TestApplier_MirrorSameOriginAndNoFallback(t *testing.T) {
+	// Official GitHub side: would serve a GOOD artifact, but must never be hit.
+	official := newFakeArtifact(t, []byte("genuine official artifact"), true)
+
+	// Mirror side: serves checksums+sig but the binary endpoint 404s — the
+	// classic broken-mirror case that must fail loudly, not fall back.
+	var mirrorBinaryHits, mirrorMetaHits int
+	mirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/mibee-nvr-") {
+			mirrorBinaryHits++
+			if r.Method == http.MethodHead || r.Method == http.MethodGet {
+				http.NotFound(w, r)
+				return
+			}
+		}
+		mirrorMetaHits++
+		if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+			fmt.Fprint(w, sha256Line("mibee-nvr-"+testArch(), []byte("genuine official artifact")))
+			return
+		}
+		fmt.Fprint(w, "mirror-signature")
+	}))
+	defer mirror.Close()
+
+	a, rec := newTestApplier(t, official)
+	// Mirror replaces https://github.com — the {repo}/releases/... path is
+	// preserved underneath it. Clear the helper's ReleaseBase so the mirror
+	// derivation runs.
+	a.ReleaseBase = ""
+	a.Mirror = mirror.URL
+	req := testRequest(t, official)
+
+	err := a.Apply(context.Background(), req)
+	if err == nil {
+		t.Fatal("broken mirror must fail the apply")
+	}
+	if mirrorBinaryHits == 0 && mirrorMetaHits == 0 {
+		t.Fatal("mirror must have been contacted")
+	}
+	if official.binaryHits != 0 {
+		t.Fatal("must NOT fall back to the official origin when a mirror is configured")
+	}
+	if rec.restarts != 0 {
+		t.Fatal("no system change on mirror failure")
+	}
+}
+
+// Empty mirror (the default) keeps today's behavior: GitHub official URLs.
+func TestApplier_NoMirrorUsesOfficial(t *testing.T) {
+	fa := newFakeArtifact(t, []byte("artifact"), true)
+	a, _ := newTestApplier(t, fa)
+	a.ReleaseBase = "" // production default path
+	req := testRequest(t, fa)
+
+	base := a.releaseBase(req)
+	if !strings.HasPrefix(base, "https://github.com/Mi-Bee-Studio/MiBeeNvr/releases/download/v9.9.9") {
+		t.Fatalf("default base must be GitHub official, got %s", base)
+	}
+}


### PR DESCRIPTION
## 背景 (#649)

裸机自动升级(#647)的产物下载走 `github.com/releases/download`,国内网络经常不可达或极慢——Docker 有阿里云 ACR 镜像,二进制没有对应通道。

## 改动

**1. config `update.download_mirror`**(默认空 = GitHub 官方,行为与现状完全一致)
- 语义:**替换 `https://github.com` 的前缀**,其下保留 `{repo}/releases/download/...` 路径结构——ghproxy 类前缀代理与自建路径保持镜像都适用
- 版本**检测**仍走 GitHub API(按 issue 约定不动)

**2. `Applier.Mirror`**(CLI `mibee-nvr update` 手动路径与 root helper 共用——helper 加载同一配置)
- 二进制、`checksums.txt`、签名**同源镜像下载**:信任链不拼接,「官方签名 + 镜像二进制」这种保持签名有效但偷换字节面的组合在结构上不可能出现
- 镜像失败**直接报错拒绝安装,不回退官方裸下载**(验收第 3 条);验证失败照旧在系统改动前中止

**3. docs zh/en**:镜像章节(语义、信任链规则、失败语义)

## 测试(TDD)

- `TestApplier_MirrorSameOriginAndNoFallback`:镜像 404 二进制 → Apply 失败、官方源零命中、零系统改动
- `TestApplier_NoMirrorUsesOfficial`:默认空镜像 = 官方 URL
- 全包 `-race` 47+ 项绿;`internal/config` + `cmd` 全绿;golangci-lint 0 issues

## 验收对照

- [x] `download_mirror` 为空时行为与现状完全一致
- [x] 配置镜像后全流程走镜像(同源下载在结构上保证)
- [x] 镜像校验/下载失败 → 拒绝安装明确报错,不回退官方
- [ ] 官方国内分发通道评估(阿里云 OSS 等):本 PR 只做了客户端侧;官方镜像落地后只需在 docs 与默认配置注释补地址(独立跟进,不阻塞本 issue 关闭的话请标注)

Closes #649
