### PR TITLE
feat(snapshot): H.264/H.265 latest-frame (FFmpeg-gated) + MQTT snapshot trigger

### DIFF
--- a/docs/en/home-assistant.md
+++ b/docs/en/home-assistant.md
@@ -59,8 +59,8 @@ camera:
 
 About `still_image_url`:
 
-- `GET /api/cameras/{id}/latest-frame` only works for JPEG-family cameras (HTTP-JPEG/MJPEG); H.264/H.265 cameras return 404.
-- For H.264/H.265 cameras use `GET /api/cameras/{id}/snapshot` (proxies the camera's own snapshot URL; requires a device with ONVIF snapshot support) or the vendor's snapshot URL directly.
+- `GET /api/cameras/{id}/latest-frame` returns the latest frame directly for JPEG-family cameras (HTTP-JPEG/MJPEG); for H.264/H.265 cameras it returns a decoded JPEG when the optional FFmpeg is installed on the NVR host (~10s cache), and 404 otherwise.
+- H.264/H.265 cameras without FFmpeg can use `GET /api/cameras/{id}/snapshot` (proxies the camera's own snapshot URL; requires a device with ONVIF snapshot support) or the vendor's snapshot URL directly.
 
 ## Option A': MJPEG/JPEG Cameras (e.g. ESP32 cameras)
 
@@ -93,7 +93,7 @@ mqtt:
   password: "mqtt_password"
 ```
 
-The NVR subscribes to `mibee/trigger/{camera_id}` and supports `record` (start recording) and `stop` (stop recording); `snapshot` is not implemented yet. HA automation example:
+The NVR subscribes to `mibee/trigger/{camera_id}` and supports `record` (start recording), `stop` (stop recording), and `snapshot` (persist a snapshot and publish a `camera.snapshot` event). HA automation example:
 
 ```yaml
 automation:
@@ -169,8 +169,8 @@ The card runs an embedded go2rtc to convert RTSP→WebRTC (it does not consume t
 ## Known Limitations & Security Notes
 
 - RTSP output has no authentication by default — anyone on the LAN can pull streams. Either configure `server.rtsp.username/password` or keep the NVR on a trusted network.
-- The MQTT trigger's `snapshot` action is not implemented yet (logged and ignored).
-- `latest-frame` only works for JPEG-family cameras; H.264/H.265 cameras use the `snapshot` endpoint or the vendor's snapshot URL instead.
+- The MQTT-triggered `snapshot` action persists snapshots to `{storage_root}/snapshots/{camera_id}/` and publishes a `camera.snapshot` event when `mqtt.status_events` is enabled.
+- `latest-frame` works directly for JPEG-family cameras; H.264/H.265 cameras need the optional FFmpeg on the NVR host (otherwise use the `snapshot` endpoint or the vendor's snapshot URL).
 - Neither the RTSP output nor the WebRTC card covers MJPEG/JPEG cameras (use Option A').
 - There is no app-level push-notification loop from NVR to HA; build notification automations in HA (e.g. triggered by the health topic).
 

--- a/docs/en/mqtt-integration.md
+++ b/docs/en/mqtt-integration.md
@@ -8,7 +8,7 @@ MiBee NVR supports MQTT recording triggers and status publishing for smart home 
 - **Trigger (subscribe)**: `{prefix}/trigger/{camera_id}`
 - **Status (publish)**: `{prefix}/health/{camera_id}`, `{prefix}/event/{topic}` (see [Status Publishing](#status-publishing))
 - **Trigger payload**: JSON with `action` field
-- **Actions**: `record`, `stop` (`snapshot` is not implemented yet — logged and ignored)
+- **Actions**: `record`, `stop`, `snapshot` (persisted to storage + `camera.snapshot` event)
 - **Auto-reconnect**: Built-in with exponential backoff; a broker that is unreachable at NVR startup is retried continuously (tiered 1s→5s→10s→60s backoff) — no start-order dependency
 
 ## Configuration
@@ -85,13 +85,15 @@ Stop recording on a specific camera:
 
 #### Trigger Snapshot
 
-Take a snapshot from a specific camera (**not implemented yet**: a `snapshot` action is currently only logged, nothing is executed; snapshot persistence is planned, see #656):
+Capture one snapshot from a specific camera and persist it (#656):
 
 ```json
 {
   "action": "snapshot"
 }
 ```
+
+Capture tries each capability in order: JPEG-family cameras (HTTP-JPEG/MJPEG) answer from the recorder's latest frame; H.264/H.265 cameras go through a one-shot StreamHub subscription (the cached IDR replays immediately — no GOP wait) decoded to JPEG by the optional FFmpeg, falling back to the camera's configured `snapshot_url` (with the camera's credentials) when FFmpeg is absent. The JPEG is persisted atomically (temp file → rename) to `{storage_root}/snapshots/{camera_id}/{timestamp}.jpg`, and a `camera.snapshot` event is published on success (see the event forwarding table below).
 
 **Topic**: `home/security/trigger/front-door`  
 **Message**: `{"action": "snapshot"}`
@@ -127,6 +129,7 @@ Gating: `mqtt.enabled: true` **and** `mqtt.status_events: true`. The following e
 | `camera.added` | `{prefix}/event/camera.added` | `camera_id`, `name`, `endpoint`, `source` |
 | `camera.quality` | `{prefix}/event/camera.quality` | `camera_id`, `from`, `to`, `reason` |
 | `storage.health.changed` | `{prefix}/event/storage.health.changed` | `camera_id`, `previous_state`, `current_state`, `message` |
+| `camera.snapshot` | `{prefix}/event/camera.snapshot` | `camera_id`, `file_path` (relative to storage root), `timestamp`, `trigger` |
 
 High-frequency topics (e.g. AI detections) are deliberately excluded from the whitelist. Messages use QoS 1 and retain=false; events are dropped when the broker is slow (the event bus drops on overflow and never blocks recording).
 

--- a/docs/zh/home-assistant.md
+++ b/docs/zh/home-assistant.md
@@ -59,8 +59,8 @@ camera:
 
 关于 `still_image_url`：
 
-- `GET /api/cameras/{id}/latest-frame` 仅对 JPEG 系相机（HTTP-JPEG/MJPEG）有效，H.264/H.265 相机返回 404。
-- H.264/H.265 相机可用 `GET /api/cameras/{id}/snapshot`（转发相机自身的快照 URL，仅 ONVIF 快照能力的设备可用），或直接填相机厂商的快照地址。
+- `GET /api/cameras/{id}/latest-frame` 对 JPEG 系相机（HTTP-JPEG/MJPEG）直接返回最新帧；H.264/H.265 相机在 NVR 所在主机装有可选 FFmpeg 时也能返回解码后的 JPEG（约 10 秒缓存），无 FFmpeg 则返回 404。
+- 无 FFmpeg 的 H.264/H.265 相机可用 `GET /api/cameras/{id}/snapshot`（转发相机自身的快照 URL，仅 ONVIF 快照能力的设备可用），或直接填相机厂商的快照地址。
 
 ## 方案 A'：MJPEG/JPEG 相机（如 ESP32 摄像头）
 
@@ -93,7 +93,7 @@ mqtt:
   password: "mqtt_password"
 ```
 
-NVR 订阅 `mibee/trigger/{camera_id}`，支持 `record`（开始录制）与 `stop`（停止录制）；`snapshot` 尚未实现。HA 自动化示例：
+NVR 订阅 `mibee/trigger/{camera_id}`，支持 `record`（开始录制）、`stop`（停止录制）与 `snapshot`（快照落盘并发布 `camera.snapshot` 事件）。HA 自动化示例：
 
 ```yaml
 automation:
@@ -169,8 +169,8 @@ muted: true
 ## 已知限制与安全注意事项
 
 - RTSP 输出默认无鉴权，局域网内任何设备都能拉流。要么配置 `server.rtsp.username/password`，要么确保 NVR 处于可信网络。
-- MQTT 触发的 `snapshot` 动作尚未实现（仅记录日志）。
-- `latest-frame` 仅 JPEG 系相机可用；H.264/H.265 相机的静态图用 `snapshot` 端点或相机自身快照 URL 替代。
+- MQTT 触发的 `snapshot` 动作会将快照落盘到 `{存储根目录}/snapshots/{camera_id}/`，并在开启 `mqtt.status_events` 时发布 `camera.snapshot` 事件。
+- `latest-frame` 对 JPEG 系相机直接可用；H.264/H.265 相机需 NVR 主机装有可选 FFmpeg（否则用 `snapshot` 端点或相机自身快照 URL 替代）。
 - RTSP 输出与 WebRTC 卡片方案均不覆盖 MJPEG/JPEG 相机（用方案 A'）。
 - NVR → HA 没有应用级推送通知闭环，告警通知需在 HA 里自行搭自动化（可订阅健康主题触发）。
 

--- a/docs/zh/mqtt-integration.md
+++ b/docs/zh/mqtt-integration.md
@@ -8,7 +8,7 @@ MiBee NVR 支持 MQTT 触发录制与状态发布，用于智能家居自动化�
 - **触发（订阅）**: `{prefix}/trigger/{camera_id}`
 - **状态（发布）**: `{prefix}/health/{camera_id}`、`{prefix}/event/{topic}`（见[状态发布](#状态发布)）
 - **触发负载**: 包含 `action` 字段的 JSON
-- **触发操作**: `record`, `stop`（`snapshot` 尚未实现，收到后仅记录日志）
+- **触发操作**: `record`, `stop`, `snapshot`（快照落盘并发布 `camera.snapshot` 事件）
 - **自动重连**: 内置指数退避重连；代理在 NVR 启动时尚不可达也会持续重试（1s→5s→10s→60s 分层退避），不要求代理先于 NVR 启动
 
 ## 配置
@@ -85,13 +85,15 @@ mqtt:
 
 #### 触发快照
 
-从特定摄像头拍摄快照（**尚未实现**：当前收到 `snapshot` 只会记录日志，不执行任何操作，快照落盘能力规划中，见 #656）：
+从特定摄像头拍摄一张快照并落盘（#656）：
 
 ```json
 {
   "action": "snapshot"
 }
 ```
+
+捕获按能力依次尝试：JPEG 系摄像头（HTTP-JPEG/MJPEG）直接取录像器最新帧；H.264/H.265 摄像头经一次性 StreamHub 订阅（缓存 IDR 立即回放，无需等待下个 GOP）后由可选 FFmpeg 解码为 JPEG，FFmpeg 缺失时回退到摄像头配置的 `snapshot_url`（携带摄像头凭据）。快照以原子写（临时文件 → 重命名）保存到 `{存储根目录}/snapshots/{camera_id}/{时间戳}.jpg`，成功后发布 `camera.snapshot` 事件（见下方事件转发表）。
 
 **主题**: `home/security/trigger/front-door`  
 **消息**: `{"action": "snapshot"}`
@@ -127,6 +129,7 @@ NVR 会将以下状态发布到 MQTT（均需 `mqtt.enabled: true`）：
 | `camera.added` | `{prefix}/event/camera.added` | `camera_id`、`name`、`endpoint`、`source` |
 | `camera.quality` | `{prefix}/event/camera.quality` | `camera_id`、`from`、`to`、`reason` |
 | `storage.health.changed` | `{prefix}/event/storage.health.changed` | `camera_id`、`previous_state`、`current_state`、`message` |
+| `camera.snapshot` | `{prefix}/event/camera.snapshot` | `camera_id`、`file_path`（相对存储根目录）、`timestamp`、`trigger` |
 
 高频主题（如 AI 检测）刻意不在转发白名单内。消息 QoS 1、不保留（retain=false）；代理缓慢时事件会被丢弃（事件总线满即丢，不阻塞录制）。
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -128,6 +128,13 @@ type snapshotCache struct {
 	timestamp time.Time
 }
 
+// SnapshotCapturer captures one JPEG for a camera — satisfied by
+// *snapshot.Capturer (FFmpeg-gated decode + device snapshot-URL fallback,
+// #657). Interface keeps the handler testable with a stub.
+type SnapshotCapturer interface {
+	Capture(cameraID string) ([]byte, error)
+}
+
 // Handler holds dependencies for the REST API handlers.
 
 type Handler struct {
@@ -143,6 +150,7 @@ type Handler struct {
 	configPath        string
 	snapshotMu        sync.RWMutex
 	snapshots         map[string]*snapshotCache // cameraID -> cached snapshot
+	snapCapturer      SnapshotCapturer
 	mergeMgr          *merge.MergeManager
 	rollingMergeMgr   *merge.RollingMergeCoordinator
 	healthMgr         HealthManager
@@ -493,6 +501,19 @@ func (h *Handler) SetStabilityProvider(p StabilityProvider) {
 // SetDownloader sets the FFmpeg downloader on the handler.
 func (h *Handler) SetDownloader(d TranscodeDownloader) {
 	h.downloader = d
+}
+
+// SetSnapshotCapturer wires the FFmpeg-gated snapshot capturer used by the
+// latest-frame endpoint for H.264/H.265 cameras (#657). Without it the
+// endpoint keeps its JPEG-recorder-only behavior.
+func (h *Handler) SetSnapshotCapturer(c SnapshotCapturer) {
+	h.snapCapturer = c
+}
+
+// HasSnapshotCapturer reports whether the snapshot capturer is wired —
+// observable wiring guard for the pkg/app regression tests.
+func (h *Handler) HasSnapshotCapturer() bool {
+	return h.snapCapturer != nil
 }
 
 // SetEventBus sets the event bus on the handler.

--- a/internal/api/handlers_mjpeg.go
+++ b/internal/api/handlers_mjpeg.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
@@ -130,32 +131,61 @@ func (h *Handler) handleLatestFrame(w http.ResponseWriter, r *http.Request) {
 	w.Write(frame)
 }
 
-// getLatestFrameFromRecorder extracts the latest JPEG frame from a camera's recorder.
+// latestFrameCacheTTL bounds how long a decoded snapshot serves repeated
+// latest-frame polls before re-capturing. Var so tests can manipulate expiry.
+var latestFrameCacheTTL = 10 * time.Second
+
+// getLatestFrameFromRecorder extracts the latest JPEG frame from a camera's
+// recorder. JPEG-family recorders answer from their frame cache; everything
+// else (H.264/H.265, or no live recorder) goes through the FFmpeg-gated
+// snapshot capturer with the shared snapshot TTL cache (#657).
 func (h *Handler) getLatestFrameFromRecorder(cameraID string) []byte {
-	if h.camMgr == nil {
-		return nil
-	}
+	if h.camMgr != nil {
+		if rec := h.camMgr.GetRecorder(cameraID); rec != nil {
+			// Unwrap delegate layers (ONVIF → inner recorder)
+			for {
+				type delegater interface{ Delegate() model.Recorder }
+				if u, ok := rec.(delegater); ok {
+					if d := u.Delegate(); d != nil {
+						rec = d
+						continue
+					}
+				}
+				break
+			}
 
-	rec := h.camMgr.GetRecorder(cameraID)
-	if rec == nil {
-		return nil
-	}
-
-	// Unwrap delegate layers (ONVIF → inner recorder)
-	for {
-		type delegater interface{ Delegate() model.Recorder }
-		if u, ok := rec.(delegater); ok {
-			if d := u.Delegate(); d != nil {
-				rec = d
-				continue
+			type latestFramer interface{ LatestFrame() []byte }
+			if lr, ok := rec.(latestFramer); ok {
+				return lr.LatestFrame()
 			}
 		}
-		break
+	}
+	return h.getDecodedLatestFrame(cameraID)
+}
+
+// getDecodedLatestFrame captures one frame via the snapshot capturer (hub IDR
+// decode → device snapshot URL) and caches it. Any failure degrades to nil —
+// the endpoint answers 404, never 500 (FFmpeg stays optional).
+func (h *Handler) getDecodedLatestFrame(cameraID string) []byte {
+	if h.snapCapturer == nil {
+		return nil
 	}
 
-	type latestFramer interface{ LatestFrame() []byte }
-	if lr, ok := rec.(latestFramer); ok {
-		return lr.LatestFrame()
+	h.snapshotMu.RLock()
+	cached, ok := h.snapshots[cameraID]
+	h.snapshotMu.RUnlock()
+	if ok && time.Since(cached.timestamp) < latestFrameCacheTTL {
+		return cached.data
 	}
-	return nil
+
+	frame, err := h.snapCapturer.Capture(cameraID)
+	if err != nil || len(frame) == 0 {
+		mjpegLogger.Debug("latest-frame capture unavailable", "camera_id", cameraID, "error", err)
+		return nil
+	}
+
+	h.snapshotMu.Lock()
+	h.snapshots[cameraID] = &snapshotCache{data: frame, timestamp: time.Now()}
+	h.snapshotMu.Unlock()
+	return frame
 }

--- a/internal/api/handlers_mjpeg_decoded_test.go
+++ b/internal/api/handlers_mjpeg_decoded_test.go
@@ -1,0 +1,136 @@
+package api
+
+// Tests for the FFmpeg-gated decoded latest-frame path (#657): H.264/H.265
+// cameras (and cameras with only a device snapshot URL) get frames through
+// the snapshot.Capturer with the shared 10s TTL cache.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSnapCapturer is the injectable snapshot capturer stub.
+type fakeSnapCapturer struct {
+	mu    sync.Mutex
+	calls int
+	jpeg  []byte
+	err   error
+}
+
+func (f *fakeSnapCapturer) Capture(string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.jpeg, f.err
+}
+
+func (f *fakeSnapCapturer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestLatestFrame_DecodedPath_Served(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	jpeg := []byte{0xff, 0xd8, 0x00, 0x01, 0xff, 0xd9}
+	h.SetSnapshotCapturer(&fakeSnapCapturer{jpeg: jpeg})
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "image/jpeg", rr.Header().Get("Content-Type"))
+	assert.Equal(t, jpeg, rr.Body.Bytes())
+}
+
+func TestLatestFrame_DecodedPath_CachedWithinTTL(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	capt := &fakeSnapCapturer{jpeg: []byte{0xff, 0xd8}}
+	h.SetSnapshotCapturer(capt)
+
+	rr1 := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr1.Code)
+	rr2 := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr2.Code)
+
+	assert.Equal(t, 1, capt.callCount(), "second poll within the TTL must be served from cache")
+	assert.Equal(t, rr1.Header().Get("ETag"), rr2.Header().Get("ETag"), "cached frame keeps a stable ETag")
+}
+
+func TestLatestFrame_DecodedPath_ETagConditional(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	h.SetSnapshotCapturer(&fakeSnapCapturer{jpeg: []byte{0xff, 0xd8}})
+
+	rr1 := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr1.Code)
+	etag := rr1.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/cameras/cam-h264/latest-frame", nil)
+	req.Header.Set("If-None-Match", etag)
+	rr2 := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr2, req)
+	require.Equal(t, http.StatusNotModified, rr2.Code)
+	assert.Empty(t, rr2.Body.Len())
+}
+
+func TestLatestFrame_DecodedPath_StaleCacheRefreshes(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	fresh := []byte{0xff, 0xd9}
+	capt := &fakeSnapCapturer{jpeg: fresh}
+	h.SetSnapshotCapturer(capt)
+
+	// Seed an expired cache entry: the next request must re-capture.
+	h.snapshotMu.Lock()
+	h.snapshots["cam-h264"] = &snapshotCache{data: []byte("stale"), timestamp: time.Now().Add(-latestFrameCacheTTL - time.Second)}
+	h.snapshotMu.Unlock()
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, fresh, rr.Body.Bytes())
+	assert.Equal(t, 1, capt.callCount())
+}
+
+func TestLatestFrame_CaptureError_Still404(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+	h.SetSnapshotCapturer(&fakeSnapCapturer{err: errFakeCapture})
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code, "capture failure must degrade to 404, never 500")
+}
+
+func TestLatestFrame_NoCapturer_Unchanged404(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store) // no capturer wired — pre-existing behavior
+
+	rr := doRequest(t, h.Routes(), "GET", "/api/cameras/cam-h264/latest-frame", nil, "", "")
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// errFakeCapture distinguishes a stub error from snapshot.ErrNoFrame.
+var errFakeCapture = &fakeCaptureError{}
+
+type fakeCaptureError struct{}
+
+func (*fakeCaptureError) Error() string { return "fake capture failure" }

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -33,6 +33,11 @@ const (
 	// notification (SUBSCRIBE/NOTIFY Alarm, or a MESSAGE-delivered alarm).
 	// Payload: event.GB28181AlarmEvent. Surfaces via /api/events SSE.
 	TopicGB28181Alarm = "gb28181.alarm"
+	// TopicCameraSnapshot is published when a snapshot is captured and
+	// persisted to storage (#656, MQTT trigger). Payload:
+	// event.CameraSnapshotEvent. Forwarded to MQTT via mqtt.status_events
+	// so smart-home automations can react.
+	TopicCameraSnapshot = "camera.snapshot"
 )
 
 var ErrDuplicateSubscriber = errors.New("subscriber already registered for this topic")

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -59,6 +59,16 @@ type AIDetection struct {
 	ClassLabel string     `json:"class_label"`
 }
 
+// CameraSnapshotEvent is published when a snapshot is captured and persisted
+// under {storage_root}/snapshots/ (TopicCameraSnapshot). FilePath is relative
+// to the storage root for cross-server compatibility.
+type CameraSnapshotEvent struct {
+	CameraID  string    `json:"camera_id"`
+	FilePath  string    `json:"file_path"`
+	Timestamp time.Time `json:"timestamp"`
+	Trigger   string    `json:"trigger"` // e.g. "mqtt"
+}
+
 // GB28181AlarmEvent is published when a GB/T 28181 device pushes an alarm
 // notification (TopicGB28181Alarm).
 type GB28181AlarmEvent struct {

--- a/internal/mqtt/actions.go
+++ b/internal/mqtt/actions.go
@@ -17,6 +17,13 @@ type CameraLifecycle interface {
 	StopCamera(ctx context.Context, cameraID string) error
 }
 
+// SnapshotRunner captures a frame, persists it under the storage root, and
+// publishes a camera.snapshot event. Satisfied by *snapshot.Runner (wired in
+// pkg/app); narrow interface keeps the dispatcher testable with a stub.
+type SnapshotRunner interface {
+	RunSnapshot(ctx context.Context, cameraID string, trigger string) (string, error)
+}
+
 // Trigger actions accepted on {prefix}/trigger/{camera_id}.
 const (
 	actionRecord   = "record"
@@ -33,43 +40,55 @@ var actionLogger = slog.Default().With("component", "mqtt-trigger")
 // NewActionDispatcher maps MQTT trigger actions to camera lifecycle
 // operations and returns the onAction callback for NewClient. Each action
 // runs on its own goroutine: the paho message handler must never block
-// (internal/mqtt anti-pattern), and StartCamera dials the camera.
-func NewActionDispatcher(lifecycle CameraLifecycle) func(cameraID, action string) {
+// (internal/mqtt anti-pattern), and StartCamera dials the camera. The
+// snapshot action runs the SnapshotRunner (capture → persist → event, #656).
+func NewActionDispatcher(lifecycle CameraLifecycle, snap SnapshotRunner) func(cameraID, action string) {
 	return func(cameraID, action string) {
-		if action != actionRecord && action != actionStop {
-			switch action {
-			case actionSnapshot:
-				// TODO(#656): capture a frame and persist it to storage.
-				actionLogger.Warn("mqtt snapshot trigger is not implemented yet", "camera_id", cameraID)
-			default:
-				actionLogger.Warn("unknown mqtt trigger action ignored", "camera_id", cameraID, "action", action)
-			}
-			return
-		}
-		if lifecycle == nil {
-			actionLogger.Error("mqtt trigger dropped: no camera lifecycle wired", "camera_id", cameraID, "action", action)
-			return
-		}
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
-			defer cancel()
-
-			var err error
-			if action == actionRecord {
-				err = lifecycle.StartCamera(ctx, cameraID)
-			} else {
-				err = lifecycle.StopCamera(ctx, cameraID)
-			}
-			if err != nil {
-				var running *model.CameraAlreadyRunningError
-				if errors.As(err, &running) {
-					actionLogger.Info("mqtt trigger: camera already recording", "camera_id", cameraID, "action", action)
-					return
-				}
-				actionLogger.Warn("mqtt trigger action failed", "camera_id", cameraID, "action", action, "error", err)
+		switch action {
+		case actionRecord, actionStop:
+			if lifecycle == nil {
+				actionLogger.Error("mqtt trigger dropped: no camera lifecycle wired", "camera_id", cameraID, "action", action)
 				return
 			}
-			actionLogger.Info("mqtt trigger applied", "camera_id", cameraID, "action", action)
-		}()
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+				defer cancel()
+
+				var err error
+				if action == actionRecord {
+					err = lifecycle.StartCamera(ctx, cameraID)
+				} else {
+					err = lifecycle.StopCamera(ctx, cameraID)
+				}
+				if err != nil {
+					var running *model.CameraAlreadyRunningError
+					if errors.As(err, &running) {
+						actionLogger.Info("mqtt trigger: camera already recording", "camera_id", cameraID, "action", action)
+						return
+					}
+					actionLogger.Warn("mqtt trigger action failed", "camera_id", cameraID, "action", action, "error", err)
+					return
+				}
+				actionLogger.Info("mqtt trigger applied", "camera_id", cameraID, "action", action)
+			}()
+		case actionSnapshot:
+			if snap == nil {
+				actionLogger.Warn("mqtt snapshot trigger dropped: no snapshot runner wired", "camera_id", cameraID)
+				return
+			}
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), actionTimeout)
+				defer cancel()
+
+				path, err := snap.RunSnapshot(ctx, cameraID, "mqtt")
+				if err != nil {
+					actionLogger.Warn("mqtt snapshot trigger failed", "camera_id", cameraID, "error", err)
+					return
+				}
+				actionLogger.Info("mqtt snapshot captured", "camera_id", cameraID, "path", path)
+			}()
+		default:
+			actionLogger.Warn("unknown mqtt trigger action ignored", "camera_id", cameraID, "action", action)
+		}
 	}
 }

--- a/internal/mqtt/actions_snapshot_test.go
+++ b/internal/mqtt/actions_snapshot_test.go
@@ -1,0 +1,116 @@
+package mqtt
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSnapshotRunner records RunSnapshot calls for the dispatcher tests.
+type fakeSnapshotRunner struct {
+	mu    sync.Mutex
+	calls []string
+	path  string
+	err   error
+}
+
+func (f *fakeSnapshotRunner) RunSnapshot(_ context.Context, cameraID string, _ string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, cameraID)
+	return f.path, f.err
+}
+
+func (f *fakeSnapshotRunner) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func TestActionDispatcher_Snapshot_RunsCapture(t *testing.T) {
+	t.Helper()
+	fake := &fakeSnapshotRunner{path: "snapshots/cam-1/x.jpg"}
+	dispatch := NewActionDispatcher(&fakeLifecycle{}, fake)
+
+	dispatch("cam-1", "snapshot")
+
+	require.Eventually(t, func() bool {
+		return len(fake.recorded()) == 1
+	}, 15*time.Second, 50*time.Millisecond, "RunSnapshot should be called for the snapshot action")
+	assert.Equal(t, []string{"cam-1"}, fake.recorded())
+}
+
+func TestActionDispatcher_Snapshot_OwnGoroutine(t *testing.T) {
+	t.Helper()
+	// The paho message handler must never block: dispatch returns before the
+	// (slow) snapshot capture finishes.
+	block := make(chan struct{})
+	late := make(chan struct{})
+	slow := &blockingSnapshotRunner{block: block, done: late}
+	dispatch := NewActionDispatcher(&fakeLifecycle{}, slow)
+
+	returned := make(chan struct{})
+	go func() {
+		dispatch("cam-1", "snapshot")
+		close(returned)
+	}()
+	select {
+	case <-returned:
+		// good: dispatch returned while capture is still blocked
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatch blocked on the snapshot capture — must run on its own goroutine")
+	}
+
+	close(block) // release the capture
+	select {
+	case <-late:
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshot capture never ran")
+	}
+}
+
+type blockingSnapshotRunner struct {
+	block chan struct{}
+	done  chan struct{}
+}
+
+func (b *blockingSnapshotRunner) RunSnapshot(_ context.Context, _ string, _ string) (string, error) {
+	<-b.block
+	close(b.done)
+	return "snapshots/cam-1/x.jpg", nil
+}
+
+func TestActionDispatcher_Snapshot_NilRunner_NoPanic(t *testing.T) {
+	t.Helper()
+	dispatch := NewActionDispatcher(&fakeLifecycle{}, nil)
+	require.NotPanics(t, func() { dispatch("cam-1", "snapshot") })
+}
+
+func TestActionDispatcher_Snapshot_FailureLoggedNotFatal(t *testing.T) {
+	t.Helper()
+	fake := &fakeSnapshotRunner{err: errors.New("no frame")}
+	dispatch := NewActionDispatcher(&fakeLifecycle{}, fake)
+
+	require.NotPanics(t, func() { dispatch("cam-1", "snapshot") })
+
+	require.Eventually(t, func() bool {
+		return len(fake.recorded()) == 1
+	}, 15*time.Second, 50*time.Millisecond, "failed capture must still be attempted (and logged), not skipped")
+}
+
+func TestActionDispatcher_Snapshot_DoesNotTouchLifecycle(t *testing.T) {
+	t.Helper()
+	life := &fakeLifecycle{}
+	dispatch := NewActionDispatcher(life, &fakeSnapshotRunner{path: "p"})
+
+	dispatch("cam-1", "snapshot")
+
+	assert.Never(t, func() bool {
+		return len(life.started()) > 0 || len(life.stopped()) > 0
+	}, 500*time.Millisecond, 50*time.Millisecond, "snapshot action must never start/stop the camera")
+}

--- a/internal/mqtt/actions_test.go
+++ b/internal/mqtt/actions_test.go
@@ -57,7 +57,7 @@ func (f *fakeLifecycle) stopped() []string {
 func TestActionDispatcher_Record_StartsCamera(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "record")
 
@@ -71,7 +71,7 @@ func TestActionDispatcher_Record_StartsCamera(t *testing.T) {
 func TestActionDispatcher_Stop_StopsCamera(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "stop")
 
@@ -85,7 +85,7 @@ func TestActionDispatcher_Stop_StopsCamera(t *testing.T) {
 func TestActionDispatcher_UnknownAction_NoCalls(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "reboot")
 
@@ -97,7 +97,7 @@ func TestActionDispatcher_UnknownAction_NoCalls(t *testing.T) {
 func TestActionDispatcher_Snapshot_LogsOnly(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "snapshot")
 
@@ -109,7 +109,7 @@ func TestActionDispatcher_Snapshot_LogsOnly(t *testing.T) {
 func TestActionDispatcher_AlreadyRunning_Idempotent(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{startErr: &model.CameraAlreadyRunningError{CameraID: "cam-1"}}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "record")
 
@@ -125,7 +125,7 @@ func TestActionDispatcher_AlreadyRunning_Idempotent(t *testing.T) {
 func TestActionDispatcher_StartError_NotFatal(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{startErr: errors.New("dial timeout")}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	dispatch("cam-1", "record")
 	require.Eventually(t, func() bool {
@@ -142,7 +142,7 @@ func TestActionDispatcher_StartError_NotFatal(t *testing.T) {
 func TestActionDispatcher_NonBlocking(t *testing.T) {
 	t.Helper()
 	fake := &fakeLifecycle{blockFor: 300 * time.Millisecond}
-	dispatch := NewActionDispatcher(fake)
+	dispatch := NewActionDispatcher(fake, nil)
 
 	start := time.Now()
 	dispatch("cam-1", "record")
@@ -153,7 +153,7 @@ func TestActionDispatcher_NonBlocking(t *testing.T) {
 
 func TestActionDispatcher_NilLifecycle_Noop(t *testing.T) {
 	t.Helper()
-	dispatch := NewActionDispatcher(nil)
+	dispatch := NewActionDispatcher(nil, nil)
 
 	dispatch("cam-1", "record")
 	dispatch("cam-1", "stop")

--- a/internal/mqtt/status_publisher.go
+++ b/internal/mqtt/status_publisher.go
@@ -24,6 +24,9 @@ var statusTopics = []string{
 	event.TopicCameraAdded,
 	event.TopicCameraQuality,
 	event.TopicStorageHealthChanged,
+	// Persisted snapshot metadata (file_path relative to storage root) so
+	// smart-home automations can react to MQTT-triggered captures (#656).
+	event.TopicCameraSnapshot,
 }
 
 var statusLogger = slog.Default().With("component", "mqtt-status")

--- a/internal/mqtt/status_publisher_test.go
+++ b/internal/mqtt/status_publisher_test.go
@@ -184,3 +184,27 @@ func TestStatusPublisher_Name(t *testing.T) {
 	p := NewStatusPublisher(newStatusTestBus(t), &mockStatusMQTT{})
 	assert.Equal(t, "mqtt-status", p.Name())
 }
+
+func TestStatusPublisher_ForwardsCameraSnapshot(t *testing.T) {
+	t.Helper()
+	bus := newStatusTestBus(t)
+	mock := &mockStatusMQTT{}
+	p := NewStatusPublisher(bus, mock)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() { require.NoError(t, p.Stop()) }()
+
+	snap := event.CameraSnapshotEvent{
+		CameraID:  "front-door",
+		FilePath:  "snapshots/front-door/20260903-103005.123.jpg",
+		Timestamp: time.Date(2026, 9, 3, 10, 30, 5, 0, time.UTC),
+		Trigger:   "mqtt",
+	}
+	bus.Publish(context.Background(), event.TopicCameraSnapshot, snap)
+
+	require.Eventually(t, func() bool {
+		return mock.calls() == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	topic, got := mock.last()
+	assert.Equal(t, "event/camera.snapshot", topic)
+	assert.Equal(t, snap, got)
+}

--- a/internal/snapshot/persist.go
+++ b/internal/snapshot/persist.go
@@ -1,0 +1,127 @@
+// Persistence + event publishing for captured snapshots (#656): atomic
+// temp→rename writes under {root}/snapshots/{camera_id}/, then a
+// camera.snapshot event so consumers (mqtt.status_events forwarding,
+// automations) can react.
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+)
+
+// Persistor writes snapshot JPEGs under {Root}/snapshots/{cameraID}/ using
+// the storage convention (write temp in the same directory, then rename).
+// Now is injectable for deterministic filenames in tests.
+type Persistor struct {
+	Root string
+	Now  func() time.Time
+}
+
+func (p *Persistor) now() time.Time {
+	if p.Now != nil {
+		return p.Now()
+	}
+	return time.Now()
+}
+
+// Persist writes jpeg and returns the path relative to Root
+// (slash-separated, e.g. "snapshots/cam-1/20260903-103005.123.jpg").
+// Same-millisecond persists get a numeric suffix instead of overwriting.
+func (p *Persistor) Persist(cameraID string, jpeg []byte) (string, error) {
+	// Camera IDs are kebab-case by convention; Base is a guard so a stray
+	// separator can never escape the camera's snapshots directory.
+	safeID := filepath.Base(cameraID)
+
+	dir := filepath.Join(p.Root, "snapshots", safeID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("snapshot: create dir: %w", err)
+	}
+
+	base := p.now().UTC().Format("20060102-150405.000")
+	final := filepath.Join(dir, base+".jpg")
+	for i := 2; ; i++ {
+		if _, err := os.Stat(final); os.IsNotExist(err) {
+			break
+		}
+		final = filepath.Join(dir, fmt.Sprintf("%s-%d.jpg", base, i))
+	}
+
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, jpeg, 0o644); err != nil {
+		return "", fmt.Errorf("snapshot: write temp: %w", err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("snapshot: rename: %w", err)
+	}
+
+	rel, err := filepath.Rel(p.Root, final)
+	if err != nil {
+		return "", fmt.Errorf("snapshot: rel path: %w", err)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// FrameSource captures a JPEG for a camera — satisfied by *Capturer; kept as
+// an interface so the Runner is testable with a stub.
+type FrameSource interface {
+	Capture(cameraID string) ([]byte, error)
+}
+
+// Publisher is the event-bus surface the Runner needs (satisfied by
+// *event.EventBus).
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data any)
+}
+
+// Runner couples capture → persist → event publish. Wired in pkg/app for the
+// MQTT snapshot trigger; the capture runs on the caller's goroutine (the MQTT
+// dispatcher already moves it off the paho handler).
+type Runner struct {
+	Source  FrameSource
+	Storage *Persistor
+	Bus     Publisher
+	Now     func() time.Time
+}
+
+func (r *Runner) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
+}
+
+// RunSnapshot captures one frame, persists it under the storage root, and
+// publishes a camera.snapshot event. Trigger records what caused the capture
+// (e.g. "mqtt") for downstream consumers.
+func (r *Runner) RunSnapshot(ctx context.Context, cameraID string, trigger string) (string, error) {
+	if r.Source == nil {
+		return "", fmt.Errorf("snapshot: no capture source wired")
+	}
+	jpeg, err := r.Source.Capture(cameraID)
+	if err != nil {
+		return "", err
+	}
+
+	now := r.now()
+	rel, err := r.Storage.Persist(cameraID, jpeg)
+	if err != nil {
+		return "", err
+	}
+
+	if r.Bus != nil {
+		r.Bus.Publish(ctx, event.TopicCameraSnapshot, event.CameraSnapshotEvent{
+			CameraID:  cameraID,
+			FilePath:  rel,
+			Timestamp: now,
+			Trigger:   trigger,
+		})
+	}
+	return rel, nil
+}

--- a/internal/snapshot/persist_test.go
+++ b/internal/snapshot/persist_test.go
@@ -1,0 +1,165 @@
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Persistor ---------------------------------------------------------------
+
+func TestPersistor_Persist(t *testing.T) {
+	root := t.TempDir()
+	fixed := time.Date(2026, 9, 3, 10, 30, 5, 123456789, time.UTC)
+	p := &Persistor{Root: root, Now: func() time.Time { return fixed }}
+
+	rel, err := p.Persist("front-door", []byte("jpeg-bytes"))
+	require.NoError(t, err)
+	assert.Equal(t, "snapshots/front-door/20260903-103005.123.jpg", rel)
+
+	got, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("jpeg-bytes"), got)
+
+	// Atomic write leaves no temp files behind.
+	entries, err := os.ReadDir(filepath.Join(root, "snapshots", "front-door"))
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestPersistor_SameTimestamp_NoOverwrite(t *testing.T) {
+	root := t.TempDir()
+	fixed := time.Date(2026, 9, 3, 10, 30, 5, 123456789, time.UTC)
+	p := &Persistor{Root: root, Now: func() time.Time { return fixed }}
+
+	rel1, err := p.Persist("cam", []byte("first"))
+	require.NoError(t, err)
+	rel2, err := p.Persist("cam", []byte("second"))
+	require.NoError(t, err)
+
+	require.NotEqual(t, rel1, rel2, "same-millisecond persists must not overwrite")
+	b1, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel1)))
+	require.NoError(t, err)
+	b2, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel2)))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("first"), b1)
+	assert.Equal(t, []byte("second"), b2)
+}
+
+func TestPersistor_CameraIDPathGuard(t *testing.T) {
+	// A camera ID must never escape its snapshots/ subdirectory.
+	root := t.TempDir()
+	p := &Persistor{Root: root, Now: func() time.Time { return time.Now() }}
+
+	rel, err := p.Persist("../evil", []byte("x"))
+	require.NoError(t, err)
+	assert.NotContains(t, rel, "..", "relative path must stay under snapshots/")
+	_, err = os.Stat(filepath.Join(root, "snapshots", ".."))
+	require.NoError(t, err, "sanity: parent still exists")
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	under, err := filepath.Rel(filepath.Join(root, "snapshots"), full)
+	require.NoError(t, err)
+	assert.NotContains(t, under, "..", "file must live under snapshots/")
+}
+
+// --- Runner ------------------------------------------------------------------
+
+type fakeBus struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (b *fakeBus) Publish(_ context.Context, topic string, data any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.events = append(b.events, event.Event{Topic: topic, Data: data})
+}
+
+func (b *fakeBus) collected() []event.Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]event.Event(nil), b.events...)
+}
+
+type fakeFrameSource struct {
+	jpeg []byte
+	err  error
+}
+
+func (f *fakeFrameSource) Capture(string) ([]byte, error) { return f.jpeg, f.err }
+
+func TestRunner_RunSnapshot_PersistsAndPublishes(t *testing.T) {
+	root := t.TempDir()
+	bus := &fakeBus{}
+	fixed := time.Date(2026, 9, 3, 11, 0, 0, 0, time.UTC)
+	r := &Runner{
+		Source:  &fakeFrameSource{jpeg: []byte("snap-jpeg")},
+		Storage: &Persistor{Root: root},
+		Bus:     bus,
+		Now:     func() time.Time { return fixed },
+	}
+
+	rel, err := r.RunSnapshot(context.Background(), "cam-1", "mqtt")
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("snap-jpeg"), got)
+
+	events := bus.collected()
+	require.Len(t, events, 1)
+	assert.Equal(t, event.TopicCameraSnapshot, events[0].Topic)
+	// The bus stores Data as any; the typed payload must round-trip.
+	if ev, ok := events[0].Data.(event.CameraSnapshotEvent); ok {
+		assert.Equal(t, "cam-1", ev.CameraID)
+		assert.Equal(t, rel, ev.FilePath)
+		assert.Equal(t, "mqtt", ev.Trigger)
+		assert.True(t, ev.Timestamp.Equal(fixed))
+	} else {
+		t.Fatalf("event payload is %T, want event.CameraSnapshotEvent", events[0].Data)
+	}
+}
+
+func TestRunner_RunSnapshot_CaptureFails_NoEventNoFile(t *testing.T) {
+	root := t.TempDir()
+	bus := &fakeBus{}
+	r := &Runner{
+		Source:  &fakeFrameSource{err: ErrNoFrame},
+		Storage: &Persistor{Root: root},
+		Bus:     bus,
+		Now:     time.Now,
+	}
+
+	_, err := r.RunSnapshot(context.Background(), "cam-1", "mqtt")
+	require.ErrorIs(t, err, ErrNoFrame)
+	assert.Empty(t, bus.collected())
+
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "failed capture must not create files")
+}
+
+func TestRunner_RunSnapshot_NilBus_NoPanic(t *testing.T) {
+	r := &Runner{
+		Source:  &fakeFrameSource{jpeg: []byte("j")},
+		Storage: &Persistor{Root: t.TempDir()},
+		Now:     time.Now,
+	}
+	_, err := r.RunSnapshot(context.Background(), "cam", "mqtt")
+	require.NoError(t, err)
+}
+
+func TestRunner_RunSnapshot_NilSource_Errors(t *testing.T) {
+	r := &Runner{Storage: &Persistor{Root: t.TempDir()}, Now: time.Now}
+	_, err := r.RunSnapshot(context.Background(), "cam", "mqtt")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errors.New("different"))
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,0 +1,198 @@
+// Package snapshot captures still frames from any recorder type (#657/#656).
+//
+// Capture order (mirrors the issues' capability ladder):
+//  1. JPEG-family recorders implementing LatestFrame() — direct, no network
+//  2. H.264/H.265 cameras: one-shot StreamHub subscribe (the IDR cache replays
+//     the cached param-sets+IDR access unit immediately — no GOP wait) decoded
+//     to JPEG through the OPTIONAL FFmpeg subprocess (DecodeFunc)
+//  3. cameras with a configured snapshot URL (ONVIF GetSnapshotUri): direct
+//     HTTP fetch with the camera's credentials
+//
+// FFmpeg stays optional: when absent, path 2 fails and the caller degrades
+// (API keeps 404, MQTT logs unsupported).
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+)
+
+// DecodeFunc decodes one Annex-B access unit (parameter sets + IDR) into a
+// JPEG. Production wires transcoding.DecodeAUToJPEG; tests inject a stub.
+type DecodeFunc func(au [][]byte) ([]byte, error)
+
+// ErrNoFrame is returned when no capture path can produce a frame for the
+// camera (wrong recorder type, no hub frames yet, FFmpeg absent and no
+// snapshot URL). Callers degrade gracefully on it.
+var ErrNoFrame = errors.New("snapshot: no frame available for this camera")
+
+const (
+	// snapshotURLTimeout bounds the snapshot-URL fetch; snapshotBodyCap bounds
+	// its body (a JPEG is a few MB at most).
+	snapshotURLTimeout = 5 * time.Second
+	snapshotBodyCap    = 8 << 20
+)
+
+// hubWaitTimeout bounds the one-shot StreamHub subscription: with the IDR
+// cache the callback is immediate; without frames flowing (camera offline)
+// this is pure wait. Var (not const) so tests can shorten it.
+var hubWaitTimeout = 3 * time.Second
+
+var subSeq atomic.Int64
+
+// FrameFromRecorder captures one JPEG frame from the recorder:
+// LatestFrame() fast path for JPEG-family recorders, otherwise a one-shot
+// StreamHub subscription decoded through the injected DecodeFunc.
+// Unwraps ONVIF delegate layers first.
+func FrameFromRecorder(rec model.Recorder, decode DecodeFunc) ([]byte, error) {
+	for {
+		type delegater interface{ Delegate() model.Recorder }
+		if u, ok := rec.(delegater); ok {
+			if d := u.Delegate(); d != nil {
+				rec = d
+				continue
+			}
+		}
+		break
+	}
+
+	type latestFramer interface{ LatestFrame() []byte }
+	if lr, ok := rec.(latestFramer); ok {
+		if frame := lr.LatestFrame(); frame != nil {
+			return frame, nil
+		}
+	}
+
+	type hubber interface{ GetHub() *streamhub.StreamHub }
+	if h, ok := rec.(hubber); ok && decode != nil && h.GetHub() != nil {
+		return frameFromHub(h.GetHub(), decode)
+	}
+	return nil, ErrNoFrame
+}
+
+// frameFromHub subscribes once, waits for the cached-IDR replay (or the next
+// keyframe), and decodes it. The subscription is ALWAYS removed before
+// returning — a leaked subscriber would pin frames forever.
+func frameFromHub(hub *streamhub.StreamHub, decode DecodeFunc) ([]byte, error) {
+	id := fmt.Sprintf("snapshot-%d", subSeq.Add(1))
+	auCh := make(chan [][]byte, 1)
+	if err := hub.Subscribe(id, func(_ int64, au [][]byte) {
+		select {
+		case auCh <- au:
+		default: // first AU wins; later frames are dropped
+		}
+	}); err != nil {
+		return nil, fmt.Errorf("snapshot: hub subscribe: %w", err)
+	}
+	defer hub.Unsubscribe(id)
+
+	select {
+	case au := <-auCh:
+		jpeg, err := decode(au)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot: decode: %w", err)
+		}
+		return jpeg, nil
+	case <-time.After(hubWaitTimeout):
+		return nil, ErrNoFrame
+	}
+}
+
+// CameraSource resolves the live recorder (satisfied by *camera.CameraManager).
+type CameraSource interface {
+	GetRecorder(cameraID string) model.Recorder
+}
+
+// ConfigSource resolves per-camera snapshot URL + credentials (satisfied by
+// *camera.CameraManager).
+type ConfigSource interface {
+	GetCameraConfig(cameraID string) *config.CameraConfig
+}
+
+// HTTPClient is the snapshot-URL fetch seam (tests inject a stub).
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Capturer tries every capture capability in order for one camera.
+type Capturer struct {
+	Decode   DecodeFunc
+	Client   HTTPClient
+	Recorder CameraSource
+	Config   ConfigSource
+}
+
+// fetchSnapshotURL is the injectable HTTP fetch (production: real transport).
+var fetchSnapshotURL = fetchViaClient
+
+// Capture produces one JPEG for the camera: recorder frame → hub+decode →
+// configured snapshot URL.
+func (c *Capturer) Capture(cameraID string) ([]byte, error) {
+	if rec := c.Recorder.GetRecorder(cameraID); rec != nil {
+		jpeg, err := FrameFromRecorder(rec, c.Decode)
+		if err == nil {
+			return jpeg, nil
+		}
+		if !errors.Is(err, ErrNoFrame) {
+			// A real decode failure is worth surfacing, but the snapshot-URL
+			// fallback may still save us.
+			if jpeg, urlErr := c.trySnapshotURL(cameraID); urlErr == nil {
+				return jpeg, nil
+			}
+			return nil, err
+		}
+	}
+	return c.trySnapshotURL(cameraID)
+}
+
+func (c *Capturer) trySnapshotURL(cameraID string) ([]byte, error) {
+	if c.Config == nil || c.Client == nil {
+		return nil, ErrNoFrame
+	}
+	cam := c.Config.GetCameraConfig(cameraID)
+	if cam == nil || strings.TrimSpace(cam.SnapshotURL) == "" {
+		return nil, ErrNoFrame
+	}
+	return fetchSnapshotURL(c.Client, cam.SnapshotURL, cam.Username, cam.Password)
+}
+
+func fetchViaClient(client HTTPClient, url, username, password string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), snapshotURLTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Cameras commonly require Basic auth on the snapshot endpoint even when
+	// the ONVIF service itself is unauthenticated (mirrors handleSnapshot).
+	if username != "" {
+		req.SetBasicAuth(username, password)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("snapshot: snapshot URL returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, snapshotBodyCap+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > snapshotBodyCap {
+		return nil, errors.New("snapshot: snapshot URL body exceeds cap")
+	}
+	return body, nil
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -1,0 +1,281 @@
+package snapshot
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fixtures ---------------------------------------------------------------
+
+// h264IDRAU is a complete H.264 keyframe access unit (raw NALUs, no start
+// codes): SPS (type 7) + PPS (type 8) + IDR (type 5) — the minimum the hub's
+// HasCompleteParamSets gate accepts for IDR-cache replay.
+func h264IDRAU() [][]byte {
+	return [][]byte{
+		{0x67, 0x64, 0x00, 0x1f, 0xac, 0xd9, 0x40, 0x50, 0x05, 0xbb, 0x01, 0x6c, 0x80},
+		{0x68, 0xeb, 0xec, 0xb2, 0x2c},
+		{0x65, 0x88, 0x84, 0x21, 0xa0, 0x7b, 0xdf, 0x3f},
+	}
+}
+
+func shortenHubWait(t *testing.T) {
+	t.Helper()
+	old := hubWaitTimeout
+	hubWaitTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { hubWaitTimeout = old })
+}
+
+// --- recorder stubs ----------------------------------------------------------
+
+type frameRecorder struct {
+	model.Recorder // embedded nil: Start/Stop/Status never called in these tests
+	frame          []byte
+}
+
+func (r *frameRecorder) LatestFrame() []byte { return r.frame }
+
+type delegatingRecorder struct {
+	model.Recorder
+	inner model.Recorder
+}
+
+func (r *delegatingRecorder) Delegate() model.Recorder { return r.inner }
+
+type hubRecorder struct {
+	model.Recorder
+	hub *streamhub.StreamHub
+}
+
+func (r *hubRecorder) GetHub() *streamhub.StreamHub { return r.hub }
+
+// --- source stubs ------------------------------------------------------------
+
+type stubCamSource struct {
+	rec model.Recorder
+}
+
+func (s stubCamSource) GetRecorder(string) model.Recorder { return s.rec }
+
+type stubConfigSource struct {
+	cam *config.CameraConfig
+}
+
+func (s stubConfigSource) GetCameraConfig(string) *config.CameraConfig { return s.cam }
+
+// --- FrameFromRecorder -------------------------------------------------------
+
+func TestFrameFromRecorder_LatestFrame(t *testing.T) {
+	want := []byte{0xff, 0xd8, 0x00, 0x01, 0xff, 0xd9}
+	rec := &frameRecorder{frame: want}
+
+	got, err := FrameFromRecorder(rec, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestFrameFromRecorder_DelegateUnwrap(t *testing.T) {
+	// ONVIF recorders wrap a JPEG delegate — unwrap must reach LatestFrame.
+	want := []byte{0xff, 0xd8, 0x02}
+	rec := &delegatingRecorder{inner: &frameRecorder{frame: want}}
+
+	got, err := FrameFromRecorder(rec, nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestFrameFromRecorder_HubCachedIDRReplay(t *testing.T) {
+	hub := streamhub.New()
+	// Broadcast BEFORE subscribing: the cached IDR must be replayed to the new
+	// one-shot subscriber without waiting for the next GOP.
+	au := h264IDRAU()
+	hub.Broadcast(1000, au, true)
+
+	var gotAU [][]byte
+	decode := func(in [][]byte) ([]byte, error) {
+		gotAU = in
+		return []byte{0xff, 0xd8}, nil
+	}
+
+	got, err := FrameFromRecorder(&hubRecorder{hub: hub}, decode)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0xff, 0xd8}, got)
+	assert.Equal(t, au, gotAU, "decoder must receive the cached IDR AU with param sets")
+}
+
+func TestFrameFromRecorder_HubNoFrames_ErrNoFrame(t *testing.T) {
+	shortenHubWait(t)
+	hub := streamhub.New()
+
+	_, err := FrameFromRecorder(&hubRecorder{hub: hub}, func([][]byte) ([]byte, error) {
+		return nil, errors.New("must not be called")
+	})
+	assert.ErrorIs(t, err, ErrNoFrame)
+}
+
+func TestFrameFromRecorder_NoDecodeFunc_ErrNoFrame(t *testing.T) {
+	hub := streamhub.New()
+	hub.Broadcast(1000, h264IDRAU(), true)
+
+	// FFmpeg absent (decode nil): hub path unavailable, no snapshot URL here.
+	_, err := FrameFromRecorder(&hubRecorder{hub: hub}, nil)
+	assert.ErrorIs(t, err, ErrNoFrame)
+}
+
+func TestFrameFromRecorder_DecodeErrorWraps(t *testing.T) {
+	hub := streamhub.New()
+	hub.Broadcast(1000, h264IDRAU(), true)
+
+	_, err := FrameFromRecorder(&hubRecorder{hub: hub}, func([][]byte) ([]byte, error) {
+		return nil, errors.New("ffmpeg failed")
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoFrame, "decode failure must surface, not alias to ErrNoFrame")
+}
+
+// --- Capturer ----------------------------------------------------------------
+
+func TestCapturer_RecorderPathWins(t *testing.T) {
+	var httpCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		httpCalls.Add(1)
+		w.Write([]byte("url-jpeg"))
+	}))
+	defer srv.Close()
+
+	c := &Capturer{
+		Recorder: stubCamSource{rec: &frameRecorder{frame: []byte("rec-jpeg")}},
+		Config:   stubConfigSource{cam: &config.CameraConfig{SnapshotURL: srv.URL}},
+		Client:   srv.Client(),
+	}
+
+	got, err := c.Capture("cam")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("rec-jpeg"), got)
+	assert.Zero(t, httpCalls.Load(), "snapshot URL must not be hit when the recorder supplies a frame")
+}
+
+func TestCapturer_SnapshotURLFallbackWithAuth(t *testing.T) {
+	var user, pass string
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte("url-jpeg"))
+	}))
+	defer srv.Close()
+	user, pass = "admin", "secret"
+
+	c := &Capturer{
+		Recorder: stubCamSource{rec: nil},
+		Config: stubConfigSource{cam: &config.CameraConfig{
+			SnapshotURL: srv.URL,
+			Username:    user,
+			Password:    pass,
+		}},
+		Client: srv.Client(),
+	}
+
+	got, err := c.Capture("cam")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("url-jpeg"), got)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.SetBasicAuth(user, pass)
+	assert.Equal(t, req.Header.Get("Authorization"), gotAuth, "camera credentials must be sent as Basic auth")
+}
+
+func TestCapturer_DecodeFailureFallsBackToURL(t *testing.T) {
+	hub := streamhub.New()
+	hub.Broadcast(1000, h264IDRAU(), true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("url-jpeg"))
+	}))
+	defer srv.Close()
+
+	c := &Capturer{
+		Decode:   func([][]byte) ([]byte, error) { return nil, errors.New("ffmpeg failed") },
+		Recorder: stubCamSource{rec: &hubRecorder{hub: hub}},
+		Config:   stubConfigSource{cam: &config.CameraConfig{SnapshotURL: srv.URL}},
+		Client:   srv.Client(),
+	}
+
+	got, err := c.Capture("cam")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("url-jpeg"), got, "a decode failure must still try the snapshot URL")
+}
+
+func TestCapturer_NoPathAvailable_ErrNoFrame(t *testing.T) {
+	c := &Capturer{
+		Recorder: stubCamSource{rec: nil},
+		Config:   stubConfigSource{cam: &config.CameraConfig{}}, // no SnapshotURL
+		Client:   http.DefaultClient,
+	}
+
+	_, err := c.Capture("cam")
+	assert.ErrorIs(t, err, ErrNoFrame)
+}
+
+func TestCapturer_URLNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := &Capturer{
+		Recorder: stubCamSource{rec: nil},
+		Config:   stubConfigSource{cam: &config.CameraConfig{SnapshotURL: srv.URL}},
+		Client:   srv.Client(),
+	}
+
+	_, err := c.Capture("cam")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoFrame)
+}
+
+func TestCapturer_URLBodyCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(make([]byte, snapshotBodyCap+1))
+	}))
+	defer srv.Close()
+
+	c := &Capturer{
+		Recorder: stubCamSource{rec: nil},
+		Config:   stubConfigSource{cam: &config.CameraConfig{SnapshotURL: srv.URL}},
+		Client:   srv.Client(),
+	}
+
+	_, err := c.Capture("cam")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cap")
+}
+
+func TestFrameFromRecorder_SubscribeAlwaysUnsubscribed(t *testing.T) {
+	hub := streamhub.New()
+	hub.Broadcast(1000, h264IDRAU(), true)
+
+	before := subSeq.Load()
+	_, err := FrameFromRecorder(&hubRecorder{hub: hub}, func([][]byte) ([]byte, error) {
+		return []byte("j"), nil
+	})
+	require.NoError(t, err)
+
+	// The one-shot ID must be released after capture — a leaked subscriber
+	// pins frames forever. Re-subscribing the SAME id succeeding proves the
+	// Unsubscribe ran.
+	used := fmt.Sprintf("snapshot-%d", before+1)
+	reSubErr := hub.Subscribe(used, func(int64, [][]byte) {})
+	require.NoError(t, reSubErr, "one-shot subscription %q must be released after capture", used)
+	hub.Unsubscribe(used)
+}

--- a/internal/transcoding/snapshot.go
+++ b/internal/transcoding/snapshot.go
@@ -1,0 +1,162 @@
+// FFmpeg-gated single-frame snapshot decoding (#657).
+//
+// H.264/H.265 cameras have no pure-Go decoder (verified — see AGENTS.md), so
+// latest-frame snapshots for them decode one cached IDR access unit through
+// the OPTIONAL FFmpeg subprocess. This stays inside the transcoding package
+// (the sanctioned FFmpeg zone); callers treat ErrFFmpegUnavailable as "not
+// supported here" and degrade gracefully — the NVR runs fully without FFmpeg.
+
+package transcoding
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+)
+
+// ErrFFmpegUnavailable is returned when FFmpeg is not installed: callers keep
+// their legacy behavior (e.g. the latest-frame endpoint stays 404).
+var ErrFFmpegUnavailable = errors.New("transcoding: ffmpeg not available")
+
+// snapshotFFmpegPath resolves the ffmpeg binary ("" = unavailable). Injectable
+// for tests — hermetic fake-script fixtures per the anti-flaky test rules.
+var snapshotFFmpegPath = func() string {
+	if p, err := exec.LookPath("ffmpeg"); err == nil {
+		return p
+	}
+	return ""
+}
+
+const (
+	// snapshotDecodeTimeout bounds one frame decode; a hung pipe (broken AU,
+	// exotic bitstream) must never wedge the calling handler/trigger.
+	snapshotDecodeTimeout = 10 * time.Second
+	// maxSnapshotJPEG caps the collected JPEG bytes (a 4K JPEG is ~1-2MB; a
+	// runaway ffmpeg must not buffer unbounded output in RAM).
+	maxSnapshotJPEG = 4 << 20
+)
+
+// DecodeAUToJPEG decodes ONE Annex-B access unit (parameter sets + IDR, NALUs
+// without start codes) into a single JPEG image. The codec is detected from
+// the parameter-set NAL types (H.264 SPS=7 / H.265 SPS=33).
+func DecodeAUToJPEG(au [][]byte) ([]byte, error) {
+	ffmpeg := snapshotFFmpegPath()
+	if ffmpeg == "" {
+		return nil, ErrFFmpegUnavailable
+	}
+	if len(au) == 0 {
+		return nil, errors.New("transcoding: empty access unit")
+	}
+
+	format := "h264"
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		if nalu[0]&0x1F == 7 { // H.264 SPS
+			format = "h264"
+			break
+		}
+		if (nalu[0]>>1)&0x3F == 33 { // H.265 SPS
+			format = "hevc"
+			break
+		}
+	}
+
+	// Reassemble Annex-B with 4-byte start codes.
+	var annexb bytes.Buffer
+	for _, nalu := range au {
+		annexb.WriteString("\x00\x00\x00\x01")
+		annexb.Write(nalu)
+	}
+
+	cmd := exec.Command(ffmpeg,
+		"-hide_banner", "-loglevel", "error",
+		"-f", format,
+		"-i", "pipe:0",
+		"-frames:v", "1",
+		"-f", "image2pipe",
+		"-c:v", "mjpeg", "-q:v", "3",
+		"pipe:1",
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	// Own process group BEFORE start: cleanup kills must reach ffmpeg's
+	// children too, or they keep the stdio pipes open and deadlock Wait.
+	prepareSnapshotProcessGroup(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	// Watchdog: kill a hung decode so Wait always returns within the budget.
+	kill := func() { killSnapshotProcessGroup(cmd) }
+	timer := time.AfterFunc(snapshotDecodeTimeout, kill)
+	defer timer.Stop()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := stdin.Write(annexb.Bytes())
+		if cerr := stdin.Close(); err == nil {
+			err = cerr
+		}
+		writeErr <- err
+	}()
+
+	var jpeg []byte
+	var readErr error
+	jpeg, readErr = readBounded(stdout, kill)
+	stderrBuf, _ := io.ReadAll(io.LimitReader(stderr, 4<<10))
+	waitErr := cmd.Wait()
+	<-writeErr
+
+	if readErr != nil {
+		return nil, fmt.Errorf("transcoding: snapshot decode: %w", readErr)
+	}
+	if waitErr != nil {
+		detail := string(stderrBuf)
+		if detail == "" {
+			detail = waitErr.Error()
+		}
+		return nil, fmt.Errorf("transcoding: ffmpeg frame decode failed: %s", detail)
+	}
+	if len(jpeg) == 0 {
+		return nil, errors.New("transcoding: ffmpeg produced no frame (incomplete access unit?)")
+	}
+	return jpeg, nil
+}
+
+// readBounded collects stdout capped at maxSnapshotJPEG. On overflow it kills
+// the producer BEFORE returning — otherwise cmd.Wait would block forever on a
+// process stalled writing into a pipe nobody reads. It errors (never
+// truncates): a silent truncation would emit a corrupt JPEG downstream.
+func readBounded(r io.Reader, kill func()) ([]byte, error) {
+	buf := make([]byte, 0, 256<<10)
+	tmp := make([]byte, 32<<10)
+	for {
+		n, err := r.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if len(buf) > maxSnapshotJPEG {
+			kill()
+			return nil, errors.New("output exceeds cap")
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return buf, nil
+			}
+			return nil, err
+		}
+	}
+}

--- a/internal/transcoding/snapshot_test.go
+++ b/internal/transcoding/snapshot_test.go
@@ -1,0 +1,121 @@
+package transcoding
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFakeFFmpeg creates a fake ffmpeg executable. Behaviors (selected by the
+// FAKE_FFMPEG_MODE env var it sets for itself... actually by argv inspection):
+//   - default: consume stdin, write fakeJPEG to stdout, exit 0. The invoked
+//     args are also written to <dir>/args.txt for assertions.
+//   - FAKE_FAIL=1: exit 1 with stderr noise.
+func writeFakeFFmpeg(t *testing.T, fakeJPEG []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-ffmpeg")
+	body := `#!/bin/sh
+echo "$@" > "` + dir + `/args.txt"
+cat > /dev/null
+if [ -n "$FAKE_FAIL" ]; then
+  echo "fake ffmpeg failure" >&2
+  exit 1
+fi
+printf '%s' "` + string(fakeJPEG) + `"
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestDecodeAUToJPEG_SuccessH264(t *testing.T) {
+	fakeJPEG := []byte{0xFF, 0xD8, 0xFF, 0xE0, 'f', 'a', 'k', 'e', 0xFF, 0xD9}
+	fake := writeFakeFFmpeg(t, fakeJPEG)
+
+	prev := snapshotFFmpegPath
+	snapshotFFmpegPath = func() string { return fake }
+	t.Cleanup(func() { snapshotFFmpegPath = prev })
+
+	// H.264 access unit: SPS(7) + PPS(8) + IDR(5).
+	got, err := DecodeAUToJPEG([][]byte{{0x67, 0x42}, {0x68, 0xCE}, {0x65, 0x01, 0x02}})
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(got) != string(fakeJPEG) {
+		t.Fatalf("jpeg bytes wrong: %x", got)
+	}
+
+	args, err := os.ReadFile(filepath.Join(filepath.Dir(fake), "args.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "-f h264") {
+		t.Fatalf("H.264 AU must select -f h264, args: %s", args)
+	}
+	if !strings.Contains(string(args), "-frames:v 1") {
+		t.Fatalf("must decode exactly one frame, args: %s", args)
+	}
+}
+
+func TestDecodeAUToJPEG_HEVCSelectsHevcFormat(t *testing.T) {
+	fake := writeFakeFFmpeg(t, []byte("jpg"))
+	prev := snapshotFFmpegPath
+	snapshotFFmpegPath = func() string { return fake }
+	t.Cleanup(func() { snapshotFFmpegPath = prev })
+
+	// H.265 access unit: VPS(32) + SPS(33) + PPS(34) + IDR_W_RADL(19).
+	if _, err := DecodeAUToJPEG([][]byte{{0x40, 0x01}, {0x42, 0x01}, {0x44, 0x01}, {0x26, 0x01}}); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	args, _ := os.ReadFile(filepath.Join(filepath.Dir(fake), "args.txt"))
+	if !strings.Contains(string(args), "-f hevc") {
+		t.Fatalf("H.265 AU must select -f hevc, args: %s", args)
+	}
+}
+
+func TestDecodeAUToJPEG_FFmpegUnavailable(t *testing.T) {
+	prev := snapshotFFmpegPath
+	snapshotFFmpegPath = func() string { return "" }
+	t.Cleanup(func() { snapshotFFmpegPath = prev })
+
+	_, err := DecodeAUToJPEG([][]byte{{0x67}})
+	if !errors.Is(err, ErrFFmpegUnavailable) {
+		t.Fatalf("expected ErrFFmpegUnavailable, got %v", err)
+	}
+}
+
+func TestDecodeAUToJPEG_FFmpegFailure(t *testing.T) {
+	fake := writeFakeFFmpeg(t, []byte("jpg"))
+	prev := snapshotFFmpegPath
+	snapshotFFmpegPath = func() string { return fake }
+	t.Cleanup(func() { snapshotFFmpegPath = prev })
+	t.Setenv("FAKE_FAIL", "1")
+
+	_, err := DecodeAUToJPEG([][]byte{{0x67}, {0x68}, {0x65}})
+	if err == nil || !strings.Contains(err.Error(), "fake ffmpeg failure") {
+		t.Fatalf("ffmpeg failure must propagate with stderr, got %v", err)
+	}
+}
+
+func TestDecodeAUToJPEG_BoundedOutput(t *testing.T) {
+	// A runaway "ffmpeg" writing unbounded stdout must not OOM the NVR: the
+	// decoder caps collected bytes and errors out.
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-ffmpeg-runaway")
+	body := "#!/bin/sh\ncat > /dev/null\nyes A | head -c 100000000\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prev := snapshotFFmpegPath
+	snapshotFFmpegPath = func() string { return script }
+	t.Cleanup(func() { snapshotFFmpegPath = prev })
+
+	_, err := DecodeAUToJPEG([][]byte{{0x67}, {0x68}, {0x65}})
+	if err == nil {
+		t.Fatal("runaway output must fail, not buffer 100MB")
+	}
+}

--- a/internal/transcoding/snapshot_unix.go
+++ b/internal/transcoding/snapshot_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package transcoding
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// prepareSnapshotProcessGroup puts the ffmpeg child into its own process
+// group so a cleanup kill reaches ffmpeg's own children too (shell wrapper
+// fixtures spawn pipelines — killing only the shell leaves grandchildren
+// holding the stdio pipes, deadlocking Wait).
+func prepareSnapshotProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killSnapshotProcessGroup kills the whole child process group, then the
+// leader as a belt-and-braces fallback.
+func killSnapshotProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = cmd.Process.Kill()
+}

--- a/internal/transcoding/snapshot_windows.go
+++ b/internal/transcoding/snapshot_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package transcoding
+
+import (
+	"os/exec"
+)
+
+// Windows has no process groups in the POSIX sense; Kill terminates the
+// direct child, which is all the snapshot decoder spawns there.
+func prepareSnapshotProcessGroup(*exec.Cmd) {}
+
+func killSnapshotProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtmp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/snapshot"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/srt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
@@ -805,10 +806,28 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	deps.cleanupMgr = cleanupMgr
 	deps.archiveDeleter = cleanup.NewArchiveDeleter(db, store)
 
+	// Shared snapshot capturer (#657): FFmpeg-gated hub-IDR decode for
+	// H.264/H.265 cameras + device snapshot-URL fallback. Wired into the
+	// latest-frame API below and the MQTT snapshot runner (Step 9). Every
+	// consumer degrades gracefully when FFmpeg is absent — the decode just
+	// fails and callers fall back / answer 404.
+	snapCapturer := &snapshot.Capturer{
+		Decode:   transcoding.DecodeAUToJPEG,
+		Client:   http.DefaultClient,
+		Recorder: deps.camMgr,
+		Config:   deps.camMgr,
+	}
+
 	// Step 9: Optional MQTT client. The trigger dispatcher wires
-	// record/stop actions to the camera manager (camMgr is built at Step 5.6).
+	// record/stop actions to the camera manager (camMgr is built at Step 5.6)
+	// and the snapshot action to the capture→persist→event runner (#656).
 	if cfg.MQTT.Enabled {
-		deps.mqttClient = mqtt.NewClient(cfg.MQTT.Broker, cfg.MQTT.ClientID, cfg.MQTT.Topic, cfg.MQTT.Username, cfg.MQTT.Password, mqtt.NewActionDispatcher(deps.camMgr))
+		deps.snapRunner = &snapshot.Runner{
+			Source:  snapCapturer,
+			Storage: &snapshot.Persistor{Root: store.RootDir()},
+			Bus:     deps.eventBus,
+		}
+		deps.mqttClient = mqtt.NewClient(cfg.MQTT.Broker, cfg.MQTT.ClientID, cfg.MQTT.Topic, cfg.MQTT.Username, cfg.MQTT.Password, mqtt.NewActionDispatcher(deps.camMgr, deps.snapRunner))
 	}
 
 	// Wire MQTT client into health manager for event publishing
@@ -850,6 +869,8 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	handler.SetHealthManager(healthMgr)
 	handler.SetStabilityProvider(healthMgr)
 	handler.SetEventBus(deps.eventBus)
+	// FFmpeg-gated snapshot capturer for the latest-frame endpoint (#657).
+	handler.SetSnapshotCapturer(snapCapturer)
 	api.SetAPIMetrics(m)
 	if deps.rollingMergeMgr != nil {
 		handler.SetTimelapseMergeMgr(deps.rollingMergeMgr)

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtmp"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/rtsp"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/snapshot"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/srt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
@@ -85,6 +86,7 @@ type appDeps struct {
 	// Ingest listeners (optional)
 	mqttClient        *mqtt.Client
 	mqttStatusPub     *mqtt.StatusPublisher
+	snapRunner        *snapshot.Runner // MQTT snapshot trigger: capture → persist → event (#656)
 	ftpServer         *ftp.Server
 	rtmpServer        *rtmp.Server
 	srtListener       *srt.Listener

--- a/pkg/app/snapshot_wiring_test.go
+++ b/pkg/app/snapshot_wiring_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"testing"
+)
+
+// TestBuildAppDeps_SnapshotCapturerWired guards the production wiring for the
+// FFmpeg-gated latest-frame path (#657): the API handler must be constructed
+// with the snapshot capturer, or H.264/H.265 cameras keep answering 404 even
+// with FFmpeg present (same wiring-bug class as the #653 onAction=nil lesson).
+func TestBuildAppDeps_SnapshotCapturerWired(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if deps.handler == nil {
+		t.Fatal("deps.handler is nil")
+	}
+	if !deps.handler.HasSnapshotCapturer() {
+		t.Fatal("api handler has no snapshot capturer wired: latest-frame stays JPEG-only")
+	}
+}
+
+// TestBuildAppDeps_MQTTSnapshotRunnerWired guards the #656 wiring: with
+// mqtt.enabled the snapshot runner (capture → persist → event) must be built
+// and handed to the action dispatcher.
+func TestBuildAppDeps_MQTTSnapshotRunnerWired(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+	cfg.MQTT.Enabled = true
+	cfg.MQTT.Broker = "tcp://127.0.0.1:1" // unreachable is fine: connect happens in Start, not build
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if deps.snapRunner == nil {
+		t.Fatal("deps.snapRunner is nil with mqtt.enabled=true: snapshot trigger would be dropped")
+	}
+}
+
+// TestBuildAppDeps_MQTTDisabled_NoSnapRunner mirrors MQTTDisabled_NoClient.
+func TestBuildAppDeps_MQTTDisabled_NoSnapRunner(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+	cfg.MQTT.Enabled = false
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if deps.snapRunner != nil {
+		t.Fatal("deps.snapRunner should be nil with mqtt.enabled=false")
+	}
+}


### PR DESCRIPTION
## Summary

Implements both snapshot issues together — they share one capture pipeline.

### #657 — `latest-frame` coverage for H.264/H.265 cameras (FFmpeg-gated)

- **`internal/transcoding.DecodeAUToJPEG`**: pipes one Annex-B access unit (SPS/PPS+IDR) into `ffmpeg -frames:v 1 -f image2pipe`, collects a single JPEG. 10s watchdog via process-group kill (`Setpgid` + `kill(-pid)` — children must not outlive the pipe), output capped at 4MB. Returns `ErrFFmpegUnavailable` when the binary is absent — FFmpeg stays OPTIONAL, nothing else in the NVR requires it.
- **`internal/snapshot.Capturer`**: capture ladder per camera — ① JPEG-family recorders answer `LatestFrame()` directly; ② H.264/H.265 recorders get a **one-shot StreamHub subscribe** (`Subscribe` replays the cached param-sets+IDR immediately — no GOP wait; the replayed AU is validated to carry complete param sets by the hub itself) decoded through the FFmpeg seam; ③ fallback to the camera's configured `snapshot_url` with Basic auth. The one-shot subscription is always released.
- **API**: `GET /api/cameras/{id}/latest-frame` now falls through to the capturer when the recorder has no `LatestFrame()`, caching results in the existing 10s snapshot TTL map (shared with `/snapshot`). ETag/304 semantics unchanged. Any capture failure still answers 404 — never 500.

### #656 — MQTT `snapshot` trigger action

- `internal/snapshot.Persistor`: atomic temp→rename writes to `{storage_root}/snapshots/{camera_id}/{UTC-timestamp}.jpg` (same-ms collisions get a suffix, camera ID is path-guarded).
- `internal/snapshot.Runner`: capture → persist → publish `event.CameraSnapshotEvent{camera_id, file_path (relative), timestamp, trigger}` on new topic **`camera.snapshot`**, which joins the `mqtt.status_events` forwarding whitelist (`{prefix}/event/camera.snapshot`).
- `NewActionDispatcher(lifecycle, snapRunner)` — the snapshot action runs on its own goroutine with the 30s action timeout (paho handler never blocks), logging success path/failure without touching camera lifecycle.

### Wiring (guarded per the #653 lesson)

`pkg/app/builders.go` builds one shared `Capturer` for both consumers; regression tests assert the handler has the capturer wired (`HasSnapshotCapturer`) and the runner exists with `mqtt.enabled=true`.

## Tests

- TDD red→green throughout; fake-ffmpeg script fixtures (hermetic, no real FFmpeg needed in CI), stub recorders/sources, httptest snapshot-URL servers.
- `go test -race ./internal/{snapshot,mqtt,api,event,transcoding}/ ./pkg/app/` — 1147 passed; `make lint` clean.
- Docs updated: `docs/{zh,en}/mqtt-integration.md` (snapshot section + event table) and `docs/{zh,en}/home-assistant.md` (Option A now works for H.264/H.265 with FFmpeg present).

Closes #657
Closes #656
