### PR TITLE
test(xiaomi): fix Start/Stop status-assertion flake on loaded CI runners

### DIFF
--- a/internal/xiaomi/recorder_safety_test.go
+++ b/internal/xiaomi/recorder_safety_test.go
@@ -607,7 +607,7 @@ func TestRecorderStartStopIdempotent(t *testing.T) {
 
 	ctx := context.Background()
 	require.NoError(t, r.Start(ctx))
-	require.Equal(t, model.StatusRecording, r.Status())
+	assertRecorderRunning(t, r)
 
 	require.NoError(t, r.Stop())
 	require.Equal(t, model.StatusStopped, r.Status())

--- a/internal/xiaomi/recorder_test.go
+++ b/internal/xiaomi/recorder_test.go
@@ -182,6 +182,18 @@ func TestXiaomiRecorderStopWithoutStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// assertRecorderRunning accepts either running state. Start() sets Recording
+// synchronously, but the run goroutine can flip to Reconnecting (the expected
+// credential-less connect failure) before the assertion executes — exact-value
+// assertions race on loaded CI runners (observed on PR #679's CI run).
+func assertRecorderRunning(t *testing.T, r *XiaomiRecorder) {
+	t.Helper()
+	require.Contains(t,
+		[]model.RecorderStatus{model.StatusRecording, model.StatusReconnecting},
+		r.Status(),
+		"recorder must be in a running state right after Start()")
+}
+
 func TestXiaomiRecorderStartAndStop(t *testing.T) {
 	t.Helper()
 	store := &noopSegmentStore{}
@@ -194,7 +206,7 @@ func TestXiaomiRecorderStartAndStop(t *testing.T) {
 	ctx := context.Background()
 	err := r.Start(ctx)
 	require.NoError(t, err)
-	require.Equal(t, model.StatusRecording, r.Status())
+	assertRecorderRunning(t, r)
 
 	// Stop should wait for goroutine to finish.
 	err = r.Stop()


### PR DESCRIPTION
## Summary

`TestXiaomiRecorderStartAndStop` / `TestRecorderStartStopIdempotent` asserted `Status() == StatusRecording` immediately after `Start()`. `Start()` sets `Recording` synchronously, but the spawned `run()` goroutine flips the status to `Reconnecting` as soon as the (expected, credential-less) `ResolveMISSURL` attempt fails — which value the test observes is pure goroutine scheduling. On loaded CI runners the test thread occasionally loses that race (observed on PR #679's first CI run; the same commit passes locally with `-race -count=3`).

Fix: assert the running-state set (`Recording` OR `Reconnecting`) via a shared `assertRecorderRunning` helper — deterministic, and matches the tests' actual intent (recorder is running, not stopped). This is exactly the #571 rule: assert observable end state, don't race the scheduler.

`TestSetStatus` is untouched (it drives `setStatus` directly, no goroutine).

## Tests

`go test -race -count=3 -run 'TestXiaomiRecorderStartAndStop|TestRecorderStartStopIdempotent|TestSetStatus' ./internal/xiaomi/` — 9 passed; full package `-race -count=1` — 298 passed; lint clean.
