### PR TITLE
test(observability): pin #644 acceptance — pprof gating + runtime metrics

### DIFF
--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -630,3 +630,35 @@ func TestMergeMetrics_FailureReasons(t *testing.T) {
 	}
 	t.Fatal("expected nvr_merge_failures_total metric family")
 }
+
+// runtimeMetricNames returns the exact metric family names in the registry —
+// the acceptance list for issue #644 (goroutines / GC / memstats / process).
+func registryMetricNames(t *testing.T, m *Metrics) map[string]bool {
+	t.Helper()
+	families, err := m.Registry.Gather()
+	require.NoError(t, err)
+	names := make(map[string]bool)
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+	return names
+}
+
+// TestRegistryExposesIssue644RuntimeMetrics pins the #644 acceptance list:
+// goroutine count, GC timing, memory stats, and process CPU/RSS must all be
+// scrapeable from /api/metrics.
+func TestRegistryExposesIssue644RuntimeMetrics(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+	names := registryMetricNames(t, NewMetrics())
+
+	for _, want := range []string{
+		"go_goroutines",
+		"go_gc_duration_seconds",
+		"go_memstats_alloc_bytes",
+		"nvr_process_cpu_seconds_total",
+		"nvr_process_resident_memory_bytes",
+	} {
+		require.True(t, names[want], "expected metric %q in registry (issue #644 acceptance)", want)
+	}
+}

--- a/pkg/app/pprof_wiring_test.go
+++ b/pkg/app/pprof_wiring_test.go
@@ -1,0 +1,79 @@
+package app
+
+// End-to-end guard for the remote pprof diagnostics mount (#470, acceptance
+// for #644): observability.enable_pprof must gate /debug/pprof/* behind the
+// main auth middleware — a profile leak is a memory-data leak.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const pprofTestPassword = "pprof-test-pass"
+
+func buildPprofRouter(t *testing.T, enabled bool) http.Handler {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+	cfg.Observability.EnablePprof = enabled
+	hash, err := bcrypt.GenerateFromPassword([]byte(pprofTestPassword), bcrypt.MinCost)
+	require.NoError(t, err)
+	cfg.Auth.PasswordHash = string(hash)
+	cfg.Auth.Password = ""
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+	require.NotNil(t, deps.router)
+	return deps.router
+}
+
+func pprofRequest(t *testing.T, h http.Handler, path, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if password != "" {
+		req.SetBasicAuth("admin", password)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestPprof_Disabled_NotMounted(t *testing.T) {
+	t.Helper()
+	h := buildPprofRouter(t, false)
+
+	// Route absent → 404, never a profile payload.
+	rr := pprofRequest(t, h, "/debug/pprof/goroutine?debug=1", pprofTestPassword)
+	assert.Equal(t, http.StatusNotFound, rr.Code, "pprof must stay unmounted with enable_pprof=false")
+}
+
+func TestPprof_Enabled_RequiresAuth(t *testing.T) {
+	t.Helper()
+	h := buildPprofRouter(t, true)
+
+	rr := pprofRequest(t, h, "/debug/pprof/goroutine?debug=1", "")
+	assert.Equal(t, http.StatusUnauthorized, rr.Code, "pprof must sit behind the auth middleware")
+}
+
+func TestPprof_Enabled_ServesProfiles(t *testing.T) {
+	t.Helper()
+	h := buildPprofRouter(t, true)
+
+	rr := pprofRequest(t, h, "/debug/pprof/goroutine?debug=1", pprofTestPassword)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "goroutine", "goroutine profile text expected")
+
+	rr = pprofRequest(t, h, "/debug/pprof/heap", pprofTestPassword)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Body.Bytes(), "heap profile payload expected")
+
+	// 1s CPU profile (default 30s would stall the test).
+	rr = pprofRequest(t, h, "/debug/pprof/profile?seconds=1", pprofTestPassword)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.NotEmpty(t, rr.Body.Bytes(), "CPU profile payload expected")
+}


### PR DESCRIPTION
## Summary

Issue #644 asked for two things — an auth-protected optional pprof endpoint and runtime metrics on `/api/metrics`. **Both already exist on main**:

- pprof: `observability.enable_pprof` (default off) mounts `/debug/pprof/*` behind the main auth middleware since #470 (`pkg/app/router.go`); documented in `docs/{zh,en}/configuration.md` + `observability.md`.
- metrics: `go_goroutines`, `go_gc_duration_seconds`, `go_memstats_*` (Go collector, MemStats collection) and `nvr_process_cpu_seconds_total` / `nvr_process_resident_memory_bytes` (process collector) are all registered in `internal/metrics`.

What was missing was any guard on either. This PR adds the acceptance pins:

- `pkg/app/pprof_wiring_test.go` — end-to-end through the real router: `enable_pprof=false` → 404; enabled + no credentials → 401; enabled + BasicAuth → goroutine (text), heap, and 1s CPU profiles all served.
- `internal/metrics/metrics_test.go` — `TestRegistryExposesIssue644RuntimeMetrics` pins the five acceptance metric names so a future collector change can't silently drop them.

`go test -race ./pkg/app/ ./internal/metrics/` — 81 passed; lint clean.

Closes #644 (verified implemented; this adds the regression coverage)
