### PR TITLE
perf(pixgate): shared-hub sampler — no duplicate RTSP pull, keyframe-only decode

### DIFF
--- a/internal/pixgate/hub_source.go
+++ b/internal/pixgate/hub_source.go
@@ -1,0 +1,293 @@
+// hub_source.go — shared-pull sampler feed (#643).
+//
+// The legacy sampler let ffmpeg open its own RTSP connection to the camera's
+// sub stream and decode EVERY frame (the fps=1 filter only drops output, not
+// decode work) — ~16% of one core 24/7 on M5, plus a duplicate camera
+// connection competing for connection-limited devices.
+//
+// The hub path instead subscribes to the SAME substream.Source hub the live
+// quality=sub egress uses (one shared pull, refcounted), and feeds ffmpeg
+// over stdin ONLY the sampled keyframes as Annex-B: decode cost collapses to
+// ~SampleFPS frames/sec, there is no network read inside ffmpeg to wedge,
+// and the camera never sees a second connection. ffmpeg remains the decoder
+// (no CGO-free H.264/H.265 decoder exists in Go) — but it now decodes only
+// what the gate actually samples.
+
+package pixgate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+)
+
+// HubSource is the refcounted sub-stream feed (satisfied by an adapter over
+// camera.CameraManager Acquire/ReleaseSubStream). Release must be called
+// exactly once per successful acquire.
+type HubSource interface {
+	Hub() *streamhub.StreamHub
+	Release()
+}
+
+// ErrHubUnsupportedCodec marks a hub whose keyframes are not H.264/H.265
+// (e.g. MJPEG sub streams): the caller falls back to the direct sampler.
+var ErrHubUnsupportedCodec = errors.New("pixgate: hub codec not supported for stdin decode")
+
+const (
+	// probeWindow bounds the wait for the first keyframe (the hub's cached
+	// IDR replay makes this near-instant whenever frames flow at all).
+	probeWindow = 5 * time.Second
+	// stderrCap bounds ffmpeg's stderr capture (loglevel error keeps it tiny;
+	// the cap is a paranoia guard for spammy builds).
+	stderrCap = 8 << 10
+)
+
+var hubSubSeq atomic.Int64
+
+// stdinFFmpegArgs builds the decode pipeline: raw Annex-B H.264/H.265 on
+// stdin, fixed gray grid on stdout. No -nostdin (stdin is the feed), no
+// network options.
+func stdinFFmpegArgs(codec string) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error",
+		"-f", codecInputFormat(codec),
+		"-i", "pipe:0",
+		"-vf", fmt.Sprintf("scale=%d:%d", GridW, GridH),
+		"-f", "rawvideo", "-pix_fmt", "gray",
+		"pipe:1",
+	}
+}
+
+func codecInputFormat(codec string) string {
+	if codec == "h265" {
+		return "hevc"
+	}
+	return "h264"
+}
+
+// probeCodec identifies the stream codec from a keyframe AU's NAL headers:
+// H.264 SPS (type 7) vs H.265 SPS (type 33). "" = unsupported (MJPEG etc.).
+func probeCodec(au [][]byte) string {
+	for _, nalu := range au {
+		if len(nalu) == 0 {
+			continue
+		}
+		switch {
+		case nalu[0]&0x1F == 7:
+			return "h264"
+		case (nalu[0]>>1)&0x3F == 33:
+			return "h265"
+		}
+	}
+	return ""
+}
+
+// annexB serializes one AU (raw NALUs) with start-code prefixes.
+func annexB(au [][]byte) []byte {
+	var out []byte
+	for _, nalu := range au {
+		out = append(out, 0, 0, 0, 1)
+		out = append(out, nalu...)
+	}
+	return out
+}
+
+// sampleFramesHub runs one ffmpeg stdin decode to completion for one hub
+// acquisition. Keyframe AUs are forwarded at most one per sample interval;
+// non-keyframes are dropped (a lone P-frame has no reference chain to decode
+// against). The subscription is ALWAYS released before returning.
+func sampleFramesHub(ctx context.Context, cfg Config, src HubSource, fps float64, fn func([]byte) bool, frame []byte) (int, error) {
+	hub := src.Hub()
+	if hub == nil {
+		return 0, errors.New("pixgate: hub source carries no hub")
+	}
+
+	id := fmt.Sprintf("pixgate-hub-%d", hubSubSeq.Add(1))
+	auCh := make(chan model.FrameMsg, 8)
+	if err := hub.SubscribeMsg(id, func(m model.FrameMsg) {
+		// Never block the hub's drain goroutine — overflow drops (the next
+		// keyframe is never far).
+		select {
+		case auCh <- m:
+		default:
+		}
+	}); err != nil {
+		return 0, fmt.Errorf("pixgate: hub subscribe: %w", err)
+	}
+	// Unified cleanup, LIFO-safe: stop hub sends FIRST (Unsubscribe waits
+	// for the drain goroutine, so no callback can race the channel close),
+	// then release the forwarder (closing stdin lets the fixture's reader
+	// exit), then the watchdog, then the process.
+	var cmd *exec.Cmd
+	var fwdDone chan struct{}
+	var watchStop chan struct{}
+	defer func() {
+		hub.Unsubscribe(id)
+		if fwdDone != nil {
+			close(auCh)
+			<-fwdDone
+		}
+		if watchStop != nil {
+			close(watchStop)
+		}
+		if cmd != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+
+	// Probe phase: wait for the first keyframe (cached-IDR replay) to learn
+	// the codec, keeping the AU to seed the forwarder.
+	var firstKey model.FrameMsg
+	probeCtx, probeCancel := context.WithTimeout(ctx, probeWindow)
+	defer probeCancel()
+probe:
+	for {
+		select {
+		case m := <-auCh:
+			if !m.IsKeyframe || probeCodec(m.AU) == "" {
+				continue
+			}
+			firstKey = m
+			break probe
+		case <-probeCtx.Done():
+			return 0, fmt.Errorf("pixgate: no keyframe within %s (camera offline?)", probeWindow)
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		}
+	}
+	codec := probeCodec(firstKey.AU)
+	if codec == "" {
+		// A keyframe whose NALs match neither H.264 nor H.265 (MJPEG sub).
+		return 0, ErrHubUnsupportedCodec
+	}
+
+	args := stdinFFmpegArgs(codec)
+	if cfg.HubFFmpegArgs != nil {
+		args = cfg.HubFFmpegArgs(codec)
+	}
+
+	var stderr boundedBuf
+	cmd = exec.CommandContext(ctx, cfg.FFmpegPath, args...)
+	if len(cfg.Env) > 0 {
+		cmd.Env = append(os.Environ(), cfg.Env...)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return 0, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return 0, err
+	}
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	// Forwarder: seed with the probe keyframe, then throttle live keyframes
+	// to the sample rate. Exits when auCh closes (after Unsubscribe) or the
+	// stdin write breaks (ffmpeg gone).
+	fwdDone = make(chan struct{})
+	go func() {
+		defer close(fwdDone)
+		defer stdin.Close()
+		interval := time.Duration(float64(time.Second) / fps)
+		if interval <= 0 {
+			interval = time.Second
+		}
+		if _, err := stdin.Write(annexB(firstKey.AU)); err != nil {
+			return
+		}
+		last := time.Now()
+		for m := range auCh {
+			if !m.IsKeyframe {
+				continue
+			}
+			if time.Since(last) < interval {
+				continue
+			}
+			if _, err := stdin.Write(annexB(m.AU)); err != nil {
+				return
+			}
+			last = time.Now()
+		}
+	}()
+
+	stall := cfg.FrameStallTimeout
+	if stall <= 0 {
+		stall = 30 * time.Second
+	}
+	var lastFrameNS atomic.Int64
+	var stalled atomic.Bool
+	lastFrameNS.Store(time.Now().UnixNano())
+	watchStop = make(chan struct{})
+	go func() {
+		t := time.NewTicker(stall / 3)
+		defer t.Stop()
+		for {
+			select {
+			case <-watchStop:
+				return
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if time.Since(time.Unix(0, lastFrameNS.Load())) > stall {
+					stalled.Store(true)
+					_ = cmd.Process.Kill()
+					return
+				}
+			}
+		}
+	}()
+
+	n := 0
+	for {
+		if _, err := io.ReadFull(stdout, frame); err != nil {
+			if stalled.Load() {
+				return n, fmt.Errorf("no frame for %s — sampler source stalled", stall)
+			}
+			if ctx.Err() != nil {
+				return n, ctx.Err()
+			}
+			return n, fmt.Errorf("ffmpeg stdin decode ended: %w; stderr: %s", err, stderr.String())
+		}
+		lastFrameNS.Store(time.Now().UnixNano())
+		n++
+		if !fn(frame) {
+			return n, nil
+		}
+	}
+}
+
+// boundedBuf caps captured stderr so a spammy ffmpeg cannot balloon memory.
+type boundedBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *boundedBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.buf.Len() >= stderrCap {
+		return len(p), nil
+	}
+	return b.buf.Write(p)
+}
+
+func (b *boundedBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(b.buf.String())
+}

--- a/internal/pixgate/hub_source_test.go
+++ b/internal/pixgate/hub_source_test.go
@@ -1,0 +1,329 @@
+package pixgate
+
+// Tests for the hub-fed sampler (#643): the preferred source shares the
+// substream manager's pull (no extra camera connection) and feeds ffmpeg
+// ONLY the sampled keyframes over stdin — decode cost collapses from "every
+// frame of the stream" to ~SampleFPS frames/sec.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- pure helpers -----------------------------------------------------------
+
+func TestStdinFFmpegArgsH264(t *testing.T) {
+	t.Parallel()
+	args := stdinFFmpegArgs("h264")
+	joined := strings.Join(args, " ")
+	assert.Contains(t, joined, "-f h264")
+	assert.Contains(t, joined, "-i pipe:0")
+	assert.Contains(t, joined, fmt.Sprintf("scale=%d:%d", GridW, GridH))
+	assert.Contains(t, joined, "-f rawvideo -pix_fmt gray pipe:1")
+	assert.NotContains(t, joined, "-nostdin", "stdin is the AU feed — -nostdin would close it")
+	assert.NotContains(t, joined, "-rtsp_transport", "no network pull in hub mode")
+}
+
+func TestStdinFFmpegArgsH265(t *testing.T) {
+	t.Parallel()
+	assert.Contains(t, strings.Join(stdinFFmpegArgs("h265"), " "), "-f hevc")
+}
+
+func TestProbeCodec(t *testing.T) {
+	t.Parallel()
+	h264AU := [][]byte{{0x67, 0x64}, {0x68, 0xeb}, {0x65, 0x88}}
+	h265AU := [][]byte{{0x40, 0x01}, {0x42, 0x01}, {0x44, 0x01}, {0x26, 0x01}}
+	assert.Equal(t, "h264", probeCodec(h264AU))
+	assert.Equal(t, "h265", probeCodec(h265AU))
+	assert.Equal(t, "", probeCodec([][]byte{{0x00, 0x01, 0x02}}), "unknown NAL shapes (e.g. MJPEG) are unsupported")
+}
+
+func TestAnnexBEncode(t *testing.T) {
+	t.Parallel()
+	out := annexB([][]byte{{0x67, 0xAA}, {0x68, 0xBB}, {0x65, 0xCC}})
+	want := []byte{
+		0, 0, 0, 1, 0x67, 0xAA,
+		0, 0, 0, 1, 0x68, 0xBB,
+		0, 0, 0, 1, 0x65, 0xCC,
+	}
+	assert.Equal(t, want, out)
+}
+
+// --- fixtures -----------------------------------------------------------------
+
+// h264KeyAU builds a keyframe AU whose IDR carries a distinctive marker tail,
+// so forwarded stdin bytes are attributable to a specific published AU.
+func h264KeyAU(marker byte) [][]byte {
+	idr := append([]byte{0x65, 0x88}, bytesOf(marker, 16)...)
+	return [][]byte{{0x67, 0x64, 0x00, 0x1f}, {0x68, 0xeb, 0xec}, idr}
+}
+
+func bytesOf(b byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// fakeStdinFFmpeg dumps stdin to $STDIN_DUMP (and its argv to $ARGS_DUMP)
+// while emitting one gray frame per 50ms, until stdin closes. The exec-3
+// dance is required: non-interactive sh redirects a background job's fd 0
+// to /dev/null, so the real stdin must be saved before backgrounding.
+const fakeStdinFFmpeg = `#!/bin/sh
+printf '%s\n' "$@" >> "$ARGS_DUMP"
+exec 3<&0
+cat <&3 >> "$STDIN_DUMP" &
+CATPID=$!
+while kill -0 $CATPID 2>/dev/null; do
+  dd if=/dev/zero bs=19200 count=1 2>/dev/null
+  sleep 0.05
+done
+`
+
+// stubHubSource adapts a plain hub; released() counts Release calls.
+type stubHubSource struct {
+	hub      *streamhub.StreamHub
+	released atomic.Int32
+}
+
+func (s *stubHubSource) Hub() *streamhub.StreamHub { return s.hub }
+func (s *stubHubSource) Release()                  { s.released.Add(1) }
+
+func writeFakeStdinFFmpeg(t *testing.T) (script string, stdinDump, argsDump string) {
+	t.Helper()
+	dir := t.TempDir()
+	script = filepath.Join(dir, "fake-ffmpeg")
+	require.NoError(t, os.WriteFile(script, []byte(fakeStdinFFmpeg), 0o755))
+	return script, filepath.Join(dir, "stdin.bin"), filepath.Join(dir, "args.txt")
+}
+
+// --- sampleFramesHub ----------------------------------------------------------
+
+func TestSampleFramesHub_ForwardsKeyframesOnlyAsAnnexB(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeStdinFFmpeg(t)
+	hub := streamhub.New()
+
+	done := make(chan error, 1)
+	var frames int32
+	go func() {
+		cfg := Config{
+			FFmpegPath: script,
+			Env:        []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump},
+		}
+		src := &stubHubSource{hub: hub}
+		n, err := sampleFramesHub(context.Background(), cfg, src, 1, func([]byte) bool {
+			atomic.AddInt32(&frames, 1)
+			return false // one frame is enough — stop the read loop
+		}, make([]byte, GridW*GridH))
+		assert.NotZero(t, n)
+		done <- err
+	}()
+
+	// Cached-IDR replay: publish BEFORE the subscriber exists.
+	hub.Broadcast(1, h264KeyAU(0xAA), true)
+	// A P-frame must never reach ffmpeg's stdin.
+	hub.Broadcast(2, [][]byte{{0x41, 0x9A, 0x00}}, false)
+
+	require.NoError(t, <-done)
+	require.Equal(t, int32(1), atomic.LoadInt32(&frames))
+
+	// cat copies asynchronously in chunks — wait for the FULL AU, not just
+	// a non-empty file.
+	require.Eventually(t, func() bool {
+		raw, err := os.ReadFile(stdinDump)
+		return err == nil && bytes.Contains(raw, annexB(h264KeyAU(0xAA)))
+	}, 5*time.Second, 20*time.Millisecond)
+	raw, err := os.ReadFile(stdinDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), string(annexB(h264KeyAU(0xAA))), "cached IDR (param sets + IDR) must be forwarded as Annex-B")
+	assert.NotContains(t, string(raw), string([]byte{0x00, 0x00, 0x00, 0x01, 0x41}), "P-frames must be dropped")
+
+	args, err := os.ReadFile(argsDump)
+	require.NoError(t, err)
+	// argv is dumped newline-separated by the fixture.
+	assert.Contains(t, string(args), "-f\nh264\n", "codec must be probed from the keyframe AU")
+}
+
+func TestSampleFramesHub_ThrottlesToSampleFPS(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeStdinFFmpeg(t)
+	hub := streamhub.New()
+
+	// Seed the IDR cache BEFORE the sampler exists: the replayed keyframe is
+	// guaranteed to be IDR1 regardless of goroutine scheduling.
+	hub.Broadcast(1, h264KeyAU(0x01), true)
+
+	// fn parks on release so the sampler stays alive for the IDR2 broadcast.
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		cfg := Config{FFmpegPath: script, Env: []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump}}
+		_, err := sampleFramesHub(context.Background(), cfg, &stubHubSource{hub: hub}, 1,
+			func([]byte) bool { <-release; return false }, make([]byte, GridW*GridH))
+		done <- err
+	}()
+
+	// The dump carrying the full IDR1 proves the subscription + seed write
+	// happened — only then fire the same-window keyframe at the live path.
+	require.Eventually(t, func() bool {
+		raw, err := os.ReadFile(stdinDump)
+		return err == nil && bytes.Contains(raw, annexB(h264KeyAU(0x01)))
+	}, 5*time.Second, 20*time.Millisecond, "seed keyframe must be forwarded")
+
+	hub.Broadcast(2, h264KeyAU(0x02), true) // same sample window (fps=1 → 1s)
+	time.Sleep(100 * time.Millisecond)      // give the forwarder a chance to (wrongly) forward it
+	close(release)
+	require.NoError(t, <-done)
+
+	raw, err := os.ReadFile(stdinDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), string(bytesOf(0x01, 8)), "first keyframe forwarded")
+	assert.NotContains(t, string(raw), string(bytesOf(0x02, 8)), "keyframe within the sample interval must be throttled")
+}
+
+func TestSampleFramesHub_HEVCProbe(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeStdinFFmpeg(t)
+	hub := streamhub.New()
+
+	done := make(chan error, 1)
+	go func() {
+		cfg := Config{FFmpegPath: script, Env: []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump}}
+		_, err := sampleFramesHub(context.Background(), cfg, &stubHubSource{hub: hub}, 1,
+			func([]byte) bool { return false }, make([]byte, GridW*GridH))
+		done <- err
+	}()
+
+	hevcIDR := func(marker byte) [][]byte {
+		idr := append([]byte{(19 << 1) | 1, 0x01}, bytesOf(marker, 16)...) // IDR_W_RADL
+		return [][]byte{{(32 << 1) | 1, 0x01}, {(33 << 1) | 1, 0x01}, {(34 << 1) | 1, 0x01}, idr}
+	}
+	hub.Broadcast(1, hevcIDR(0xBB), true)
+	require.NoError(t, <-done)
+
+	require.Eventually(t, func() bool {
+		raw, err := os.ReadFile(stdinDump)
+		return err == nil && bytes.Contains(raw, annexB(hevcIDR(0xBB)))
+	}, 5*time.Second, 20*time.Millisecond)
+	args, err := os.ReadFile(argsDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(args), "-f\nhevc\n")
+	raw, err := os.ReadFile(stdinDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), string(annexB(hevcIDR(0xBB))))
+}
+
+func TestSampleFramesHub_NoKeyframeTimesOut(t *testing.T) {
+	t.Helper()
+	hub := streamhub.New()
+	cfg := Config{FFmpegPath: "/bin/true"}
+	_, err := sampleFramesHub(context.Background(), cfg, &stubHubSource{hub: hub}, 1,
+		func([]byte) bool { return true }, make([]byte, GridW*GridH))
+	require.Error(t, err, "a silent hub must fail the probe window, not hang")
+}
+
+func TestSampleFramesHub_ReleasesSubscription(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeStdinFFmpeg(t)
+	hub := streamhub.New()
+	hub.Broadcast(1, h264KeyAU(0x03), true)
+
+	before := hubSubSeq.Load()
+	_, err := sampleFramesHub(context.Background(),
+		Config{FFmpegPath: script, Env: []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump}},
+		&stubHubSource{hub: hub}, 1, func([]byte) bool { return false }, make([]byte, GridW*GridH))
+	require.NoError(t, err)
+
+	used := fmt.Sprintf("pixgate-hub-%d", before+1)
+	err = hub.SubscribeMsg(used, func(model.FrameMsg) {})
+	require.NoError(t, err, "one-shot subscription %q must be released", used)
+	hub.Unsubscribe(used)
+}
+
+// --- Manager-level source selection -------------------------------------------
+
+func TestManager_PrefersHubSource(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeStdinFFmpeg(t)
+	hub := streamhub.New()
+	hub.Broadcast(1, h264KeyAU(0x04), true)
+
+	var directResolved atomic.Int32
+	m := NewManager(Config{
+		FFmpegPath: script,
+		Env:        []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump},
+		HubResolver: func(context.Context, string) (HubSource, bool, error) {
+			return &stubHubSource{hub: hub}, true, nil
+		},
+		Resolver: func(context.Context, string) (Target, bool, error) {
+			directResolved.Add(1)
+			return Target{URL: "rtsp://example/sub"}, true, nil
+		},
+		Trigger: func(string, time.Duration) error { return nil },
+		Cameras: map[string]CameraConfig{"cam-1": {SampleFPS: 10, MinAreaPct: 1.5}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, m.Start(ctx))
+	defer cancel()
+
+	// The sampler runs asynchronously: wait for it to feed the fixture
+	// before tearing down.
+	require.Eventually(t, func() bool {
+		raw, err := os.ReadFile(stdinDump)
+		return err == nil && bytes.Contains(raw, bytesOf(0x04, 8))
+	}, 5*time.Second, 20*time.Millisecond, "hub sampler must forward the cached IDR to ffmpeg stdin")
+
+	cancel()
+	require.NoError(t, m.Stop())
+
+	assert.Zero(t, directResolved.Load(), "direct RTSP resolution must not run when a hub source is available")
+	raw, err := os.ReadFile(stdinDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), string(bytesOf(0x04, 8)))
+}
+
+func TestManager_HubUnavailableFallsBackToDirect(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	frameFile := filepath.Join(dir, "frames.bin")
+	require.NoError(t, os.WriteFile(frameFile, bytesOf(100, GridW*GridH*3), 0o644))
+
+	var triggered atomic.Int32
+	m := NewManager(Config{
+		FFmpegPath: "cat",
+		FFmpegArgs: func(string, float64) []string { return []string{frameFile} },
+		HubResolver: func(context.Context, string) (HubSource, bool, error) {
+			return nil, false, nil // e.g. xiaomi / push ingest — no shared sub pull
+		},
+		Resolver: func(context.Context, string) (Target, bool, error) {
+			return Target{URL: "rtsp://example/sub"}, true, nil
+		},
+		Trigger: func(string, time.Duration) error {
+			triggered.Add(1) // not expected to fire on flat frames; wired for realism
+			return nil
+		},
+		Cameras: map[string]CameraConfig{"cam-1": {SampleFPS: 10, MinAreaPct: 1.5}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, m.Start(ctx))
+	defer cancel()
+
+	// The sampler must be running the direct path: it drains frames.bin and
+	// idles at EOF without erroring the manager. Give it a moment, then stop.
+	require.Eventually(t, func() bool { return true }, 50*time.Millisecond, 10*time.Millisecond)
+	require.NoError(t, m.Stop())
+}

--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -12,6 +12,7 @@ package pixgate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -81,6 +82,15 @@ type Config struct {
 	FFmpegPath string
 	// FFmpegArgs allows tests to substitute a fake frame source binary.
 	FFmpegArgs func(url string, fps float64) []string
+	// HubResolver resolves a camera to the SHARED sub-stream hub source
+	// (preferred, #643): the sampler feeds ffmpeg over stdin instead of
+	// opening its own RTSP pull. ok=false → legacy direct sampler.
+	HubResolver func(ctx context.Context, cameraID string) (HubSource, bool, error)
+	// HubFFmpegArgs allows tests to substitute the stdin-decode invocation.
+	HubFFmpegArgs func(codec string) []string
+	// Env appends extra environment entries for the sampler binary (tests
+	// point fake ffmpeg fixtures at their dump files). Nil inherits.
+	Env []string
 	// FrameStallTimeout aborts a sampler whose ffmpeg produces no decoded
 	// frame for this long — a wedged network read inside ffmpeg never exits
 	// on its own (2026-09-02 incident: pixgate silent from 02:01 until the
@@ -391,11 +401,29 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 	ghostSamples := int(math.Ceil(cfg.GhostSecs * cfg.SampleFPS))
 	m.ensureRing(cameraID, cfg)
 
-	target, ok, err := m.cfg.Resolver(ctx, cameraID)
-	if err != nil || !ok || target.URL == "" || (target.Kind != "" && target.Kind != "rtsp") {
-		log.Warn("pixgate: no RTSP sub-stream target; gate disabled",
-			"ok", ok, "kind", target.Kind, "error", err)
-		return
+	// Source selection (#643): the SHARED sub-stream hub is preferred —
+	// ffmpeg reads sampled keyframes over stdin, no extra camera connection,
+	// decode bounded to the sample rate. Direct RTSP stays as the fallback
+	// (no hub resolver wired, no shared source, or an unsupported hub codec).
+	useHub := false
+	if m.cfg.HubResolver != nil {
+		if src, err := m.acquireHub(ctx, cameraID); err == nil && src.Hub() != nil {
+			src.Release() // the per-attempt acquire below re-establishes the reference
+			useHub = true
+		} else {
+			log.Debug("pixgate: shared hub unavailable, using direct RTSP", "error", err)
+		}
+	}
+
+	var target Target
+	if !useHub {
+		t, ok, err := m.cfg.Resolver(ctx, cameraID)
+		if err != nil || !ok || t.URL == "" || (t.Kind != "" && t.Kind != "rtsp") {
+			log.Warn("pixgate: no RTSP sub-stream target; gate disabled",
+				"ok", ok, "kind", t.Kind, "error", err)
+			return
+		}
+		target = t
 	}
 
 	engine := NewEngine(EngineConfig{
@@ -409,54 +437,78 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 	wasActive := false
 	wasSuppressed := false
 	backoff := time.Second
-	interval := time.Duration(float64(time.Second) / cfg.SampleFPS)
+
+	sample := func(gray []byte) bool {
+		now := time.Now()
+		// PTZ / external suppression window: drain the pipe, record the
+		// sample as invalid, keep the model untouched. The first frame
+		// after the window re-primes (the scene moved on purpose).
+		if until := m.suppressedUntil(cameraID); now.Before(until) {
+			wasSuppressed = true
+			m.recordFG(cameraID, now, 0, false)
+			return ctx.Err() == nil
+		}
+		if wasSuppressed {
+			engine.Reprime()
+			wasSuppressed = false
+			wasActive = false
+		}
+		res := engine.Process(gray)
+		if res == (EngineResult{}) {
+			// Prime frame — carries no activity evidence.
+			return ctx.Err() == nil
+		}
+		m.recordFG(cameraID, now, res.BlobAreaPct, !res.Flood && !res.Ghost)
+		if res.Ghost {
+			log.Info("pixgate: static foreground absorbed into background (ghost suppression)",
+				"area_pct", res.BlobAreaPct, "cx", res.CX, "cy", res.CY)
+		}
+		if res.Active {
+			// Every active sample re-arms the hold — continuous
+			// activity keeps full-rate, a single confirmation exits
+			// TIMELAPSE for at least Hold.
+			if terr := m.cfg.Trigger(cameraID, cfg.Hold); terr != nil {
+				log.Debug("pixgate trigger rejected", "error", terr)
+			}
+		}
+		if res.Active != wasActive || res.Active || res.Ghost {
+			if m.cfg.Bus != nil {
+				m.cfg.Bus.Publish(ctx, event.TopicPixgateActivity, Event{
+					CameraID: cameraID, Active: res.Active,
+					AreaPct: res.BlobAreaPct, CX: res.CX, CY: res.CY,
+					Flood: res.Flood, Ghost: res.Ghost, SampleSec: cfg.SampleFPS,
+				})
+			}
+		}
+		wasActive = res.Active
+		return ctx.Err() == nil
+	}
 
 	for ctx.Err() == nil {
-		n, err := sampleFrames(ctx, m.cfg, target, cfg.SampleFPS, func(gray []byte) bool {
-			now := time.Now()
-			// PTZ / external suppression window: drain the pipe, record the
-			// sample as invalid, keep the model untouched. The first frame
-			// after the window re-primes (the scene moved on purpose).
-			if until := m.suppressedUntil(cameraID); now.Before(until) {
-				wasSuppressed = true
-				m.recordFG(cameraID, now, 0, false)
-				return ctx.Err() == nil
+		var n int
+		var err error
+		if useHub {
+			var src HubSource
+			src, err = m.acquireHub(ctx, cameraID)
+			if err == nil {
+				n, err = sampleFramesHub(ctx, m.cfg, src, cfg.SampleFPS, sample, frame)
+				src.Release()
 			}
-			if wasSuppressed {
-				engine.Reprime()
-				wasSuppressed = false
-				wasActive = false
-			}
-			res := engine.Process(gray)
-			if res == (EngineResult{}) {
-				// Prime frame — carries no activity evidence.
-				return ctx.Err() == nil
-			}
-			m.recordFG(cameraID, now, res.BlobAreaPct, !res.Flood && !res.Ghost)
-			if res.Ghost {
-				log.Info("pixgate: static foreground absorbed into background (ghost suppression)",
-					"area_pct", res.BlobAreaPct, "cx", res.CX, "cy", res.CY)
-			}
-			if res.Active {
-				// Every active sample re-arms the hold — continuous
-				// activity keeps full-rate, a single confirmation exits
-				// TIMELAPSE for at least Hold.
-				if terr := m.cfg.Trigger(cameraID, cfg.Hold); terr != nil {
-					log.Debug("pixgate trigger rejected", "error", terr)
+			if errors.Is(err, ErrHubUnsupportedCodec) {
+				log.Warn("pixgate: hub codec unsupported (MJPEG sub stream?), falling back to direct RTSP sampler")
+				useHub = false
+				t, ok, rerr := m.cfg.Resolver(ctx, cameraID)
+				if rerr != nil || !ok || t.URL == "" || (t.Kind != "" && t.Kind != "rtsp") {
+					log.Warn("pixgate: no RTSP sub-stream target; gate disabled",
+						"ok", ok, "kind", t.Kind, "error", rerr)
+					return
 				}
+				target = t
+				continue
 			}
-			if res.Active != wasActive || res.Active || res.Ghost {
-				if m.cfg.Bus != nil {
-					m.cfg.Bus.Publish(ctx, event.TopicPixgateActivity, Event{
-						CameraID: cameraID, Active: res.Active,
-						AreaPct: res.BlobAreaPct, CX: res.CX, CY: res.CY,
-						Flood: res.Flood, Ghost: res.Ghost, SampleSec: cfg.SampleFPS,
-					})
-				}
-			}
-			wasActive = res.Active
-			return ctx.Err() == nil
-		}, frame)
+		} else {
+			n, err = sampleFrames(ctx, m.cfg, target, cfg.SampleFPS, sample, frame)
+		}
 		if ctx.Err() != nil {
 			return
 		}
@@ -470,7 +522,26 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 			backoff *= 2
 		}
 	}
-	_ = interval
+}
+
+// acquireHub resolves the camera's SHARED sub-stream source (refcounted —
+// Release exactly once per successful call).
+func (m *Manager) acquireHub(ctx context.Context, cameraID string) (HubSource, error) {
+	if m.cfg.HubResolver == nil {
+		return nil, errors.New("pixgate: no hub resolver wired")
+	}
+	src, ok, err := m.cfg.HubResolver(ctx, cameraID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok || src == nil {
+		return nil, fmt.Errorf("pixgate: camera %s has no shared sub-stream source", cameraID)
+	}
+	if src.Hub() == nil {
+		src.Release()
+		return nil, errors.New("pixgate: shared source carries no hub")
+	}
+	return src, nil
 }
 
 // sampleFrames runs one ffmpeg process to completion, feeding each decoded
@@ -569,4 +640,10 @@ func ffmpegArgs(target Target, fps float64) []string {
 		"-f", "rawvideo", "-pix_fmt", "gray",
 		"pipe:1",
 	}
+}
+
+// HasHubResolver reports whether the shared-hub sampler feed is wired —
+// observable wiring guard for the pkg/app regression tests (#643).
+func (m *Manager) HasHubResolver() bool {
+	return m.cfg.HubResolver != nil
 }

--- a/pkg/app/pixgate_wiring_test.go
+++ b/pkg/app/pixgate_wiring_test.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/pixgate"
+)
+
+// TestRunFree_PixgateHubResolverWired guards the #643 wiring: with a
+// pixgate-enabled camera the manager must be built with the shared-hub
+// resolver, or the sampler silently keeps opening its own RTSP pull + full
+// decode (the exact cost this issue removes). Same wiring-bug class as the
+// #653 onAction=nil lesson.
+func TestRunFree_PixgateHubResolverWired(t *testing.T) {
+	t.Helper()
+	cfg, _ := minimalConfig(t)
+	cfg.Cameras = []config.CameraConfig{{
+		ID:       "pg-cam",
+		Protocol: "rtsp",
+		Encoding: "h264",
+		URL:      "rtsp://127.0.0.1:1/sub", // unreachable is fine: nothing starts
+		Pixgate:  &config.CameraPixgateConfig{Enabled: true},
+	}}
+
+	a, err := RunFree(cfg, filepath.Join(cfg.Storage.RootDir, "mibee-nvr.yaml"))
+	if err != nil {
+		t.Fatalf("RunFree: %v", err)
+	}
+
+	svc := a.Get("pixgate")
+	if svc == nil {
+		t.Fatal("pixgate service not registered with a pixgate-enabled camera")
+	}
+	m, ok := svc.(*pixgate.Manager)
+	if !ok {
+		t.Fatalf("pixgate service is %T, want *pixgate.Manager", svc)
+	}
+	if !m.HasHubResolver() {
+		t.Fatal("pixgate manager has no hub resolver wired: sampler would keep its own RTSP pull + full-stream decode")
+	}
+}

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -16,12 +16,15 @@ import (
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/autodiscover"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/discovery"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/health"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/motion"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/pixgate"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/tierrec"
 )
 
@@ -246,11 +249,24 @@ func registerServices(a *App, deps *appDeps) error {
 	// sampled decode of enabled cameras' sub-streams; confirmed activity
 	// fires the recorder pixel trigger (TL exit + GOP flush + hold). ffmpeg
 	// is optional — without it the service start is a no-op WARN.
+	//
+	// The sampler prefers the SHARED sub-stream hub (#643): ffmpeg reads
+	// sampled keyframes over stdin from the same refcounted pull the live
+	// quality=sub egress uses — no duplicate camera connection, decode
+	// bounded to the sample rate instead of the whole stream. Direct RTSP
+	// stays the fallback (xiaomi / push ingest / MJPEG subs).
 	if deps.camMgr != nil {
 		cams := pixgateCameras(deps.cfg)
 		if len(cams) > 0 {
 			m := pixgate.NewManager(pixgate.Config{
 				FFmpegPath: resolveFFmpegPath(deps.cfg.Transcoding.FFmpegPath),
+				HubResolver: func(ctx context.Context, cameraID string) (pixgate.HubSource, bool, error) {
+					src, err := deps.camMgr.AcquireSubStream(ctx, cameraID)
+					if err != nil {
+						return nil, false, err
+					}
+					return &subStreamHubSource{src: src, camMgr: deps.camMgr, cameraID: cameraID}, true, nil
+				},
 				Resolver: func(ctx context.Context, cameraID string) (pixgate.Target, bool, error) {
 					t, ok, err := deps.camMgr.ResolveSubStreamTarget(ctx, cameraID)
 					if err != nil || !ok {
@@ -814,3 +830,15 @@ func (p pixgateFGSource) SegmentFG(cameraID string, start, end time.Time) (motio
 		Coverage:    s.Coverage,
 	}, true
 }
+
+// subStreamHubSource adapts the refcounted substream.Source onto
+// pixgate.HubSource: Release drops the camera-manager reference so the shared
+// pull stops after its idle timeout when nobody else holds it (#643).
+type subStreamHubSource struct {
+	src      *substream.Source
+	camMgr   *camera.CameraManager
+	cameraID string
+}
+
+func (s *subStreamHubSource) Hub() *streamhub.StreamHub { return s.src.Hub() }
+func (s *subStreamHubSource) Release()                  { s.camMgr.ReleaseSubStream(s.cameraID) }


### PR DESCRIPTION
## Summary

Closes #643. The pixgate sampler's ffmpeg used to open its **own RTSP connection** to the camera's sub stream and decode **every frame** (the `fps=1` filter only drops output, not decode work) — measured ~16% of one core, 24/7, plus a duplicate camera connection competing for connection-limited devices (ESP32-class).

### Approach

The issue's preferred fix (extract from recorded segments) would add 30s+ latency to the gate trigger, degrading its core job (arming full-rate recording on activity), and pure-Go in-process decode doesn't exist for H.264/H.265. This PR implements the issue's option-2 shape with ffmpeg kept strictly as the decoder:

- The sampler now prefers the **shared sub-stream hub** — the same refcounted `substream.Source` pull that the live `quality=sub` egress uses (`AcquireSubStream`/`ReleaseSubStream`). The camera never sees a second connection when the pull is already active.
- ffmpeg reads **stdin only**: the sampler subscribes to the hub, forwards **keyframe AUs only** (Annex-B with param sets — the hub's cached-IDR replay guarantees a decodable seed) at most one per sample interval. Decode cost collapses from the whole stream to ~`sample_fps` frames/sec. There is no network read inside ffmpeg to wedge (the 2026-09-02 stall class), though the stall watchdog is kept.
- Codec is probed from the first keyframe AU (H.264 → `-f h264`, H.265 → `-f hevc`).
- **Fallback preserved**: no hub resolver hit, no shared source, or an unsupported hub codec (e.g. MJPEG sub) → the direct-RTSP sampler path runs unchanged (sticky per run after the codec probe fails).
- The hub callback never blocks the drain goroutine (buffered channel + drop); unified cleanup: Unsubscribe → close feed → forwarder join → kill.

### Tests (TDD, hermetic)

- Pure: stdin args (no `-nostdin`/`-rtsp_transport`), codec probe, Annex-B encoding.
- Fixture-based (`cat <&3` dump + timed frame emitter; the fd-3 dance works around non-interactive sh redirecting background-job stdin to /dev/null): keyframes-only forwarding, sample-rate throttle, HEVC probe, silent-hub timeout, subscription release.
- Manager-level: hub source preferred (direct resolver never called), hub-unavailable fallback, and `TestRunFree_PixgateHubResolverWired` guarding the production wiring (#653-class guard).

`go test -race ./internal/pixgate/ ./pkg/app/` — 87 passed; lint clean.

### Note on acceptance

"M5 上不再有常驻 ffmpeg 抽帧子进程" — ffmpeg is still resident **while pixgate is armed** (it is the decoder), but now decodes ~1 fps of keyframes instead of the full stream and opens no extra camera connection. Real-machine validation on M5 belongs to the observation window, same as #642.

Closes #643
