### PR TITLE
fix(pixgate): batch-close hub sampler stdin so EOF-gated ffmpeg flushes frames (#688)

### DIFF
--- a/internal/pixgate/hub_source.go
+++ b/internal/pixgate/hub_source.go
@@ -51,6 +51,14 @@ const (
 	// stderrCap bounds ffmpeg's stderr capture (loglevel error keeps it tiny;
 	// the cap is a paranoia guard for spammy builds).
 	stderrCap = 8 << 10
+	// defaultHubBatchWindow is how long one hub-fed ffmpeg batch keeps its
+	// stdin open before closing (issue #688): real ffmpeg builds flush
+	// decoded rawvideo only at stdin EOF, so the sampler runs in bounded
+	// batches — feed keyframes for the window, close stdin, drain the
+	// flushed frames, let the run loop spawn the next batch. Spawn cost is
+	// ~tens of ms per multi-second batch, and sample latency stays bounded
+	// by window + flush delay.
+	defaultHubBatchWindow = 5 * time.Second
 )
 
 var hubSubSeq atomic.Int64
@@ -197,8 +205,13 @@ probe:
 	}
 
 	// Forwarder: seed with the probe keyframe, then throttle live keyframes
-	// to the sample rate. Exits when auCh closes (after Unsubscribe) or the
-	// stdin write breaks (ffmpeg gone).
+	// to the sample rate. Exits when auCh closes (after Unsubscribe), the
+	// batch window elapses (#688: closing stdin makes ffmpeg flush its
+	// buffered decoded frames), or the stdin write breaks (ffmpeg gone).
+	batchWindow := cfg.HubBatchWindow
+	if batchWindow <= 0 {
+		batchWindow = defaultHubBatchWindow
+	}
 	fwdDone = make(chan struct{})
 	go func() {
 		defer close(fwdDone)
@@ -211,17 +224,29 @@ probe:
 			return
 		}
 		last := time.Now()
-		for m := range auCh {
-			if !m.IsKeyframe {
-				continue
-			}
-			if time.Since(last) < interval {
-				continue
-			}
-			if _, err := stdin.Write(annexB(m.AU)); err != nil {
+		batch := time.NewTimer(batchWindow)
+		defer batch.Stop()
+		for {
+			select {
+			case m, ok := <-auCh:
+				if !ok {
+					return
+				}
+				if !m.IsKeyframe {
+					continue
+				}
+				if time.Since(last) < interval {
+					continue
+				}
+				if _, err := stdin.Write(annexB(m.AU)); err != nil {
+					return
+				}
+				last = time.Now()
+			case <-batch.C:
+				// Batch window elapsed: close stdin (the deferred Close above)
+				// so an EOF-gated ffmpeg flushes its decoded frames (#688).
 				return
 			}
-			last = time.Now()
 		}
 	}()
 
@@ -260,6 +285,13 @@ probe:
 			}
 			if ctx.Err() != nil {
 				return n, ctx.Err()
+			}
+			// #688 batch-close: stdin closed at the window boundary → ffmpeg
+			// flushed its frames and exited. EOF with a silent stderr is a
+			// clean batch completion; stderr content still means a decode
+			// failure the caller must see (and back off from).
+			if (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) && stderr.String() == "" {
+				return n, nil
 			}
 			return n, fmt.Errorf("ffmpeg stdin decode ended: %w; stderr: %s", err, stderr.String())
 		}

--- a/internal/pixgate/hub_source_test.go
+++ b/internal/pixgate/hub_source_test.go
@@ -110,6 +110,52 @@ func writeFakeStdinFFmpeg(t *testing.T) (script string, stdinDump, argsDump stri
 	return script, filepath.Join(dir, "stdin.bin"), filepath.Join(dir, "args.txt")
 }
 
+// eofGatedFFmpeg emulates the REAL field behavior from issue #688 (M5
+// ffmpeg 7.1.5): with `-f hevc -i pipe:0` and a held-open stdin, decoded
+// rawvideo frames stay buffered inside ffmpeg — stdout only carries them
+// AFTER stdin reaches EOF. The eager fakeStdinFFmpeg above never trips this,
+// which is exactly why CI stayed green while the field sampler stalled.
+const eofGatedFFmpeg = `#!/bin/sh
+printf '%s\n' "$@" >> "$ARGS_DUMP"
+exec 3<&0
+cat <&3 >> "$STDIN_DUMP"
+dd if=/dev/zero bs=19200 count=3 2>/dev/null
+`
+
+func writeFakeEOFGatedFFmpeg(t *testing.T) (script string, stdinDump, argsDump string) {
+	t.Helper()
+	dir := t.TempDir()
+	script = filepath.Join(dir, "eof-gated-ffmpeg")
+	require.NoError(t, os.WriteFile(script, []byte(eofGatedFFmpeg), 0o755))
+	return script, filepath.Join(dir, "stdin.bin"), filepath.Join(dir, "args.txt")
+}
+
+// TestSampleFramesHub_BatchCloseFlushesEOFGatedDecoder pins issue #688: a
+// single sampleFramesHub call must deliver decoded frames even when the
+// decoder only flushes at stdin EOF — i.e. the feed must close stdin within
+// the batch window instead of holding the pipe open for the whole run.
+func TestSampleFramesHub_BatchCloseFlushesEOFGatedDecoder(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeEOFGatedFFmpeg(t)
+	hub := streamhub.New()
+	hub.Broadcast(1, h264KeyAU(0xCC), true) // cached-IDR replay feeds the probe
+
+	cfg := Config{
+		FFmpegPath:        script,
+		Env:               []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump},
+		FrameStallTimeout: 4 * time.Second, // tight: the default 30s would make the pre-fix failure slow
+		HubBatchWindow:    time.Second,
+	}
+	n, err := sampleFramesHub(context.Background(), cfg, &stubHubSource{hub: hub}, 1,
+		func([]byte) bool { return true }, make([]byte, GridW*GridH))
+	require.NoError(t, err, "EOF-gated decoder (issue #688): stdin must be batch-closed to flush frames, not held open until the stall watchdog kills ffmpeg")
+	assert.GreaterOrEqual(t, n, 1, "flushed frames must be decoded and delivered")
+
+	raw, err := os.ReadFile(stdinDump)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), string(annexB(h264KeyAU(0xCC))), "seed keyframe must still be forwarded")
+}
+
 // --- sampleFramesHub ----------------------------------------------------------
 
 func TestSampleFramesHub_ForwardsKeyframesOnlyAsAnnexB(t *testing.T) {

--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -96,10 +96,17 @@ type Config struct {
 	// on its own (2026-09-02 incident: pixgate silent from 02:01 until the
 	// 05:09 service restart). <=0 → 30s.
 	FrameStallTimeout time.Duration
-	Resolver          Resolver
-	Trigger           Trigger
-	Bus               Publisher
-	Log               *slog.Logger
+	// HubBatchWindow bounds how long ONE hub-fed ffmpeg batch keeps its
+	// stdin open before closing it (issue #688: real ffmpeg builds buffer
+	// decoded rawvideo until stdin EOF — an indefinitely-open pipe yields
+	// zero stdout frames and trips the stall watchdog forever; observed on
+	// M5 ffmpeg 7.1.5). The batch closes, the buffered frames flush, and
+	// the caller's run loop respawns the next batch. <=0 → defaultHubBatchWindow.
+	HubBatchWindow time.Duration
+	Resolver       Resolver
+	Trigger        Trigger
+	Bus            Publisher
+	Log            *slog.Logger
 	// Cameras is the enabled set, refreshed via SetCameras.
 	Cameras map[string]CameraConfig
 }
@@ -511,6 +518,13 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 		}
 		if ctx.Err() != nil {
 			return
+		}
+		if err == nil && n > 0 {
+			// #688 batch-close: a hub batch ran to completion and delivered
+			// frames — respawn the next batch immediately, no backoff (the
+			// batch window already paces the loop).
+			backoff = time.Second
+			continue
 		}
 		log.Warn("pixgate sampler stopped", "frames", n, "error", err, "retry_in", backoff)
 		select {


### PR DESCRIPTION
Fixes #688.

## Root cause (field-proven on M5)

Real ffmpeg builds (M5 7.1.5) buffer decoded rawvideo and only carry it on stdout **after stdin reaches EOF**. The #683 hub sampler held the pipe open for the whole run, so stdout stayed silent forever → the 30s stall watchdog killed ffmpeg → permanent `frames=0` stall loop (one WARN every ~62s since the first #683 deploy). CI never saw it because the test fixture emitted frames *while* stdin was open — the opposite of the real decoder's behavior.

## Fix — bounded batches

- `sampleFramesHub` now feeds keyframes for `HubBatchWindow` (new config, default 5s), then **closes stdin**: the EOF-gated decoder flushes its frames, the read loop drains them, and `runCamera` respawns the next batch immediately (no backoff on a clean batch — the window already paces the loop).
- EOF with silent stderr = clean batch completion; stderr content still surfaces as an error.
- Stall watchdog unchanged as the pathological-case guard.

## Test (TDD)

`TestSampleFramesHub_BatchCloseFlushesEOFGatedDecoder` — new `eofGatedFFmpeg` fixture reproduces the field behavior exactly (frames only after stdin EOF). Fails on pre-fix code with the stall error; green after.

## M5 field verification (v0.12.0-23-g76e140f3, 2026-09-03 21:19–21:30)

- Zero `pixgate sampler stopped` warnings post-deploy (pre-fix: one per ~62s guaranteed; a zero-frame clean batch would also WARN by construction).
- Batch ffmpeg processes cycling continuously; caught a live batch exiting with `wchar=57600` = exactly 3 decoded gray frames on stdout.
- 视通 (cam-5b24e253) pixel gate back online — recordings/tierrec unaffected throughout.