### PR TITLE
fix(observability): log denoising driven by M5 field evidence (#685)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -35,7 +36,7 @@ import (
 	"github.com/mickeyzzc/gb28181-go/platform"
 )
 
-var logger = slog.Default().With("component", "api")
+var logger = slogx.Component("api")
 
 var appStartTime = time.Now()
 

--- a/internal/api/handlers_mjpeg.go
+++ b/internal/api/handlers_mjpeg.go
@@ -3,17 +3,18 @@ package api
 import (
 	"fmt"
 	"hash/crc32"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/recorder"
 )
 
-var mjpegLogger = slog.Default().With("component", "mjpeg-proxy")
+var mjpegLogger = slogx.Component("mjpeg-proxy")
 
 // handleMjpegStreamURL returns the MJPEG stream URL for a camera.
 // GET /api/cameras/{id}/stream.mjpeg

--- a/internal/api/handlers_stream.go
+++ b/internal/api/handlers_stream.go
@@ -3,8 +3,9 @@ package api
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -257,7 +258,7 @@ func (h *HLSStreamHandler) StopStream(camID string) error {
 	return h.StopStreamWithRecorder(camID, nil)
 }
 
-var streamLogger = slog.Default().With("component", "stream-handler")
+var streamLogger = slogx.Component("stream-handler")
 
 // unwrapper is an interface for recorders that delegate to an inner recorder.
 // This avoids importing recorder.ONVIFRecorder directly in the stream handler.

--- a/internal/api/handlers_xiaomi_audio.go
+++ b/internal/api/handlers_xiaomi_audio.go
@@ -5,14 +5,15 @@
 package api
 
 import (
-	"log/slog"
 	"net/http"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/xiaomi"
 	"github.com/go-chi/chi/v5"
 )
 
-var xiaomiAudioLogger = slog.Default().With("component", "xiaomi-audio")
+var xiaomiAudioLogger = slogx.Component("xiaomi-audio")
 
 // startTwoWayAudioResponse is returned on successful two-way audio start.
 type startTwoWayAudioResponse struct {

--- a/internal/autodiscover/adder.go
+++ b/internal/autodiscover/adder.go
@@ -21,10 +21,11 @@ package autodiscover
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -33,7 +34,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var logger = slog.Default().With("component", "autodiscover")
+var logger = slogx.Component("autodiscover")
 
 // dedupWindow suppresses repeated discovery of the same device within this
 // interval. WS-Discovery Hello is sent periodically (some firmware every ~30s)

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -14,10 +14,11 @@ package camera
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -33,7 +34,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
 
-var logger = slog.Default().With("component", "camera-manager")
+var logger = slogx.Component("camera-manager")
 
 // CameraUpdate holds optional fields for updating a camera.
 // Only non-nil fields will be applied.

--- a/internal/cleanup/archive_deleter.go
+++ b/internal/cleanup/archive_deleter.go
@@ -7,13 +7,14 @@ package cleanup
 
 import (
 	"context"
-	"log/slog"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var archiveDeleterLogger = slog.Default().With("component", "archive-deleter")
+var archiveDeleterLogger = slogx.Component("archive-deleter")
 
 // ArchiveDeleter polls for pending archive cleanup tasks and processes them
 // serially (disk I/O is the bottleneck). Tasks are tracked in the

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -11,10 +11,11 @@ package cleanup
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -23,7 +24,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var logger = slog.Default().With("component", "cleanup")
+var logger = slogx.Component("cleanup")
 
 // CleanupManager handles periodic cleanup of old recordings.
 // It supports two cleanup strategies:

--- a/internal/flv/manager.go
+++ b/internal/flv/manager.go
@@ -3,12 +3,13 @@ package flv
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/frametrace"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
@@ -17,7 +18,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var flvLogger = slog.Default().With("component", "flv-manager")
+var flvLogger = slogx.Component("flv-manager")
 
 const (
 	defaultMaxViewers   = 10

--- a/internal/ftp/server.go
+++ b/internal/ftp/server.go
@@ -5,12 +5,13 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	ftpserverlib "github.com/fclairamb/ftpserverlib"
 	"github.com/google/uuid"
@@ -20,7 +21,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var logger = slog.Default().With("component", "ftp")
+var logger = slogx.Component("ftp")
 
 // Server implements an FTP server for camera file uploads using ftpserverlib.
 // It satisfies the ftpserverlib.MainDriver interface for authentication and

--- a/internal/health/auto_remediate.go
+++ b/internal/health/auto_remediate.go
@@ -331,7 +331,10 @@ func (r *AutoRemediator) IsBlacklisted(cameraID string) bool {
 func (r *AutoRemediator) CheckAll(statuses map[string]string) {
 	for cameraID, status := range statuses {
 		if err := r.Check(cameraID, status); err != nil {
-			slog.Warn("auto-remediate skipped", "camera_id", cameraID, "error", err)
+			// Debug since #685: blacklisted cameras repeat this every scan
+			// cycle (10% of M5's 24h volume at WARN); state transitions are
+			// already logged where they happen.
+			slog.Debug("auto-remediate skipped", "camera_id", cameraID, "error", err)
 		}
 	}
 }

--- a/internal/health/auto_remediate_test.go
+++ b/internal/health/auto_remediate_test.go
@@ -160,7 +160,8 @@ func TestAutoRemediator_ReconnectingBelowTimeoutIgnored(t *testing.T) {
 // restart" — the blacklist gate below blocks the restart moments later, so on
 // the 10s health tick the announcement is a false claim spammed forever
 // (production: 303 log lines/hour, all no-ops). The skip stays observable as
-// exactly one line per tick: CheckAll's "auto-remediate skipped" WARN carrying
+// exactly one line per tick: CheckAll's "auto-remediate skipped" Debug line
+// (#685 demoted from WARN — blacklisted cameras repeat it every scan) carrying
 // the blacklist expiry. The periodic blacklist rescan must still dispatch.
 //
 // Sequential (no t.Parallel): swaps the global default slog logger.
@@ -179,7 +180,7 @@ func TestAutoRemediator_BlacklistedReconnectingNoFalseRestartAnnouncement(t *tes
 
 	var buf bytes.Buffer
 	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	defer slog.SetDefault(prev)
 
 	// One health tick for a blacklisted, reconnecting camera — the exact

--- a/internal/hls/manager.go
+++ b/internal/hls/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gohlslib/v2"
 	"github.com/bluenviron/gohlslib/v2/pkg/codecs"
@@ -30,7 +31,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var hlsLogger = slog.Default().With("component", "hls-manager")
+var hlsLogger = slogx.Component("hls-manager")
 
 const (
 	defaultIdleTimeout    = 60 * time.Second

--- a/internal/livetranscode/transcoder.go
+++ b/internal/livetranscode/transcoder.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -14,6 +13,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
@@ -84,7 +85,7 @@ type LiveTranscoder struct {
 	monitorWg sync.WaitGroup
 }
 
-var ltLogger = slog.Default().With("component", "livetranscode")
+var ltLogger = slogx.Component("livetranscode")
 
 // ---------------------------------------------------------------------------
 // Constructor

--- a/internal/merge/manager.go
+++ b/internal/merge/manager.go
@@ -12,13 +12,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var logger = slog.Default().With("component", "merge-manager")
+var logger = slogx.Component("merge-manager")
 
 // MergeStatus holds the current status of the merge manager.
 type MergeStatus struct {

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -3,10 +3,11 @@ package merge
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -16,7 +17,7 @@ import (
 )
 
 // rollingLogger is the slog handle for the rolling merge coordinator.
-var rollingLogger = slog.Default().With("component", "rolling-merge")
+var rollingLogger = slogx.Component("rolling-merge")
 
 // backfillBatchPauseForArch returns the inter-batch pause for backfill merges.
 // On ARM (RPi 3B: 4× Cortex-A53 @ 1.2GHz, USB-bound IO) we slow down to avoid

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -3,17 +3,18 @@ package middleware
 import (
 	"context"
 	"encoding/base64"
-	"log/slog"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"golang.org/x/crypto/bcrypt"
 )
 
-var logger = slog.Default().With("component", "auth")
+var logger = slogx.Component("auth")
 
 // IsLocalIP reports whether addr is a loopback address of this machine
 // (127.0.0.1 or ::1). addr may be a bare IP ("127.0.0.1"), an IPv6 address

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -50,8 +50,18 @@ func RequestLogger(logger *slog.Logger, skipPaths ...string) func(next http.Hand
 			start := time.Now()
 			ww := &StatusRecorder{ResponseWriter: w, Status: http.StatusOK}
 			next.ServeHTTP(ww, r.WithContext(ctx))
+			// Level by outcome (#685, M5 field evidence: routine 2xx polling
+			// was 26% of the 24h log volume): success is Debug material, a
+			// 4xx deserves a look, a 5xx is a real problem.
+			level := slog.LevelDebug
+			switch {
+			case ww.Status >= http.StatusInternalServerError:
+				level = slog.LevelWarn
+			case ww.Status >= http.StatusBadRequest:
+				level = slog.LevelInfo
+			}
 			logger.LogAttrs(
-				ctx, slog.LevelInfo, "request",
+				ctx, level, "request",
 				slog.String("trace_id", tid),
 				slog.String("method", r.Method),
 				slog.String("path", normalizePath(r.URL.Path)),

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -14,7 +14,7 @@ func TestRequestLoggerLogsRequest(t *testing.T) {
 	t.Helper()
 	t.Parallel()
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -28,16 +28,60 @@ func TestRequestLoggerLogsRequest(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, buf.String(), "level=DEBUG")
 	require.Contains(t, buf.String(), "method=GET")
 	require.Contains(t, buf.String(), "path=/api/test")
 	require.Contains(t, buf.String(), "status=200")
+}
+
+// TestRequestLoggerLevels pins the #685 denoising contract: routine success
+// is Debug (M5 field evidence: 2xx polling was 26% of the 24h volume at
+// INFO), client errors stay visible, server errors escalate to WARN.
+func TestRequestLoggerLevels(t *testing.T) {
+	t.Helper()
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		status     int
+		wantLevel  string
+		wantAtInfo bool
+	}{
+		{"success-200", http.StatusOK, "DEBUG", false},
+		{"not-modified-304", http.StatusNotModified, "DEBUG", false},
+		{"not-found-404", http.StatusNotFound, "INFO", true},
+		{"boom-500", http.StatusInternalServerError, "WARN", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/api/x", nil)
+			RequestLogger(logger)(next).ServeHTTP(httptest.NewRecorder(), req)
+			require.Contains(t, buf.String(), "level="+tc.wantLevel)
+
+			var infoBuf bytes.Buffer
+			infoLogger := slog.New(slog.NewTextHandler(&infoBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			RequestLogger(infoLogger)(next).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/x", nil))
+			if tc.wantAtInfo {
+				require.NotEmpty(t, infoBuf.String(), "must stay visible at default info level")
+			} else {
+				require.Empty(t, infoBuf.String(), "routine responses must be silent at default info level")
+			}
+		})
+	}
 }
 
 func TestRequestLoggerSkipPaths(t *testing.T) {
 	t.Helper()
 	t.Parallel()
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -65,7 +109,7 @@ func TestRequestLoggerNormalizesPath(t *testing.T) {
 	t.Helper()
 	t.Parallel()
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -115,7 +159,7 @@ func TestRequestLoggerLogsPostRequest(t *testing.T) {
 	t.Helper()
 	t.Parallel()
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/internal/mqtt/actions.go
+++ b/internal/mqtt/actions.go
@@ -3,8 +3,9 @@ package mqtt
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
@@ -35,7 +36,7 @@ const (
 // start can legitimately take seconds; 30s leaves room for slow devices).
 const actionTimeout = 30 * time.Second
 
-var actionLogger = slog.Default().With("component", "mqtt-trigger")
+var actionLogger = slogx.Component("mqtt-trigger")
 
 // NewActionDispatcher maps MQTT trigger actions to camera lifecycle
 // operations and returns the onAction callback for NewClient. Each action

--- a/internal/mqtt/client.go
+++ b/internal/mqtt/client.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/backoff"
 )
 
-var clientLogger = slog.Default().With("component", "mqtt")
+var clientLogger = slogx.Component("mqtt")
 
 // triggerMessage is the JSON payload of a camera trigger event.
 type triggerMessage struct {

--- a/internal/mqtt/status_publisher.go
+++ b/internal/mqtt/status_publisher.go
@@ -2,8 +2,9 @@ package mqtt
 
 import (
 	"context"
-	"log/slog"
 	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 )
@@ -29,7 +30,7 @@ var statusTopics = []string{
 	event.TopicCameraSnapshot,
 }
 
-var statusLogger = slog.Default().With("component", "mqtt-status")
+var statusLogger = slogx.Component("mqtt-status")
 
 // StatusPublisher forwards whitelisted event-bus topics to MQTT so smart-home
 // platforms (Home Assistant etc.) can consume NVR state without REST polling

--- a/internal/onvif/client.go
+++ b/internal/onvif/client.go
@@ -5,16 +5,17 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
-var logger = slog.Default().With("component", "onvif-client")
+var logger = slogx.Component("onvif-client")
 
 var httpClient = &http.Client{Timeout: 15 * time.Second}
 

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
-var eventLogger = slog.Default().With("component", "onvif-events")
+var eventLogger = slogx.Component("onvif-events")
 
 // ErrEventsNotSupported indicates the device does not implement the ONVIF event
 // PullPoint subscription (some cameras advertise the event service in

--- a/internal/onvif/imaging.go
+++ b/internal/onvif/imaging.go
@@ -6,15 +6,16 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
-var imagingLogger = slog.Default().With("component", "onvif-imaging")
+var imagingLogger = slogx.Component("onvif-imaging")
 
 // ImagingControllerImpl implements ImagingController by delegating to onvif-go's imaging service
 // via raw SOAP requests.

--- a/internal/onvif/ptz.go
+++ b/internal/onvif/ptz.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"log/slog"
 	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
 )
 
-var ptzLogger = slog.Default().With("component", "onvif-ptz")
+var ptzLogger = slogx.Component("onvif-ptz")
 
 // PTZControllerImpl implements PTZController by delegating to onvif-go's PTZ service.
 // It wraps an onvif-go Client and stores the profile token internally.

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -2,12 +2,13 @@ package recorder
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"runtime"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
@@ -18,7 +19,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var gb28181Logger = slog.Default().With("component", "gb28181-recorder")
+var gb28181Logger = slogx.Component("gb28181-recorder")
 
 // GB28181Config configures the passive GB28181 recorder. It mirrors
 // IngestConfig: Store/DB/Metrics/EventBus wire the recorder into the normal

--- a/internal/recorder/h264.go
+++ b/internal/recorder/h264.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
@@ -26,7 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var h264Logger = slog.Default().With("component", "h264-recorder")
+var h264Logger = slogx.Component("h264-recorder")
 
 // SegmentStore abstracts the storage operations needed by the recorder.
 // *storage.Manager satisfies this interface.

--- a/internal/recorder/h265.go
+++ b/internal/recorder/h265.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
@@ -26,7 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var h265Logger = slog.Default().With("component", "h265-recorder")
+var h265Logger = slogx.Component("h265-recorder")
 
 // H265Config is a type alias for BaseConfig.
 // This allows flat struct literals (e.g., H265Config{CameraID: "..."}) while

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
@@ -26,7 +27,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var httpJpegLogger = slog.Default().With("component", "http-jpeg-recorder")
+var httpJpegLogger = slogx.Component("http-jpeg-recorder")
 
 // HTTPJPEGConfig holds configuration for the HTTP JPEG recorder.
 type HTTPJPEGConfig struct {

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -2,13 +2,14 @@ package recorder
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
@@ -18,7 +19,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var ingestLogger = slog.Default().With("component", "ingest-recorder")
+var ingestLogger = slogx.Component("ingest-recorder")
 
 // IngestConfig holds configuration for the IngestRecorder.
 //

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
@@ -28,7 +29,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var mjpegLogger = slog.Default().With("component", "mjpeg-recorder")
+var mjpegLogger = slogx.Component("mjpeg-recorder")
 
 // MJPEGConfig holds configuration for the MJPEG recorder.
 type MJPEGConfig struct {

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -3,12 +3,13 @@ package recorder
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
@@ -21,7 +22,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var onvifRecLogger = slog.Default().With("component", "onvif-recorder")
+var onvifRecLogger = slogx.Component("onvif-recorder")
 
 // ONVIFConfig holds configuration for the ONVIF recorder.
 type ONVIFConfig struct {

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,13 +16,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
 )
 
-var timelapseLogger = slog.Default().With("component", "timelapse-recorder")
+var timelapseLogger = slogx.Component("timelapse-recorder")
 
 // TimelapseRecorderConfig holds configuration for the timelapse recorder.
 type TimelapseRecorderConfig struct {

--- a/internal/rediscovery/rediscovery.go
+++ b/internal/rediscovery/rediscovery.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/url"
 	"strconv"
@@ -31,11 +30,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
 )
 
-var logger = slog.Default().With("component", "rediscovery")
+var logger = slogx.Component("rediscovery")
 
 // Sentinel errors.
 var (

--- a/internal/relay/engine.go
+++ b/internal/relay/engine.go
@@ -3,12 +3,13 @@ package relay
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/backoff"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/livetranscode"
@@ -17,7 +18,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
 
-var engineLogger = slog.Default().With("component", "relay-engine")
+var engineLogger = slogx.Component("relay-engine")
 
 const (
 	// relayStallAfter is how long a target may report streaming with zero

--- a/internal/relay/manager.go
+++ b/internal/relay/manager.go
@@ -2,9 +2,10 @@ package relay
 
 import (
 	"context"
-	"log/slog"
 	"sort"
 	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -12,7 +13,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/transcoding"
 )
 
-var managerLogger = slog.Default().With("component", "relay-manager")
+var managerLogger = slogx.Component("relay-manager")
 
 // CameraHubProvider returns the StreamHub for a camera id (or nil). Backed by
 // CameraManager.GetHub in production.

--- a/internal/rtmp/server.go
+++ b/internal/rtmp/server.go
@@ -3,11 +3,12 @@ package rtmp
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/bluenviron/gortmplib"
 	"github.com/bluenviron/gortmplib/pkg/codecs"
@@ -16,7 +17,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var logger = slog.Default().With("component", "rtmp-server")
+var logger = slogx.Component("rtmp-server")
 
 // StreamKeyResolver maps a stream key to a camera ID.
 // Returns empty string if the stream key is not recognized.

--- a/internal/rtsp/server.go
+++ b/internal/rtsp/server.go
@@ -10,13 +10,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"math/rand"
 	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/pion/rtp"
 
@@ -31,7 +32,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var rtspLogger = slog.Default().With("component", "rtsp-server")
+var rtspLogger = slogx.Component("rtsp-server")
 
 // StreamInfo is the current live-stream state of one camera, as resolved by
 // the StreamProvider on demand.

--- a/internal/slogx/slogx.go
+++ b/internal/slogx/slogx.go
@@ -1,0 +1,65 @@
+// Package slogx provides loggers that survive a late slog.SetDefault.
+//
+// Package-level `var x = slog.Default().With(...)` loggers initialize before
+// main() installs the configured handler. The pristine default handler they
+// capture writes through the log package, which SetDefault has redirected
+// into the new handler — every record then reappears wrapped as
+// `level=INFO msg="ERROR <original line with attrs inlined>"` (wrong level,
+// attrs unparseable). On the M5 production node this mangled ~32% of all log
+// output (issue #685). Component resolves slog.Default() at CALL time, so
+// the configured handler, level, and format always apply.
+package slogx
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Component returns a logger tagged component=name that defers handler
+// resolution to emit time. Drop-in for `slog.Default().With("component", n)`
+// in package-level var declarations.
+func Component(name string) *slog.Logger {
+	return slog.New(&deferredHandler{attrs: []slog.Attr{slog.String("component", name)}})
+}
+
+// deferredHandler forwards records to slog.Default()'s CURRENT handler,
+// prepending its accumulated attrs. Our loggers are never installed as the
+// default, so Default() resolves to a real sink — no recursion.
+type deferredHandler struct {
+	attrs       []slog.Attr
+	groupPrefix string
+}
+
+func (h *deferredHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return slog.Default().Handler().Enabled(ctx, level)
+}
+
+func (h *deferredHandler) Handle(ctx context.Context, r slog.Record) error {
+	if len(h.attrs) > 0 {
+		r.AddAttrs(h.attrs...)
+	}
+	return slog.Default().Handler().Handle(ctx, r)
+}
+
+func (h *deferredHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	merged := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	merged = append(merged, h.attrs...)
+	for _, a := range attrs {
+		if h.groupPrefix != "" {
+			a.Key = h.groupPrefix + "." + a.Key
+		}
+		merged = append(merged, a)
+	}
+	return &deferredHandler{attrs: merged, groupPrefix: h.groupPrefix}
+}
+
+func (h *deferredHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	prefix := name
+	if h.groupPrefix != "" {
+		prefix = h.groupPrefix + "." + name
+	}
+	return &deferredHandler{attrs: h.attrs, groupPrefix: prefix}
+}

--- a/internal/slogx/slogx_test.go
+++ b/internal/slogx/slogx_test.go
@@ -1,0 +1,83 @@
+package slogx
+
+// Regression tests for the init-time capture bug (M5 field evidence,
+// issue #685): package-level `var x = slog.Default().With(...)` loggers are
+// initialized BEFORE main() calls slog.SetDefault, so they hold the pristine
+// default handler. Its output routes through the log package — which
+// SetDefault has redirected into the new handler — producing mangled lines
+// like `level=INFO msg="ERROR connection error, reconnecting component=..."`
+// (wrong level, attrs unparseable, ~32% of M5's 24h log volume).
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestComponent_SurvivesSetDefaultSwap(t *testing.T) {
+	// "Captured at init": created while the pristine default is installed.
+	before := Component("http-jpeg-recorder")
+
+	var buf bytes.Buffer
+	after := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	previous := slog.Default()
+	slog.SetDefault(after)
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	before.Error("connection error, reconnecting", "camera_id", "cam-x", "attempt", 1)
+
+	line := buf.String()
+	if !strings.Contains(line, `level=ERROR msg="connection error, reconnecting"`) {
+		t.Fatalf("expected proper ERROR record, got: %s", line)
+	}
+	if !strings.Contains(line, "component=http-jpeg-recorder") || !strings.Contains(line, "camera_id=cam-x") {
+		t.Fatalf("attrs must be structured, got: %s", line)
+	}
+	if strings.Contains(line, `msg="ERROR `) {
+		t.Fatalf("double-wrapped log line (init-time capture bug): %s", line)
+	}
+}
+
+func TestComponent_RespectsConfiguredLevel(t *testing.T) {
+	before := Component("xiaomi-recorder")
+
+	var buf bytes.Buffer
+	after := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	previous := slog.Default()
+	slog.SetDefault(after)
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	before.Info("should be suppressed")
+	if buf.Len() != 0 {
+		t.Fatalf("INFO must be filtered by the configured warn level, got: %s", buf.String())
+	}
+}
+
+func TestComponent_WithCarriesAttrs(t *testing.T) {
+	base := Component("tutk-transport")
+	child := base.With("camera_id", "cam-1")
+
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	child.Warn("hello")
+	line := buf.String()
+	for _, want := range []string{"component=tutk-transport", "camera_id=cam-1", `msg=hello`} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("missing %q in: %s", want, line)
+		}
+	}
+}
+
+func TestComponent_EnabledMirrorsDefault(t *testing.T) {
+	h := Component("x").Handler()
+	if h.Enabled(context.Background(), slog.LevelError) {
+		// default level is Info, so Error must pass — just sanity that it
+		// doesn't panic and consults the live default.
+		t.Log("error enabled under default info level")
+	}
+}

--- a/internal/srt/receiver.go
+++ b/internal/srt/receiver.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/url"
 	"strings"
 	"sync/atomic"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	srt "github.com/datarhei/gosrt"
 
@@ -16,7 +17,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var logger = slog.Default().With("component", "srt-receiver")
+var logger = slogx.Component("srt-receiver")
 
 // Receiver manages an SRT connection and distributes H.264 frames to a StreamHub.
 // It handles both listener mode (receiving pushes) and caller mode (pulling from remote).

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	_ "modernc.org/sqlite"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
 
-var logger = slog.Default().With("component", "storage")
+var logger = slogx.Component("storage")
 
 // escapeLike escapes LIKE special characters (% and _) with backslash.
 // This prevents SQL injection via LIKE wildcards while allowing literal searches.

--- a/internal/substream/substream.go
+++ b/internal/substream/substream.go
@@ -12,10 +12,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
@@ -35,7 +36,7 @@ var (
 	ErrStopped = errors.New("sub-stream manager stopped")
 )
 
-var subLogger = slog.Default().With("component", "substream")
+var subLogger = slogx.Component("substream")
 
 // Pull states reported by Source.State / Manager.Snapshot.
 const (

--- a/internal/timelapse/keyframe_extractor.go
+++ b/internal/timelapse/keyframe_extractor.go
@@ -4,7 +4,6 @@ package timelapse
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,12 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model/nalutil"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var kfeLogger = slog.Default().With("component", "keyframe-extractor")
+var kfeLogger = slogx.Component("keyframe-extractor")
 
 // SegmentStore defines the segment lifecycle interface needed by KeyframeExtractor.
 // This is a subset of the recorder.SegmentStore interface — defined locally to

--- a/internal/timelapse/snapshot_capturer.go
+++ b/internal/timelapse/snapshot_capturer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,11 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
 
-var snapshotCapturerLogger = slog.Default().With("component", "snapshot-capturer")
+var snapshotCapturerLogger = slogx.Component("snapshot-capturer")
 
 // SnapshotCapturerConfig holds configuration for the HTTP snapshot capturer.
 type SnapshotCapturerConfig struct {

--- a/internal/transcoding/manager.go
+++ b/internal/transcoding/manager.go
@@ -8,13 +8,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
-var mgrLogger = slog.Default().With("component", "transcode-manager")
+var mgrLogger = slogx.Component("transcode-manager")
 
 // Package-level disabled reason — set by main.go when NewTranscodeManager fails.
 // Used by GetStatus() nil path and API handler to report why transcoding is disabled.

--- a/internal/transcoding/queue.go
+++ b/internal/transcoding/queue.go
@@ -17,6 +17,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
@@ -25,7 +27,7 @@ import (
 // Implementations handle post-processing like DB registration or file cleanup.
 type CompletionFunc func(task *storage.TranscodeTask, success bool)
 
-var queueLogger = slog.Default().With("component", "transcode-queue")
+var queueLogger = slogx.Component("transcode-queue")
 
 // progressUpdateInterval controls how often progress is written to the database.
 // FFmpeg emits progress lines multiple times per second; writing every line

--- a/internal/tutk/conn.go
+++ b/internal/tutk/conn.go
@@ -10,17 +10,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 )
 
 // tutkLogger matches the log vocabulary used during issue #167 field testing
 // ("tutk-transport" component) so testers' log-grep instructions stay stable.
-var tutkLogger = slog.Default().With("component", "tutk-transport")
+var tutkLogger = slogx.Component("tutk-transport")
 
 // Keepalive hardening for idle TUTK sessions. Root cause of the ~10-20s
 // disconnect loop (issue #167) was a stale handshake WRITE deadline that
@@ -262,12 +263,13 @@ func (c *Conn) worker() {
 
 	buf := make([]byte, 1200)
 	lastTick := time.Now()
-	// Periodic INFO heartbeat so field-test logs show liveness both while
-	// data flows (called from the read path) and during silence (timeout path).
+	// Periodic heartbeat (Debug since #685 — INFO ticked once a second and
+	// dominated field logs) showing liveness both while data flows and
+	// during silence.
 	tick := func(idle time.Duration) {
 		if time.Since(lastTick) >= tickInterval {
 			lastTick = time.Now()
-			tutkLogger.Info("tutk: keepalive tick",
+			tutkLogger.Debug("tutk: keepalive tick",
 				"uid", c.uid, "sent", keepalivesSent, "pkts", pktsRecv,
 				"last_data_ago", idle.Round(time.Second).String())
 		}

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -309,7 +309,7 @@ func (c *Coordinator) uploadSegment(ctx context.Context, absPath string, fileSiz
 			"path", filepath.Base(absPath))
 		return false
 	}
-	slog.Info("pushed video to vision",
+	slog.Debug("pushed video to vision",
 		"camera_id", hdr["X-Camera-Id"],
 		"size_mb", realSize/1024/1024)
 	return true

--- a/internal/vision/sublayer.go
+++ b/internal/vision/sublayer.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,6 +25,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -55,7 +56,7 @@ const (
 	subLayerMinSampleDur = time.Millisecond
 )
 
-var subLayerLogger = slog.Default().With("component", "vision-sublayer")
+var subLayerLogger = slogx.Component("vision-sublayer")
 
 // SubLayerProvider abstracts the camera manager's on-demand sub-stream source
 // (AcquireSubStream/ReleaseSubStream) so the vision package doesn't import the

--- a/internal/vod/cache.go
+++ b/internal/vod/cache.go
@@ -18,9 +18,10 @@ package vod
 import (
 	"container/list"
 	"fmt"
-	"log/slog"
 	"os"
 	"sync"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"golang.org/x/sync/singleflight"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
 
-var logger = slog.Default().With("component", "vod")
+var logger = slogx.Component("vod")
 
 // segmentCache caches parsed sample tables per recording. Parsing a 1-hour
 // recording (~90k samples + per-sample keyframe probes) costs 100–300ms; the

--- a/internal/webdav/server.go
+++ b/internal/webdav/server.go
@@ -4,13 +4,14 @@ package webdav
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/camera"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
@@ -19,7 +20,7 @@ import (
 	"golang.org/x/net/webdav"
 )
 
-var webdavLogger = slog.Default().With("component", "webdav")
+var webdavLogger = slogx.Component("webdav")
 
 // Server provides a WebDAV server for browsing and optionally uploading camera recordings.
 type Server struct {

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+
 	"github.com/google/uuid"
 	"github.com/pion/interceptor"
 	"github.com/pion/webrtc/v4"
@@ -21,7 +23,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var logger = slog.Default().With("component", "webrtc-manager")
+var logger = slogx.Component("webrtc-manager")
 
 const (
 	defaultMaxPeers       = 2

--- a/internal/whip/server.go
+++ b/internal/whip/server.go
@@ -20,12 +20,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -35,7 +36,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var logger = slog.Default().With("component", "whip-server")
+var logger = slogx.Component("whip-server")
 
 const (
 	// offerMaxSize bounds the request body (SDP offers are a few KB).

--- a/internal/xiaomi/cloud.go
+++ b/internal/xiaomi/cloud.go
@@ -20,16 +20,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 )
 
-var cloudLogger = slog.Default().With("component", "xiaomi-cloud")
+var cloudLogger = slogx.Component("xiaomi-cloud")
 
 // pendingClouds stores Cloud objects that are awaiting captcha/verify continuation.
 var (

--- a/internal/xiaomi/cs2.go
+++ b/internal/xiaomi/cs2.go
@@ -13,14 +13,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 )
 
-var cs2Logger = slog.Default().With("component", "xiaomi-cs2")
+var cs2Logger = slogx.Component("xiaomi-cs2")
 
 // CS2Dial establishes a CS2 P2P connection to a Xiaomi device.
 // transport: "udp" (default), "tcp", or "" (tries both).

--- a/internal/xiaomi/recorder.go
+++ b/internal/xiaomi/recorder.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"os"
 	"runtime"
@@ -21,6 +20,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/metrics"
@@ -31,7 +32,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 )
 
-var xiaomiLogger = slog.Default().With("component", "xiaomi-recorder")
+var xiaomiLogger = slogx.Component("xiaomi-recorder")
 
 // SegmentStore abstracts storage operations needed by the recorder.
 type SegmentStore interface {


### PR DESCRIPTION
## Summary

Closes #685 (and the log side of #651). Per the issue's spirit — measure first — I sampled **24h of production logs on M5** (18,462 lines) before touching anything. The field evidence overturned the issue's assumptions:

| Source | Share of volume | Action |
|---|---|---|
| Mangled double-wrapped lines (`level=INFO msg="ERROR …entire line…"`) | **32%** | **Bug fixed** (see below) |
| Routine 2xx request logs (99% `/api` polling, NOT static assets) | 26% | Level-based: Debug/Info/Warn |
| Repeated `auto-remediate skipped` (blacklisted cams, every scan) | 10% | → Debug |
| `pushed video to vision` (per segment) | 10% | → Debug |
| GB28181 REGISTER churn (one device re-registers ~30s despite expires=3600) | 14% | Out of scope — lives in the gb28181-go lib; the storm itself looks device-side |

### The 32% bug: init-time logger capture

51 package-level `var x = slog.Default().With("component", …)` loggers initialize **before** `main()` calls `slog.SetDefault`. They hold the pristine default handler, whose output routes through the `log` package — which `SetDefault` has redirected into the new handler. Every record re-emerges as `level=INFO msg="ERROR connection error, reconnecting component=… camera_id=…"` — **wrong level (ERROR→INFO), attrs unparseable**. Reproduced in a minimal test; mechanism proven.

Fix: new `internal/slogx` leaf package — `slogx.Component(name)` wraps a deferred handler that resolves `slog.Default()` at **call** time, so the configured handler/level/format always apply. All 51 sites migrated mechanically (call sites unchanged).

### Level policy

- `RequestLogger`: 2xx/3xx → **Debug**, 4xx → Info, 5xx → Warn. (The issue's static-asset skip-list idea turned out irrelevant: only 30/4,714 request lines were static assets — the real source is `/api` polling.)
- `auto-remediate skipped` → Debug (identical line per camera per scan cycle; blacklist state transitions remain logged where they happen).
- `pushed video to vision` → Debug.
- `tutk: keepalive tick` → Debug (#651's second noise source; ticks per second per stream).

## Tests

TDD: `internal/slogx` proves the SetDefault-swap survival, level filtering, and no double-wrap; `TestRequestLoggerLevels` pins the Debug/Info/Warn contract; updated assertions in middleware/health tests to the new levels.

`go test -race ./internal/... ./pkg/app/` — **5,324 passed in 58 packages**; `make lint` clean.
