### PR TITLE
fix(pixgate): retire exec.CommandContext watchCtx via cmd.Wait (#691)

### DIFF
--- a/internal/pixgate/hub_source.go
+++ b/internal/pixgate/hub_source.go
@@ -150,8 +150,12 @@ func sampleFramesHub(ctx context.Context, cfg Config, src HubSource, fps float64
 			close(watchStop)
 		}
 		if cmd != nil {
-			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
+			if cmd.Process != nil { // pipe setup failed before Start — nothing spawned
+				_ = cmd.Process.Kill()
+			}
+			// cmd.Wait (not just Process.Wait) retires exec.CommandContext's
+			// watchCtx goroutine — os-level reaping leaks it (#691: ~600/h on M5).
+			_ = cmd.Wait()
 		}
 	}()
 

--- a/internal/pixgate/leak_test.go
+++ b/internal/pixgate/leak_test.go
@@ -1,0 +1,97 @@
+package pixgate
+
+// Goroutine-leak guards (#691): every sampleFrames/sampleFramesHub call
+// spawns an exec.CommandContext child whose watchCtx goroutine only retires
+// via cmd.Wait() — os-level Process.Wait() does NOT close it, and neither
+// does cancelling the parent ctx afterwards. watchCtx only spawns for a
+// CANCELLABLE context (Start skips it when ctx.Done()==nil), so these tests
+// must use an uncancelled WithCancel ctx — exactly the production shape
+// (the manager's long-lived run context). On M5 the periodic sampler leaked
+// ~600 watchCtx goroutines per hour until the process restarted.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+)
+
+// leakTolerance allows unrelated runtime goroutines (timers, GC helpers)
+// without masking a per-call leak: 25 invocations leaking 1 goroutine each
+// must fail the guard.
+const (
+	leakIterations = 25
+	leakTolerance  = 5
+)
+
+func goroutinesSettleToBaseline(t *testing.T, baseline int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baseline+leakTolerance
+	}, 15*time.Second, 100*time.Millisecond,
+		"goroutines did not return to baseline: exec.Cmd watchers are leaking (got %d, baseline %d)",
+		runtime.NumGoroutine(), baseline)
+}
+
+func TestSampleFramesHub_NoCmdWatcherLeak(t *testing.T) {
+	t.Helper()
+	script, stdinDump, argsDump := writeFakeEOFGatedFFmpeg(t)
+	cfg := Config{
+		FFmpegPath:        script,
+		Env:               []string{"STDIN_DUMP=" + stdinDump, "ARGS_DUMP=" + argsDump},
+		FrameStallTimeout: 4 * time.Second,
+		HubBatchWindow:    500 * time.Millisecond,
+	}
+
+	// Production shape: a cancellable-but-long-lived context. A Background
+	// ctx would spawn no watcher at all and the test would pass vacuously.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	baseline := runtime.NumGoroutine()
+	for i := range leakIterations {
+		hub := newHubWithKeyframe(t)
+		n, err := sampleFramesHub(ctx, cfg, &stubHubSource{hub: hub}, 1,
+			func([]byte) bool { return true }, make([]byte, GridW*GridH))
+		require.NoError(t, err, "iteration %d", i)
+		require.Positive(t, n, "iteration %d should decode the flushed frames", i)
+	}
+	goroutinesSettleToBaseline(t, baseline)
+}
+
+func TestSampleFrames_NoCmdWatcherLeak(t *testing.T) {
+	t.Helper()
+	empty, err := os.Create(filepath.Join(t.TempDir(), "frames.bin"))
+	require.NoError(t, err)
+	require.NoError(t, empty.Close())
+
+	cfg := Config{
+		FFmpegPath: "cat",
+		FFmpegArgs: func(string, float64) []string { return []string{empty.Name()} },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	baseline := runtime.NumGoroutine()
+	for range leakIterations {
+		// cat dumps an empty file → immediate EOF → the error return is the
+		// expected path here; the point is the Cmd lifecycle, not the frames.
+		_, _ = sampleFrames(ctx, cfg, Target{}, 1,
+			func([]byte) bool { return true }, make([]byte, GridW*GridH))
+	}
+	goroutinesSettleToBaseline(t, baseline)
+}
+
+func newHubWithKeyframe(t *testing.T) *streamhub.StreamHub {
+	t.Helper()
+	hub := streamhub.New()
+	hub.Broadcast(1, h264KeyAU(0xCC), true) // cached-IDR replay feeds the probe
+	return hub
+}

--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -582,7 +582,9 @@ func sampleFrames(ctx context.Context, cfg Config, target Target, fps float64, f
 	}
 	defer func() {
 		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
+		// cmd.Wait (not just Process.Wait) retires exec.CommandContext's
+		// watchCtx goroutine — os-level reaping leaks it (#691: ~600/h on M5).
+		_ = cmd.Wait()
 	}()
 
 	// Stall watchdog (2026-09-02 incident): a wedged source — ffmpeg blocked


### PR DESCRIPTION
## Problem (#691)

M5 production pprof: **5830 of 6204 goroutines were `os/exec.(*Cmd).watchCtx`** — one leaked per sampler invocation (~600/hour, service uptime 9.5 h), keeping `/api/health` permanently `unhealthy` (threshold 1000).

Root cause: pixgate's cleanup did `cmd.Process.Kill()` + `cmd.Process.Wait()` — **os-level reaping**. Go's `exec.CommandContext` spawns a `watchCtx` goroutine (only for cancellable contexts) that retires **exclusively via `cmd.Wait()`** — verified against Go 1.26 source plus a minimal repro: neither `Process.Wait()` nor cancelling the parent ctx afterwards retires it.

## Fix

- `sampleFrames` and `sampleFramesHub` deferred cleanup now calls `cmd.Wait()` (hub_source also guards the nil-Process path where pipe setup failed before `Start`)
- Audited every other `exec.Command*` site in the repo (relay, livetranscode, transcoding queue/snapshot/ffprobe/probe/downloader, health audit): all use `Run`/`Output`/`Wait` correctly — pixgate was the only leak

## Tests (TDD)

- `leak_test.go`: NumGoroutine baseline guards, 25 invocations per sampler path. **Pre-fix RED: 2→27→52** (exactly one leak per call); post-fix settles back to baseline
- Key subtlety pinned in the test comment: `watchCtx` only spawns for **cancellable** contexts — a `context.Background()` test passes vacuously. Tests use an uncancelled `WithCancel` ctx, matching the production manager shape
- `go test -race ./internal/pixgate/` clean; golangci-lint 0 issues

## Post-merge

Deploy to M5 and confirm the goroutine count stays flat (was +1 per ~6 s); closes #691.