### PR TITLE
test: goleak TestMain across lifecycle packages + AST exec-site guard (#691)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	modernc.org/sqlite v1.54.0
 )
 
+require go.uber.org/goleak v1.3.0
+
 require (
 	github.com/mickeyzzc/gb28181-go v0.2.2
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
@@ -80,7 +82,7 @@ require (
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/sync v0.22.0
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/event/adapter_test.go
+++ b/internal/event/adapter_test.go
@@ -52,6 +52,7 @@ func TestBusAdapter_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Subscribe failed: %v", err)
 	}
+	t.Cleanup(func() { adapter.Unsubscribe("test.topic", ch) })
 
 	adapter.Publish(context.Background(), "test.topic", "hello")
 
@@ -76,6 +77,7 @@ func TestBusAdapter_PrefixMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubscribeByPrefix failed: %v", err)
 	}
+	t.Cleanup(func() { adapter.UnsubscribeByPrefix("test.", ch) })
 
 	adapter.Publish(context.Background(), "test.one", "one")
 	adapter.Publish(context.Background(), "test.two", "two")
@@ -112,6 +114,7 @@ func TestBusAdapter_UnsubscribeStopsDelivery(t *testing.T) {
 
 	ch := make(chan pkgeventbus.Event, 16)
 	err := adapter.Subscribe("unsub", ch, 16)
+	t.Cleanup(func() { adapter.Unsubscribe("unsub", ch) })
 	if err != nil {
 		t.Fatalf("Subscribe failed: %v", err)
 	}
@@ -135,6 +138,7 @@ func TestBusAdapter_UnsubscribeByPrefixIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubscribeByPrefix failed: %v", err)
 	}
+	t.Cleanup(func() { adapter.UnsubscribeByPrefix("test.", ch) })
 
 	adapter.UnsubscribeByPrefix("test.", ch)
 	adapter.UnsubscribeByPrefix("test.", ch)
@@ -150,6 +154,7 @@ func TestBusAdapter_PrefixMatch_EmptyMatchesAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SubscribeByPrefix failed: %v", err)
 	}
+	t.Cleanup(func() { adapter.UnsubscribeByPrefix("", ch) })
 
 	adapter.Publish(context.Background(), "any.topic", "hello")
 

--- a/internal/event/goleak_testmain_test.go
+++ b/internal/event/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package event
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/livetranscode/goleak_testmain_test.go
+++ b/internal/livetranscode/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package livetranscode
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/livetranscode/transcoder_test.go
+++ b/internal/livetranscode/transcoder_test.go
@@ -658,6 +658,7 @@ func TestLiveTranscoder_RealFFmpeg(t *testing.T) {
 
 	err = lt.Start(ctx)
 	require.NoError(t, err)
+	defer lt.Stop() // goleak: cancel() alone does not join the transcoder goroutines
 
 	// Write a minimal H.265 AU with valid start codes
 	au := AccessUnit{

--- a/internal/mqtt/goleak_testmain_test.go
+++ b/internal/mqtt/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package mqtt
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/pixgate/goleak_testmain_test.go
+++ b/internal/pixgate/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package pixgate
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/relay/goleak_testmain_test.go
+++ b/internal/relay/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package relay
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/staticguard/staticguard_test.go
+++ b/internal/staticguard/staticguard_test.go
@@ -1,0 +1,151 @@
+package staticguard
+
+// Static guard (#691 defense-in-depth): every non-test function that spawns
+// a child process via exec.Command/exec.CommandContext must, within the same
+// function, call one of the wait-family methods (Wait/Run/Output/CombinedOutput).
+// exec.CommandContext's watchCtx goroutine only retires via cmd.Wait(); a new
+// call site that forgets it leaks one goroutine per invocation (the M5 field
+// leak was exactly this). Cross-function lifecycles (Start in one method,
+// Wait in another) go through waitFamilyAllowlist with a reviewed reason —
+// adding an entry forces a conscious decision in code review.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// waitFamilyAllowlist permits exec sites whose Wait lives in another
+// function (session-style lifecycles). Key: "path/from/repo/root.go:FuncName".
+var waitFamilyAllowlist = map[string]string{
+	"internal/livetranscode/transcoder.go:Start": "session lifecycle: Start() spawns ffmpeg, Stop() calls cmd.Wait() (transcoder.go)",
+}
+
+func scanForUnwaitedExec(src []byte, filename string) []string {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		return []string{filename + ": parse error: " + err.Error()}
+	}
+
+	var violations []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		hasExec, hasWait := false, false
+		ast.Inspect(fn.Body, func(m ast.Node) bool {
+			call, ok := m.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "exec" &&
+				(sel.Sel.Name == "Command" || sel.Sel.Name == "CommandContext") {
+				hasExec = true
+			}
+			switch sel.Sel.Name {
+			case "Wait":
+				// Only cmd.Wait() retires watchCtx. cmd.Process.Wait() is a
+				// two-level selector (X.Y.Wait) and does NOT — the exact #691 trap.
+				if _, single := sel.X.(*ast.Ident); single {
+					hasWait = true
+				}
+			case "Run", "Output", "CombinedOutput":
+				hasWait = true
+			}
+			return true
+		})
+		if hasExec && !hasWait {
+			pos := fset.Position(fn.Pos())
+			key := filename + ":" + fn.Name.Name
+			if _, allowed := waitFamilyAllowlist[key]; !allowed {
+				violations = append(violations,
+					pos.String()+" ("+fn.Name.Name+") spawns exec.Command* without Wait/Run/Output/CombinedOutput in the same function")
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+func TestScanner_FlagsUnwaitedExecFixture(t *testing.T) {
+	bad := []byte(`package x
+import ("os/exec"; "context")
+func badSpawn(ctx context.Context) {
+	cmd := exec.CommandContext(ctx, "ffmpeg")
+	_ = cmd.Start()
+	_ = cmd.Process.Wait()
+}`)
+	if v := scanForUnwaitedExec(bad, "fixtures/bad.go"); len(v) != 1 {
+		t.Fatalf("scanner must flag the os-level-reap-only pattern, got %v", v)
+	}
+
+	good := []byte(`package x
+import ("os/exec"; "context")
+func goodSpawn(ctx context.Context) {
+	cmd := exec.CommandContext(ctx, "ffmpeg")
+	_ = cmd.Start()
+	defer func() { _ = cmd.Wait() }()
+}`)
+	if v := scanForUnwaitedExec(good, "fixtures/good.go"); len(v) != 0 {
+		t.Fatalf("scanner must accept cmd.Wait cleanup, got %v", v)
+	}
+
+	runner := []byte(`package x
+import "os/exec"
+func runIt() { _ = exec.Command("true").Run() }`)
+	if v := scanForUnwaitedExec(runner, "fixtures/run.go"); len(v) != 0 {
+		t.Fatalf("scanner must accept Run(), got %v", v)
+	}
+}
+
+func TestRepo_ExecSitesAreWaited(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate test file")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+
+	var violations []string
+	for _, dir := range []string{"internal", "pkg", "cmd"} {
+		root := filepath.Join(repoRoot, dir)
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			violations = append(violations, scanForUnwaitedExec(src, rel)...)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	for _, v := range violations {
+		t.Errorf("unwaited exec site: %s", v)
+	}
+	if len(violations) == 0 {
+		t.Log("all exec.Command* sites call Wait/Run/Output/CombinedOutput (or are reviewed allowlist entries)")
+	}
+}

--- a/internal/streamhub/goleak_testmain_test.go
+++ b/internal/streamhub/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package streamhub
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/streamhub/stream_stats_test.go
+++ b/internal/streamhub/stream_stats_test.go
@@ -26,6 +26,7 @@ func TestStreamHub_Snapshot(t *testing.T) {
 		received++
 		mu.Unlock()
 	}))
+	t.Cleanup(func() { hub.Unsubscribe("consumer-a") })
 
 	hub.Broadcast(100, [][]byte{make([]byte, 10), make([]byte, 5)}, false)
 	hub.Broadcast(200, [][]byte{make([]byte, 20)}, true)
@@ -71,6 +72,7 @@ func TestStreamHub_SubscribeMsgRelaysIngestAt(t *testing.T) {
 	require.NoError(t, hub.SubscribeMsg("ws-cam-msg", func(msg model.FrameMsg) {
 		got <- msg
 	}))
+	t.Cleanup(func() { hub.Unsubscribe("ws-cam-msg") })
 
 	before := time.Now().UnixNano()
 	hub.Broadcast(1000, [][]byte{{0x65, 0x01}}, true)

--- a/internal/streamhub/stream_test.go
+++ b/internal/streamhub/stream_test.go
@@ -12,6 +12,14 @@ import (
 )
 
 // helper must be used in all test helpers (project convention).
+// subscribeCleanup subscribes and guarantees Unsubscribe at test end —
+// goleak (TestMain) fails the package on leaked drain goroutines otherwise.
+func subscribeCleanup(t *testing.T, hub *StreamHub, id string, cb func(pts int64, au [][]byte)) {
+	t.Helper()
+	require.NoError(t, hub.Subscribe(id, cb))
+	t.Cleanup(func() { hub.Unsubscribe(id) })
+}
+
 func newTestStreamHub(t *testing.T) *StreamHub {
 	t.Helper()
 	return New()
@@ -36,6 +44,7 @@ func TestStreamHub_SubscribeAndBroadcast(t *testing.T) {
 			mu.Unlock()
 		})
 		require.NoError(t, err)
+		t.Cleanup(func() { hub.Unsubscribe(cid) })
 	}
 
 	// Broadcast 5 frames
@@ -267,6 +276,7 @@ func TestStreamHub_AudioSubscribeAndBroadcast(t *testing.T) {
 			mu.Unlock()
 		})
 		require.NoError(t, err)
+		t.Cleanup(func() { hub.UnsubscribeAudio(cid) })
 	}
 
 	// Broadcast 5 audio frames
@@ -1150,11 +1160,11 @@ func TestStreamHub_ReplaysIDROnSubscribe(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("late", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "late", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -1179,11 +1189,11 @@ func TestStreamHub_ReplaysH264IDR(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -1205,11 +1215,11 @@ func TestStreamHub_NoReplayWhenCacheEmpty(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 
 	// Give the drain goroutine a moment, then assert nothing arrived.
 	time.Sleep(50 * time.Millisecond)
@@ -1238,11 +1248,11 @@ func TestStreamHub_IDRCacheRingSize(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -1281,11 +1291,11 @@ func TestStreamHub_ReplaySkipsIncompleteIDR(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
@@ -1309,11 +1319,11 @@ func TestStreamHub_NoReplayWhenAllIncomplete(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 	time.Sleep(50 * time.Millisecond)
 	mu.Lock()
 	defer mu.Unlock()
@@ -1331,11 +1341,11 @@ func TestStreamHub_DisabledIDRCacheNoReplay(t *testing.T) {
 		mu       sync.Mutex
 		received []frameInfo
 	)
-	require.NoError(t, hub.Subscribe("c1", func(pts int64, au [][]byte) {
+	subscribeCleanup(t, hub, "c1", func(pts int64, au [][]byte) {
 		mu.Lock()
 		received = append(received, frameInfo{pts: pts, au: au})
 		mu.Unlock()
-	}))
+	})
 	time.Sleep(50 * time.Millisecond)
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/transcoding/goleak_testmain_test.go
+++ b/internal/transcoding/goleak_testmain_test.go
@@ -1,0 +1,15 @@
+package transcoding
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// TestMain fails the package if any test leaves goroutines behind (#691
+// defense-in-depth: goleak catches leaks on EVERY test, not just dedicated
+// guard tests). If a goroutine is legitimately long-lived for the whole
+// binary, add a targeted goleak.IgnoreTopFunction here with a reason.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
Implements the defense-in-depth agreed after #691: TDD baseline guards alone cannot catch leaks on untested paths — these two layers close the biggest gaps.

## 1. goleak TestMain (7 packages)

`goleak.VerifyTestMain` in **pixgate, mqtt, event, streamhub, relay, livetranscode, transcoding** — any test in these packages that leaves goroutines behind now fails the package, independent of whether someone wrote a dedicated guard test.

Enabling it immediately surfaced real debt (all fixed here):

- 10+ streamhub test subscriptions without `Unsubscribe` (added a `subscribeCleanup` helper + `t.Cleanup`s)
- event adapter tests: 5 prefix/exact subscriptions never unsubscribed
- livetranscode `TestLiveTranscoder_RealFFmpeg`: never called `Stop()` — `cancel()` alone does not join the transcoder pumps

`internal/health` is deferred to #693: deterministic full-run leak with **zero per-test leaks** (not a parallelism artifact) — needs its own root-cause pass rather than a hasty cleanup.

## 2. AST exec-site guard (`internal/staticguard`)

Repo-wide static scan: every non-test function calling `exec.Command`/`exec.CommandContext` must call Wait/Run/Output/CombinedOutput **in the same function**. Key subtlety: two-level selectors (`cmd.Process.Wait()`) do NOT count — that is precisely the #691 trap, validated by in-repo fixtures (the bad pattern must be flagged; `cmd.Wait()` and `.Run()` must pass). Cross-function lifecycles (livetranscode Start/Stop) go through a reviewed `waitFamilyAllowlist` — adding an entry is a visible, justified decision.

A new exec call site that forgets `Wait` now fails CI before it ships.

## Verification

- `go test -race` clean across all 8 packages (incl. staticguard)
- golangci-lint 0 issues; goleak is now a direct dep (v1.3.0, MIT)
- AGENTS.md goroutine-leak rule updated to describe the three-layer mechanism
