### PR TITLE
fix(health): idempotent Manager.Start + goleak TestMain (#693)

### DIFF
--- a/internal/health/goleak_testmain_test.go
+++ b/internal/health/goleak_testmain_test.go
@@ -1,0 +1,11 @@
+package health
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/health/manager.go
+++ b/internal/health/manager.go
@@ -136,10 +136,18 @@ func (m *Manager) Start(ctx context.Context) error {
 		return nil
 	}
 
+	// Idempotent: a second Start while running must not spawn another loop —
+	// it would overwrite m.cancel/m.done and orphan the first goroutine
+	// forever (leak caught by the package goleak TestMain).
+	if m.cancel != nil {
+		return nil
+	}
+
 	// Metrics-only mode: just run the collector loop, no alert cleanup.
 	if m.metricsOnly {
 		childCtx, cancel := context.WithCancel(ctx)
 		m.cancel = cancel
+		m.done = make(chan struct{})
 		go m.run(childCtx)
 		slog.Info("health manager started (metrics-only mode — stream stats active, alerts disabled)")
 		return nil
@@ -158,6 +166,7 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	childCtx, cancel := context.WithCancel(ctx)
 	m.cancel = cancel
+	m.done = make(chan struct{})
 
 	// Wire offline-duration lookup so auto-remediation can gate reconnecting-
 	// triggered restarts on ReconnectingTimeoutMinutes (m.conn is set in the
@@ -205,6 +214,7 @@ func (m *Manager) Stop() {
 	}
 	m.cancel()
 	<-m.done
+	m.cancel = nil // allow Start-after-Stop restart (run() re-arms done)
 	slog.Info("health manager stopped")
 }
 

--- a/internal/health/manager_test.go
+++ b/internal/health/manager_test.go
@@ -39,6 +39,16 @@ func newMockRecorderWithHub() *mockRecorder {
 	}
 }
 
+// addCamera registers a camera and guarantees OnCameraRemoved at test end —
+// OnCameraAdded subscribes hub drain goroutines that goleak (TestMain) flags
+// if the test never removes the camera. Idempotent cleanup: double removal
+// is a no-op.
+func addCamera(t *testing.T, m *Manager, id string, rec model.Recorder) {
+	t.Helper()
+	m.OnCameraAdded(id, rec, nil)
+	t.Cleanup(func() { m.OnCameraRemoved(id, rec) })
+}
+
 // newMockRecorderWithoutHub returns a recorder that doesn't implement GetHub.
 type mockRecorderNoHub struct{}
 
@@ -133,7 +143,7 @@ func TestManagerOnCameraAdded(t *testing.T) {
 	m := newTestManager(t, newTestManagerConfig())
 	rec := newMockRecorderWithHub()
 
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Verify StreamHub has subscribers
 	if count := rec.hub.ConsumerCount(); count != 2 {
@@ -165,7 +175,7 @@ func TestManagerMetricsOnly_OnCameraAdded(t *testing.T) {
 	}
 	rec := newMockRecorderWithHub()
 
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Metrics-only mode: only stats subscriber, no freeze subscriber.
 	if count := rec.hub.ConsumerCount(); count != 1 {
@@ -179,7 +189,7 @@ func TestManagerOnCameraAddedNoHub(t *testing.T) {
 	rec := &mockRecorderNoHub{}
 
 	// Should not panic when recorder has no hub
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Connection monitor should still track the camera
 	m.conn.mu.Lock()
@@ -196,7 +206,7 @@ func TestManagerOnCameraRemoved(t *testing.T) {
 	rec := newMockRecorderWithHub()
 
 	// Add first
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 	if count := rec.hub.ConsumerCount(); count != 2 {
 		t.Fatalf("expected 2 consumers after add, got %d", count)
 	}
@@ -238,7 +248,7 @@ func TestManagerOnStatusChange(t *testing.T) {
 	t.Helper()
 	m := newTestManager(t, newTestManagerConfig())
 	rec := newMockRecorderWithHub()
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Simulate status change to error
 	m.OnStatusChange("cam-1", string(model.StatusError))
@@ -307,7 +317,7 @@ func TestManagerStartStopNil(t *testing.T) {
 func TestManagerOnCameraAddedNil(t *testing.T) {
 	t.Helper()
 	var m *Manager
-	m.OnCameraAdded("cam-1", newMockRecorderWithHub(), nil) // Should not panic
+	addCamera(t, m, "cam-1", newMockRecorderWithHub()) // Should not panic
 }
 
 func TestManagerOnCameraRemovedNil(t *testing.T) {
@@ -411,9 +421,16 @@ func TestManagerDoubleStart(t *testing.T) {
 	if err := m.Start(ctx); err != nil {
 		t.Fatalf("first Start returned error: %v", err)
 	}
-	// Second start should work without panic (overwrites cancel)
+	// Second Start must be an idempotent no-op: spawning a second loop would
+	// orphan the first (leak — guarded by the package goleak TestMain).
 	if err := m.Start(ctx); err != nil {
 		t.Fatalf("second Start returned error: %v", err)
+	}
+	m.Stop()
+
+	// Restart after Stop re-arms the loop for another full cycle.
+	if err := m.Start(ctx); err != nil {
+		t.Fatalf("restart after Stop returned error: %v", err)
 	}
 	m.Stop()
 }
@@ -431,7 +448,7 @@ func TestManager_StatusPolling(t *testing.T) {
 
 	// Add camera (sets initial status in conn and knownStatuses)
 	rec := newMockRecorderWithHub()
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Initial poll — no transition expected
 	m.pollStatuses()
@@ -480,7 +497,7 @@ func TestManagerOnStatusChangeResetsCollector(t *testing.T) {
 	t.Helper()
 	m := newTestManager(t, newTestManagerConfig())
 	rec := newMockRecorderWithHub()
-	m.OnCameraAdded("cam-1", rec, nil)
+	addCamera(t, m, "cam-1", rec)
 
 	// Simulate frames to set lastIDRTime on the collector
 	cb := m.collector.OnFrame("cam-1")


### PR DESCRIPTION
Closes #693 — and corrects its premise.

## The #693 mystery dissolved

The reported signature ("deterministic full-run leak with **zero per-test leaks**") was an artifact: the original bisect used a broken result comparison, so per-test runs had never actually been verified. Re-checked correctly, the leakers fail solo — ordinary causes all along.

## Fixes

**Real product bug** — `Manager.Start()` called twice overwrote `m.cancel`/`m.done`, orphaning the first `run` loop forever (goroutine leak **plus** duplicated polling/alerting). `TestManagerDoubleStart` documents this as intended behavior ("overwrites cancel") — under goleak it was a live RED.

- `Start` is now idempotent: no-op while running
- `Stop` clears `cancel`; each start cycle re-arms `done` — Start-after-Stop restart works (test extended with a full restart cycle)

**Test hygiene** — 7 tests subscribed hub drain goroutines via `OnCameraAdded` without `OnCameraRemoved`; new `addCamera` helper pairs them with `t.Cleanup`.

## Result

`internal/health` runs `goleak.VerifyTestMain` like the other 7 lifecycle packages — the #691 defense-in-depth net is now complete across all of them.

`go test -race -count=3 ./internal/health/` clean; pkg/app clean; golangci-lint 0 issues.