### PR TITLE
fix(merge): rolling merge survives out-of-order segment arrival (#698)

### DIFF
--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -242,7 +242,15 @@ type bucketInfo struct {
 	// append's wall contribution is lastEnded→ended — inter-segment GAPS
 	// (disconnects, TL pauses) stay visible on the wall axis, matching the
 	// row's started_at..ended_at span instead of silently shrinking it.
+	// Kept as a MAX across appends: an out-of-order earlier segment must not
+	// drag it backward (#698).
 	lastEnded time.Time
+	// rowStart is the merged row's started_at (the first bucket segment's
+	// start; set by createBucket). On out-of-order appends it moves BACKWARD
+	// to cover the earlier segment — the row must never end before it starts
+	// (#698: a swapped merge order produced ended_at < started_at rows).
+	// Zero only for in-flight buckets created before this field existed.
+	rowStart time.Time
 }
 
 // segmentAudioKey derives the audio compatibility key for a parsed segment.

--- a/internal/merge/rolling_batch.go
+++ b/internal/merge/rolling_batch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
 	"strconv"
 	"time"
 
@@ -258,6 +259,26 @@ func splitRunsByCompatKey(recs []*model.Recording, infos []*SegmentInfo) []segme
 // mergeAudioRun merges one audio-homogeneous run into a single output file and
 // updates the DB atomically. Returns the number of source segments merged.
 func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID string, recs []*model.Recording, infos []*SegmentInfo) (int, error) {
+	// Chronological order, always (#698): the row anchors on recs[0].StartedAt
+	// and recs[last].EndedAt, and the merged FILE plays in input order — an
+	// unsorted run inverts the row range AND the playback order. mergeSegments
+	// sorts before dispatch; this guards backfill and any future caller.
+	if len(recs) == len(infos) && len(recs) > 1 {
+		idx := make([]int, len(recs))
+		for i := range idx {
+			idx[i] = i
+		}
+		sort.SliceStable(idx, func(a, b int) bool { return recs[idx[a]].StartedAt.Before(recs[idx[b]].StartedAt) })
+		if !sort.IntsAreSorted(idx) {
+			sortedRecs := make([]*model.Recording, len(recs))
+			sortedInfos := make([]*SegmentInfo, len(infos))
+			for i, j := range idx {
+				sortedRecs[i], sortedInfos[i] = recs[j], infos[j]
+			}
+			recs, infos = sortedRecs, sortedInfos
+		}
+	}
+
 	sourcePaths := make([]string, 0, len(recs))
 	for _, rec := range recs {
 		sourcePaths = append(sourcePaths, rec.FilePath)

--- a/internal/merge/rolling_bucket.go
+++ b/internal/merge/rolling_bucket.go
@@ -63,6 +63,9 @@ func (r *RollingMergeCoordinator) createBucket(
 	bucket.wallDurSec = wallSec
 	bucket.fileDurSec = fileSec
 	bucket.lastEnded = seg.endedAt
+	// The row's started_at anchors at this segment's start; later appends may
+	// move it backward (out-of-order arrival, #698) but never forward.
+	bucket.rowStart = seg.startedAt
 	bucket.wallFile = stats.WallToFile
 	if len(bucket.wallFile) == 0 {
 		bucket.wallFile = [][2]float64{{0, 0}, {wallSec, fileSec}}
@@ -187,9 +190,27 @@ func (r *RollingMergeCoordinator) appendToBucket(
 	if segWall := seg.endedAt.Sub(seg.startedAt).Seconds(); deltaWall < segWall {
 		deltaWall = segWall
 	}
-	bucket.lastEnded = seg.endedAt
+	// Out-of-order guard (#698): lastEnded only ever advances, and an earlier
+	// segment extends the row's start backward. Before this, a swapped merge
+	// order (later segment first) wrote ended_at < started_at — an inverted
+	// row that broke every timeline invariant downstream.
+	if seg.endedAt.After(bucket.lastEnded) {
+		bucket.lastEnded = seg.endedAt
+	}
+	if !bucket.rowStart.IsZero() && seg.startedAt.Before(bucket.rowStart) {
+		bucket.rowStart = seg.startedAt
+	}
 	bucket.wallDurSec += deltaWall
 	bucket.fileDurSec += deltaFile
+	// I1 (duration == wall span): when the backward extension outpaces the
+	// accumulated deltas (an earlier segment arrives late and its gap was
+	// never counted), clamp the wall axis up to the full row span. No-op in
+	// the ordered flow, where the gap rule already keeps them equal.
+	if !bucket.rowStart.IsZero() {
+		if span := bucket.lastEnded.Sub(bucket.rowStart).Seconds(); span > bucket.wallDurSec {
+			bucket.wallDurSec = span
+		}
+	}
 	if len(bucket.wallFile) == 0 {
 		bucket.wallFile = [][2]float64{{0, 0}}
 	}
@@ -197,14 +218,22 @@ func (r *RollingMergeCoordinator) appendToBucket(
 
 	totalFrames := bucketInfo.SampleCount + newInfo.SampleCount
 
+	rowStart := bucket.rowStart
+	if rowStart.IsZero() {
+		// Legacy in-flight bucket (created before rowStart was tracked): the
+		// row's true start is unknown here; pass the segment-relative value —
+		// the DB update applies min(started_at, ?) so the stored start can
+		// only move backward, never shrink coverage.
+		rowStart = seg.startedAt
+	}
 	mergedRecID = bucket.mergedRecID
 	mergedRec := &model.Recording{
 		ID:          mergedRecID,
 		CameraID:    seg.cameraID,
 		FilePath:    finalPath,
 		Format:      model.Format(seg.format),
-		StartedAt:   bucket.windowStart,
-		EndedAt:     seg.endedAt,
+		StartedAt:   rowStart,
+		EndedAt:     bucket.lastEnded,
 		Duration:    bucket.wallDurSec,
 		FileSize:    fi.Size(),
 		FrameCount:  totalFrames,

--- a/internal/merge/rolling_live.go
+++ b/internal/merge/rolling_live.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -172,6 +173,15 @@ type pendingSegmentInfo struct {
 // It acquires a per-camera non-blocking lock; if a merge is already in progress,
 // the segments are left for the next periodic merge pass (MergeManager) as a fallback.
 func (r *RollingMergeCoordinator) mergeSegments(ctx context.Context, cameraID string, segs []pendingSegmentInfo) {
+	// Chronological order, always (#698): dispatch order follows lock
+	// acquisition, which does NOT follow event order under load — a swapped
+	// batch fed recs[0]/recs[last] an inverted range and wrote ended_at <
+	// started_at rows. Sorting here fixes the batch path (2+ segments) and
+	// the bucket path's create-vs-append sequencing within one dispatch.
+	sort.SliceStable(segs, func(i, j int) bool {
+		return segs[i].startedAt.Before(segs[j].startedAt)
+	})
+
 	// For real-time events, use BLOCKING lock acquisition instead of try-lock.
 	// The backfill path uses try-lock (skips if busy), so real-time events
 	// will eventually get the lock. We wait with a timeout (2 min) to avoid

--- a/internal/merge/wall_axis_ooo_test.go
+++ b/internal/merge/wall_axis_ooo_test.go
@@ -1,0 +1,126 @@
+// wall_axis_ooo_test.go — 乱序到达场景（#698）。
+//
+// CI 实证（run 33848470012）：TestWallAxis_WindowRolloverTwoBuckets 失败行
+// "duration 120.00 must equal wall span -1.00" —— 产物行 ended_at 早于
+// started_at。根因是同相机两段的合并顺序可与时间顺序颠倒（锁获取顺序不
+// 保证派发顺序）。本文件用确定性的直接调用复现两条路径：
+//
+//	O1 桶 append 乱序   — 晚段先入桶、早段后 append，行必须仍自洽；
+//	O2 批量乱序         — 同一 dispatch 内 [晚, 早] 排列，行必须仍自洽。
+package merge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// oooSeg 落盘一个源段并入库（不走事件总线，避免 debounce 派发的不确定性），
+// 返回可直接交给 mergeSegments 的 pendingSegmentInfo。
+func oooSeg(t *testing.T, env *mergeTestEnv, cameraID, recID string, startedAt time.Time, samples []wallSample) pendingSegmentInfo {
+	t.Helper()
+	nalus := make([][]byte, len(samples))
+	durs := make([]time.Duration, len(samples))
+	var wall time.Duration
+	for i, s := range samples {
+		if s.key {
+			nalus[i] = wallIDR
+		} else {
+			nalus[i] = wallP
+		}
+		durs[i] = s.d
+		wall += s.d
+	}
+	path := createH264SegmentWithDurations(t, t.TempDir(), recID+".mp4", wallSps, wallPps, nalus, durs)
+	seg := pendingSegmentInfo{
+		recordingID: recID,
+		filePath:    path,
+		format:      "h264",
+		cameraID:    cameraID,
+		startedAt:   startedAt,
+		endedAt:     startedAt.Add(wall),
+		fileSize:    0, // batch 路径不用它做磁盘准入（live 路径），置零无害
+	}
+	require.NoError(t, env.db.InsertRecording(context.Background(), &model.Recording{
+		ID:         recID,
+		CameraID:   cameraID,
+		FilePath:   path,
+		Format:     model.FormatH264,
+		StartedAt:  startedAt,
+		EndedAt:    seg.endedAt,
+		Duration:   wall.Seconds(),
+		FrameCount: len(samples),
+	}))
+	return seg
+}
+
+// requireRowSelfConsistent 断言一条 merged 行的最小自洽不变量（#698 的
+// 核心诉求）：started_at ≤ ended_at，且 duration 与墙钟跨度一致（±2s）。
+func requireRowSelfConsistent(t *testing.T, env *mergeTestEnv, cameraID string) model.Recording {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var rows []model.Recording
+	for time.Now().Before(deadline) {
+		all, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+		require.NoError(t, err)
+		rows = nil
+		for _, rr := range all {
+			if rr.MergeStatus == model.MergeStatusMerged {
+				rows = append(rows, rr)
+			}
+		}
+		if len(rows) == 1 && len(all) == 1 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.Len(t, rows, 1, "expected exactly one merged row")
+	full, err := env.db.GetRecording(context.Background(), rows[0].ID)
+	require.NoError(t, err)
+	require.False(t, full.EndedAt.Before(full.StartedAt),
+		"row %s: ended_at %v is before started_at %v (inverted row)", full.ID, full.EndedAt, full.StartedAt)
+	span := full.EndedAt.Sub(full.StartedAt).Seconds()
+	require.InDelta(t, span, full.Duration, 2.0,
+		"row %s: duration %.2f must equal wall span %.2f", full.ID, full.Duration, span)
+	return *full
+}
+
+// O1 桶 append 乱序：晚段（base+61s）先 createBucket，早段（base）后
+// appendToBucket。CI 失败签名（duration 120 / span −1）即此路径错位的
+// 行端点。修复后行必须覆盖 [base, base+121s]，duration ≥ 120。
+func TestMergeOutOfOrder_AppendSwapped(t *testing.T) {
+	env, _, r := wallEnv(t)
+	cam := "cam-ooo1"
+	base := time.Now().UTC().Truncate(time.Hour).Add(10 * time.Minute)
+
+	late := oooSeg(t, env, cam, "ooo-late", base.Add(61*time.Second), sparseSeg(2))
+	early := oooSeg(t, env, cam, "ooo-early", base, sparseSeg(2))
+
+	r.mergeSegments(context.Background(), cam, []pendingSegmentInfo{late})
+	r.mergeSegments(context.Background(), cam, []pendingSegmentInfo{early})
+
+	full := requireRowSelfConsistent(t, env, cam)
+	// 时间范围必须覆盖两段：started 不晚于早段 start，ended 不早于晚段 end。
+	require.False(t, full.StartedAt.After(early.startedAt), "started_at must cover the earlier segment")
+	require.False(t, full.EndedAt.Before(late.endedAt), "ended_at must cover the later segment")
+}
+
+// O2 批量乱序：同一 dispatch 携带 [晚, 早]。mergeAudioRun 直接取
+// recs[0].StartedAt / recs[last].EndedAt，乱序输入即产生倒挂行。
+func TestMergeOutOfOrder_BatchUnsorted(t *testing.T) {
+	env, _, r := wallEnv(t)
+	cam := "cam-ooo2"
+	base := time.Now().UTC().Truncate(time.Hour).Add(10 * time.Minute)
+
+	late := oooSeg(t, env, cam, "ooo-b-late", base.Add(61*time.Second), sparseSeg(2))
+	early := oooSeg(t, env, cam, "ooo-b-early", base, sparseSeg(2))
+
+	r.mergeSegments(context.Background(), cam, []pendingSegmentInfo{late, early})
+
+	full := requireRowSelfConsistent(t, env, cam)
+	require.False(t, full.StartedAt.After(early.startedAt), "started_at must cover the earlier segment")
+	require.False(t, full.EndedAt.Before(late.endedAt), "ended_at must cover the later segment")
+}

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -298,9 +298,13 @@ func (d *DB) RollingReplaceRecordings(ctx context.Context, merged *model.Recordi
 			return err
 		}
 	} else {
-		// Case 2: Append — UPDATE existing merged recording.
-		q := `UPDATE recordings SET file_path = ?, ended_at = ?, duration = ?, file_size = ?, frame_count = ?, merge_quality = ?, motion_score = ?, motion_confidence = ?, activity_flags = ?, timeline_map = ? WHERE id = ?;`
-		_, err = tx.ExecContext(ctx, q, merged.FilePath, timeToDB(merged.EndedAt), merged.Duration,
+		// Case 2: Append — UPDATE existing merged recording. started_at/ended_at
+		// use SQL min()/max(): appends may extend the row backward when an
+		// out-of-order earlier segment arrives (#698), and the endpoints must
+		// never invert or shrink the covered range. The canonical time format
+		// (big-endian, zero-padded) makes lexicographic min/max time-correct.
+		q := `UPDATE recordings SET file_path = ?, started_at = min(started_at, ?), ended_at = max(ended_at, ?), duration = ?, file_size = ?, frame_count = ?, merge_quality = ?, motion_score = ?, motion_confidence = ?, activity_flags = ?, timeline_map = ? WHERE id = ?;`
+		_, err = tx.ExecContext(ctx, q, merged.FilePath, timeToDB(merged.StartedAt), timeToDB(merged.EndedAt), merged.Duration,
 			merged.FileSize, merged.FrameCount, merged.MergeQuality, motionScore, motionConf, motionFlags, merged.TimelineMap, existingMergedID)
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #698. PR #697 CI 首跑失败暴露的真 bug：`TestWallAxis_WindowRolloverTwoBuckets` 产出 `ended_at < started_at` 的合并行（duration 120 / wall span −1，倒挂 1 秒）。

## 根因（#698 issue 里已详述，实现按其方案 1+2）

同相机两段的合并顺序跟随**锁获取顺序**而非事件顺序。乱序进入两条路径都会破坏行自洽：

1. **批量路径** `mergeAudioRun`：行锚点直接取 `recs[0].StartedAt` / `recs[last].EndedAt`，`[晚, 早]` 输入即产出倒挂行（CI 签名即此）；且合并**文件内容也按输入序拼接**——播放顺序同样错。
2. **桶 append 路径** `appendToBucket`：行的 `started_at` 固定为首个入桶段的 start（DB UPDATE 从不触碰该列），`ended_at = seg.endedAt` 无条件覆盖、`lastEnded` 无条件回写——早段晚到会把 `ended_at` 拉回去，覆盖范围倒缩甚至倒挂。

## 修复（乱序不敏感，而非追求派发保序）

- `mergeSegments` 入口按 `startedAt` 稳定排序；`mergeAudioRun` 内部再防御性排序（recs/infos 成对置换，保护 backfill 调用方）。批量路径的行锚点、文件播放顺序、compat-run 切分全部回到时间序。
- `appendToBucket`：`lastEnded` 只前进不后退（max）；新增 `bucket.rowStart`（createBucket 锚定首段 start），早段晚到时**向后扩展**；墙钟轴钳制到完整行跨度（I1 不变量 `duration == 墙钟跨度` 在任意到达序下成立——正常流程此钳制为 no-op）。
- `RollingReplaceRecordings` 的 append UPDATE：`started_at = min(started_at, ?)`、`ended_at = max(ended_at, ?)`——SQL 层终审，行端点永不倒挂/倒缩（canonical 时间格式字典序即时间序）。
- 存量升级兼容：升级时在途的旧桶 `rowStart` 为零值 → 该次 append 维持旧行为（不参与钳制），窗口翻转后新桶自然获得完整保障；DB 的 min/max 终审对该次同样生效。

## 测试（TDD：先红后绿）

- `wall_axis_ooo_test.go` 两个确定性复现（直接调 `mergeSegments`，绕开 debounce 派发的不确定性）：O1 桶 append 换序、O2 批量乱序——修复前双双命中 CI 同款倒挂签名（`ended_at … is before started_at … (inverted row)`），修复后断言行自洽 + 时间范围完整覆盖两段。
- 回归：merge + storage 全量 `-race`、`TestWallAxis|TestMergeOutOfOrder` ×3 `-race`（S1–S8 时间轴不变量全部保持）、golangci-lint 0 issues。

## 备注

- issue 中方案 3（per-camera FIFO 派发队列）未做：排序 + 端点终审已让结果对任意到达序不敏感，结构改造收益不再成立。若未来出现同相机高频乱序的真实场景再评估。
- 一个已知的残余局限（注释中已声明）：桶 append 路径在真正乱序时，合并**文件内**的帧序仍是先入桶段在前——源段在每次 append 后即删除，无法事后重排。行元数据与时间轴正确，极端罕见场景下单桶内播放顺序有瑕疵；批量路径（≥2 段同 dispatch）无此问题。