### PR TITLE
feat(vision): 多消费端实例接入 — 实例列表/相机路由/扇出推送/按 key 归因

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -296,7 +296,18 @@ observability:
 # a healthy consumer receives video-segment pushes and writes AI events back.
 # vision:
 #   enabled: false                      # Enable the push integration (default: false)
-#   url: "http://192.168.1.110:9091"   # Consumer base address
+#   url: "http://192.168.1.110:9091"   # Legacy single consumer base address. When
+#                                       # `instances` is empty this URL becomes the
+#                                       # implicit instance "default" — existing
+#                                       # single-instance setups need no change.
+#   instances:                          # Multiple consumers (each with its own model
+#     - name: jetson-y26                # config). Per-instance heartbeat health,
+#       url: "http://192.168.1.110:9091"# offline compensation, and push fan-out.
+#       api_key_name: "jetson"          # API key name used to attribute heartbeats /
+#       enabled: true                   # events / ai_status reports to this instance.
+#     - name: lab-v8                    # Cameras route via cameras[].vision_targets
+#       url: "http://192.168.1.50:9091" # (empty = ALL enabled instances).
+#       api_key_name: "lab"
 #   heartbeat_timeout_secs: 60          # Consider consumer offline after this long without a heartbeat
 #   push_mode: "notify"                 # "notify" = tell consumer to fetch; "upload" = push video bytes
 #   skip_cameras:                       # Cameras never pushed (e.g. MJPEG/JPEG encodings the

--- a/internal/api/handlers_ai.go
+++ b/internal/api/handlers_ai.go
@@ -108,6 +108,8 @@ func (h *Handler) handleCreateAIEvent(w http.ResponseWriter, r *http.Request) {
 		BBox:           bboxStr,
 		SnapshotPath:   body.SnapshotPath,
 		Metadata:       metadataStr,
+		// 写入方实例归因(多 Vision 接入):API Key 名落库,列表按 source 过滤。
+		Source: middleware.APIKeyNameFromContext(r.Context()),
 	}
 
 	id, err := h.db.InsertAIEvent(r.Context(), aiEvent)
@@ -151,6 +153,7 @@ func (h *Handler) handleListAIEvents(w http.ResponseWriter, r *http.Request) {
 	f := storage.AIEventFilter{
 		CameraID:  r.URL.Query().Get("camera_id"),
 		EventType: r.URL.Query().Get("event_type"),
+		Source:    r.URL.Query().Get("source"),
 	}
 	f.Limit, f.Offset = parsePagination(r, 0, 0) // no default/cap; ListAIEvents clamps to 50 internally
 	// Time-range filtering for timeline overlay support.

--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -398,6 +398,9 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		// Push-out relay targets (replace whole list) + retention
 		PushTargets       *[]config.PushTargetConfig `json:"push_targets"`
 		PushRetentionDays *int                       `json:"push_retention_days"`
+		// Vision instance routing (replace whole list; empty = all enabled
+		// instances). Unknown names are rejected with a 400.
+		VisionTargets *[]string `json:"vision_targets"`
 		// IP self-healing: stable hardware ID (ONVIF serial) + candidate subnets.
 		StableID    *string   `json:"stable_id"`
 		SubnetHints *[]string `json:"subnet_hints"`
@@ -413,6 +416,22 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		!strings.HasPrefix(*body.SubStreamURL, "rtsp://") && !strings.HasPrefix(*body.SubStreamURL, "rtsps://") {
 		WriteError(w, http.StatusBadRequest, "sub_stream_url must be an rtsp:// or rtsps:// URL")
 		return
+	}
+
+	// vision_targets must reference existing vision instances — a typo would
+	// silently route the camera nowhere (empty resolved route), so reject it.
+	if body.VisionTargets != nil && h.config != nil {
+		known := make(map[string]bool, len(h.config.Vision.Instances)+1)
+		for _, ins := range h.config.Vision.EffectiveInstances() {
+			known[ins.Name] = true
+		}
+		for _, name := range *body.VisionTargets {
+			if !known[name] {
+				WriteError(w, http.StatusBadRequest,
+					"vision_targets references unknown vision instance: "+name)
+				return
+			}
+		}
 	}
 
 	// Reject a dirty stable_id at the API boundary (see #216). nil/empty means
@@ -482,6 +501,7 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		SRTStreamID:            body.SRTStreamID,
 		PushTargets:            body.PushTargets,
 		PushRetentionDays:      body.PushRetentionDays,
+		VisionTargets:          body.VisionTargets,
 		GB28181:                body.GB28181.toConfigPtr(),
 	}
 

--- a/internal/api/handlers_camera_create.go
+++ b/internal/api/handlers_camera_create.go
@@ -103,6 +103,8 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		// Push-out relay targets + retention
 		PushTargets       []config.PushTargetConfig `json:"push_targets"`
 		PushRetentionDays *int                      `json:"push_retention_days"`
+		// Vision instance routing (empty = all enabled instances).
+		VisionTargets []string `json:"vision_targets"`
 		// IP self-healing: stable hardware ID (ONVIF serial) + candidate subnets.
 		StableID    string   `json:"stable_id"`
 		SubnetHints []string `json:"subnet_hints"`
@@ -116,6 +118,21 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		WriteError(w, http.StatusBadRequest, "invalid request body")
 		return
+	}
+
+	// vision_targets must reference existing vision instances (see update path).
+	if len(body.VisionTargets) > 0 && h.config != nil {
+		known := make(map[string]bool, len(h.config.Vision.Instances)+1)
+		for _, ins := range h.config.Vision.EffectiveInstances() {
+			known[ins.Name] = true
+		}
+		for _, name := range body.VisionTargets {
+			if !known[name] {
+				WriteError(w, http.StatusBadRequest,
+					"vision_targets references unknown vision instance: "+name)
+				return
+			}
+		}
 	}
 	if body.Name == "" {
 		WriteError(w, http.StatusBadRequest, "name is required")
@@ -310,6 +327,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		SRTStreamID:       body.SRTStreamID,
 		PushTargets:       body.PushTargets,
 		PushRetentionDays: body.PushRetentionDays,
+		VisionTargets:     body.VisionTargets,
 		StableID:          body.StableID,
 		SubnetHints:       body.SubnetHints,
 	}

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -64,6 +65,13 @@ func (h *Handler) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 		},
 		"mibeevision": map[string]any{
 			"api_keys": buildAPIKeyInfo(h.config.APIKeys, h.apiKeyLastUsed()),
+		},
+		"vision": map[string]any{
+			"enabled":                h.config.Vision.Enabled,
+			"url":                    h.config.Vision.URL,
+			"push_mode":              h.config.Vision.PushMode,
+			"heartbeat_timeout_secs": h.config.Vision.HeartbeatTimeoutSecs,
+			"instances":              h.config.Vision.Instances,
 		},
 		"update": map[string]any{
 			// Bare-metal auto-apply toggle (#648 UI switch, #647 execution).
@@ -196,6 +204,13 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 			PathPrefix *string `json:"path_prefix"`
 			ReadWrite  *bool   `json:"read_write"`
 		} `json:"webdav"`
+		Vision *struct {
+			// 多实例消费端配置(整表替换)。实例名唯一/URL http(s) 在此校验;
+			// 删除仍被相机路由引用的实例会被 400 拒绝(先解路由再删)。
+			Enabled   *bool                    `json:"enabled"`
+			URL       *string                  `json:"url"`
+			Instances *[]config.VisionInstance `json:"instances"`
+		} `json:"vision"`
 		Timezone *string `json:"timezone"`
 		Server   *struct {
 			Listen *string `json:"listen"`
@@ -322,6 +337,59 @@ func (h *Handler) handleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		if body.WebDAV.ReadWrite != nil {
 			h.config.WebDAV.ReadWrite = *body.WebDAV.ReadWrite
 		}
+	}
+
+	// Update vision consumer instances (multi-instance routing). The
+	// coordinator reads cfg live (same pointer), so changes apply without a
+	// restart; instance health trackers survive edits (reconciled by name).
+	if body.Vision != nil {
+		if body.Vision.Instances != nil {
+			seen := make(map[string]bool, len(*body.Vision.Instances))
+			for i, ins := range *body.Vision.Instances {
+				if strings.TrimSpace(ins.Name) == "" {
+					WriteError(w, http.StatusBadRequest, fmt.Sprintf("vision.instances[%d].name is required", i))
+					return
+				}
+				if seen[ins.Name] {
+					WriteError(w, http.StatusBadRequest, fmt.Sprintf("vision.instances[%d] duplicate name %q", i, ins.Name))
+					return
+				}
+				seen[ins.Name] = true
+				u, perr := url.Parse(ins.URL)
+				if perr != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+					WriteError(w, http.StatusBadRequest, fmt.Sprintf("vision.instances[%d].url must be an http(s) URL, got %q", i, ins.URL))
+					return
+				}
+			}
+			// Removing an instance still referenced by a camera's routing
+			// would silently strand that camera — reject with the offenders.
+			known := seen
+			known["default"] = true
+			var stranded []string
+			for _, cam := range h.config.Cameras {
+				for _, name := range cam.VisionTargets {
+					if !known[name] {
+						stranded = append(stranded, cam.ID+"→"+name)
+						break
+					}
+				}
+			}
+			if len(stranded) > 0 {
+				WriteError(w, http.StatusBadRequest,
+					"cameras still route to removed vision instances: "+strings.Join(stranded, ", "))
+				return
+			}
+			h.config.Vision.Instances = *body.Vision.Instances
+		}
+		if body.Vision.URL != nil {
+			h.config.Vision.URL = strings.TrimSpace(*body.Vision.URL)
+		}
+		if body.Vision.Enabled != nil {
+			h.config.Vision.Enabled = *body.Vision.Enabled
+		}
+		logger.Info("vision settings updated",
+			"instances", len(h.config.Vision.EffectiveInstances()),
+			"enabled", h.config.Vision.Enabled)
 	}
 
 	// Update timezone

--- a/internal/api/handlers_vision.go
+++ b/internal/api/handlers_vision.go
@@ -6,12 +6,14 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/go-chi/chi/v5"
 )
 
 // registerVisionPublicRoutes 注册无需认证的 Vision 端点(与 SSE 一样在 public 组)。
 // 心跳是 Vision 的"我在"信号,不应要求 BasicAuth(Vision 只有 API Key)。
+// 若请求恰好携带了 API Key(心跳 v2 客户端都会带),则用于多实例归因。
 func (h *Handler) registerVisionPublicRoutes(r chi.Router) {
 	r.Post("/api/vision/heartbeat", h.handleVisionHeartbeat)
 }
@@ -22,9 +24,12 @@ func (h *Handler) registerVisionRoutes(r chi.Router) {
 	r.Get("/api/vision/metrics", h.handleVisionMetrics)
 }
 
-// handleVisionHeartbeat 接收 MiBeeVision 的心跳报告。
-// Vision 每 30 秒 POST 一次,NVR 据此判断 Vision 是否健康。
-// 只有健康的 Vision 才会收到段推送。
+// handleVisionHeartbeat 接收 MiBeeVision 实例的心跳报告。
+// Vision 每 30 秒 POST 一次,NVR 据此判断实例是否健康。
+// 只有健康的实例才会收到段推送。
+//
+// 多实例归因:请求携带的 Bearer API Key 名匹配 vision.instances[].api_key_name
+// 时心跳记到该实例;匿名/未匹配落到 default 实例(兼容旧版单实例部署)。
 //
 // 心跳 v2 (#671) 增加两个可选块(旧版本消费者不带,完全向后兼容):
 //   - drops:批量丢弃报告(压缩范围)。收到即把受影响录像标记
@@ -55,7 +60,11 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	h.visionCoordinator.Health().RecordHeartbeat(vision.HeartbeatStatus{
+	keyName := ""
+	if middleware.IsAPIKeyAuthenticated(r.Context()) {
+		keyName = middleware.APIKeyNameFromContext(r.Context())
+	}
+	insName := h.visionCoordinator.RecordHeartbeat(keyName, vision.HeartbeatStatus{
 		Status:         body.Status,
 		Device:         body.Device,
 		QueueDepth:     body.QueueDepth,
@@ -67,12 +76,17 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 
 	resp := map[string]interface{}{
 		"ok":           true,
-		"push_enabled": h.visionCoordinator.Health().IsHealthy(),
+		"push_enabled": false,
+	}
+	if tracker, _ := h.visionCoordinator.InstanceByName(insName); tracker != nil {
+		resp["push_enabled"] = tracker.IsHealthy()
 	}
 	if body.Drops != nil {
 		if h.db != nil {
 			if marked := vision.ApplyDrops(r.Context(), h.db, body.Drops); marked > 0 {
-				h.visionCoordinator.Health().NoteMarkedDrops(marked)
+				if tracker, _ := h.visionCoordinator.InstanceByName(insName); tracker != nil {
+					tracker.NoteMarkedDrops(marked)
+				}
 			}
 		}
 		// ack = "已收到并消费这份报告"。即使个别范围数据坏掉被跳过,
@@ -83,7 +97,8 @@ func (h *Handler) handleVisionHeartbeat(w http.ResponseWriter, r *http.Request) 
 }
 
 // handleVisionStatus 返回 Vision 集成的当前状态(供 NVR Web UI 展示)。
-// 这个端点在 authMW 保护组内,只有登录用户可访问。
+// 顶层字段保持单实例时代的形状(= default 实例),多实例部署附加
+// instances[] 数组逐实例展开。
 func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 	if h.visionCoordinator == nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -100,6 +115,7 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 		"queue_depth":  status.QueueDepth,
 		"processed":    status.ProcessedCount,
 		"skip_cameras": status.SkipCameras, // #515: 消费者声明的跳单(空=nil=全推)
+		"instances":    h.visionCoordinator.InstancesStatus(),
 	}
 	if status.Metrics != nil {
 		resp["metrics"] = status.Metrics
@@ -116,7 +132,7 @@ func (h *Handler) handleVisionStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleVisionMetrics 返回心跳历史采样环(内存,约 24h @ 30s),供仪表盘
-// 趋势图。?hours=1..168(默认 24)。
+// 趋势图。?hours=1..168(默认 24);?instance=NAME 指定实例(默认 default)。
 func (h *Handler) handleVisionMetrics(w http.ResponseWriter, r *http.Request) {
 	if h.visionCoordinator == nil {
 		writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -139,10 +155,21 @@ func (h *Handler) handleVisionMetrics(w http.ResponseWriter, r *http.Request) {
 	if hours > 168 {
 		hours = 168
 	}
+	tracker, name := h.visionCoordinator.InstanceByName(r.URL.Query().Get("instance"))
+	if tracker == nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"enabled":      true,
+			"instance":     "",
+			"points":       []vision.VisionSample{},
+			"marked_total": 0,
+		})
+		return
+	}
 	since := time.Now().Add(-time.Duration(hours) * time.Hour)
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"enabled":      true,
-		"points":       h.visionCoordinator.Health().MetricsHistory(since),
-		"marked_total": h.visionCoordinator.Health().MarkedDropTotal(),
+		"instance":     name,
+		"points":       tracker.MetricsHistory(since),
+		"marked_total": tracker.MarkedDropTotal(),
 	})
 }

--- a/internal/api/handlers_vision_test.go
+++ b/internal/api/handlers_vision_test.go
@@ -7,12 +7,14 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/vision"
 	"github.com/stretchr/testify/require"
 )
@@ -180,4 +182,81 @@ func TestVision_HeartbeatV2UnparseableRangeTimesStill200(t *testing.T) {
 	rr := doRequest(t, routes, http.MethodPost, "/api/vision/heartbeat", strings.NewReader(body), "", "")
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Contains(t, rr.Body.String(), `"ack_drops":9`)
+}
+
+// 多实例心跳归因:携带 Bearer API Key 的心跳落到 key 关联的实例
+// (vision.instances[].api_key_name);未关联的 key/匿名落 default。
+// GET /api/vision/status 的 instances[] 按实例展开健康状态。
+func TestVision_HeartbeatInstanceAttribution(t *testing.T) {
+	t.Parallel()
+	db, store := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	h := TestHandler(db, store)
+
+	keyStore := middleware.NewAPIKeyStore()
+	keyStore.SetKeys(map[string]string{
+		"mbv_testkey0001": "key-a",
+		"mbv_testkey0002": "key-b",
+	})
+	h.SetAPIKeyStore(keyStore)
+
+	enabled := true
+	h.SetVisionCoordinator(vision.NewCoordinator(
+		func() config.VisionConfig {
+			return config.VisionConfig{
+				HeartbeatTimeoutSecs: 30,
+				Instances: []config.VisionInstance{
+					{Name: "a", URL: "http://a:9091", APIKeyName: "key-a"},
+					{Name: "b", URL: "http://b:9091", APIKeyName: "key-b", Enabled: &enabled},
+				},
+			}
+		},
+		func() string { return store.RootDir() },
+		event.NewEventBus(4),
+		nil, nil,
+	))
+	// 生产链路里 APIKey 中间件挂在根路由(Routes() 之外)——测试手动补一层,
+	// 否则 Bearer 不会被识别、归因永远落 default。
+	routes := middleware.APIKeyAuthMiddleware(keyStore, h.Routes())
+
+	beat := func(key, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/vision/heartbeat", strings.NewReader(body))
+		if key != "" {
+			req.Header.Set("Authorization", "Bearer "+key)
+		}
+		rr := httptest.NewRecorder()
+		routes.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// key-a 的心跳 → 只实例 a 健康。
+	rr := beat("mbv_testkey0001", `{"status":"healthy","device":"cuda-a"}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"push_enabled":true`)
+
+	// key-b 的心跳带 degraded → 实例 b 不健康(但请求本身成功)。
+	rr = beat("mbv_testkey0002", `{"status":"degraded","device":"cuda-b"}`)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"push_enabled":false`)
+
+	rr = doRequest(t, routes, http.MethodGet, "/api/vision/status", nil, "", "")
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp struct {
+		Instances []vision.InstanceStatus `json:"instances"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Instances, 2)
+	require.Equal(t, "a", resp.Instances[0].Name)
+	require.True(t, resp.Instances[0].Healthy)
+	require.Equal(t, "cuda-a", resp.Instances[0].Device)
+	require.Equal(t, "b", resp.Instances[1].Name)
+	require.False(t, resp.Instances[1].Healthy)
+	require.Equal(t, "cuda-b", resp.Instances[1].Device)
+
+	// ?instance=b 的 metrics 端点返回实例 b 的采样。
+	req := httptest.NewRequest(http.MethodGet, "/api/vision/metrics?instance=b", nil)
+	rr = httptest.NewRecorder()
+	routes.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"instance":"b"`)
 }

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -595,6 +595,9 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 	if updates.PushTargets != nil {
 		cam.PushTargets = *updates.PushTargets
 	}
+	if updates.VisionTargets != nil {
+		cam.VisionTargets = *updates.VisionTargets
+	}
 	if updates.PushRetentionDays != nil {
 		cam.PushRetentionDays = updates.PushRetentionDays
 	}

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -99,6 +99,9 @@ type CameraUpdate struct {
 	// Push-out relay targets (replace the whole list when set). nil = unchanged.
 	PushTargets       *[]config.PushTargetConfig
 	PushRetentionDays *int
+	// Vision instance routing (replace the whole list when set; empty = all
+	// enabled instances). nil = unchanged.
+	VisionTargets *[]string
 	// IP self-healing: stable hardware ID (ONVIF serial) + candidate subnets.
 	// nil = unchanged. Empty string/nil slice = clear.
 	StableID    *string

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -169,6 +169,11 @@ type CameraConfig struct {
 	// Applies to ANY camera protocol — the engine subscribes to the camera's
 	// StreamHub, so no re-pull happens. Each entry is one independent target.
 	PushTargets []PushTargetConfig `yaml:"push_targets,omitempty" json:"push_targets,omitempty"`
+	// VisionTargets names the vision instances this camera's recordings are
+	// pushed to (multi-instance routing). Empty = all enabled instances (the
+	// single-instance default). Names must exist in vision.instances; validated
+	// at the API layer with a 400 for unknown names.
+	VisionTargets []string `yaml:"vision_targets,omitempty" json:"vision_targets,omitempty"`
 	// Per-camera push-in retention override. nil = follow global retention,
 	// 0 = live-only (no recording), N = keep N days. Only meaningful for srt/rtmp.
 	PushRetentionDays *int `yaml:"push_retention_days,omitempty" json:"push_retention_days,omitempty"`

--- a/internal/config/config_vision.go
+++ b/internal/config/config_vision.go
@@ -15,7 +15,15 @@ type VisionConfig struct {
 
 	// URL Vision 服务的基地址,如 "http://192.168.63.110:9091"。
 	// NVR 将 POST 到 {URL}/vision/segment/notify。
+	//
+	// 多实例部署时此字段退化为兼容显示字段,实际推送目标以 instances 为准;
+	// instances 为空且 URL 非空时,运行时合成为名为 "default" 的单实例。
 	URL string `yaml:"url" json:"url"`
+
+	// Instances 多个 Vision 消费端实例。每个实例独立的地址/身份/启停;
+	// 相机可通过 camera.vision_targets 选择接哪些实例(空=全部启用实例)。
+	// 不同实例可挂不同模型配置,实现按场景分流分析。
+	Instances []VisionInstance `yaml:"instances,omitempty" json:"instances,omitempty"`
 
 	// HeartbeatTimeoutSecs 心跳超时(秒)。超过此时间未收到 Vision 心跳,
 	// NVR 认为 Vision 不健康,暂停推送。默认 60。
@@ -60,6 +68,71 @@ type VisionConfig struct {
 	// 正式录像库的 layer=1 行,非 #537 的临时 sublayer 目录)。skip_cameras
 	// 优先于此列表。
 	TieredCameras []string `yaml:"tiered_cameras" json:"tieredCameras"`
+}
+
+// VisionInstance 一个 Vision 消费端实例的接入描述。
+type VisionInstance struct {
+	// Name 实例名(稳定标识,相机 vision_targets 引用它;唯一)。
+	Name string `yaml:"name" json:"name"`
+
+	// URL 实例基地址,NVR POST 到 {URL}/vision/segment/upload。
+	URL string `yaml:"url" json:"url"`
+
+	// APIKeyName 关联的 API Key 名(可选)。心跳/事件/ai_status 回传携带
+	// 该 key 时,NVR 据此把回传归因到本实例。缺省时回传归因到 default 实例。
+	APIKeyName string `yaml:"api_key_name,omitempty" json:"apiKeyName,omitempty"`
+
+	// Enabled 是否参与推送(nil/true=启用)。禁用的实例保留配置但不出现在
+	// 路由目标中。
+	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+}
+
+// EnabledOrDefault 报告实例是否启用(nil 视为启用,兼容省略写法)。
+func (i VisionInstance) EnabledOrDefault() bool {
+	return i.Enabled == nil || *i.Enabled
+}
+
+// EffectiveInstances 返回生效的实例列表(保持配置顺序)。
+// instances 为空时合成单实例 "default"(URL 取 legacy 字段,可为空——
+// "Vision 先部署、NVR 还没配地址"的阶段心跳仍可记录,推送自然空转):
+// 现有单实例部署零变化。instances 与 URL 同时配置时 instances 优先。
+func (v VisionConfig) EffectiveInstances() []VisionInstance {
+	if len(v.Instances) > 0 {
+		return v.Instances
+	}
+	return []VisionInstance{{Name: "default", URL: v.URL}}
+}
+
+// EnabledInstances 返回启用中的实例(EffectiveInstances 过滤 enabled)。
+func (v VisionConfig) EnabledInstances() []VisionInstance {
+	all := v.EffectiveInstances()
+	out := make([]VisionInstance, 0, len(all))
+	for _, ins := range all {
+		if ins.EnabledOrDefault() {
+			out = append(out, ins)
+		}
+	}
+	return out
+}
+
+// RouteFor 解析一台相机的推送目标实例。cameraTargets 为空 → 全部启用实例
+// (默认广播,单实例部署即"推给唯一实例");非空 → 按其顺序返回已知且启用的
+// 实例(未知名称忽略——配置校验层负责提前 400,运行时容错防 typo 瘫痪)。
+func (v VisionConfig) RouteFor(cameraTargets []string) []VisionInstance {
+	if len(cameraTargets) == 0 {
+		return v.EnabledInstances()
+	}
+	byName := make(map[string]VisionInstance, len(v.Instances)+1)
+	for _, ins := range v.EffectiveInstances() {
+		byName[ins.Name] = ins
+	}
+	out := make([]VisionInstance, 0, len(cameraTargets))
+	for _, name := range cameraTargets {
+		if ins, ok := byName[name]; ok && ins.EnabledOrDefault() {
+			out = append(out, ins)
+		}
+	}
+	return out
 }
 
 // ShouldSkipCamera 报告 camera_id 是否在 SkipCameras 列表中。

--- a/internal/config/config_vision_test.go
+++ b/internal/config/config_vision_test.go
@@ -35,3 +35,138 @@ func TestSubLayerCameraSet(t *testing.T) {
 
 	require.Empty(t, VisionConfig{}.SubLayerCameraSet())
 }
+
+func boolPtr(b bool) *bool { return &b }
+
+// 多实例:legacy 单 URL 配置必须无损合成为名为 "default" 的实例——
+// 现有部署零变化,心跳/推送路径全兼容。
+func TestVisionEffectiveInstancesLegacySynthesis(t *testing.T) {
+	v := VisionConfig{Enabled: true, URL: "http://jetson:9091"}
+	ins := v.EffectiveInstances()
+	require.Len(t, ins, 1)
+	require.Equal(t, "default", ins[0].Name)
+	require.Equal(t, "http://jetson:9091", ins[0].URL)
+	require.True(t, ins[0].EnabledOrDefault(), "legacy instance must default to enabled")
+}
+
+// 既配 legacy URL 又配 instances:instances 优先(URL 保留作显示字段,不再合成)。
+func TestVisionEffectiveInstancesExplicitWins(t *testing.T) {
+	v := VisionConfig{
+		URL: "http://old:9091",
+		Instances: []VisionInstance{
+			{Name: "a", URL: "http://a:9091"},
+			{Name: "b", URL: "http://b:9091", Enabled: boolPtr(false)},
+		},
+	}
+	ins := v.EffectiveInstances()
+	require.Len(t, ins, 2)
+	require.Equal(t, "a", ins[0].Name)
+	require.Equal(t, "b", ins[1].Name)
+}
+
+// 全部禁用 → EnabledInstances 为空(推送整体停摆,但心跳仍可记录)。
+func TestVisionEnabledInstancesFilters(t *testing.T) {
+	v := VisionConfig{Instances: []VisionInstance{
+		{Name: "a", URL: "http://a:9091"},
+		{Name: "b", URL: "http://b:9091", Enabled: boolPtr(false)},
+	}}
+	enabled := v.EnabledInstances()
+	require.Len(t, enabled, 1)
+	require.Equal(t, "a", enabled[0].Name)
+
+	allOff := VisionConfig{Instances: []VisionInstance{
+		{Name: "a", URL: "http://a:9091", Enabled: boolPtr(false)},
+	}}
+	require.Empty(t, allOff.EnabledInstances())
+}
+
+// 路由解析:相机未配置(空)→ 全部启用实例(默认广播);
+// 显式配置 → 按配置顺序返回已知实例;未知名称在配置校验层拦截,
+// 运行时兜底为忽略(防止 typo 让推送整体瘫痪)。
+func TestVisionRouteFor(t *testing.T) {
+	v := VisionConfig{Instances: []VisionInstance{
+		{Name: "a", URL: "http://a:9091"},
+		{Name: "b", URL: "http://b:9091"},
+		{Name: "c", URL: "http://c:9091", Enabled: boolPtr(false)},
+	}}
+
+	// 空 targets → 全部启用实例(a+b,c 被禁用排除)。
+	routed := v.RouteFor(nil)
+	require.Len(t, routed, 2)
+	require.Equal(t, "a", routed[0].Name)
+	require.Equal(t, "b", routed[1].Name)
+
+	// 显式子集,保持配置顺序。
+	routed = v.RouteFor([]string{"b", "a"})
+	require.Len(t, routed, 2)
+	require.Equal(t, "b", routed[0].Name)
+	require.Equal(t, "a", routed[1].Name)
+
+	// 显式选中已禁用实例 → 该实例不生效(enabled 过滤优先于路由)。
+	routed = v.RouteFor([]string{"a", "c"})
+	require.Len(t, routed, 1)
+	require.Equal(t, "a", routed[0].Name)
+
+	// 未知名称忽略(配置校验负责 400,运行时容错)。
+	routed = v.RouteFor([]string{"ghost", "a"})
+	require.Len(t, routed, 1)
+	require.Equal(t, "a", routed[0].Name)
+}
+
+// legacy 合成下的路由:单实例部署,相机无论配不配 targets 都路由到 default。
+func TestVisionRouteForLegacy(t *testing.T) {
+	v := VisionConfig{URL: "http://jetson:9091"}
+	require.Len(t, v.RouteFor(nil), 1)
+	require.Equal(t, "default", v.RouteFor(nil)[0].Name)
+	require.Len(t, v.RouteFor([]string{"anything-else"}), 0,
+		"explicit unknown target on legacy config routes nowhere (validation catches earlier)")
+}
+
+// 配置校验:实例名唯一/必填、URL 必须 http(s)、相机 vision_targets 引用
+// 已定义实例(default 合成名也算)、legacy 单 URL(空 instances)不校验 URL。
+func TestValidateVisionInstances(t *testing.T) {
+	base := func(mod func(*Config)) *Config {
+		cfg := &Config{}
+		cfg.ApplyDefaults() // 零值配置会被 FTP/segment_duration 等校验拦
+		mod(cfg)
+		return cfg
+	}
+
+	require.NoError(t, Validate(base(func(c *Config) {
+		c.Vision = VisionConfig{URL: "http://a:9091"} // legacy,无显式实例
+	})))
+
+	require.ErrorContains(t, Validate(base(func(c *Config) {
+		c.Vision = VisionConfig{Instances: []VisionInstance{{Name: "a"}}} // 缺 URL
+	})), "http(s)")
+
+	require.ErrorContains(t, Validate(base(func(c *Config) {
+		c.Vision = VisionConfig{Instances: []VisionInstance{
+			{Name: "a", URL: "http://a:9091"},
+			{Name: "a", URL: "http://b:9091"},
+		}}
+	})), "duplicate name")
+
+	require.ErrorContains(t, Validate(base(func(c *Config) {
+		c.Vision = VisionConfig{Instances: []VisionInstance{
+			{Name: "", URL: "http://a:9091"},
+		}}
+	})), "name is required")
+
+	// 相机路由引用未知实例 → 拒绝;引用 default/显式实例 → 通过。
+	withCam := func(targets []string, instances []VisionInstance) *Config {
+		return base(func(c *Config) {
+			c.Vision = VisionConfig{Instances: instances}
+			c.Cameras = []CameraConfig{{
+				ID: "cam-1", Protocol: "rtsp", URL: "rtsp://192.168.1.10:554/stream1",
+				Encoding: "h264", VisionTargets: targets,
+			}}
+		})
+	}
+	require.ErrorContains(t, Validate(withCam([]string{"ghost"},
+		[]VisionInstance{{Name: "a", URL: "http://a:9091"}})),
+		"unknown vision instance")
+	require.NoError(t, Validate(withCam([]string{"a", "default"},
+		[]VisionInstance{{Name: "a", URL: "http://a:9091"}})))
+	require.NoError(t, Validate(withCam(nil, nil))) // legacy 全兼容
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -88,6 +88,24 @@ func validateConfigDetails(cfg *Config) error {
 	if p := cfg.Server.Discovery.UDP.Port; p < 0 || p > 65535 {
 		return fmt.Errorf("server.discovery.udp.port must be between 1 and 65535, got %d", p)
 	}
+	// Vision 多实例:名称唯一必填;URL 合法 http(s)(legacy url 字段为空的
+	// "default 合成"不算显式实例,跳过 URL 检查)。
+	visionNames := make(map[string]bool, len(cfg.Vision.Instances)+1)
+	for i, ins := range cfg.Vision.Instances {
+		if strings.TrimSpace(ins.Name) == "" {
+			return fmt.Errorf("vision.instances[%d].name is required", i)
+		}
+		if visionNames[ins.Name] {
+			return fmt.Errorf("vision.instances[%d] duplicate name %q", i, ins.Name)
+		}
+		visionNames[ins.Name] = true
+		u, uerr := url.Parse(ins.URL)
+		if uerr != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("vision.instances[%d].url must be an http(s) URL, got %q", i, ins.URL)
+		}
+	}
+	// legacy 合成名 default 与显式实例同坐标系:相机可路由到 "default"。
+	visionNames["default"] = true
 	// cameras must have id and url
 	seen := make(map[string]int)
 	for i, c := range cfg.Cameras {
@@ -161,6 +179,13 @@ func validateConfigDetails(cfg *Config) error {
 		}
 
 		// Validate IP self-healing fields (stable_id + subnet_hints).
+		// 相机的 vision_targets 必须引用已定义实例——typo 会让该相机静默
+		// 失去推送路由。
+		for j, name := range c.VisionTargets {
+			if !visionNames[name] {
+				return fmt.Errorf("camera[%d].vision_targets[%d] references unknown vision instance %q", i, j, name)
+			}
+		}
 		// A non-empty stable_id that fails IsValidStableID (IP, URL, all-zero
 		// MAC — frozen in YAML by a prior firmware glitch, see #216) is logged
 		// as a WARNING, NOT a hard error. Hard-erroring would brick startup on

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -241,7 +241,7 @@ func (d *DB) ReadPoolStats() (sql.DBStats, bool) {
 // Also ensured via idempotent ALTER; pre-v34 rows carry -1 = "full weight".
 //
 // The schema_meta table tracks the schema version for future migrations.
-const currentSchemaVersion = "34"
+const currentSchemaVersion = "35"
 
 func (d *DB) Init(ctx context.Context) error {
 	// ── Tables (full baseline — new installs get the final schema in one step) ──
@@ -357,6 +357,7 @@ func (d *DB) Init(ctx context.Context) error {
 		bbox TEXT,
 		snapshot_path TEXT,
 		metadata TEXT,
+		source TEXT DEFAULT '',
 		created_at TEXT DEFAULT (datetime('now'))
 	)`
 	timelapseMergesSQL := `CREATE TABLE IF NOT EXISTS timelapse_merges (
@@ -575,6 +576,19 @@ func (d *DB) ensureRecordingsMotionColumns(ctx context.Context) error {
 		if _, err := d.db.ExecContext(ctx,
 			`ALTER TABLE recordings ADD COLUMN layer INTEGER DEFAULT 0`); err != nil {
 			return fmt.Errorf("add layer column: %w", err)
+		}
+	}
+	// v35: AI 事件来源实例(多 Vision 接入,事件按 API Key 名归因;空=旧数据/匿名)。
+	var aiSourceColExists int
+	if err := d.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pragma_table_info('ai_events') WHERE name='source'`,
+	).Scan(&aiSourceColExists); err != nil {
+		return fmt.Errorf("check ai_events.source column: %w", err)
+	}
+	if aiSourceColExists == 0 {
+		if _, err := d.db.ExecContext(ctx,
+			`ALTER TABLE ai_events ADD COLUMN source TEXT DEFAULT ''`); err != nil {
+			return fmt.Errorf("add ai_events.source column: %w", err)
 		}
 	}
 	return nil

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -24,18 +24,19 @@ type AIEvent struct {
 	BBox           string  `json:"bbox,omitempty"` // JSON array [x1,y1,x2,y2] normalized
 	SnapshotPath   string  `json:"snapshot_path,omitempty"`
 	Metadata       string  `json:"metadata,omitempty"` // JSON
+	Source         string  `json:"source,omitempty"`   // 写入方 API Key 名(多 Vision 实例归因;空=旧数据/匿名)
 	CreatedAt      string  `json:"created_at"`
 }
 
 // InsertAIEvent stores a new AI event from MiBeeVision.
 func (d *DB) InsertAIEvent(ctx context.Context, e *AIEvent) (int64, error) {
-	q := `INSERT INTO ai_events (camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
+	q := `INSERT INTO ai_events (camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, source)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 	result, err := d.db.ExecContext(
 		ctx, q,
 		e.CameraID, e.RecordingID, e.EventType, e.Severity,
 		e.ZoneName, e.ClassName, e.Confidence, e.FrameIdx,
-		e.FrameTimestamp, e.BBox, e.SnapshotPath, e.Metadata,
+		e.FrameTimestamp, e.BBox, e.SnapshotPath, e.Metadata, e.Source,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("insert ai event: %w", err)
@@ -53,6 +54,7 @@ type AIEventFilter struct {
 	CameraID    string
 	RecordingID string // filter by recording_id (used by merge migration tests + NVR UI)
 	EventType   string
+	Source      string     // filter by writer instance (API key name, v35)
 	StartTime   *time.Time // inclusive lower bound on created_at
 	EndTime     *time.Time // inclusive upper bound on created_at
 	AscOrder    bool       // order by created_at ASC (for timeline overlay)
@@ -87,6 +89,10 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 		where = append(where, "event_type = ?")
 		args = append(args, f.EventType)
 	}
+	if f.Source != "" {
+		where = append(where, "source = ?")
+		args = append(args, f.Source)
+	}
 	if f.StartTime != nil {
 		where = append(where, "created_at >= ?")
 		args = append(args, f.StartTime.Format("2006-01-02 15:04:05.999999999"))
@@ -114,7 +120,7 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 	}
 
 	// Data
-	dataQ := `SELECT id, camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, created_at
+	dataQ := `SELECT id, camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, source, created_at
 		FROM ai_events` + whereClause + orderClause + ` LIMIT ? OFFSET ?`
 	rows, err := d.readConn().QueryContext(ctx, dataQ, append(args, f.Limit, f.Offset)...)
 	if err != nil {
@@ -125,10 +131,10 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 	var events []AIEvent
 	for rows.Next() {
 		var e AIEvent
-		var recordingID, zoneName, className, frameTS, bbox, snapshotPath, metadata sql.NullString
+		var recordingID, zoneName, className, frameTS, bbox, snapshotPath, metadata, source sql.NullString
 		if err := rows.Scan(&e.ID, &e.CameraID, &recordingID, &e.EventType, &e.Severity,
 			&zoneName, &className, &e.Confidence, &e.FrameIdx, &frameTS,
-			&bbox, &snapshotPath, &metadata, &e.CreatedAt); err != nil {
+			&bbox, &snapshotPath, &metadata, &source, &e.CreatedAt); err != nil {
 			return nil, 0, err
 		}
 		e.RecordingID = recordingID.String
@@ -138,6 +144,7 @@ func (d *DB) ListAIEvents(ctx context.Context, f AIEventFilter) ([]AIEvent, int,
 		e.BBox = bbox.String
 		e.SnapshotPath = snapshotPath.String
 		e.Metadata = metadata.String
+		e.Source = source.String
 		e.CreatedAt = aiCreatedAtToRFC3339(e.CreatedAt)
 		events = append(events, e)
 	}
@@ -166,14 +173,14 @@ func aiCreatedAtToRFC3339(s string) string {
 
 // GetAIEvent returns a single AI event by ID.
 func (d *DB) GetAIEvent(ctx context.Context, id int64) (*AIEvent, error) {
-	q := `SELECT id, camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, created_at
+	q := `SELECT id, camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, source, created_at
 		FROM ai_events WHERE id = ?`
 	row := d.readConn().QueryRowContext(ctx, q, id)
 	var e AIEvent
-	var recordingID, zoneName, className, frameTS, bbox, snapshotPath, metadata sql.NullString
+	var recordingID, zoneName, className, frameTS, bbox, snapshotPath, metadata, source sql.NullString
 	err := row.Scan(&e.ID, &e.CameraID, &recordingID, &e.EventType, &e.Severity,
 		&zoneName, &className, &e.Confidence, &e.FrameIdx, &frameTS,
-		&bbox, &snapshotPath, &metadata, &e.CreatedAt)
+		&bbox, &snapshotPath, &metadata, &source, &e.CreatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
@@ -187,6 +194,7 @@ func (d *DB) GetAIEvent(ctx context.Context, id int64) (*AIEvent, error) {
 	e.BBox = bbox.String
 	e.SnapshotPath = snapshotPath.String
 	e.Metadata = metadata.String
+	e.Source = source.String
 	e.CreatedAt = aiCreatedAtToRFC3339(e.CreatedAt)
 	return &e, nil
 }

--- a/internal/storage/db_ai_test.go
+++ b/internal/storage/db_ai_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -121,4 +123,85 @@ func TestAICreatedAtToRFC3339(t *testing.T) {
 	for _, c := range cases {
 		require.Equal(t, c.want, aiCreatedAtToRFC3339(c.in), "input %q", c.in)
 	}
+}
+
+// v35 多实例归因:source(API Key 名)随事件落库、列表可按 source 过滤。
+func TestAIEventSourceRoundTripAndFilter(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	mk := func(source string) *AIEvent {
+		return &AIEvent{CameraID: "cam-1", EventType: "person", Severity: "info", Source: source}
+	}
+	_, err := db.InsertAIEvent(ctx, mk("jetson-y26"))
+	require.NoError(t, err)
+	_, err = db.InsertAIEvent(ctx, mk("vm-v8"))
+	require.NoError(t, err)
+	_, err = db.InsertAIEvent(ctx, mk("")) // 旧版消费者不带 key
+	require.NoError(t, err)
+
+	all, total, err := db.ListAIEvents(ctx, AIEventFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, 3, total)
+	sources := map[string]bool{}
+	for _, e := range all {
+		sources[e.Source] = true
+	}
+	require.True(t, sources["jetson-y26"] && sources["vm-v8"] && sources[""],
+		"all three sources must round-trip, got %v", sources)
+
+	only, total, err := db.ListAIEvents(ctx, AIEventFilter{Limit: 10, Source: "vm-v8"})
+	require.NoError(t, err)
+	require.Equal(t, 1, total)
+	require.Equal(t, "vm-v8", only[0].Source)
+}
+
+// 多实例聚合卫兵:completed 不被 failed/skipped/processing 降级;
+// skipped 可被 completed 升级(补推后真实处理完成的场景)。
+func TestUpdateRecordingAIStatusAggregateGuard(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	rec := &model.Recording{
+		ID: "rec-guard", CameraID: "cam-1", FilePath: "/x/a.mp4",
+		Format:    model.FormatH264,
+		StartedAt: time.Now().Add(-time.Minute), EndedAt: time.Now(),
+		MergeStatus: model.MergeStatusPending,
+	}
+	require.NoError(t, db.InsertRecording(ctx, rec))
+
+	set := func(status string) string {
+		require.NoError(t, db.UpdateRecordingAIStatus(ctx, "rec-guard", status, ""))
+		got, err := db.GetRecordingAIStatus(ctx, "rec-guard")
+		require.NoError(t, err)
+		return got
+	}
+
+	require.Equal(t, "processing", set("processing"))
+	require.Equal(t, "failed", set("failed"))
+	// 另一实例 completed 胜出(最高优先级)。
+	require.Equal(t, "completed", set("completed"))
+	// completed 之后:failed/skipped/processing 全部不得降级。
+	require.Equal(t, "completed", set("failed"))
+	require.Equal(t, "completed", set("skipped"))
+	require.Equal(t, "completed", set("processing"))
+
+	// failed 之上 skipped 可写入(丢弃优先于历史失败);再被 completed 升级。
+	rec2 := &model.Recording{
+		ID: "rec-guard2", CameraID: "cam-1", FilePath: "/x/b.mp4",
+		Format:    model.FormatH264,
+		StartedAt: time.Now().Add(-time.Minute), EndedAt: time.Now(),
+		MergeStatus: model.MergeStatusPending,
+	}
+	require.NoError(t, db.InsertRecording(ctx, rec2))
+	set2 := func(status string) string {
+		require.NoError(t, db.UpdateRecordingAIStatus(ctx, "rec-guard2", status, ""))
+		got, err := db.GetRecordingAIStatus(ctx, "rec-guard2")
+		require.NoError(t, err)
+		return got
+	}
+	require.Equal(t, "failed", set2("failed"))
+	require.Equal(t, "skipped", set2("skipped"), "skipped outranks failed")
+	require.Equal(t, "skipped", set2("failed"))
+	require.Equal(t, "completed", set2("completed"), "re-processing after a drop upgrades to completed")
+	require.Equal(t, "completed", set2("skipped"))
 }

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -1085,12 +1085,42 @@ func (d *DB) ListZeroDurationRecordings(ctx context.Context, cameraID string, li
 // ai_processed_at. The list previously held only "done", which the handler
 // rejects, so ai_processed_at was NEVER stamped on successful processing.
 // Non-terminal statuses (pending/processing) leave it untouched.
+//
+// Multi-instance aggregate guard: with several vision consumers processing
+// the same recording, the single ai_status column must never regress —
+// writes are ranked (completed > skipped > failed > pending/processing/”)
+// and only land when their rank EXCEEDS the current one. A consumer retry
+// flow (failed → processing → completed) therefore shows "failed" until the
+// final "completed" lands, and one instance's completed result is never
+// clobbered by another's failed/skipped report.
 func (d *DB) UpdateRecordingAIStatus(ctx context.Context, id, status, errMsg string) error {
 	now := time.Now().UTC().Format("2006-01-02 15:04:05.999999999")
+	rank := aiStatusRank(status)
+	const currentRank = `CASE COALESCE(ai_status,'') WHEN 'completed' THEN 3 WHEN 'skipped' THEN 2 WHEN 'failed' THEN 1 ELSE 0 END`
 	_, err := d.db.ExecContext(ctx,
-		`UPDATE recordings SET ai_status=?, ai_error=?, ai_processed_at=CASE WHEN ? IN ('completed','done','failed','skipped') THEN ? ELSE ai_processed_at END WHERE id=?;`,
-		status, errMsg, status, now, id)
+		`UPDATE recordings SET
+			ai_status = CASE WHEN ? >= (`+currentRank+`) THEN ? ELSE ai_status END,
+			ai_error = CASE WHEN ? >= (`+currentRank+`) THEN ? ELSE ai_error END,
+			ai_processed_at = CASE WHEN ? >= (`+currentRank+`) AND ? IN ('completed','done','failed','skipped') THEN ? ELSE ai_processed_at END
+		WHERE id=?;`,
+		rank, status,
+		rank, errMsg,
+		rank, status, now, id)
 	return err
+}
+
+// aiStatusRank maps an ai_status value to its aggregate precedence.
+func aiStatusRank(status string) int {
+	switch status {
+	case "completed":
+		return 3
+	case "skipped":
+		return 2
+	case "failed":
+		return 1
+	default: // pending / processing / ''
+		return 0
+	}
 }
 
 // GetRecordingAIStatus returns the AI processing status of a recording.

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -3,7 +3,12 @@
 // NVR 在段刚落盘时,直接把视频文件字节流 POST 给 Vision(不是通知 file_path 让 Vision 下载)。
 // 这样视频数据在 NVR 合并进程删除原文件之前就已经到了 Vision 手里——彻底消除 404。
 //
-// 推送条件:Vision 心跳健康(HealthTracker.IsHealthy)。
+// 多实例(vision.instances):NVR 可同时接入多个 Vision 消费端,每实例独立的
+// 地址/心跳健康/暂停窗/离线补偿;相机按 vision_instances 路由(空 = 全部启用
+// 实例),推送对路由内全部实例扇出,单实例失败不影响其它。实例身份由心跳/
+// 事件/ai_status 回传携带的 API Key 名归因(api_key_name 关联,缺省落 default)。
+//
+// 推送条件:目标实例心跳健康(HealthTracker.IsHealthy)。
 // 未启用时(enabled=false)退化为现有 SSE 模式(向后兼容)。
 package vision
 
@@ -41,31 +46,45 @@ type Repusher interface {
 	ListRecordingsForVisionRepush(ctx context.Context, since, until time.Time, limit int) ([]model.Recording, error)
 }
 
-// Coordinator 订阅 segment.completed 事件,在 Vision 健康时把视频文件推送给 Vision。
+// instance 是一个 Vision 消费端实例的运行时状态。配置变化时按 name 对账
+// 保留(心跳历史/暂停窗跨配置编辑存活)。
+type instance struct {
+	name       string
+	url        string
+	apiKeyName string
+	health     *HealthTracker
+	// pausedSince 是该实例的推送暂停窗口起点(Coordinator.mu 保护;零值=未暂停)。
+	pausedSince  time.Time
+	compensating atomic.Bool // 该实例的补偿重推 single-flight
+}
+
+// Coordinator 订阅 segment.completed 事件,把视频文件推送给路由命中的各个
+// Vision 实例。
 type Coordinator struct {
-	health       *HealthTracker
-	eventBus     *event.EventBus
-	eventCh      chan event.Event
-	cfg          func() config.VisionConfig
-	storageRoot  func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
-	db           Repusher      // nil → 补偿重推禁用(测试/降级部署)
-	client       *http.Client
-	wg           sync.WaitGroup
-	cancelFn     context.CancelFunc
-	mu           sync.Mutex
-	runCtx       context.Context // 供恢复回调 goroutine 使用(Start 时设置)
-	pausedSince  time.Time       // 推送暂停窗口起点(mu 保护;零值=未暂停)
-	compensating atomic.Bool     // 补偿重推 single-flight
+	eventBus      *event.EventBus
+	eventCh       chan event.Event
+	cfg           func() config.VisionConfig
+	storageRoot   func() string // 返回 NVR 录像根目录,用于解析段的绝对路径
+	db            Repusher      // nil → 补偿重推禁用(测试/降级部署)
+	client        *http.Client
+	wg            sync.WaitGroup
+	cancelFn      context.CancelFunc
+	mu            sync.Mutex
+	runCtx        context.Context                // 供恢复回调 goroutine 使用(Start 时设置)
+	cameraTargets func(cameraID string) []string // nil → 相机未配置路由(全部实例)
+	// instMu 保护 insts/order;reconcileInstances 按配置对账。
+	instMu sync.Mutex
+	insts  map[string]*instance
+	order  []string // 配置顺序的实例名
 	// subLayer 是子码流分析层 (#514)。nil(未接 provider)时整个层停用。
 	subLayer *SubLayerManager
 }
 
 // NewCoordinator 创建推送协调器。db 可为 nil(禁用离线补偿);provider 可为
-// nil(禁用子码流分析层)。
+// nil(禁用子码流分析层)。相机路由解析器由 builders 通过 SetCameraTargets
+// 注入(nil = 全部实例)。
 func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, eventBus *event.EventBus, db Repusher, provider SubLayerProvider) *Coordinator {
-	vcfg := cfg()
 	c := &Coordinator{
-		health:      NewHealthTracker(vcfg.HeartbeatTimeoutSecs),
 		eventBus:    eventBus,
 		cfg:         cfg,
 		storageRoot: storageRoot,
@@ -73,26 +92,224 @@ func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, e
 		client: &http.Client{
 			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
+		insts: map[string]*instance{},
 	}
 	if provider != nil {
 		c.subLayer = NewSubLayerManager(provider, cfg, storageRoot, SubLayerDeps{
 			Push:    c.pushSubSegment,
-			Healthy: c.health.IsHealthy,
+			Healthy: c.anyInstanceHealthy,
 		})
 	}
-	// 心跳恢复(不健康→健康)触发离线补偿重推 (#329)。
-	c.health.SetOnRecovery(c.compensateOffline)
 	return c
+}
+
+// SetCameraTargets 注入相机 → vision 实例名的解析器(camera.vision_targets)。
+// nil 或返回 nil 表示该相机走默认路由(全部启用实例)。
+func (c *Coordinator) SetCameraTargets(fn func(cameraID string) []string) {
+	c.cameraTargets = fn
+}
+
+// reconcileInstances 按当前配置对账实例集:新增的建 tracker,消失的丢弃,
+// 同名保留(健康状态/心跳历史/暂停窗跨配置编辑存活)。
+func (c *Coordinator) reconcileInstances() {
+	vcfg := c.cfg()
+	want := vcfg.EffectiveInstances()
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	if c.insts == nil {
+		c.insts = map[string]*instance{}
+	}
+	seen := make(map[string]bool, len(want))
+	order := make([]string, 0, len(want))
+	for _, ins := range want {
+		seen[ins.Name] = true
+		order = append(order, ins.Name)
+		if old, ok := c.insts[ins.Name]; ok {
+			old.url = ins.URL
+			old.apiKeyName = ins.APIKeyName
+			continue
+		}
+		h := NewHealthTracker(vcfg.HeartbeatTimeoutSecs)
+		// 心跳恢复(不健康→健康)触发该实例的离线补偿重推 (#329)。
+		name := ins.Name
+		h.SetOnRecovery(func() { c.compensateOffline(name) })
+		c.insts[ins.Name] = &instance{
+			name:       ins.Name,
+			url:        ins.URL,
+			apiKeyName: ins.APIKeyName,
+			health:     h,
+		}
+	}
+	for name := range c.insts {
+		if !seen[name] {
+			delete(c.insts, name)
+		}
+	}
+	c.order = order
+}
+
+// defaultInstance 返回兼容视角的"默认实例":优先名为 default 的(legacy 单
+// 实例合成名),否则配置顺序第一个。无实例时返回 nil。
+func (c *Coordinator) defaultInstance() *instance {
+	c.reconcileInstances()
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	if d, ok := c.insts["default"]; ok {
+		return d
+	}
+	for _, name := range c.order {
+		if c.insts[name] != nil {
+			return c.insts[name]
+		}
+	}
+	return nil
+}
+
+// Health 返回默认实例的 HealthTracker,供 API handler/旧测试记录心跳。
+// 单实例部署即唯一实例;多实例部署心跳应走 RecordHeartbeat 按 key 归因。
+// 无实例时返回一个临时 tracker(永不健康,行为同旧版未配置)。
+func (c *Coordinator) Health() *HealthTracker {
+	if ins := c.defaultInstance(); ins != nil {
+		return ins.health
+	}
+	return NewHealthTracker(c.cfg().HeartbeatTimeoutSecs)
+}
+
+// RecordHeartbeat 按 API Key 名把心跳归因到实例(找不到 key 关联或匿名 →
+// default 实例,兼容旧版消费者)。返回实例名;"" 表示当前没有任何实例
+// (集成未启用)。
+func (c *Coordinator) RecordHeartbeat(apiKeyName string, st HeartbeatStatus) string {
+	ins := c.instanceByAPIKey(apiKeyName)
+	if ins == nil {
+		return ""
+	}
+	ins.health.RecordHeartbeat(st)
+	return ins.name
+}
+
+// instanceByAPIKey 按 api_key_name 查实例;key 为空或未命中时落 default。
+func (c *Coordinator) instanceByAPIKey(key string) *instance {
+	c.reconcileInstances()
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	if key != "" {
+		for _, name := range c.order {
+			if ins := c.insts[name]; ins != nil && ins.apiKeyName == key {
+				return ins
+			}
+		}
+		slog.Debug("vision heartbeat key matches no instance, attributing to default",
+			"api_key_name", key)
+	}
+	if d, ok := c.insts["default"]; ok {
+		return d
+	}
+	for _, name := range c.order {
+		if c.insts[name] != nil {
+			return c.insts[name]
+		}
+	}
+	return nil
+}
+
+// routedInstances 解析一台相机当前的推送目标实例(路由配置 + 实例启用态;
+// 健康与否在推送时逐实例判断)。
+func (c *Coordinator) routedInstances(cameraID string) []*instance {
+	vcfg := c.cfg()
+	var targets []string
+	if c.cameraTargets != nil {
+		targets = c.cameraTargets(cameraID)
+	}
+	routed := vcfg.RouteFor(targets)
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	out := make([]*instance, 0, len(routed))
+	for _, ins := range routed {
+		if live := c.insts[ins.Name]; live != nil {
+			out = append(out, live)
+		}
+	}
+	return out
+}
+
+// anyInstanceHealthy 报告是否至少一个启用实例健康(子层扫描门控用)。
+func (c *Coordinator) anyInstanceHealthy() bool {
+	for _, ins := range c.routedInstances("") {
+		if ins.health.IsHealthy() {
+			return true
+		}
+	}
+	return false
+}
+
+// InstanceStatus 一个实例的对外状态快照(供 /api/vision/status)。
+type InstanceStatus struct {
+	Name        string         `json:"name"`
+	URL         string         `json:"url"`
+	Healthy     bool           `json:"healthy"`
+	LastSeen    *time.Time     `json:"last_seen,omitempty"`
+	Device      string         `json:"device,omitempty"`
+	QueueDepth  int            `json:"queue_depth,omitempty"`
+	Processed   int            `json:"processed,omitempty"`
+	SkipCameras []string       `json:"skip_cameras,omitempty"`
+	Metrics     *VisionMetrics `json:"metrics,omitempty"`
+	MarkedDrops int64          `json:"drops_marked_total,omitempty"`
+}
+
+// InstancesStatus 返回全部生效实例的状态(配置顺序)。
+func (c *Coordinator) InstancesStatus() []InstanceStatus {
+	c.reconcileInstances()
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	out := make([]InstanceStatus, 0, len(c.order))
+	for _, name := range c.order {
+		ins := c.insts[name]
+		if ins == nil {
+			continue
+		}
+		st := InstanceStatus{Name: ins.name, URL: ins.url}
+		healthy, lastSeen, hs := ins.health.Snapshot()
+		st.Healthy = healthy
+		if !lastSeen.IsZero() {
+			t := lastSeen
+			st.LastSeen = &t
+		}
+		st.Device = hs.Device
+		st.QueueDepth = hs.QueueDepth
+		st.Processed = hs.ProcessedCount
+		st.SkipCameras = hs.SkipCameras
+		st.Metrics = hs.Metrics
+		st.MarkedDrops = ins.health.MarkedDropTotal()
+		out = append(out, st)
+	}
+	return out
+}
+
+// InstanceByName 按名取实例的 HealthTracker(供 /api/vision/metrics?instance=)。
+// 未知名或未指定时回落 default 实例。
+func (c *Coordinator) InstanceByName(name string) (*HealthTracker, string) {
+	c.reconcileInstances()
+	c.instMu.Lock()
+	defer c.instMu.Unlock()
+	if name != "" {
+		if ins := c.insts[name]; ins != nil {
+			return ins.health, ins.name
+		}
+	}
+	if d, ok := c.insts["default"]; ok {
+		return d.health, d.name
+	}
+	for _, n := range c.order {
+		if c.insts[n] != nil {
+			return c.insts[n].health, c.insts[n].name
+		}
+	}
+	return nil, ""
 }
 
 // SubLayer exposes the sub-layer manager (observability/tests). May be nil.
 func (c *Coordinator) SubLayer() *SubLayerManager {
 	return c.subLayer
-}
-
-// Health 返回 HealthTracker,供 API handler 记录心跳。
-func (c *Coordinator) Health() *HealthTracker {
-	return c.health
 }
 
 // Start 订阅 segment.completed 并启动事件处理循环。
@@ -115,7 +332,7 @@ func (c *Coordinator) Start(ctx context.Context) error {
 	c.subLayer.Start(ctx)
 	slog.Info("vision coordinator started",
 		"push_mode", c.cfg().PushMode,
-		"vision_url", c.cfg().URL,
+		"instances", len(c.InstancesStatus()),
 		"sub_layer_cameras", len(c.cfg().SubLayerCameras))
 	return nil
 }
@@ -154,10 +371,14 @@ func (c *Coordinator) eventLoop(ctx context.Context) {
 	}
 }
 
-// handleSegment 把段视频文件直接推送给 Vision。
+// handleSegment 把段视频文件推送给相机路由命中的各个 Vision 实例。
 func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentCompleted) {
 	vcfg := c.cfg()
-	if !vcfg.Enabled || vcfg.URL == "" {
+	if !vcfg.Enabled {
+		return
+	}
+	routed := c.routedInstances(seg.CameraID)
+	if len(routed) == 0 {
 		return
 	}
 	// Feed the sub-layer's recording-id join regardless of push outcome — a
@@ -167,12 +388,6 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	if c.subLayer != nil && seg.Layer == model.LayerMain {
 		c.subLayer.NoteMainSegment(seg.CameraID, seg.RecordingID)
 	}
-	if !c.health.IsHealthy() {
-		c.markPaused()
-		slog.Debug("vision not healthy, skip push",
-			"recording_id", seg.RecordingID)
-		return
-	}
 	if seg.Format == "timelapse" {
 		return
 	}
@@ -180,13 +395,6 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	// 带宽与 CPU,直接跳过(离线补偿重推走同一路径,一并跳过)。
 	if vcfg.ShouldSkipCamera(seg.CameraID) {
 		slog.Debug("vision push skipped by skip_cameras config",
-			"camera_id", seg.CameraID,
-			"recording_id", seg.RecordingID)
-		return
-	}
-	// 消费者心跳声明的跳单(#515):与静态配置取并集生效。
-	if c.health.SkipCamera(seg.CameraID) {
-		slog.Debug("vision push skipped by consumer-reported skip list",
 			"camera_id", seg.CameraID,
 			"recording_id", seg.RecordingID)
 		return
@@ -206,7 +414,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 		if !filepath.IsAbs(absPath) {
 			absPath = filepath.Join(c.storageRoot(), absPath)
 		}
-		c.uploadSegment(ctx, absPath, seg.FileSize, map[string]string{
+		c.fanout(ctx, routed, absPath, seg.FileSize, map[string]string{
 			"X-Recording-Id": seg.RecordingID,
 			"X-Camera-Id":    seg.CameraID,
 			"X-Format":       seg.Format,
@@ -240,7 +448,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 		absPath = filepath.Join(c.storageRoot(), absPath)
 	}
 
-	c.uploadSegment(ctx, absPath, seg.FileSize, map[string]string{
+	c.fanout(ctx, routed, absPath, seg.FileSize, map[string]string{
 		"X-Recording-Id": seg.RecordingID,
 		"X-Camera-Id":    seg.CameraID,
 		"X-Format":       seg.Format,
@@ -251,9 +459,40 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	})
 }
 
-// uploadSegment POSTs a segment file's bytes to Vision. Headers carry the
-// metadata (Vision's minimal HTTP parser can't do chunked encoding — Content-
-// Length is set explicitly). Returns true on a 2xx response.
+// fanout 逐实例推送(健康检查+消费者跳单+上传各自独立,失败互不影响)。
+func (c *Coordinator) fanout(ctx context.Context, routed []*instance, absPath string, fileSize int64, hdr map[string]string) {
+	for _, ins := range routed {
+		c.pushToInstance(ctx, ins, absPath, fileSize, hdr)
+	}
+}
+
+// pushToInstance 单实例推送:无地址(default 合成、URL 未配)→ 静默跳过;
+// 不健康 → 记暂停窗(补偿重推的窗口锚点)并跳过;该实例心跳声明的跳单
+// (#515)→ 跳过;否则上传。
+func (c *Coordinator) pushToInstance(ctx context.Context, ins *instance, absPath string, fileSize int64, hdr map[string]string) bool {
+	if ins.url == "" {
+		return false
+	}
+	if !ins.health.IsHealthy() {
+		c.markPausedFor(ins)
+		slog.Debug("vision instance not healthy, skip push",
+			"instance", ins.name,
+			"recording_id", hdr["X-Recording-Id"])
+		return false
+	}
+	if ins.health.SkipCamera(hdr["X-Camera-Id"]) {
+		slog.Debug("vision push skipped by consumer-reported skip list",
+			"instance", ins.name,
+			"camera_id", hdr["X-Camera-Id"],
+			"recording_id", hdr["X-Recording-Id"])
+		return false
+	}
+	return c.uploadSegment(ctx, ins.url, absPath, fileSize, hdr)
+}
+
+// uploadSegment POSTs a segment file's bytes to a Vision instance. Headers
+// carry the metadata (Vision's minimal HTTP parser can't do chunked encoding —
+// Content-Length is set explicitly). Returns true on a 2xx response.
 //
 // Content-Length MUST come from the file on disk, never from the event's
 // FileSize: producers count only media bytes while the muxer appends the moov
@@ -261,7 +500,7 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 // a short Content-Length against a longer body aborts the transfer client-
 // side ("ContentLength=X with Body length Y" — field data 2026-09-02: 530
 // consecutive tiered-push losses before this was found).
-func (c *Coordinator) uploadSegment(ctx context.Context, absPath string, fileSize int64, hdr map[string]string) bool {
+func (c *Coordinator) uploadSegment(ctx context.Context, baseURL string, absPath string, fileSize int64, hdr map[string]string) bool {
 	file, err := os.Open(absPath)
 	if err != nil {
 		slog.Warn("open segment file for push failed",
@@ -281,7 +520,7 @@ func (c *Coordinator) uploadSegment(ctx context.Context, absPath string, fileSiz
 	realSize := st.Size()
 	hdr["X-File-Size"] = strconv.FormatInt(realSize, 10)
 
-	url := strings.TrimRight(c.cfg().URL, "/") + "/vision/segment/upload"
+	url := strings.TrimRight(baseURL, "/") + "/vision/segment/upload"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, file)
 	if err != nil {
 		slog.Error("create upload request", "error", err)
@@ -315,86 +554,133 @@ func (c *Coordinator) uploadSegment(ctx context.Context, absPath string, fileSiz
 	return true
 }
 
-// pushSubSegment pushes one sub-layer segment (#514). Same transport/headers
-// as the main layer, plus X-Layer: sub; the recording id already carries the
-// joined MAIN recording so consumer-side dedup and ai_status semantics are
-// unchanged. Returns true when the consumer accepted it (caller deletes).
+// pushSubSegment pushes one sub-layer segment (#514) to every routed instance.
+// Same transport/headers as the main layer, plus X-Layer: sub; the recording
+// id already carries the joined MAIN recording so consumer-side dedup and
+// ai_status semantics are unchanged. Returns true (caller deletes) only when
+// EVERY currently-healthy routed instance accepted it — an offline instance's
+// copy waits on disk for its recovery (TTL-bounded); zero healthy instances
+// keeps the file too.
 func (c *Coordinator) pushSubSegment(ctx context.Context, seg SubSegment) bool {
 	vcfg := c.cfg()
-	if !vcfg.Enabled || vcfg.URL == "" || !c.health.IsHealthy() {
+	if !vcfg.Enabled {
 		return false
 	}
-	ok := c.uploadSegment(ctx, seg.Path, seg.FileSize, map[string]string{
-		"X-Recording-Id": seg.RecordingID,
-		"X-Camera-Id":    seg.CameraID,
-		"X-Format":       seg.Codec,
-		"X-Encoding":     seg.Codec,
-		"X-Started-At":   seg.StartedAt.UTC().Format(time.RFC3339Nano),
-		"X-Ended-At":     seg.EndedAt.UTC().Format(time.RFC3339Nano),
-		"X-File-Size":    strconv.FormatInt(seg.FileSize, 10),
-		"X-Layer":        "sub",
-	})
-	if ok {
-		slog.Info("pushed sub-layer video to vision",
+	routed := c.routedInstances(seg.CameraID)
+	if len(routed) == 0 {
+		return false
+	}
+	healthy, accepted := 0, 0
+	for _, ins := range routed {
+		if !ins.health.IsHealthy() {
+			continue
+		}
+		healthy++
+		if c.pushToInstance(ctx, ins, seg.Path, seg.FileSize, map[string]string{
+			"X-Recording-Id": seg.RecordingID,
+			"X-Camera-Id":    seg.CameraID,
+			"X-Format":       seg.Codec,
+			"X-Encoding":     seg.Codec,
+			"X-Started-At":   seg.StartedAt.UTC().Format(time.RFC3339Nano),
+			"X-Ended-At":     seg.EndedAt.UTC().Format(time.RFC3339Nano),
+			"X-File-Size":    strconv.FormatInt(seg.FileSize, 10),
+			"X-Layer":        "sub",
+		}) {
+			accepted++
+		}
+	}
+	if healthy > 0 && accepted == healthy {
+		slog.Info("pushed sub-layer video to vision instances",
 			"camera_id", seg.CameraID,
 			"recording_id", seg.RecordingID,
+			"instances", accepted,
 			"size_mb", seg.FileSize/1024/1024)
+		return true
 	}
-	return ok
+	return false
 }
 
-// markPaused records the start of a push-pause window (first segment skipped
-// while Vision is unhealthy). The timestamp bounds the offline-compensation
-// query when Vision recovers (#329).
-func (c *Coordinator) markPaused() {
+// markPausedFor records the start of an instance's push-pause window (first
+// segment skipped while that instance is unhealthy). The timestamp bounds the
+// offline-compensation query when the instance recovers (#329).
+func (c *Coordinator) markPausedFor(ins *instance) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.pausedSince.IsZero() {
-		c.pausedSince = time.Now()
+	if ins.pausedSince.IsZero() {
+		ins.pausedSince = time.Now()
 		slog.Info("vision push paused — offline window starts (segments will be compensated on recovery)",
-			"since", c.pausedSince)
+			"instance", ins.name,
+			"since", ins.pausedSince)
 	}
 }
 
-// rearmPaused restores the pause window with the given start (used when
-// Vision drops again mid-compensation, so the next recovery retries the
+// rearmPausedFor restores the pause window with the given start (used when the
+// instance drops again mid-compensation, so the next recovery retries the
 // remainder instead of only the new gap).
-func (c *Coordinator) rearmPaused(since time.Time) {
+func (c *Coordinator) rearmPausedFor(ins *instance, since time.Time) {
 	c.mu.Lock()
-	c.pausedSince = since
+	ins.pausedSince = since
 	c.mu.Unlock()
 }
 
-// takePausedSince returns and clears the pause-window start.
-func (c *Coordinator) takePausedSince() time.Time {
+// takePausedSinceFor returns and clears the instance's pause-window start.
+func (c *Coordinator) takePausedSinceFor(ins *instance) time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	since := c.pausedSince
-	c.pausedSince = time.Time{}
+	since := ins.pausedSince
+	ins.pausedSince = time.Time{}
 	return since
 }
 
-// compensateOffline re-pushes segments that completed while Vision was
-// offline. Triggered by the health tracker's recovery callback — a heartbeat
-// after an unhealthy gap. New segments keep flowing through the event loop
-// concurrently; Vision dedups by X-Recording-Id, so overlap is harmless.
-func (c *Coordinator) compensateOffline() {
+// takePausedSince 兼容访问器:default 实例的暂停窗(旧测试用)。
+func (c *Coordinator) takePausedSince() time.Time {
+	if ins := c.defaultInstance(); ins != nil {
+		return c.takePausedSinceFor(ins)
+	}
+	return time.Time{}
+}
+
+func (c *Coordinator) markPaused() {
+	if ins := c.defaultInstance(); ins != nil {
+		c.markPausedFor(ins)
+	}
+}
+
+func (c *Coordinator) rearmPaused(since time.Time) {
+	if ins := c.defaultInstance(); ins != nil {
+		c.rearmPausedFor(ins, since)
+	}
+}
+
+// compensateOffline re-pushes segments that completed while ONE instance was
+// offline. Triggered by that instance's health tracker recovery callback.
+// The re-push routes through handleSegment, so every currently-routed healthy
+// instance receives it again — overlap with never-offline instances is
+// harmless (consumers dedup by X-Recording-Id) and keeps the single-code-path
+// property; the bandwidth cost is bounded by repushWindow.
+func (c *Coordinator) compensateOffline(name string) {
 	c.mu.Lock()
 	ctx := c.runCtx
 	c.mu.Unlock()
 	if ctx == nil || ctx.Err() != nil {
 		return
 	}
-	since := c.takePausedSince()
+	c.instMu.Lock()
+	ins := c.insts[name]
+	c.instMu.Unlock()
+	if ins == nil {
+		return
+	}
+	since := c.takePausedSinceFor(ins)
 	if since.IsZero() || c.db == nil {
 		return
 	}
-	// Only one compensation run at a time (heartbeats can flap).
-	if !c.compensating.CompareAndSwap(false, true) {
-		c.rearmPaused(since)
+	// Only one compensation run per instance at a time (heartbeats can flap).
+	if !ins.compensating.CompareAndSwap(false, true) {
+		c.rearmPausedFor(ins, since)
 		return
 	}
-	defer c.compensating.Store(false)
+	defer ins.compensating.Store(false)
 
 	if time.Since(since) > repushWindow {
 		since = time.Now().Add(-repushWindow)
@@ -402,15 +688,16 @@ func (c *Coordinator) compensateOffline() {
 
 	recs, err := c.db.ListRecordingsForVisionRepush(ctx, since, time.Now(), repushMax)
 	if err != nil {
-		c.rearmPaused(since)
-		slog.Warn("vision compensation lookup failed", "error", err)
+		c.rearmPausedFor(ins, since)
+		slog.Warn("vision compensation lookup failed", "error", err, "instance", name)
 		return
 	}
 	if len(recs) == 0 {
-		slog.Debug("vision recovered — nothing to compensate")
+		slog.Debug("vision recovered — nothing to compensate", "instance", name)
 		return
 	}
 	slog.Info("vision recovered — re-pushing segments missed while offline",
+		"instance", name,
 		"count", len(recs), "since", since)
 
 	pushed := 0
@@ -418,11 +705,12 @@ func (c *Coordinator) compensateOffline() {
 		if ctx.Err() != nil {
 			return
 		}
-		if !c.health.IsHealthy() {
+		if !ins.health.IsHealthy() {
 			// Dropped again mid-compensation: restore the window so the next
 			// recovery retries the remainder.
-			c.rearmPaused(since)
+			c.rearmPausedFor(ins, since)
 			slog.Warn("vision unhealthy during compensation — stopping early",
+				"instance", name,
 				"pushed", pushed, "total", len(recs))
 			return
 		}
@@ -431,7 +719,9 @@ func (c *Coordinator) compensateOffline() {
 		// Pace the burst so a long offline gap doesn't storm Vision.
 		time.Sleep(repushPacing)
 	}
-	slog.Info("vision offline compensation finished", "pushed", pushed, "window", time.Since(since).Round(time.Second))
+	slog.Info("vision offline compensation finished",
+		"instance", name,
+		"pushed", pushed, "window", time.Since(since).Round(time.Second))
 }
 
 // recordingToSegment synthesizes the push payload from a DB recording row.

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -49,13 +49,21 @@ type Repusher interface {
 // instance 是一个 Vision 消费端实例的运行时状态。配置变化时按 name 对账
 // 保留(心跳历史/暂停窗跨配置编辑存活)。
 type instance struct {
-	name       string
-	url        string
-	apiKeyName string
-	health     *HealthTracker
-	// pausedSince 是该实例的推送暂停窗口起点(Coordinator.mu 保护;零值=未暂停)。
-	pausedSince  time.Time
+	// name 创建后不变;url/apiKeyName 由 reconcile 在 instMu 内写、路由快照
+	// (routedInstances) 同锁内拷贝读取——推路径只见不可变值拷贝。
+	name         string
+	url          string
+	apiKeyName   string
+	health       *HealthTracker
 	compensating atomic.Bool // 该实例的补偿重推 single-flight
+}
+
+// routeTarget 是推送路径使用的实例快照(值类型,字段在 instMu 内复制——
+// 与 reconcile 的字段写不竞态)。
+type routeTarget struct {
+	name   string
+	url    string
+	health *HealthTracker
 }
 
 // Coordinator 订阅 segment.completed 事件,把视频文件推送给路由命中的各个
@@ -76,6 +84,8 @@ type Coordinator struct {
 	instMu sync.Mutex
 	insts  map[string]*instance
 	order  []string // 配置顺序的实例名
+	// paused 是各实例的推送暂停窗口起点(mu 保护;缺键=未暂停)。
+	paused map[string]time.Time
 	// subLayer 是子码流分析层 (#514)。nil(未接 provider)时整个层停用。
 	subLayer *SubLayerManager
 }
@@ -92,7 +102,8 @@ func NewCoordinator(cfg func() config.VisionConfig, storageRoot func() string, e
 		client: &http.Client{
 			Timeout: 120 * time.Second, // 大文件传输可能需要较长时间
 		},
-		insts: map[string]*instance{},
+		insts:  map[string]*instance{},
+		paused: map[string]time.Time{},
 	}
 	if provider != nil {
 		c.subLayer = NewSubLayerManager(provider, cfg, storageRoot, SubLayerDeps{
@@ -214,7 +225,7 @@ func (c *Coordinator) instanceByAPIKey(key string) *instance {
 
 // routedInstances 解析一台相机当前的推送目标实例(路由配置 + 实例启用态;
 // 健康与否在推送时逐实例判断)。
-func (c *Coordinator) routedInstances(cameraID string) []*instance {
+func (c *Coordinator) routedInstances(cameraID string) []routeTarget {
 	vcfg := c.cfg()
 	var targets []string
 	if c.cameraTargets != nil {
@@ -223,10 +234,10 @@ func (c *Coordinator) routedInstances(cameraID string) []*instance {
 	routed := vcfg.RouteFor(targets)
 	c.instMu.Lock()
 	defer c.instMu.Unlock()
-	out := make([]*instance, 0, len(routed))
+	out := make([]routeTarget, 0, len(routed))
 	for _, ins := range routed {
 		if live := c.insts[ins.Name]; live != nil {
-			out = append(out, live)
+			out = append(out, routeTarget{name: live.name, url: live.url, health: live.health})
 		}
 	}
 	return out
@@ -460,34 +471,34 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 }
 
 // fanout 逐实例推送(健康检查+消费者跳单+上传各自独立,失败互不影响)。
-func (c *Coordinator) fanout(ctx context.Context, routed []*instance, absPath string, fileSize int64, hdr map[string]string) {
-	for _, ins := range routed {
-		c.pushToInstance(ctx, ins, absPath, fileSize, hdr)
+func (c *Coordinator) fanout(ctx context.Context, routed []routeTarget, absPath string, fileSize int64, hdr map[string]string) {
+	for _, rt := range routed {
+		c.pushToInstance(ctx, rt, absPath, fileSize, hdr)
 	}
 }
 
 // pushToInstance 单实例推送:无地址(default 合成、URL 未配)→ 静默跳过;
 // 不健康 → 记暂停窗(补偿重推的窗口锚点)并跳过;该实例心跳声明的跳单
 // (#515)→ 跳过;否则上传。
-func (c *Coordinator) pushToInstance(ctx context.Context, ins *instance, absPath string, fileSize int64, hdr map[string]string) bool {
-	if ins.url == "" {
+func (c *Coordinator) pushToInstance(ctx context.Context, rt routeTarget, absPath string, fileSize int64, hdr map[string]string) bool {
+	if rt.url == "" {
 		return false
 	}
-	if !ins.health.IsHealthy() {
-		c.markPausedFor(ins)
+	if !rt.health.IsHealthy() {
+		c.markPausedFor(rt.name)
 		slog.Debug("vision instance not healthy, skip push",
-			"instance", ins.name,
+			"instance", rt.name,
 			"recording_id", hdr["X-Recording-Id"])
 		return false
 	}
-	if ins.health.SkipCamera(hdr["X-Camera-Id"]) {
+	if rt.health.SkipCamera(hdr["X-Camera-Id"]) {
 		slog.Debug("vision push skipped by consumer-reported skip list",
-			"instance", ins.name,
+			"instance", rt.name,
 			"camera_id", hdr["X-Camera-Id"],
 			"recording_id", hdr["X-Recording-Id"])
 		return false
 	}
-	return c.uploadSegment(ctx, ins.url, absPath, fileSize, hdr)
+	return c.uploadSegment(ctx, rt.url, absPath, fileSize, hdr)
 }
 
 // uploadSegment POSTs a segment file's bytes to a Vision instance. Headers
@@ -571,12 +582,12 @@ func (c *Coordinator) pushSubSegment(ctx context.Context, seg SubSegment) bool {
 		return false
 	}
 	healthy, accepted := 0, 0
-	for _, ins := range routed {
-		if !ins.health.IsHealthy() {
+	for _, rt := range routed {
+		if !rt.health.IsHealthy() {
 			continue
 		}
 		healthy++
-		if c.pushToInstance(ctx, ins, seg.Path, seg.FileSize, map[string]string{
+		if c.pushToInstance(ctx, rt, seg.Path, seg.FileSize, map[string]string{
 			"X-Recording-Id": seg.RecordingID,
 			"X-Camera-Id":    seg.CameraID,
 			"X-Format":       seg.Codec,
@@ -603,52 +614,55 @@ func (c *Coordinator) pushSubSegment(ctx context.Context, seg SubSegment) bool {
 // markPausedFor records the start of an instance's push-pause window (first
 // segment skipped while that instance is unhealthy). The timestamp bounds the
 // offline-compensation query when the instance recovers (#329).
-func (c *Coordinator) markPausedFor(ins *instance) {
+func (c *Coordinator) markPausedFor(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if ins.pausedSince.IsZero() {
-		ins.pausedSince = time.Now()
+	if _, ok := c.paused[name]; !ok {
+		c.paused[name] = time.Now()
 		slog.Info("vision push paused — offline window starts (segments will be compensated on recovery)",
-			"instance", ins.name,
-			"since", ins.pausedSince)
+			"instance", name,
+			"since", c.paused[name])
 	}
 }
 
 // rearmPausedFor restores the pause window with the given start (used when the
 // instance drops again mid-compensation, so the next recovery retries the
 // remainder instead of only the new gap).
-func (c *Coordinator) rearmPausedFor(ins *instance, since time.Time) {
+func (c *Coordinator) rearmPausedFor(name string, since time.Time) {
 	c.mu.Lock()
-	ins.pausedSince = since
+	c.paused[name] = since
 	c.mu.Unlock()
 }
 
 // takePausedSinceFor returns and clears the instance's pause-window start.
-func (c *Coordinator) takePausedSinceFor(ins *instance) time.Time {
+func (c *Coordinator) takePausedSinceFor(name string) time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	since := ins.pausedSince
-	ins.pausedSince = time.Time{}
+	since, ok := c.paused[name]
+	delete(c.paused, name)
+	if !ok {
+		return time.Time{}
+	}
 	return since
 }
 
 // takePausedSince 兼容访问器:default 实例的暂停窗(旧测试用)。
 func (c *Coordinator) takePausedSince() time.Time {
 	if ins := c.defaultInstance(); ins != nil {
-		return c.takePausedSinceFor(ins)
+		return c.takePausedSinceFor(ins.name)
 	}
 	return time.Time{}
 }
 
 func (c *Coordinator) markPaused() {
 	if ins := c.defaultInstance(); ins != nil {
-		c.markPausedFor(ins)
+		c.markPausedFor(ins.name)
 	}
 }
 
 func (c *Coordinator) rearmPaused(since time.Time) {
 	if ins := c.defaultInstance(); ins != nil {
-		c.rearmPausedFor(ins, since)
+		c.rearmPausedFor(ins.name, since)
 	}
 }
 
@@ -671,13 +685,13 @@ func (c *Coordinator) compensateOffline(name string) {
 	if ins == nil {
 		return
 	}
-	since := c.takePausedSinceFor(ins)
+	since := c.takePausedSinceFor(name)
 	if since.IsZero() || c.db == nil {
 		return
 	}
 	// Only one compensation run per instance at a time (heartbeats can flap).
 	if !ins.compensating.CompareAndSwap(false, true) {
-		c.rearmPausedFor(ins, since)
+		c.rearmPausedFor(name, since)
 		return
 	}
 	defer ins.compensating.Store(false)
@@ -688,7 +702,7 @@ func (c *Coordinator) compensateOffline(name string) {
 
 	recs, err := c.db.ListRecordingsForVisionRepush(ctx, since, time.Now(), repushMax)
 	if err != nil {
-		c.rearmPausedFor(ins, since)
+		c.rearmPausedFor(name, since)
 		slog.Warn("vision compensation lookup failed", "error", err, "instance", name)
 		return
 	}
@@ -708,7 +722,7 @@ func (c *Coordinator) compensateOffline(name string) {
 		if !ins.health.IsHealthy() {
 			// Dropped again mid-compensation: restore the window so the next
 			// recovery retries the remainder.
-			c.rearmPausedFor(ins, since)
+			c.rearmPausedFor(name, since)
 			slog.Warn("vision unhealthy during compensation — stopping early",
 				"instance", name,
 				"pushed", pushed, "total", len(recs))

--- a/internal/vision/coordinator_test.go
+++ b/internal/vision/coordinator_test.go
@@ -412,7 +412,7 @@ func TestCoordinatorUploadContentLengthMatchesFile(t *testing.T) {
 		nil, nil,
 	)
 	// Deliberately lie in the event-derived size AND header, as tierrec did.
-	ok := c.uploadSegment(context.Background(), path, 30000, map[string]string{
+	ok := c.uploadSegment(context.Background(), visionSrv.URL, path, 30000, map[string]string{
 		"X-File-Size": "30000",
 		"X-Camera-Id": "cam-x",
 	})
@@ -420,4 +420,164 @@ func TestCoordinatorUploadContentLengthMatchesFile(t *testing.T) {
 	require.Equal(t, int64(len(payload)), got.contentLength, "Content-Length must be the on-disk size")
 	require.Equal(t, int64(len(payload)), got.bodyLen, "server must receive the whole file")
 	require.Equal(t, strconv.Itoa(len(payload)), got.headerSize, "X-File-Size must be corrected to the real size")
+}
+
+// ---- 多实例(vision.instances)----
+
+// 双实例扇出:一台相机(未配 vision_targets)的段推给全部启用实例;
+// 显式配置 vision_targets 的相机只推指定实例;一台实例离线不影响另一台。
+func TestCoordinatorMultiInstanceFanout(t *testing.T) {
+	var mu sync.Mutex
+	got := map[string]map[string]int{} // server -> recording id -> count
+	mkSrv := func(name string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			if got[name] == nil {
+				got[name] = map[string]int{}
+			}
+			got[name][r.Header.Get("X-Recording-Id")]++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	srvA, srvB := mkSrv("a"), mkSrv("b")
+	defer srvA.Close()
+	defer srvB.Close()
+
+	enabled := true
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{
+		Enabled: true,
+		Instances: []config.VisionInstance{
+			{Name: "a", URL: srvA.URL, APIKeyName: "key-a"},
+			{Name: "b", URL: srvB.URL, APIKeyName: "key-b", Enabled: &enabled},
+		},
+	}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil,
+		nil,
+	)
+	targets := map[string][]string{"cam-pinned": {"b"}}
+	c.SetCameraTargets(func(cameraID string) []string { return targets[cameraID] })
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	// 心跳按 API key 名归因:两条 key 分别落到各自实例。
+	require.Equal(t, "a", c.RecordHeartbeat("key-a", HeartbeatStatus{Status: "healthy"}))
+	require.Equal(t, "b", c.RecordHeartbeat("key-b", HeartbeatStatus{Status: "healthy"}))
+
+	dir := t.TempDir()
+	publish := func(cam, rec string) {
+		p := filepath.Join(dir, rec+".mp4")
+		require.NoError(t, os.WriteFile(p, make([]byte, 8), 0o644))
+		bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+			CameraID: cam, FilePath: p, Format: "mp4",
+			FileSize: 8, RecordingID: rec,
+		})
+	}
+	publish("cam-broadcast", "rec-broadcast")
+	publish("cam-pinned", "rec-pinned")
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return got["a"]["rec-broadcast"] == 1 && got["b"]["rec-broadcast"] == 1 &&
+			got["a"]["rec-pinned"] == 0 && got["b"]["rec-pinned"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "broadcast must reach both, pinned only b")
+
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 1, got["a"]["rec-broadcast"], "no duplicates to a")
+	require.Equal(t, 1, got["b"]["rec-broadcast"], "no duplicates to b")
+	require.NotContains(t, got["a"], "rec-pinned", "pinned camera must not reach a")
+}
+
+// 单实例故障隔离:b 离线(无心跳)时段只到 a;b 的暂停窗记账,恢复后补推。
+func TestCoordinatorMultiInstanceIsolation(t *testing.T) {
+	var mu sync.Mutex
+	count := map[string]int{}
+	mkSrv := func(name string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			count[name]++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	srvA, srvB := mkSrv("a"), mkSrv("b")
+	defer srvA.Close()
+	defer srvB.Close()
+
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{
+		Enabled: true,
+		Instances: []config.VisionInstance{
+			{Name: "a", URL: srvA.URL},
+			{Name: "b", URL: srvB.URL},
+		},
+	}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus,
+		nil,
+		nil,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	t.Cleanup(c.Stop)
+
+	// 只有 a 健康(匿名心跳落 default=第一个实例)。
+	require.Equal(t, "a", c.RecordHeartbeat("", HeartbeatStatus{Status: "healthy"}))
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "seg.mp4")
+	require.NoError(t, os.WriteFile(p, make([]byte, 8), 0o644))
+	bus.Publish(context.Background(), event.TopicSegmentCompleted, event.SegmentCompleted{
+		CameraID: "cam1", FilePath: p, Format: "mp4",
+		FileSize: 8, RecordingID: "rec-iso",
+	})
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return count["a"] == 1
+	}, 5*time.Second, 50*time.Millisecond, "healthy instance a must receive the push")
+
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	require.Zero(t, count["b"], "offline instance b must not be attempted")
+	mu.Unlock()
+
+	// 匿名心跳归因 default(第一个实例)——旧行为兼容。
+	// 指名 key 归因未配置 key 的实例也落 default。
+	require.Equal(t, "a", c.RecordHeartbeat("unknown-key", HeartbeatStatus{Status: "healthy"}))
+}
+
+// InstancesStatus 按配置顺序展开,含健康与 last_seen。
+func TestCoordinatorInstancesStatus(t *testing.T) {
+	cfg := config.VisionConfig{
+		Enabled: true,
+		URL:     "http://jetson:9091", // legacy → default
+	}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		event.NewEventBus(8),
+		nil, nil,
+	)
+	st := c.InstancesStatus()
+	require.Len(t, st, 1)
+	require.Equal(t, "default", st[0].Name)
+	require.False(t, st[0].Healthy)
+	require.Nil(t, st[0].LastSeen, "no heartbeat yet — omit zero time")
+
+	c.RecordHeartbeat("", HeartbeatStatus{Status: "healthy", Device: "cuda"})
+	st = c.InstancesStatus()
+	require.True(t, st[0].Healthy)
+	require.NotNil(t, st[0].LastSeen)
+	require.Equal(t, "cuda", st[0].Device)
 }

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -349,8 +349,16 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			db,
 			camMgr,
 		)
+		// 多实例路由:相机的 vision_targets(空 = 全部启用实例)。
+		deps.visionMgr.SetCameraTargets(func(cameraID string) []string {
+			if cam := camMgr.GetCameraConfig(cameraID); cam != nil {
+				return cam.VisionTargets
+			}
+			return nil
+		})
 		slog.Info("Vision push integration enabled",
 			"url", cfg.Vision.URL,
+			"instances", len(cfg.Vision.EffectiveInstances()),
 			"push_mode", cfg.Vision.PushMode,
 			"sub_layer_cameras", len(cfg.Vision.SubLayerCameras))
 	}

--- a/web/src/__tests__/CameraForm.test.ts
+++ b/web/src/__tests__/CameraForm.test.ts
@@ -11,7 +11,7 @@ vi.mock('$lib/i18n', () => ({
 
 // --- Mock lucide-svelte icons ---
 vi.mock('lucide-svelte', () => {
-  const icons = ['Eye', 'EyeOff', 'PlugZap', 'Plus', 'Trash2', 'ArrowUpRight', 'Copy', 'Layers'];
+  const icons = ['Eye', 'EyeOff', 'PlugZap', 'Plus', 'Trash2', 'ArrowUpRight', 'Copy', 'Layers', 'Brain'];
   const mock: Record<string, () => HTMLElement> = {};
   for (const name of icons) {
     mock[name] = () => document.createElement('span');

--- a/web/src/lib/api/ai-events.ts
+++ b/web/src/lib/api/ai-events.ts
@@ -21,6 +21,8 @@ export interface AIEvent {
   bbox?: string; // JSON array [x1,y1,x2,y2]
   snapshot_path?: string;
   metadata?: string;
+  /** Writer instance (API key name) — multi-instance attribution; empty = legacy/anonymous. */
+  source?: string;
   created_at: string;
 }
 
@@ -45,6 +47,7 @@ export interface AIEventStatsResponse {
 export interface AIEventFilter {
   camera_id?: string;
   event_type?: string;
+  source?: string;
   start?: string;
   end?: string;
   asc?: boolean;
@@ -56,6 +59,7 @@ export async function listAIEvents(filter: AIEventFilter = {}): Promise<AIEventL
   const params = new URLSearchParams();
   if (filter.camera_id) params.set('camera_id', filter.camera_id);
   if (filter.event_type) params.set('event_type', filter.event_type);
+  if (filter.source) params.set('source', filter.source);
   if (filter.start) params.set('start', filter.start);
   if (filter.end) params.set('end', filter.end);
   if (filter.asc) params.set('asc', 'true');

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -46,6 +46,8 @@ export interface Camera {
   cascade_enabled?: boolean | null;
   /** Cascade tier: forward the sub-stream instead of main (#512). */
   cascade_sub_stream?: boolean | null;
+  /** Vision instance names this camera pushes to (empty/undefined = all enabled instances). */
+  vision_targets?: string[];
   // Recording mode (#435): 'continuous' (default) or 'adaptive' — dynamic
   // timelapse that drops to sparse keyframes while the compressed-domain
   // activity signal stays calm. 'adaptive' holds the tuning knobs (nil = defaults).
@@ -207,6 +209,8 @@ export interface CreateCameraRequest {
   cascade_enabled?: boolean | null;
   /** Cascade tier: forward the sub-stream instead of main (#512). */
   cascade_sub_stream?: boolean | null;
+  /** Vision instance names this camera pushes to (empty/undefined = all enabled instances). */
+  vision_targets?: string[];
   // Recording mode (#435). Omit = continuous.
   recording_mode?: string;
   recording_tier?: string;
@@ -260,6 +264,8 @@ export interface UpdateCameraRequest {
   cascade_enabled?: boolean | null;
   /** Cascade tier: forward the sub-stream instead of main (#512). */
   cascade_sub_stream?: boolean | null;
+  /** Vision instance names this camera pushes to (empty/undefined = all enabled instances). */
+  vision_targets?: string[];
   // Recording mode (#435). Omit = unchanged. Changing it restarts the recorder.
   recording_mode?: string;
   recording_tier?: string;

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -244,6 +244,7 @@ export {
   generateAPIKey,
   revokeAPIKey,
   getVisionStatus,
+  updateVisionSettings,
 } from './settings';
 
 export type {
@@ -264,6 +265,9 @@ export type {
   RtspOutputSettings,
   RtspOutputUpdate,
   VisionStatus,
+  VisionInstanceConfig,
+  VisionSettingsConfig,
+  VisionInstanceStatus,
 } from './settings';
 
 // Xiaomi — cloud auth, devices, sync

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -79,11 +79,32 @@ export interface MiBeeVisionConfig {
   }>;
 }
 
+/** One vision consumer instance (multi-instance routing). */
+export interface VisionInstanceConfig {
+  name: string;
+  url: string;
+  /** API key name used to attribute heartbeats/events/ai_status reports. */
+  api_key_name?: string;
+  /** undefined = enabled (omitted in YAML round-trips). */
+  enabled?: boolean;
+}
+
+/** The `vision` settings section (push integration). */
+export interface VisionSettingsConfig {
+  enabled?: boolean;
+  /** Legacy single-consumer URL; becomes the implicit instance "default". */
+  url?: string;
+  push_mode?: string;
+  heartbeat_timeout_secs?: number;
+  instances?: VisionInstanceConfig[];
+}
+
 export interface SettingsConfig {
   cleanup: CleanupConfig;
   webdav: WebDAVConfig;
   streaming?: StreamingConfig;
   mibeevision?: MiBeeVisionConfig;
+  vision?: VisionSettingsConfig;
   gb28181?: GB28181Config;
   timezone?: string; // "Local", "UTC", or IANA timezone name
   timezone_display?: string; // Human-readable timezone label (e.g. "Asia/Shanghai (UTC+8)")
@@ -431,10 +452,38 @@ export interface VisionStatus {
   metrics?: VisionMetrics;
   /** Recordings marked ai_status='skipped' from consumer drop reports. */
   drops_marked_total?: number;
+  /** Per-instance runtime state (multi-instance); always ≥1 entry ("default"). */
+  instances?: VisionInstanceStatus[];
+}
+
+/** One instance's status block inside GET /api/vision/status. */
+export interface VisionInstanceStatus {
+  name: string;
+  url: string;
+  healthy: boolean;
+  last_seen?: string;
+  device?: string;
+  queue_depth?: number;
+  processed?: number;
+  skip_cameras?: string[];
+  metrics?: VisionMetrics;
+  drops_marked_total?: number;
 }
 
 export async function getVisionStatus(signal?: AbortSignal): Promise<VisionStatus> {
   return apiRequest<VisionStatus>('/vision/status', { signal });
+}
+
+/** PUT /settings {vision} — partial update (nil fields unchanged). */
+export async function updateVisionSettings(
+  config: VisionSettingsConfig,
+  signal?: AbortSignal,
+): Promise<{ status: string }> {
+  return apiRequest<{ status: string }>('/settings', {
+    method: 'PUT',
+    body: JSON.stringify({ vision: config }),
+    signal,
+  });
 }
 
 // One heartbeat sample in the in-memory history ring (#671) — the data source
@@ -451,11 +500,14 @@ export interface VisionSample {
 
 export interface VisionMetricsResponse {
   enabled: boolean;
+  instance?: string;
   points: VisionSample[];
   marked_total: number;
 }
 
-/** GET /api/vision/metrics?hours= — heartbeat history ring (~24h @ 30s). */
-export async function getVisionMetrics(hours = 24, signal?: AbortSignal): Promise<VisionMetricsResponse> {
-  return apiRequest<VisionMetricsResponse>(`/vision/metrics?hours=${hours}`, { signal });
+/** GET /api/vision/metrics?hours=[&instance=] — heartbeat history ring (~24h @ 30s). */
+export async function getVisionMetrics(hours = 24, instance?: string, signal?: AbortSignal): Promise<VisionMetricsResponse> {
+  const q = new URLSearchParams({ hours: String(hours) });
+  if (instance) q.set('instance', instance);
+  return apiRequest<VisionMetricsResponse>(`/vision/metrics?${q.toString()}`, { signal });
 }

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -17,6 +17,7 @@
         getCameraStorageRoot,
         setCameraStorageRoot,
         getStorageMigrateStatus,
+        getSettings,
     } from '$lib/api';
     import type {
         Camera,
@@ -36,7 +37,7 @@
         CameraAudioTriggerConfig,
         CameraPixgateConfig,
     } from '$lib/api';
-    import { Eye, EyeOff, PlugZap, Plus, Trash2, ArrowUpRight, Copy, Layers } from 'lucide-svelte';
+    import { Eye, EyeOff, PlugZap, Plus, Trash2, ArrowUpRight, Copy, Layers, Brain } from 'lucide-svelte';
     import { onDestroy } from 'svelte';
     import { showToast } from '$lib/toast';
     import { copyText } from '$lib/clipboard';
@@ -156,6 +157,23 @@
   let formPushRetentionDays = $state<number | null>(null);
   // Push-out relay targets
   let formPushTargets = $state<PushTargetConfig[]>([]);
+  // Vision instance routing: which analysis consumers receive this camera's
+  // recordings. Empty selection = all enabled instances.
+  let formVisionTargets = $state<string[]>([]);
+  let visionInstanceOptions = $state<Array<{ name: string; enabled: boolean }>>([]);
+
+  async function loadVisionInstanceOptions() {
+    try {
+      const settings = await getSettings();
+      const instances = settings.vision?.instances;
+      visionInstanceOptions = instances?.length
+        ? instances.map((i) => ({ name: i.name, enabled: i.enabled ?? true }))
+        // Legacy single-instance deployment: the implicit "default" instance.
+        : [{ name: 'default', enabled: true }];
+    } catch {
+      visionInstanceOptions = [];
+    }
+  }
   // Push-out live status (fetched when editing)
   let pushStatus = $state<PushTargetStatusType[]>([]);
   let pushStatusTimer: ReturnType<typeof setInterval> | null = null;
@@ -214,6 +232,7 @@ let validationErrors = $state<Record<string, string>>({});
 
   // Populate form when editingCamera changes
   $effect(() => {
+    loadVisionInstanceOptions();
     if (editingCamera) {
       populateForm(editingCamera);
       loadMergeConfig(editingCamera.id);
@@ -309,6 +328,7 @@ let validationErrors = $state<Record<string, string>>({});
     formPushRetentionDays = null;
     formPushTargets = [];
     pushStatus = [];
+    formVisionTargets = [];
   }
 
   async function loadCameraStorage(cameraId: string) {
@@ -443,6 +463,7 @@ let validationErrors = $state<Record<string, string>>({});
     formGB28181ChannelID = camera.gb28181?.channel_id || '';
     formPushRetentionDays = camera.push_retention_days ?? null;
     formPushTargets = (camera.push_targets ?? []).map((p) => ({ ...p }));
+    formVisionTargets = camera.vision_targets ? [...camera.vision_targets] : [];
     // Start polling push-out status while editing (only if there are targets).
     startPushStatusPolling(camera.id);
   }
@@ -481,6 +502,12 @@ let validationErrors = $state<Record<string, string>>({});
   function removePushTarget(id: string) {
     formPushTargets = formPushTargets.filter((t) => t.id !== id);
   }
+  function toggleVisionTarget(name: string, checked: boolean) {
+    formVisionTargets = checked
+      ? [...new Set([...formVisionTargets, name])]
+      : formVisionTargets.filter((n) => n !== name);
+  }
+
   function updatePushTarget(id: string, patch: Partial<PushTargetConfig>) {
     formPushTargets = formPushTargets.map((t) => (t.id === id ? { ...t, ...patch } : t));
   }
@@ -785,6 +812,7 @@ async function performCameraSave() {
             srt_stream_id: formProtocol === 'srt' ? (formSRTStreamID || undefined) : undefined,
             gb28181: formProtocol === 'gb28181' ? { device_id: formGB28181DeviceID, channel_id: formGB28181ChannelID } : undefined,
             push_targets: formPushTargets.length > 0 ? formPushTargets : [],
+            vision_targets: formVisionTargets,
             push_retention_days: (formProtocol === 'srt' || formProtocol === 'rtmp' || formProtocol === 'whip') ? formPushRetentionDays : undefined,
             dark_frame_filter_enabled: formDarkFrameFilterEnabled,
             dark_frame_threshold: formDarkFrameFilterEnabled ? formDarkFrameThreshold : undefined,
@@ -857,6 +885,7 @@ async function performCameraSave() {
             srt_stream_id: formProtocol === 'srt' ? (formSRTStreamID || undefined) : undefined,
             gb28181: formProtocol === 'gb28181' ? { device_id: formGB28181DeviceID, channel_id: formGB28181ChannelID } : undefined,
             push_targets: formPushTargets.length > 0 ? formPushTargets : undefined,
+            vision_targets: formVisionTargets,
             push_retention_days: (formProtocol === 'srt' || formProtocol === 'rtmp' || formProtocol === 'whip') ? formPushRetentionDays : undefined,
             dark_frame_filter_enabled: formDarkFrameFilterEnabled,
             dark_frame_threshold: formDarkFrameFilterEnabled ? formDarkFrameThreshold : undefined,
@@ -1447,6 +1476,41 @@ async function performCameraSave() {
             <p class="text-xs th-text-muted mt-1">{t('cameras.subProfileTokenHint')}</p>
           </div>
           {/if}
+        </div>
+      </details>
+    </div>
+    {/if}
+
+    <!-- AI analysis routing: which vision consumer instances receive this
+         camera's recordings. No selection = all enabled instances. -->
+    {#if visionInstanceOptions.length > 0}
+    <div class="md:col-span-2">
+      <details class="rounded-md border th-border">
+        <summary class="cursor-pointer p-3 flex items-center gap-2 th-bg-hover">
+          <Brain size={16} class="th-text-secondary" />
+          <span class="font-medium th-text-primary">{t('cameras.visionRoutingTitle')}</span>
+          {#if formVisionTargets.length > 0}
+            <span class="text-xs px-2 py-0.5 rounded-full th-bg-muted th-text-secondary">{formVisionTargets.length}</span>
+          {:else}
+            <span class="text-xs px-2 py-0.5 rounded-full th-bg-muted th-text-secondary">{t('cameras.visionRoutingAll')}</span>
+          {/if}
+        </summary>
+        <div class="p-3 border-t th-border space-y-2">
+          <p class="text-xs th-text-muted">{t('cameras.visionRoutingHint')}</p>
+          {#each visionInstanceOptions as ins (ins.name)}
+            <label class="flex items-center gap-2 text-sm th-text-primary cursor-pointer" data-testid="vision-target-{ins.name}">
+              <input
+                type="checkbox"
+                class="checkbox"
+                checked={formVisionTargets.includes(ins.name)}
+                onchange={(e) => toggleVisionTarget(ins.name, (e.currentTarget as HTMLInputElement).checked)}
+              />
+              <span>{ins.name}</span>
+              {#if !ins.enabled}
+                <span class="badge badge-warning ml-1">{t('cameras.visionRoutingDisabled')}</span>
+              {/if}
+            </label>
+          {/each}
         </div>
       </details>
     </div>

--- a/web/src/lib/components/VisionMonitorPanel.svelte
+++ b/web/src/lib/components/VisionMonitorPanel.svelte
@@ -11,6 +11,10 @@
   // ring (~24h @ 30s). Mounted at the top of the dashboard Vision tab; renders
   // nothing until the first successful fetch.
 
+  // instance: render ONE named consumer instance (multi-instance); empty =
+  // the legacy top-level view (= default instance).
+  let { instance = '' }: { instance?: string } = $props();
+
   let status = $state<VisionStatus | null>(null);
   let points = $state<VisionSample[]>([]);
   let failed = $state(false);
@@ -20,7 +24,10 @@
 
   async function refresh() {
     try {
-      const [s, m] = await Promise.all([getVisionStatus(), getVisionMetrics(HISTORY_HOURS)]);
+      const [s, m] = await Promise.all([
+        getVisionStatus(),
+        getVisionMetrics(HISTORY_HOURS, instance || undefined),
+      ]);
       status = s;
       points = m.points ?? [];
       failed = false;
@@ -28,6 +35,14 @@
       failed = true;
     }
   }
+
+  // The per-instance view: header/tile fields come from the named instance's
+  // status block instead of the top-level (default) one.
+  let view = $derived.by(() => {
+    if (!status) return null;
+    if (!instance) return status;
+    return status.instances?.find((i) => i.name === instance) ?? null;
+  });
 
   onMount(() => {
     refresh();
@@ -77,26 +92,26 @@
   };
 </script>
 
-{#if status?.enabled}
-  <div class="vision-monitor th-bg-elevated" data-testid="vision-monitor-panel">
+{#if status?.enabled && view}
+  <div class="vision-monitor th-bg-elevated" data-testid={'vision-monitor-panel' + (instance ? `-${instance}` : '')}>
     <div class="vm-head">
       <div class="vm-title">
         <BrainCircuit size={16} />
-        <span>{t('visionMonitor.title')}</span>
+        <span>{t('visionMonitor.title')}{instance ? ` · ${instance}` : ''}</span>
       </div>
       <div class="vm-status">
-        {#if status.healthy}
+        {#if view.healthy}
           <span class="dot dot-ok"></span>
           <span>{t('visionMonitor.healthy')}</span>
         {:else}
           <span class="dot dot-bad"></span>
           <span>{t('visionMonitor.degraded')}</span>
         {/if}
-        {#if status.device}
-          <span class="vm-chip">{status.device}</span>
+        {#if view.device}
+          <span class="vm-chip">{view.device}</span>
         {/if}
-        {#if status.last_seen}
-          <span class="vm-chip">{t('visionMonitor.lastSeen', { time: fmtSeen(status.last_seen) })}</span>
+        {#if view.last_seen}
+          <span class="vm-chip">{t('visionMonitor.lastSeen', { time: fmtSeen(view.last_seen) })}</span>
         {/if}
         <span class="vm-range">{t('visionMonitor.sampleNote')}</span>
       </div>
@@ -106,12 +121,12 @@
       <p class="vm-error">{t('visionMonitor.refreshFailed')}</p>
     {/if}
 
-    {#if status.metrics}
-      {@const m = status.metrics}
+    {#if view.metrics}
+      {@const m = view.metrics}
       <div class="vm-tiles">
         <div class="vm-tile" data-testid="vm-tile-queue">
           <span class="vm-k">{t('visionMonitor.queue')}</span>
-          <span class="vm-v">{status.queue_depth ?? 0}<span class="vm-sub">/{m.queue_capacity ?? '?'}</span></span>
+          <span class="vm-v">{view.queue_depth ?? 0}<span class="vm-sub">/{m.queue_capacity ?? '?'}</span></span>
         </div>
         <div class="vm-tile" data-testid="vm-tile-decoded">
           <span class="vm-k">{t('visionMonitor.decodedQueue')}</span>
@@ -123,7 +138,7 @@
         </div>
         <div class="vm-tile">
           <span class="vm-k">{t('visionMonitor.processed')}</span>
-          <span class="vm-v">{status.processed ?? '-'}</span>
+          <span class="vm-v">{view.processed ?? '-'}</span>
         </div>
         <div class="vm-tile">
           <span class="vm-k">{t('visionMonitor.hits')}</span>
@@ -140,7 +155,7 @@
         </div>
         <div class="vm-tile">
           <span class="vm-k">{t('visionMonitor.marked')}</span>
-          <span class="vm-v">{status.drops_marked_total ?? 0}</span>
+          <span class="vm-v">{view.drops_marked_total ?? 0}</span>
         </div>
         {#if m.mem_available_mb}
           <div class="vm-tile" class:vm-warn={m.mem_available_mb < 600}>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1891,5 +1891,20 @@
   "visionMonitor.unitDropsPerMin": "segs/min",
   "visionMonitor.lastSeen": "Last heartbeat {time}",
   "visionMonitor.sampleNote": "Last 24h · ~30s samples · 15s refresh",
-  "visionMonitor.noData": "No data"
+  "visionMonitor.noData": "No data",
+  "settings.mibeevision.instances.title": "Consumer instances",
+  "settings.mibeevision.instances.add": "Add instance",
+  "settings.mibeevision.instances.hint": "Each instance is an independent AI analysis backend (can run a different model); cameras without explicit routing push to all enabled instances. The instance's API key attributes heartbeats/events/status reports.",
+  "settings.mibeevision.instances.empty": "No instances configured — a single-instance setup uses the legacy address above (implicit \"default\" instance).",
+  "settings.mibeevision.instances.name": "Instance name",
+  "settings.mibeevision.instances.url": "Address (http://…:9091)",
+  "settings.mibeevision.instances.apiKey": "Linked API key",
+  "settings.mibeevision.instances.noKey": "None (→ default)",
+  "settings.mibeevision.instances.enabled": "Enabled",
+  "cameras.visionRoutingTitle": "AI analysis routing",
+  "cameras.visionRoutingAll": "all",
+  "cameras.visionRoutingHint": "Choose which vision instances receive this camera's recordings; unchecked = all enabled instances.",
+  "cameras.visionRoutingDisabled": "disabled",
+  "aiEvents.sourceFilter": "Source instance",
+  "aiEvents.allSources": "All sources"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1890,5 +1890,20 @@
   "visionMonitor.unitDropsPerMin": "段/分",
   "visionMonitor.lastSeen": "最近心跳 {time}",
   "visionMonitor.sampleNote": "近 24h · ~30s 采样 · 15s 刷新",
-  "visionMonitor.noData": "暂无数据"
+  "visionMonitor.noData": "暂无数据",
+  "settings.mibeevision.instances.title": "消费端实例",
+  "settings.mibeevision.instances.add": "添加实例",
+  "settings.mibeevision.instances.hint": "每个实例是一个独立的 AI 分析后端(可挂不同模型);相机未指定路由时推送给全部启用实例。实例的 API Key 用于心跳/事件/状态归因。",
+  "settings.mibeevision.instances.empty": "未配置实例——单实例部署使用下方兼容地址(合成 default 实例)。",
+  "settings.mibeevision.instances.name": "实例名",
+  "settings.mibeevision.instances.url": "地址(http://…:9091)",
+  "settings.mibeevision.instances.apiKey": "关联 API Key",
+  "settings.mibeevision.instances.noKey": "不关联(落 default)",
+  "settings.mibeevision.instances.enabled": "启用",
+  "cameras.visionRoutingTitle": "AI 分析路由",
+  "cameras.visionRoutingAll": "全部",
+  "cameras.visionRoutingHint": "选择该摄像头的录像推送给哪些 Vision 实例;不勾选 = 全部启用实例。",
+  "cameras.visionRoutingDisabled": "已停用",
+  "aiEvents.sourceFilter": "来源实例",
+  "aiEvents.allSources": "全部来源"
 }

--- a/web/src/routes/AIEvents.svelte
+++ b/web/src/routes/AIEvents.svelte
@@ -13,6 +13,7 @@
   import { AlertCircle, Brain, ChevronDown, Play, Settings } from 'lucide-svelte';
   import Pagination from '../components/Pagination.svelte';
   import VisionMonitorPanel from '../lib/components/VisionMonitorPanel.svelte';
+  import { getVisionStatus } from '$lib/api';
 
   let events = $state<AIEvent[]>([]);
   let total = $state(0);
@@ -20,6 +21,10 @@
   let error = $state('');
   let cameraFilter = $state('');
   let eventTypeFilter = $state('');
+  let sourceFilter = $state('');
+  // Vision consumer instances (multi-instance): drives the per-instance
+  // monitor panels and the source filter options.
+  let visionInstanceNames = $state<string[]>([]);
   let cameras = $state<Camera[]>([]);
   let page = $state(0);
   let expandedEvent = $state<number | null>(null);
@@ -63,6 +68,7 @@
       const resp = await listAIEvents({
         camera_id: cameraFilter || undefined,
         event_type: eventTypeFilter || undefined,
+        source: sourceFilter || undefined,
         limit: pageSize,
         offset: page * pageSize,
       });
@@ -174,6 +180,12 @@
   const miBeeVisionLoaded = $derived(getMiBeeVisionLoaded());
 
   onMount(async () => {
+    try {
+      const vs = await getVisionStatus();
+      visionInstanceNames = (vs.instances ?? []).map((i) => i.name);
+    } catch {
+      visionInstanceNames = [];
+    }
     await refreshMiBeeVisionStatus();
     if (!getMiBeeVisionConnected()) return;
     try {
@@ -211,7 +223,13 @@
   </div>
 
   <!-- Consumer monitor (heartbeat v2 metrics, #671) -->
-  <VisionMonitorPanel />
+  {#if visionInstanceNames.length > 1}
+    {#each visionInstanceNames as insName (insName)}
+      <VisionMonitorPanel instance={insName} />
+    {/each}
+  {:else}
+    <VisionMonitorPanel />
+  {/if}
 
   <!-- Filters -->
   <div class="flex flex-wrap gap-3 mb-4">
@@ -226,6 +244,15 @@
         <option value={et.value}>{et.label}</option>
       {/each}
     </select>
+
+    {#if visionInstanceNames.length > 0}
+      <select class="input" bind:value={sourceFilter} onchange={onFilterChange} aria-label={t('aiEvents.sourceFilter')}>
+        <option value="">{t('aiEvents.allSources')}</option>
+        {#each visionInstanceNames as n (n)}
+          <option value={n}>{n}</option>
+        {/each}
+      </select>
+    {/if}
   </div>
 
   <!-- Stats summary (when camera selected) -->
@@ -273,7 +300,7 @@
               <!-- Severity badge -->
               <span class="px-2 py-0.5 rounded text-xs font-medium border {severityColors[evt.severity] || severityColors.info}">
                 {severityLabel(evt.severity)}
-              </span>
+              </span> {#if evt.source}<span class="px-2 py-0.5 rounded text-xs th-bg-muted th-text-secondary" data-testid="ai-event-source">{evt.source}</span>{/if}
               <!-- Event info -->
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -2,8 +2,8 @@
   import { onMount, onDestroy } from 'svelte';
   import { getAiSettings, saveAiSettings, detectAiBackend, listCameras, getAiStatus, updateAiConfig, listAiModels } from '$lib/api';
   import { getPerCameraAiSettings, savePerCameraAiSettings, getAIZones, createAIZone, deleteAIZone } from '$lib/api';
-  import { getSettings, generateAPIKey, revokeAPIKey, getVisionStatus } from '$lib/api';
-  import type { VisionStatus } from '$lib/api';
+  import { getSettings, generateAPIKey, revokeAPIKey, getVisionStatus, updateVisionSettings } from '$lib/api';
+  import type { VisionStatus, VisionInstanceConfig, VisionSettingsConfig } from '$lib/api';
   import { refreshMiBeeVisionStatus } from '$lib/mibeevision-status.svelte';
   import { formatRelativeTime } from '$lib/format';
   import type { Camera, Zone, PerCameraAiState, AiModelInfo } from '$lib/api';
@@ -79,6 +79,41 @@
     }
   }
 
+  // Vision consumer instances (multi-instance routing): editable list saved
+  // through PUT /settings {vision.instances} (whole-table replace).
+  let visionInstances = $state<VisionInstanceConfig[]>([]);
+  let originalVisionInstances: string = '[]';
+  let visionInstancesLoaded = $state(false);
+
+  function loadVisionInstances(settings: { vision?: VisionSettingsConfig }) {
+    visionInstances = (settings.vision?.instances ?? []).map((i) => ({ ...i }));
+    originalVisionInstances = JSON.stringify(visionInstances);
+    visionInstancesLoaded = true;
+  }
+
+  const visionInstancesDirty = $derived(
+    visionInstancesLoaded && JSON.stringify(visionInstances) !== originalVisionInstances
+  );
+
+  function addVisionInstance() {
+    visionInstances = [
+      ...visionInstances,
+      { name: '', url: 'http://', api_key_name: '', enabled: true },
+    ];
+  }
+
+  function removeVisionInstance(idx: number) {
+    visionInstances = visionInstances.filter((_, i) => i !== idx);
+  }
+
+  function updateVisionInstance(idx: number, patch: Partial<VisionInstanceConfig>) {
+    visionInstances = visionInstances.map((ins, i) => (i === idx ? { ...ins, ...patch } : ins));
+  }
+
+  // Per-instance health dot source (from the polled status).
+  const instanceHealth = (name: string): boolean | undefined =>
+    visionStatus?.instances?.find((i) => i.name === name)?.healthy;
+
   // Compare two enabled-classes values for isDirty (order-insensitive).
   function classesEqual(a: string[] | null, b: string[] | null): boolean {
     if (!a && !b) return true;
@@ -96,7 +131,8 @@
       aiEmaAlpha !== originalEmaAlpha ||
       aiMaxAge !== originalMaxAge ||
       !classesEqual(aiEnabledClasses, originalEnabledClasses) ||
-      aiModelUrl !== originalModelUrl
+      aiModelUrl !== originalModelUrl ||
+      visionInstancesDirty
     )
   );
 
@@ -144,6 +180,19 @@
   }
 
   async function performSave() {
+    if (visionInstancesDirty) {
+      // Whole-table replace; the backend rejects unknown/duplicate names and
+      // instances still referenced by camera routing (400 with detail).
+      const cleaned = visionInstances.map((i) => ({
+        name: i.name.trim(),
+        url: i.url.trim(),
+        api_key_name: i.api_key_name?.trim() || undefined,
+        enabled: i.enabled ?? true,
+      }));
+      await updateVisionSettings({ instances: cleaned });
+      visionInstances = cleaned.map((i) => ({ ...i }));
+      originalVisionInstances = JSON.stringify(visionInstances);
+    }
     await updateAiConfig({
       enabled: aiEnabled,
       confidence_threshold: aiConfidenceThreshold,
@@ -173,6 +222,7 @@
   }
 
   function resetForm() {
+    visionInstances = JSON.parse(originalVisionInstances) as VisionInstanceConfig[];
     aiEnabled = originalAiEnabled;
     aiConfidenceThreshold = originalConfidence;
     aiFrameSkip = originalFrameSkip;
@@ -187,6 +237,7 @@
     mibeeVisionLoading = true;
     try {
       const settings = await getSettings();
+      loadVisionInstances(settings);
       const cfg = settings.mibeevision;
       if (cfg && cfg.api_keys) {
         mibeeVisionKeys = cfg.api_keys.map((k) => ({
@@ -660,6 +711,72 @@
           {/if}
         </div>
       {/if}
+
+      <!-- Consumer instances (multi-instance routing): each row is one
+           external consumer with its own address + API key identity. Empty
+           per-camera routing = all enabled instances. -->
+      <div class="space-y-2">
+        <div class="flex items-center justify-between">
+          <span class="text-sm font-medium th-text-primary">{t('settings.mibeevision.instances.title')}</span>
+          <button type="button" class="btn btn-ghost btn-sm" onclick={addVisionInstance}>
+            <Plus size={14} />
+            {t('settings.mibeevision.instances.add')}
+          </button>
+        </div>
+        <p class="text-xs th-text-tertiary">{t('settings.mibeevision.instances.hint')}</p>
+        {#if visionInstances.length === 0}
+          <p class="text-xs th-text-tertiary">{t('settings.mibeevision.instances.empty')}</p>
+        {:else}
+          <div class="space-y-2">
+            {#each visionInstances as ins, idx (idx)}
+              <div class="p-3 rounded-md border th-border grid grid-cols-1 md:grid-cols-[1fr_2fr_1fr_auto_auto] gap-2 items-center">
+                <input
+                  type="text"
+                  class="input"
+                  placeholder={t('settings.mibeevision.instances.name')}
+                  bind:value={ins.name}
+                  onchange={() => updateVisionInstance(idx, { name: ins.name })}
+                  data-testid="vision-instance-name-{idx}"
+                />
+                <input
+                  type="text"
+                  class="input"
+                  placeholder={t('settings.mibeevision.instances.url')}
+                  bind:value={ins.url}
+                  onchange={() => updateVisionInstance(idx, { url: ins.url })}
+                  data-testid="vision-instance-url-{idx}"
+                />
+                <select
+                  class="input"
+                  bind:value={ins.api_key_name}
+                  onchange={() => updateVisionInstance(idx, { api_key_name: ins.api_key_name })}
+                  aria-label={t('settings.mibeevision.instances.apiKey')}
+                >
+                  <option value="">{t('settings.mibeevision.instances.noKey')}</option>
+                  {#each mibeeVisionKeys.filter((k) => !k.revoked) as key (key.name)}
+                    <option value={key.name}>{key.name}</option>
+                  {/each}
+                </select>
+                <label class="flex items-center gap-1 text-xs th-text-secondary cursor-pointer">
+                  <input type="checkbox" class="checkbox" bind:checked={ins.enabled} />
+                  {t('settings.mibeevision.instances.enabled')}
+                </label>
+                <div class="flex items-center gap-2">
+                  {#if instanceHealth(ins.name) !== undefined}
+                    <span
+                      class="inline-block h-2.5 w-2.5 rounded-full {instanceHealth(ins.name) ? 'bg-green-500' : 'bg-red-500'}"
+                      title={instanceHealth(ins.name) ? t('settings.mibeevision.consumerOnline') : t('settings.mibeevision.consumerOffline')}
+                    ></span>
+                  {/if}
+                  <button type="button" class="btn btn-ghost btn-sm th-color-danger" onclick={() => removeVisionInstance(idx)}>
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
 
       <!-- Generate new key -->
       <div class="flex gap-2">


### PR DESCRIPTION
## 概要
NVR 支持同时接入多个外部 AI 后处理消费端(vision.instances),不同实例可挂不同模型配置,按相机路由分流:

- **配置**: `vision.instances[] {name, url, api_key_name, enabled}`;legacy 单 `url` 在未配 instances 时合成名为 `default` 的单实例——**现有单实例部署零变化**。相机级 `vision_targets`(空 = 全部启用实例)。校验:实例名唯一/必填、URL http(s)、路由引用存在(API 400 + 配置层双保险)。
- **推送扇出**: 每实例独立心跳健康/暂停窗/离线补偿(按 name 对账,跨配置编辑存活);段按相机路由扇出,单实例失败不影响其它;子层段全部健康路由实例接受才删源文件。
- **实例归因**: 心跳/事件/ai_status 回传携带的 Bearer API Key 名匹配 `api_key_name` 落到实例(零消费端改动);匿名/未匹配落 default(旧版兼容)。`/api/vision/status` 增 `instances[]`;`/api/vision/metrics?instance=`。
- **ai_status 多实例聚合**: completed > skipped > failed > 非终态,低秩写入不落——completed 永不被 failed/skipped 降级,补推完成可把 skipped 升级为 completed。
- **事件来源**: ai_events 新列 `source`(schema v35,可空)= 写入方 key 名;列表 `?source=` 过滤。

## 兼容与回滚
- 单实例配置全向后兼容;回滚 = 换旧二进制(source 列可空无影响,零 schema 破坏——v35 仅加列)。
- 语义默认(未答复问卷按推荐):相机未配 targets → 推全部启用实例。

## 测试
- config: 实例合成/过滤/路由/校验 7 例
- vision: 双实例扇出/故障隔离/归因/InstancesStatus 4 例(既有补偿/跳单/层级路由测试全绿)
- api: Bearer 归因 + instances 状态端点 1 例
- storage: source 往返+过滤、聚合卫兵升降级 2 例
- WSL 全量: vision/camera/storage/config/pkg/app/cmd 全绿(api 中 RTSP 连接拒绝测试为 WSL 网络环境既有失败,干净树复现,CI 为准)