### PR TITLE
fix(vision): 多实例后续 — vision_targets 回显 + SPA apiKeyName

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -74,6 +74,7 @@ func injectYAMLConfigFields(row *storage.CameraRow, cfg *config.Config) {
 		row.SRTPassphrase = cam.SRTPassphrase
 		row.SRTStreamID = cam.SRTStreamID
 		row.PushTargets = cam.PushTargets
+		row.VisionTargets = cam.VisionTargets
 		row.PushRetentionDays = cam.PushRetentionDays
 		row.StableID = cam.StableID
 		row.SubnetHints = cam.SubnetHints

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -59,6 +59,7 @@ type CameraRow struct {
 	SRTStreamID   string `json:"srt_stream_id,omitempty"`
 	// Push-out relay targets + retention, injected from YAML at API response time.
 	PushTargets       []config.PushTargetConfig `json:"push_targets,omitempty"`
+	VisionTargets     []string                  `json:"vision_targets,omitempty"`
 	PushRetentionDays *int                      `json:"push_retention_days,omitempty"`
 	// StableID is the ONVIF serial number used for IP self-healing.
 	// Persisted in DB via UpsertCamera / UpdateCameraStableID.

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1788484780594';
+const CACHE_VERSION = 'mibee-nvr-1788646312116';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/lib/api/settings.ts
+++ b/web/src/lib/api/settings.ts
@@ -83,8 +83,9 @@ export interface MiBeeVisionConfig {
 export interface VisionInstanceConfig {
   name: string;
   url: string;
-  /** API key name used to attribute heartbeats/events/ai_status reports. */
-  api_key_name?: string;
+  /** API key name used to attribute heartbeats/events/ai_status reports.
+   *  JSON wire tag is camelCase (Go struct tag); YAML uses api_key_name. */
+  apiKeyName?: string;
   /** undefined = enabled (omitted in YAML round-trips). */
   enabled?: boolean;
 }

--- a/web/src/routes/settings/AIPanel.svelte
+++ b/web/src/routes/settings/AIPanel.svelte
@@ -98,7 +98,7 @@
   function addVisionInstance() {
     visionInstances = [
       ...visionInstances,
-      { name: '', url: 'http://', api_key_name: '', enabled: true },
+      { name: '', url: 'http://', apiKeyName: '', enabled: true },
     ];
   }
 
@@ -186,7 +186,7 @@
       const cleaned = visionInstances.map((i) => ({
         name: i.name.trim(),
         url: i.url.trim(),
-        api_key_name: i.api_key_name?.trim() || undefined,
+        apiKeyName: i.apiKeyName?.trim() || undefined,
         enabled: i.enabled ?? true,
       }));
       await updateVisionSettings({ instances: cleaned });
@@ -748,8 +748,8 @@
                 />
                 <select
                   class="input"
-                  bind:value={ins.api_key_name}
-                  onchange={() => updateVisionInstance(idx, { api_key_name: ins.api_key_name })}
+                  bind:value={ins.apiKeyName}
+                  onchange={() => updateVisionInstance(idx, { apiKeyName: ins.apiKeyName })}
                   aria-label={t('settings.mibeevision.instances.apiKey')}
                 >
                   <option value="">{t('settings.mibeevision.instances.noKey')}</option>


### PR DESCRIPTION
#702 的两处实测踩坑修复(双实例 E2E 中发现):
1. CameraRow/injectYAMLConfigFields 不回显 vision_targets → SPA 编辑回读空
2. SPA 实例类型误用 api_key_name(JSON wire 是 camelCase apiKeyName)→ key 关联静默丢失,心跳归因全部落 default

WSL vitest 606/606;M5 实机验证 targets 回显+双实例归因正确。