### PR TITLE
feat(gb28181): platform-side on-demand snapshot + manual record (#708)

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/flv"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/hls"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
@@ -208,6 +209,10 @@ type Handler struct {
 	// lifecycle ops (#709). The SAME func feeds the MQTT client — wired once
 	// in builders.go so HTTP webhook and MQTT triggers share semantics.
 	triggerDispatcher func(cameraID, action string)
+	// gb28181Commander sends DeviceControl commands (#708 snapshot/record).
+	gb28181Commander gbCommander
+	// gb28181SnapMgr tracks on-demand snapshot sessions (#708).
+	gb28181SnapMgr *gb28181.SnapshotSessionManager
 }
 
 // frameListEntry is a cached sorted listing of a frame directory.
@@ -333,6 +338,11 @@ func (h *Handler) registerPublicRoutes(r chi.Router) {
 		h.registerVisionPublicRoutes(r)
 		// Webhook trigger (public, rate-limited — HMAC signature is the credential, #709)
 		h.registerTriggerRoutes(r)
+		// GB28181 snapshot upload (public, rate-limited — the session ID in
+		// the URL is the credential; devices cannot BasicAuth, #708)
+		if h.gb28181SnapMgr != nil {
+			r.Post("/api/gb28181/snapshot/upload", h.handleGB28181SnapshotUpload)
+		}
 	})
 }
 
@@ -959,6 +969,9 @@ func (h *Handler) registerGB28181Routes(r chi.Router) {
 			r.Post("/download", h.handleChannelDownloadStart)
 			r.Get("/download", h.handleChannelPlaybackStatus)
 			r.Delete("/download", h.handleChannelPlaybackStop)
+			// GB/T 28181-2022 on-demand capture (#708)
+			r.Post("/snapshot", h.handleGB28181ChannelSnapshot)
+			r.Post("/record", h.handleGB28181ChannelRecord)
 		})
 	})
 }

--- a/internal/api/handlers_gb28181_snapshot.go
+++ b/internal/api/handlers_gb28181_snapshot.go
@@ -1,0 +1,239 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/mickeyzzc/gb28181-go/manscdp"
+	"github.com/mickeyzzc/gb28181-go/platform"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
+)
+
+// GB/T 28181-2022 platform-side on-demand snapshot + manual record (#708).
+//
+//	POST /api/gb28181/channels/{id}/snapshot   {snap_num, interval}
+//	POST /api/gb28181/channels/{id}/record     {action: start|stop}
+//	POST /api/gb28181/snapshot/upload?session= (public — device POSTs JPEGs)
+//
+// The snapshot exchange: SnapShotCmd carries an UploadURL pointing at THIS
+// server plus a random SessionID; the device POSTs each captured JPEG to the
+// upload endpoint (the SessionID in the URL is the credential — devices
+// cannot BasicAuth, same threat model as WHIP stream keys), then reports
+// UploadSnapShotFinished. Sessions close on the completion notify or on
+// timeout (spec: no notify within the window = failure).
+
+// gbCommander is the DeviceControl surface these handlers need. Satisfied by
+// *platform.PTZController; narrow interface keeps the handlers testable.
+type gbCommander interface {
+	SendSnapShotCmd(channelID string, cmd manscdp.SnapShotCmd) error
+	StartManualRecord(channelID string) error
+	StopManualRecord(channelID string) error
+}
+
+var gbSnapshotLogger = slogx.Component("gb28181-snapshot")
+
+// snapshotUploadMaxBytes caps one uploaded frame. Real MJPEG/JPEG frames are
+// ≤4MB at 4K; 8MB leaves margin while keeping a hostile poster honest.
+const snapshotUploadMaxBytes = 8 << 20
+
+// SetGB28181Commander wires the DeviceControl sender for snapshot/record.
+func (h *Handler) SetGB28181Commander(c gbCommander) {
+	h.gb28181Commander = c
+}
+
+// SetGB28181SnapshotManager wires the snapshot session registry.
+func (h *Handler) SetGB28181SnapshotManager(m *gb28181.SnapshotSessionManager) {
+	h.gb28181SnapMgr = m
+}
+
+// locateGBChannel resolves a channel ID to (deviceID, ok) across registered
+// devices — same scan the invite handler uses.
+func (h *Handler) locateGBChannel(channelID string) (string, bool) {
+	if h.gb28181DeviceMgr == nil {
+		return "", false
+	}
+	for _, dev := range h.gb28181DeviceMgr.AllDevices() {
+		if _, ok := h.gb28181DeviceMgr.FindChannel(dev.ID, channelID); ok {
+			return dev.ID, true
+		}
+	}
+	return "", false
+}
+
+// gbCameraIDForChannel derives the storage/event camera ID for a channel.
+// GB cameras enroll as gb-<channelID> (the camera-manager convention), so
+// most channels map exactly; channels without an enrolled camera still get
+// the derived ID — snapshots persist under a namespaced directory and the
+// event simply references an unknown camera to UI consumers.
+func (h *Handler) gbCameraIDForChannel(channelID string) string {
+	camID := "gb-" + channelID
+	if h.camMgr != nil && h.camMgr.GetCameraConfig(camID) == nil {
+		gbSnapshotLogger.Debug("snapshot for channel without enrolled camera", "channel_id", channelID)
+	}
+	return camID
+}
+
+type gbSnapshotRequest struct {
+	SnapNum  int `json:"snap_num"` // 1..10 (spec A.2.1.24), default 1
+	Interval int `json:"interval"` // seconds between frames, >=1, 0 = single
+}
+
+// handleGB28181ChannelSnapshot sends DeviceControl(SnapShotCmd) — the device
+// captures SnapNum frames and POSTs them to the session's upload URL.
+func (h *Handler) handleGB28181ChannelSnapshot(w http.ResponseWriter, r *http.Request) {
+	channelID := r.PathValue("id")
+	if channelID == "" {
+		WriteError(w, http.StatusBadRequest, "channel ID is required")
+		return
+	}
+	var body gbSnapshotRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			WriteError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+	}
+
+	deviceID, ok := h.locateGBChannel(channelID)
+	if !ok {
+		WriteError(w, http.StatusNotFound, "channel not found")
+		return
+	}
+	if dev, found := h.gb28181DeviceMgr.Device(deviceID); !found || dev.Status.Load() == platform.DeviceOffline {
+		WriteError(w, http.StatusConflict, "device is offline, cannot snapshot channel")
+		return
+	}
+	if h.gb28181Commander == nil || h.gb28181SnapMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "GB28181 device control not available")
+		return
+	}
+
+	sess, err := h.gb28181SnapMgr.CreateSession(channelID, deviceID, h.gbCameraIDForChannel(channelID), body.SnapNum)
+	if err != nil {
+		gbSnapshotLogger.Error("create snapshot session failed", "channel_id", channelID, "error", err)
+		WriteError(w, http.StatusInternalServerError, "failed to create snapshot session")
+		return
+	}
+
+	cmd := manscdp.SnapShotCmd{
+		SnapNum:   sess.SnapNum,
+		UploadURL: "http://" + r.Host + "/api/gb28181/snapshot/upload?session=" + sess.ID,
+		SessionID: sess.ID,
+	}
+	if body.Interval > 0 {
+		cmd.Interval = body.Interval
+	}
+	if err := h.gb28181Commander.SendSnapShotCmd(channelID, cmd); err != nil {
+		// The session dies by its own timeout sweep; the command itself
+		// failed synchronously (transport or encoding) — report it now.
+		gbSnapshotLogger.Error("send SnapShotCmd failed", "channel_id", channelID, "error", err)
+		WriteError(w, http.StatusBadGateway, "failed to send snapshot command to device")
+		return
+	}
+	gbSnapshotLogger.Info("snapshot command sent",
+		"channel_id", channelID, "device_id", deviceID, "session_id", sess.ID, "snap_num", sess.SnapNum)
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"status":      "snapshot_requested",
+		"session_id":  sess.ID,
+		"channel_id":  channelID,
+		"snap_num":    sess.SnapNum,
+		"upload_path": "/api/gb28181/snapshot/upload?session=" + sess.ID,
+	})
+}
+
+type gbRecordRequest struct {
+	Action string `json:"action"` // start | stop
+}
+
+// handleGB28181ChannelRecord sends DeviceControl(RecordCmd) start/stop.
+// start = device-side manual recording begins; the platform-side stream
+// capture is the existing INVITE path (invite endpoint / auto-invite on
+// recording-enabled cameras).
+func (h *Handler) handleGB28181ChannelRecord(w http.ResponseWriter, r *http.Request) {
+	channelID := r.PathValue("id")
+	if channelID == "" {
+		WriteError(w, http.StatusBadRequest, "channel ID is required")
+		return
+	}
+	var body gbRecordRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&body); err != nil {
+		WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	deviceID, ok := h.locateGBChannel(channelID)
+	if !ok {
+		WriteError(w, http.StatusNotFound, "channel not found")
+		return
+	}
+	if dev, found := h.gb28181DeviceMgr.Device(deviceID); !found || dev.Status.Load() == platform.DeviceOffline {
+		WriteError(w, http.StatusConflict, "device is offline, cannot control recording")
+		return
+	}
+	if h.gb28181Commander == nil {
+		WriteError(w, http.StatusServiceUnavailable, "GB28181 device control not available")
+		return
+	}
+
+	var err error
+	var status string
+	switch body.Action {
+	case "start":
+		err = h.gb28181Commander.StartManualRecord(channelID)
+		status = "record_cmd_sent"
+	case "stop":
+		err = h.gb28181Commander.StopManualRecord(channelID)
+		status = "stop_cmd_sent"
+	default:
+		WriteError(w, http.StatusBadRequest, "action must be start or stop")
+		return
+	}
+	if err != nil {
+		gbSnapshotLogger.Error("send RecordCmd failed", "channel_id", channelID, "action", body.Action, "error", err)
+		WriteError(w, http.StatusBadGateway, "failed to send record command to device")
+		return
+	}
+	gbSnapshotLogger.Info("record command sent", "channel_id", channelID, "action", body.Action)
+	writeJSON(w, http.StatusAccepted, map[string]string{
+		"status":     status,
+		"channel_id": channelID,
+	})
+}
+
+// handleGB28181SnapshotUpload receives one JPEG frame from a device (public
+// endpoint — the session ID in the URL is the credential). Mounted on the
+// rate-limited public group.
+func (h *Handler) handleGB28181SnapshotUpload(w http.ResponseWriter, r *http.Request) {
+	if h.gb28181SnapMgr == nil {
+		WriteError(w, http.StatusServiceUnavailable, "snapshot receiving not available")
+		return
+	}
+	sessionID := r.URL.Query().Get("session")
+	if sessionID == "" {
+		WriteError(w, http.StatusBadRequest, "session parameter is required")
+		return
+	}
+	jpeg, err := io.ReadAll(http.MaxBytesReader(w, r.Body, snapshotUploadMaxBytes))
+	if err != nil {
+		WriteError(w, http.StatusRequestEntityTooLarge, "frame exceeds size limit")
+		return
+	}
+	path, err := h.gb28181SnapMgr.Receive(sessionID, jpeg)
+	switch {
+	case err == nil:
+		writeJSON(w, http.StatusOK, map[string]string{"status": "stored", "path": path})
+	case errors.Is(err, gb28181.ErrSnapshotSessionUnknown):
+		WriteError(w, http.StatusNotFound, "unknown or expired snapshot session")
+	case errors.Is(err, gb28181.ErrSnapshotSessionClosed):
+		WriteError(w, http.StatusConflict, "snapshot session already finished")
+	case errors.Is(err, gb28181.ErrSnapshotNotJPEG):
+		WriteError(w, http.StatusBadRequest, "body is not a JPEG frame")
+	default:
+		gbSnapshotLogger.Error("snapshot upload persist failed", "session_id", sessionID, "error", err)
+		WriteError(w, http.StatusInternalServerError, "failed to store frame")
+	}
+}

--- a/internal/api/handlers_gb28181_snapshot_test.go
+++ b/internal/api/handlers_gb28181_snapshot_test.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mickeyzzc/gb28181-go/manscdp"
+	"github.com/mickeyzzc/gb28181-go/platform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/gb28181"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/snapshot"
+)
+
+// fakeGBCommander records DeviceControl calls (snapshot + manual record).
+type fakeGBCommander struct {
+	snapshots []manscdp.SnapShotCmd
+	records   []string
+	failNext  error
+}
+
+func (f *fakeGBCommander) SendSnapShotCmd(_ string, cmd manscdp.SnapShotCmd) error {
+	if f.failNext != nil {
+		return f.failNext
+	}
+	f.snapshots = append(f.snapshots, cmd)
+	return nil
+}
+
+func (f *fakeGBCommander) StartManualRecord(_ string) error {
+	if f.failNext != nil {
+		return f.failNext
+	}
+	f.records = append(f.records, "start")
+	return nil
+}
+
+func (f *fakeGBCommander) StopManualRecord(_ string) error {
+	if f.failNext != nil {
+		return f.failNext
+	}
+	f.records = append(f.records, "stop")
+	return nil
+}
+
+// setupGBSnapshotHandler wires a handler with one online GB device/channel,
+// a recording fake commander, and a session manager over a fake store.
+func setupGBSnapshotHandler(t *testing.T) (*Handler, *fakeGBCommander, *gb28181.SnapshotSessionManager) {
+	t.Helper()
+	db, store := setupTestDB(t)
+	h := NewHandler(db, store, noopAuthMW(), nil, nil, nil, "", nil, nil, nil, nil, nil)
+	deviceMgr := platform.NewDeviceManager(time.Minute)
+	dev := &platform.Device{ID: "34020000001320000002", NetAddr: "192.168.63.118:5060"}
+	deviceMgr.Register(dev)
+	h.gb28181DeviceMgr = deviceMgr
+	deviceMgr.RegisterChannel(dev.ID, &platform.Channel{DeviceID: dev.ID, ID: "34020000001310000002"})
+
+	commander := &fakeGBCommander{}
+	h.SetGB28181Commander(commander)
+	mgr := gb28181.NewSnapshotSessionManager(&snapshot.Persistor{Root: t.TempDir()}, time.Minute)
+	t.Cleanup(mgr.Stop)
+	h.SetGB28181SnapshotManager(mgr)
+	return h, commander, mgr
+}
+
+func postJSON(t *testing.T, h http.Handler, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestGB28181ChannelSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("command carries spec fields and session", func(t *testing.T) {
+		t.Parallel()
+		h, commander, _ := setupGBSnapshotHandler(t)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/snapshot", map[string]any{"snap_num": 3, "interval": 2})
+		require.Equal(t, http.StatusAccepted, resp.Code)
+
+		require.Len(t, commander.snapshots, 1)
+		cmd := commander.snapshots[0]
+		require.Equal(t, 3, cmd.SnapNum)
+		require.Equal(t, 2, cmd.Interval)
+		require.Len(t, cmd.SessionID, 32)
+		require.Contains(t, cmd.UploadURL, "/api/gb28181/snapshot/upload?session="+cmd.SessionID)
+
+		var out struct {
+			SessionID string `json:"session_id"`
+		}
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &out))
+		require.Equal(t, cmd.SessionID, out.SessionID)
+	})
+
+	t.Run("defaults to single frame without interval", func(t *testing.T) {
+		t.Parallel()
+		h, commander, _ := setupGBSnapshotHandler(t)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/snapshot", map[string]any{})
+		require.Equal(t, http.StatusAccepted, resp.Code)
+		require.Equal(t, 1, commander.snapshots[0].SnapNum)
+		require.Equal(t, 0, commander.snapshots[0].Interval)
+	})
+
+	t.Run("unknown channel 404", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupGBSnapshotHandler(t)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000009999999999/snapshot", map[string]any{})
+		require.Equal(t, http.StatusNotFound, resp.Code)
+	})
+
+	t.Run("commander unwired 503", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupGBSnapshotHandler(t)
+		h.SetGB28181Commander(nil)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/snapshot", map[string]any{})
+		require.Equal(t, http.StatusServiceUnavailable, resp.Code)
+	})
+}
+
+func TestGB28181ChannelRecord(t *testing.T) {
+	t.Parallel()
+
+	t.Run("start and stop", func(t *testing.T) {
+		t.Parallel()
+		h, commander, _ := setupGBSnapshotHandler(t)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/record", map[string]any{"action": "start"})
+		require.Equal(t, http.StatusAccepted, resp.Code)
+		resp = postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/record", map[string]any{"action": "stop"})
+		require.Equal(t, http.StatusAccepted, resp.Code)
+		require.Equal(t, []string{"start", "stop"}, commander.records)
+	})
+
+	t.Run("unknown action 400", func(t *testing.T) {
+		t.Parallel()
+		h, commander, _ := setupGBSnapshotHandler(t)
+		resp := postJSON(t, h.Routes(), "/api/gb28181/channels/34020000001310000002/record", map[string]any{"action": "reboot"})
+		require.Equal(t, http.StatusBadRequest, resp.Code)
+		require.Empty(t, commander.records)
+	})
+}
+
+// The upload endpoint is the device's callback: no auth (session ID is the
+// credential), mounted publicly, stores frames, and refuses unknown/closed
+// sessions and non-JPEG bodies.
+func TestGB28181SnapshotUpload(t *testing.T) {
+	t.Parallel()
+
+	jpeg := append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, make([]byte, 32)...)
+
+	newUp := func(h *Handler, session string, body []byte) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/gb28181/snapshot/upload?session="+session, bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.Routes().ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("stores a frame for a live session", func(t *testing.T) {
+		t.Parallel()
+		h, _, mgr := setupGBSnapshotHandler(t)
+		sess, err := mgr.CreateSession("ch", "dev", "cam-gb", 1)
+		require.NoError(t, err)
+		resp := newUp(h, sess.ID, jpeg)
+		require.Equal(t, http.StatusOK, resp.Code)
+		require.Len(t, sess.Files(), 1)
+	})
+
+	t.Run("unknown session 404", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupGBSnapshotHandler(t)
+		resp := newUp(h, "ghost", jpeg)
+		require.Equal(t, http.StatusNotFound, resp.Code)
+	})
+
+	t.Run("non-JPEG body 400", func(t *testing.T) {
+		t.Parallel()
+		h, _, mgr := setupGBSnapshotHandler(t)
+		sess, err := mgr.CreateSession("ch", "dev", "cam-gb", 1)
+		require.NoError(t, err)
+		resp := newUp(h, sess.ID, []byte("plain text"))
+		require.Equal(t, http.StatusBadRequest, resp.Code)
+	})
+
+	t.Run("finished session 409", func(t *testing.T) {
+		t.Parallel()
+		h, _, mgr := setupGBSnapshotHandler(t)
+		sess, err := mgr.CreateSession("ch", "dev", "cam-gb", 1)
+		require.NoError(t, err)
+		mgr.Finish(sess.ID, 1)
+		resp := newUp(h, sess.ID, jpeg)
+		require.Equal(t, http.StatusConflict, resp.Code)
+	})
+
+	t.Run("missing session param 400", func(t *testing.T) {
+		t.Parallel()
+		h, _, _ := setupGBSnapshotHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/api/gb28181/snapshot/upload", bytes.NewReader(jpeg))
+		rec := httptest.NewRecorder()
+		h.Routes().ServeHTTP(rec, req)
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+// Regression: the upload route must be mounted WITHOUT auth — devices POST
+// with no credentials (verified above through Routes(), which applies
+// authMW; noopAuthMW would hide a missing public mount, so assert the route
+// table directly).
+func TestGB28181SnapshotUploadRouteMounted(t *testing.T) {
+	t.Parallel()
+	h, _, _ := setupGBSnapshotHandler(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/gb28181/snapshot/upload?session=x", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+	require.NotEqual(t, http.StatusNotFound, rec.Code, "upload endpoint must be routed")
+	require.Equal(t, http.StatusBadRequest, rec.Code, "empty body must fail JPEG validation")
+}

--- a/internal/gb28181/snapshot_sessions.go
+++ b/internal/gb28181/snapshot_sessions.go
@@ -288,9 +288,3 @@ func (m *SnapshotSessionManager) Sweep() {
 		}
 	}
 }
-
-func (m *SnapshotSessionManager) evict(sessionID string) {
-	m.mu.Lock()
-	delete(m.sessions, sessionID)
-	m.mu.Unlock()
-}

--- a/internal/gb28181/snapshot_sessions.go
+++ b/internal/gb28181/snapshot_sessions.go
@@ -1,0 +1,296 @@
+package gb28181
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// GB/T 28181-2022 platform-side on-demand snapshot sessions (#708): the
+// platform sends DeviceControl(SnapShotCmd) with an UploadURL + SessionID;
+// the device POSTs the JPEGs to the URL and finishes with an
+// UploadSnapShotFinished notify carrying the same SessionID. This manager
+// owns the session registry: it validates incoming uploads, persists frames
+// via the snapshot store, publishes camera.snapshot events, and closes
+// sessions on completion notify OR timeout (the spec's "timeout without
+// notify = failure").
+//
+// Completion notifies reach Finish() from the SIP server's MESSAGE dispatch
+// (wired in builders); until that plumbing exists upstream the timeout path
+// alone still closes every session — no leaks.
+
+// Snapshot session lifecycle errors.
+var (
+	ErrSnapshotSessionUnknown = errors.New("gb28181: unknown snapshot session")
+	ErrSnapshotSessionClosed  = errors.New("gb28181: snapshot session already closed")
+	ErrSnapshotNotJPEG        = errors.New("gb28181: upload body is not a JPEG")
+)
+
+// SnapshotOutcome is the terminal state of a snapshot session.
+type SnapshotOutcome string
+
+const (
+	SnapshotPending  SnapshotOutcome = "pending"
+	SnapshotComplete SnapshotOutcome = "complete"
+	SnapshotPartial  SnapshotOutcome = "partial"
+	SnapshotFailed   SnapshotOutcome = "failed"
+	SnapshotTimeout  SnapshotOutcome = "timeout"
+)
+
+// SnapshotStore persists one JPEG and returns the storage-root-relative
+// path. Satisfied by *snapshot.Persistor.
+type SnapshotStore interface {
+	Persist(cameraID string, jpeg []byte) (string, error)
+}
+
+// SnapshotSession is one SnapShotCmd exchange. All mutating methods are
+// called through the manager under its lock; Outcome/Files are safe from any
+// goroutine after the session reaches a terminal state.
+type SnapshotSession struct {
+	ID        string
+	ChannelID string
+	DeviceID  string
+	CameraID  string
+	SnapNum   int
+	CreatedAt time.Time
+	Deadline  time.Time
+
+	mu      sync.Mutex
+	files   []string
+	outcome SnapshotOutcome
+}
+
+// Outcome returns the session's current state (thread-safe).
+func (s *SnapshotSession) Outcome() SnapshotOutcome {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.outcome == "" {
+		return SnapshotPending
+	}
+	return s.outcome
+}
+
+// Files returns the stored frame paths (thread-safe copy).
+func (s *SnapshotSession) Files() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.files...)
+}
+
+// SnapshotSessionManager tracks in-flight snapshot sessions.
+type SnapshotSessionManager struct {
+	mu       sync.Mutex
+	sessions map[string]*SnapshotSession
+
+	store   SnapshotStore
+	timeout time.Duration
+
+	publish func(topic string, data any)
+	now     func() time.Time
+
+	sweepStop chan struct{}
+	sweepOnce sync.Once
+}
+
+// SnapshotManagerOption configures NewSnapshotSessionManager.
+type SnapshotManagerOption func(*SnapshotSessionManager)
+
+// WithSnapshotClock injects the clock (tests).
+func WithSnapshotClock(now func() time.Time) SnapshotManagerOption {
+	return func(m *SnapshotSessionManager) { m.now = now }
+}
+
+// WithSnapshotPublisher injects the event publisher (NVR event bus adapter).
+func WithSnapshotPublisher(p func(topic string, data any)) SnapshotManagerOption {
+	return func(m *SnapshotSessionManager) { m.publish = p }
+}
+
+// NewSnapshotSessionManager creates a manager. timeout bounds a session's
+// life from creation (default used when <= 0: 30s — the device-side capture
+// of ≤10 frames at ≥1s interval fits well within it).
+func NewSnapshotSessionManager(store SnapshotStore, timeout time.Duration, opts ...SnapshotManagerOption) *SnapshotSessionManager {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	m := &SnapshotSessionManager{
+		sessions:  make(map[string]*SnapshotSession),
+		store:     store,
+		timeout:   timeout,
+		publish:   func(string, any) {},
+		now:       time.Now,
+		sweepStop: make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// Start launches the expiry sweeper (1s cadence — sessions are few, the
+// tick is a map walk).
+func (m *SnapshotSessionManager) Start() {
+	m.sweepOnce.Do(func() {
+		go func() {
+			t := time.NewTicker(time.Second)
+			defer t.Stop()
+			for {
+				select {
+				case <-m.sweepStop:
+					return
+				case <-t.C:
+					m.Sweep()
+				}
+			}
+		}()
+	})
+}
+
+// Stop terminates the sweeper (idempotent).
+func (m *SnapshotSessionManager) Stop() {
+	select {
+	case <-m.sweepStop:
+	default:
+		close(m.sweepStop)
+	}
+}
+
+// CreateSession registers a new snapshot session with a random 32-hex-char
+// SessionID (spec: [A-Za-z0-9-], 32..128 bytes).
+func (m *SnapshotSessionManager) CreateSession(channelID, deviceID, cameraID string, snapNum int) (*SnapshotSession, error) {
+	if snapNum < 1 {
+		snapNum = 1
+	}
+	if snapNum > 10 {
+		snapNum = 10 // spec: SnapNum 1..10
+	}
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("gb28181: session id: %w", err)
+	}
+	now := m.now()
+	s := &SnapshotSession{
+		ID:        hex.EncodeToString(buf),
+		ChannelID: channelID,
+		DeviceID:  deviceID,
+		CameraID:  cameraID,
+		SnapNum:   snapNum,
+		CreatedAt: now,
+		Deadline:  now.Add(m.timeout),
+	}
+	m.mu.Lock()
+	m.sessions[s.ID] = s
+	m.mu.Unlock()
+	return s, nil
+}
+
+// Get returns a live (not-yet-swept) session.
+func (m *SnapshotSessionManager) Get(sessionID string) (*SnapshotSession, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[sessionID]
+	return s, ok
+}
+
+// Receive validates and stores one uploaded JPEG frame. Unknown or closed
+// sessions are refused so the HTTP endpoint can map them onto 404/409.
+func (m *SnapshotSessionManager) Receive(sessionID string, jpeg []byte) (string, error) {
+	if len(jpeg) < 4 || jpeg[0] != 0xFF || jpeg[1] != 0xD8 {
+		return "", ErrSnapshotNotJPEG
+	}
+	m.mu.Lock()
+	s, ok := m.sessions[sessionID]
+	if !ok {
+		m.mu.Unlock()
+		return "", ErrSnapshotSessionUnknown
+	}
+	// Session-scoped lock ordering: manager first, then session.
+	s.mu.Lock()
+	if s.outcome != "" {
+		s.mu.Unlock()
+		m.mu.Unlock()
+		return "", ErrSnapshotSessionClosed
+	}
+	s.mu.Unlock()
+	m.mu.Unlock()
+
+	// Persist outside both locks (disk I/O).
+	path, err := m.store.Persist(s.CameraID, jpeg)
+	if err != nil {
+		return "", fmt.Errorf("gb28181: persist snapshot: %w", err)
+	}
+
+	s.mu.Lock()
+	s.files = append(s.files, path)
+	s.mu.Unlock()
+
+	if m.publish != nil {
+		m.publish("camera.snapshot", map[string]any{
+			"camera_id":  s.CameraID,
+			"file_path":  path,
+			"timestamp":  m.now().UTC().Format(time.RFC3339Nano),
+			"trigger":    "gb28181",
+			"channel_id": s.ChannelID,
+			"session_id": s.ID,
+		})
+	}
+	return path, nil
+}
+
+// Finish applies an UploadSnapShotFinished notify: successCount is the
+// number of successfully captured+uploaded frames (the notify's SnapShotList
+// length; 0 = whole exchange failed per A.2.5.7). The session stays
+// registered (marked terminal) until Sweep evicts it, so a straggler upload
+// lands on ErrSnapshotSessionClosed rather than a misleading unknown-ID.
+func (m *SnapshotSessionManager) Finish(sessionID string, successCount int) {
+	m.mu.Lock()
+	s, ok := m.sessions[sessionID]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m.mu.Unlock()
+
+	if s.outcome != "" {
+		return
+	}
+	switch {
+	case successCount <= 0:
+		s.outcome = SnapshotFailed
+	case successCount >= s.SnapNum:
+		s.outcome = SnapshotComplete
+	default:
+		s.outcome = SnapshotPartial
+	}
+}
+
+// Sweep expires sessions past their deadline. Also evicts terminal sessions
+// missed by Finish's evict (defensive — Finish already evicts).
+func (m *SnapshotSessionManager) Sweep() {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, s := range m.sessions {
+		s.mu.Lock()
+		outcome := s.outcome
+		expired := now.After(s.Deadline)
+		if outcome == "" && expired {
+			s.outcome = SnapshotTimeout
+			outcome = SnapshotTimeout
+		}
+		s.mu.Unlock()
+		if outcome != "" {
+			delete(m.sessions, id)
+		}
+	}
+}
+
+func (m *SnapshotSessionManager) evict(sessionID string) {
+	m.mu.Lock()
+	delete(m.sessions, sessionID)
+	m.mu.Unlock()
+}

--- a/internal/gb28181/snapshot_sessions_test.go
+++ b/internal/gb28181/snapshot_sessions_test.go
@@ -1,0 +1,165 @@
+package gb28181
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSnapshotStore records Persist calls; optionally fails.
+type fakeSnapshotStore struct {
+	fail  error
+	calls []struct {
+		cameraID string
+		jpegLen  int
+	}
+}
+
+func (f *fakeSnapshotStore) Persist(cameraID string, jpeg []byte) (string, error) {
+	if f.fail != nil {
+		return "", f.fail
+	}
+	f.calls = append(f.calls, struct {
+		cameraID string
+		jpegLen  int
+	}{cameraID, len(jpeg)})
+	return fmt.Sprintf("snapshots/%s/%d.jpg", cameraID, len(f.calls)), nil
+}
+
+type publishedEvent struct {
+	topic string
+	data  any
+}
+
+func newTestSnapshotManager(t *testing.T) (*SnapshotSessionManager, *fakeSnapshotStore, *[]publishedEvent, *time.Time) {
+	t.Helper()
+	store := &fakeSnapshotStore{}
+	var events []publishedEvent
+	now := time.Now()
+	m := NewSnapshotSessionManager(store, 30*time.Second, WithSnapshotClock(func() time.Time { return now }), WithSnapshotPublisher(func(topic string, data any) {
+		events = append(events, publishedEvent{topic, data})
+	}))
+	t.Cleanup(m.Stop)
+	return m, store, &events, &now
+}
+
+var testJPEG = append([]byte{0xFF, 0xD8, 0xFF, 0xE0}, make([]byte, 64)...)
+
+func TestSnapshotSessionManager_Lifecycle(t *testing.T) {
+	t.Parallel()
+	m, store, events, _ := newTestSnapshotManager(t)
+
+	sess, err := m.CreateSession("34020000011320000001", "34020000001320000002", "cam-gb", 2)
+	require.NoError(t, err)
+	require.Len(t, sess.ID, 32, "SessionID must be 32 chars (spec: 32..128 [A-Za-z0-9-])")
+
+	// First frame received and stored.
+	path, err := m.Receive(sess.ID, testJPEG)
+	require.NoError(t, err)
+	require.Equal(t, "snapshots/cam-gb/1.jpg", path)
+	require.Len(t, store.calls, 1)
+
+	// The camera.snapshot event fires per stored file with the gb trigger.
+	require.Len(t, *events, 1)
+	require.Equal(t, "camera.snapshot", (*events)[0].topic)
+
+	// Completion notify closes the session as complete.
+	m.Finish(sess.ID, 2)
+	require.Equal(t, SnapshotComplete, sess.Outcome())
+
+	// No further receives after finish.
+	_, err = m.Receive(sess.ID, testJPEG)
+	require.ErrorIs(t, err, ErrSnapshotSessionClosed)
+}
+
+func TestSnapshotSessionManager_TimeoutSweeps(t *testing.T) {
+	t.Parallel()
+	m, _, _, now := newTestSnapshotManager(t)
+
+	sess, err := m.CreateSession("ch", "dev", "cam-gb", 1)
+	require.NoError(t, err)
+
+	*now = now.Add(31 * time.Second) // past the 30s TTL
+	m.Sweep()
+
+	require.Equal(t, SnapshotTimeout, sess.Outcome())
+
+	// An expired session is evicted by the sweep — later uploads report an
+	// unknown ID (the Closed error is reserved for finished-but-not-yet-
+	// swept sessions).
+	_, err = m.Receive(sess.ID, testJPEG)
+	require.ErrorIs(t, err, ErrSnapshotSessionUnknown)
+	m.Sweep()
+	_, err = m.Receive(sess.ID, testJPEG)
+	require.ErrorIs(t, err, ErrSnapshotSessionUnknown)
+}
+
+func TestSnapshotSessionManager_ReceiveValidation(t *testing.T) {
+	t.Parallel()
+	m, _, _, _ := newTestSnapshotManager(t)
+
+	_, err := m.Receive("no-such-session", testJPEG)
+	require.ErrorIs(t, err, ErrSnapshotSessionUnknown)
+
+	sess, err := m.CreateSession("ch", "dev", "cam-gb", 1)
+	require.NoError(t, err)
+
+	_, err = m.Receive(sess.ID, []byte("not a jpeg"))
+	require.ErrorContains(t, err, "JPEG")
+
+	// Persist failures surface but leave the session open for retries.
+	m2store := &fakeSnapshotStore{fail: errors.New("disk full")}
+	m2 := NewSnapshotSessionManager(m2store, time.Minute)
+	t.Cleanup(m2.Stop)
+	s2, err := m2.CreateSession("ch", "dev", "cam-gb", 1)
+	require.NoError(t, err)
+	_, err = m2.Receive(s2.ID, testJPEG)
+	require.ErrorContains(t, err, "disk full")
+	require.Equal(t, SnapshotPending, s2.Outcome())
+}
+
+func TestSnapshotSessionManager_FinishSignals(t *testing.T) {
+	t.Parallel()
+	m, _, _, _ := newTestSnapshotManager(t)
+
+	t.Run("empty list is failure", func(t *testing.T) {
+		sess, err := m.CreateSession("ch", "dev", "cam-gb", 3)
+		require.NoError(t, err)
+		m.Finish(sess.ID, 0)
+		require.Equal(t, SnapshotFailed, sess.Outcome())
+	})
+
+	t.Run("partial list", func(t *testing.T) {
+		sess, err := m.CreateSession("ch", "dev", "cam-gb", 3)
+		require.NoError(t, err)
+		m.Finish(sess.ID, 2)
+		require.Equal(t, SnapshotPartial, sess.Outcome())
+	})
+
+	t.Run("unknown session finish is a no-op", func(t *testing.T) {
+		require.NotPanics(t, func() { m.Finish("ghost", 1) })
+	})
+}
+
+// The session's event payload must carry the gb trigger + stored path so UI
+// automations treat device-captured snapshots like any other.
+func TestSnapshotSessionManager_EventPayload(t *testing.T) {
+	t.Parallel()
+	m, _, events, _ := newTestSnapshotManager(t)
+
+	sess, err := m.CreateSession("34020000011320000001", "dev", "cam-gb", 1)
+	require.NoError(t, err)
+	_, err = m.Receive(sess.ID, testJPEG)
+	require.NoError(t, err)
+
+	require.Len(t, *events, 1)
+	ev, ok := (*events)[0].data.(map[string]any)
+	require.True(t, ok, "payload is the CameraSnapshotEvent-compatible map")
+	require.Equal(t, "cam-gb", ev["camera_id"])
+	require.Equal(t, "gb28181", ev["trigger"])
+	require.True(t, strings.HasPrefix(fmt.Sprint(ev["file_path"]), "snapshots/cam-gb/"))
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -912,6 +912,20 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	if deps.gb28181Server != nil {
 		gbPTZController = platform.NewPTZController(deps.gb28181DevMgr, deps.gb28181Server)
 		handler.SetGB28181PTZ(gbPTZController)
+		// GB/T 28181-2022 on-demand snapshot + manual record (#708): the
+		// DeviceControl sender (snapshot/record handlers) and the session
+		// registry backing the public upload endpoint. Frames persist under
+		// the storage root like any snapshot and publish camera.snapshot.
+		handler.SetGB28181Commander(gbPTZController)
+		gbSnapMgr := gb28181.NewSnapshotSessionManager(
+			&snapshot.Persistor{Root: store.RootDir()},
+			30*time.Second,
+			gb28181.WithSnapshotPublisher(func(topic string, data any) {
+				deps.eventBus.Publish(context.Background(), topic, data)
+			}),
+		)
+		gbSnapMgr.Start()
+		handler.SetGB28181SnapshotManager(gbSnapMgr)
 		handler.SetGB28181Catalog(platform.NewCatalogController(deps.gb28181DevMgr, deps.gb28181Server))
 		handler.SetGB28181Inviter(deps.gb28181Server)
 		handler.SetGB28181ByeSender(deps.gb28181Server)


### PR DESCRIPTION
Implements #708's NVR side (library prerequisite landed with #714's pin bump).

## Endpoints
- `POST /api/gb28181/channels/{id}/snapshot` `{snap_num(1..10), interval}` → DeviceControl(SnapShotCmd) with a random 32-hex SessionID and an UploadURL pointing back at this server.
- `POST /api/gb28181/snapshot/upload?session=` — the device's JPEG callback, **public + rate-limited** (the SessionID in the URL is the credential; devices cannot BasicAuth — WHIP stream-key threat model). Frames persist via snapshot.Persistor under `snapshots/gb-<channelID>/` and publish `camera.snapshot` (trigger=gb28181) so UI/automations treat them like any snapshot. 8MB/frame cap; unknown session 404 / closed 409 / non-JPEG 400.
- `POST /api/gb28181/channels/{id}/record` `{action:start|stop}` → RecordCmd via PTZController (device-side manual recording); platform-side capture remains the existing INVITE path.

## Session lifecycle
`internal/gb28181.SnapshotSessionManager`: registry with terminal states (complete/partial/failed/timeout) + 1s expiry sweeper (30s TTL). `Finish()` is ready to consume UploadSnapShotFinished notifies — **wiring lands with gb28181-go#54** (the event dispatch PR, companion to this one); until the pin moves, timeout alone closes every session (spec: no notify within the window = failure). No session leak either way.

## Error mapping (anti-pattern compliant)
unknown channel 404 · offline 409 · unwired 503 · SIP transport failure 502 — never 500 for device faults.

## Tests (TDD)
Manager: lifecycle/validation/finish-signals/event-payload/timeout-sweep (injected clock). Handlers: SnapShotCmd field contract (SnapNum/Interval/UploadURL-session/SessionID), defaults, 404/409/503, record start+stop + unknown action 400, upload matrix incl. public mount.

## M5 field verification (deployed gb708-3069473f)
- snapshot → **202 + session**; simulated device POST (no auth) → **200 + frame on disk** (snapshots/gb-…/20260908-135635.465.jpg) + journal `snapshot command sent`; ghost session 404.
- Timeout closure: session left without completion → swept at 30s → later upload 404 `unknown or expired`.
- record start/stop → 202 + `record_cmd_sent` journal lines.
- Compliant-device closure (UploadSnapShotFinished E2E) owed on 海康/大华 real devices per the issue's acceptance; the notify dispatch itself is gb28181-go#54.