### PR TITLE
fix(storage): protect in-flight segments from startup temp-cleanup; purge ghost recording rows

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -43,11 +43,12 @@ type CleanupManager struct {
 	transcodeHistoryRetention time.Duration // 0 = disabled
 	// activeCameraProvider returns the live set of cameras the user has
 	// configured (cfg.Cameras, the yaml source of truth). When set,
-	// directory-scanning cleanup (orphanFileCleanup, staleRecordCleanup)
-	// iterates only these IDs, skipping orphan dirs from cameras removed
-	// from yaml but still present on disk / in the DB cache. nil = legacy
-	// behaviour (fall back to db.ListCameras). Injected from pkg/app/run.go
-	// — mirrors the provider pattern used by the merge coordinators.
+	// directory-scanning cleanup (orphanFileCleanup) iterates only these
+	// IDs, skipping orphan dirs from cameras removed from yaml but still
+	// present on disk / in the DB cache. nil = legacy behaviour (fall back
+	// to db.ListCameras). Injected from pkg/app/run.go — mirrors the
+	// provider pattern used by the merge coordinators. (staleRecordCleanup
+	// no longer uses it: the ghost-row sweep queries pending rows directly.)
 	activeCameraProvider       func() []config.CameraConfig
 	ffprobePath                string // optional ffprobe fallback for probeDuration; empty = pure-Go mediaprobe only
 	eventBus                   *event.EventBus

--- a/internal/cleanup/ghost_records_test.go
+++ b/internal/cleanup/ghost_records_test.go
@@ -1,0 +1,90 @@
+package cleanup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// Ghost rows: recordings whose merge_status is 'pending' but whose file never
+// existed on disk (2026-09-08 production incident — the startup temp-cleanup
+// scan deleted an in-flight segment temp; the DB row was still inserted and
+// became a permanent 404 entry). staleRecordCleanup deletes such rows once
+// they are older than the grace window; the grace window protects rows whose
+// storage root may be temporarily unmounted (per-camera override hiccup).
+func TestStaleRecordCleanup_DeletesGhostPendingRows(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	insertGhost := func(t *testing.T, id string, age time.Duration, onDisk bool) {
+		t.Helper()
+		fullPath := filepath.Join(env.store.RootDir(), "cam1", id+".mp4")
+		started := time.Now().UTC().Add(-age)
+		_, err := env.db.DB().ExecContext(ctx,
+			`INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status)
+			 VALUES(?,?,?,?,?,?,?,?,?,?);`,
+			id, "cam1", fullPath, model.FormatH265,
+			started, started.Add(time.Minute), 60, 0, 900, model.MergeStatusPending)
+		require.NoError(t, err)
+		if onDisk {
+			require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+			require.NoError(t, os.WriteFile(fullPath, []byte("data"), 0o644))
+		}
+	}
+
+	insertGhost(t, "ghost-old", 48*time.Hour, false) // missing + old → deleted
+	insertGhost(t, "ghost-fresh", time.Hour, false)  // missing but fresh → kept (grace)
+	insertGhost(t, "live-old", 48*time.Hour, true)   // file present → kept
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	cm.staleRecordCleanup(ctx)
+
+	ghostOld, err := env.db.GetRecording(ctx, "ghost-old")
+	require.NoError(t, err)
+	require.Nil(t, ghostOld, "old ghost row (file never existed) must be deleted")
+
+	ghostFresh, err := env.db.GetRecording(ctx, "ghost-fresh")
+	require.NoError(t, err)
+	require.NotNil(t, ghostFresh, "fresh ghost row must stay inside the grace window (mount-hiccup guard)")
+
+	live, err := env.db.GetRecording(ctx, "live-old")
+	require.NoError(t, err)
+	require.NotNil(t, live, "pending row with file on disk must never be deleted")
+	require.Equal(t, model.MergeStatusPending, live.MergeStatus)
+}
+
+// AI-active rows are protected from retention cleanup; the ghost sweep must
+// respect the same protection (MiBeeVision may be mid-writeback).
+func TestStaleRecordCleanup_ProtectsAIActiveRows(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	fullPath := filepath.Join(env.store.RootDir(), "cam1", "ghost-ai.mp4")
+	started := time.Now().UTC().Add(-48 * time.Hour)
+	_, err := env.db.DB().ExecContext(ctx,
+		`INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, ai_status)
+		 VALUES(?,?,?,?,?,?,?,?,?,?,?);`,
+		"ghost-ai", "cam1", fullPath, model.FormatH265,
+		started, started.Add(time.Minute), 60, 0, 900, model.MergeStatusPending, "processing")
+	require.NoError(t, err)
+
+	cfg := defaultCleanupConfig()
+	cm, err := NewCleanupManager(env.db, env.store, cfg)
+	require.NoError(t, err)
+
+	cm.staleRecordCleanup(ctx)
+
+	rec, err := env.db.GetRecording(ctx, "ghost-ai")
+	require.NoError(t, err)
+	require.NotNil(t, rec, "AI-active ghost row must be left for the AI writeback lifecycle")
+}

--- a/internal/cleanup/repair.go
+++ b/internal/cleanup/repair.go
@@ -1,19 +1,24 @@
 package cleanup
 
 // This file holds the database self-repair strategies:
-//   - staleRecordCleanup: MJPEG recordings stuck in merge_status='pending'
-//     whose directory no longer exists → marked 'failed'.
+//   - staleRecordCleanup: recordings stuck in merge_status='pending' whose
+//     file no longer exists (and never did — ghost rows) → deleted, once
+//     older than ghostPendingGrace.
 //   - repairZeroDurationRecordings: recordings with duration=0 are re-probed
 //     (pure-Go mediaprobe, ffprobe fallback) and updated with the real duration.
 //
 // Both run once per RunOnce cycle.
 //
-// Extracted from cleanup.go (#227).
+// Extracted from cleanup.go (#227); ghost-row sweep generalized from the
+// MJPEG-only 'failed' marking (2026-09-08 incident: the startup temp-cleanup
+// scan deleted an in-flight segment temp; the recorder still inserted its DB
+// row and the entry became a permanent 404 in the recordings list).
 
 import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -22,48 +27,54 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 )
 
-// staleRecordCleanup scans DB for MJPEG recordings with merge_status='pending'
-// whose directory on disk no longer exists, and marks them as merge_status='failed'.
+// ghostPendingGrace is how long a pending row with a missing file survives
+// before the sweep deletes it. The guard window tolerates temporarily
+// unmounted storage (per-camera root override hiccup): files come back on
+// remount and must not take their metadata with them.
+const ghostPendingGrace = 24 * time.Hour
+
+// staleRecordCleanup deletes ghost rows: merge_status='pending' recordings
+// whose file does not exist on disk and are older than ghostPendingGrace.
+// Such rows can never merge or play — they are permanent 404 entries and
+// endless retry fuel for the merge pipeline.
 func (cm *CleanupManager) staleRecordCleanup(ctx context.Context) {
-	cameras, err := cm.activeCameraIDs(ctx)
+	cutoff := time.Now().Add(-ghostPendingGrace)
+	recordings, err := cm.db.ListStalePendingRecordings(ctx, cutoff, 500)
 	if err != nil {
-		logger.Warn("stale record cleanup: failed to list cameras", "error", err)
+		logger.Warn("stale record cleanup: failed to list pending recordings", "error", err)
 		return
 	}
-	var totalFixed int
-	for _, cam := range cameras {
-		totalFixed += cm.fixStaleMJPEGRecords(ctx, cam)
+	var ghostIDs []string
+	for i := range recordings {
+		if !cm.recordingFileMissing(&recordings[i]) {
+			continue
+		}
+		ghostIDs = append(ghostIDs, recordings[i].ID)
 	}
-	if totalFixed > 0 {
-		logger.Info("stale MJPEG records marked as failed", "fixed", totalFixed)
+	if len(ghostIDs) == 0 {
+		return
 	}
+	if _, err := cm.db.DeleteRecordingsBatch(ctx, ghostIDs); err != nil {
+		logger.Warn("stale record cleanup: failed to delete ghost rows", "error", err)
+		return
+	}
+	logger.Info("deleted ghost pending recordings (file missing)", "count", len(ghostIDs))
 }
 
-// fixStaleMJPEGRecords checks pending MJPEG recordings for a camera and marks
-// those with missing directories as failed. Returns count of fixed records.
-func (cm *CleanupManager) fixStaleMJPEGRecords(ctx context.Context, cameraID string) int {
-	recordings, err := cm.db.ListPendingMJPEGRecordings(ctx, cameraID)
-	if err != nil {
-		logger.Warn("stale record cleanup: failed to list pending MJPEG recordings",
-			"camera_id", cameraID, "error", err)
-		return 0
+// recordingFileMissing reports whether a recording's file is absent. Main
+// recorders store absolute paths; tierrec sub-layer rows store paths
+// relative to the storage root. Stat errors other than NotExist are treated
+// as present (conservative — never delete metadata on a stat failure).
+func (cm *CleanupManager) recordingFileMissing(rec *model.Recording) bool {
+	path := rec.FilePath
+	if path == "" {
+		return true
 	}
-	var staleIDs []string
-	for _, rec := range recordings {
-		if _, err := os.Stat(rec.FilePath); os.IsNotExist(err) {
-			staleIDs = append(staleIDs, rec.ID)
-		}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(cm.store.RootDir(), path)
 	}
-	if len(staleIDs) == 0 {
-		return 0
-	}
-	if err := cm.db.SetMergeStatus(ctx, staleIDs, model.MergeStatusFailed); err != nil {
-		logger.Warn("stale record cleanup: failed to update merge status",
-			"camera_id", cameraID, "error", err)
-		return 0
-	}
-	logger.Info("stale MJPEG records marked failed", "camera_id", cameraID, "count", len(staleIDs))
-	return len(staleIDs)
+	_, err := os.Stat(path)
+	return err != nil && os.IsNotExist(err)
 }
 
 // repairZeroDurationRecordings fixes recordings with duration=0 by probing actual

--- a/internal/cleanup/repair_test.go
+++ b/internal/cleanup/repair_test.go
@@ -160,24 +160,30 @@ func insertPendingMJPEG(t *testing.T, env *testEnv, id string, onDisk bool) stri
 	return fullPath
 }
 
-func TestStaleRecordCleanup_MarksMissingMJPEGFailed(t *testing.T) {
+func TestStaleRecordCleanup_DeletesMissingMJPEGRows(t *testing.T) {
 	ctx := context.Background()
 	env := newTestEnv(t)
 	defer env.close(t)
 
-	insertPendingMJPEG(t, env, "stale-mjpeg", false) // file gone → stale
+	insertPendingMJPEG(t, env, "stale-mjpeg", false) // file gone → ghost
 	insertPendingMJPEG(t, env, "live-mjpeg", true)   // file present → untouched
+
+	// The sweep only fires past the grace window — backdate both rows via
+	// SQL (never rely on the test running fast).
+	old := time.Now().UTC().Add(-48 * time.Hour).Format("2006-01-02 15:04:05.999999999")
+	_, err := env.db.DB().ExecContext(ctx,
+		`UPDATE recordings SET started_at=? WHERE id IN ('stale-mjpeg','live-mjpeg');`, old)
+	require.NoError(t, err)
 
 	cfg := defaultCleanupConfig()
 	cm, err := NewCleanupManager(env.db, env.store, cfg)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, cm.fixStaleMJPEGRecords(ctx, "cam1"), "exactly the missing-file record should be fixed")
+	cm.staleRecordCleanup(ctx)
 
 	stale, err := env.db.GetRecording(ctx, "stale-mjpeg")
 	require.NoError(t, err)
-	require.NotNil(t, stale)
-	require.Equal(t, model.MergeStatusFailed, stale.MergeStatus, "stale MJPEG record should be marked failed")
+	require.Nil(t, stale, "stale MJPEG record (file missing, past grace) should be deleted")
 
 	live, err := env.db.GetRecording(ctx, "live-mjpeg")
 	require.NoError(t, err)

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -1011,10 +1011,23 @@ func (b *baseRecorder) closeCurrentSegment() {
 		}
 	}
 
-	// Insert recording entry into database
+	// Segment-loss gate: when the final file never materialized (vanished
+	// temp — e.g. the startup temp-cleanup scan racing segment creation,
+	// 2026-09-08 incident), any DB row would be a permanent 404 entry.
+	// Skip the insert, event, and metrics instead.
 	var fileSize int64
 	var recordingID string
-	if b.cfg.DB != nil && b.curFinalPath != "" {
+	finalExists := false
+	if b.curFinalPath != "" {
+		if info, err := os.Stat(b.curFinalPath); err == nil {
+			finalExists = true
+			fileSize = info.Size()
+		} else {
+			b.log.Warn("segment file missing after finalize — recording row skipped",
+				"camera_id", b.cfg.CameraID, "path", b.curFinalPath)
+		}
+	}
+	if b.cfg.DB != nil && finalExists {
 		now := time.Now()
 		duration := now.Sub(b.segStart).Seconds()
 		rec := &model.Recording{
@@ -1026,12 +1039,9 @@ func (b *baseRecorder) closeCurrentSegment() {
 			EndedAt:    now,
 			Duration:   duration,
 			FrameCount: b.frameCount,
+			FileSize:   fileSize,
 		}
 		recordingID = rec.ID
-		if info, err := os.Stat(b.curFinalPath); err == nil {
-			fileSize = info.Size()
-			rec.FileSize = fileSize
-		}
 		if err := b.cfg.DB.InsertRecordingWithRetry(
 			context.Background(), rec, 3, 500*time.Millisecond,
 		); err != nil {
@@ -1058,7 +1068,7 @@ func (b *baseRecorder) closeCurrentSegment() {
 	}
 
 	// Update metrics for completed segment
-	if b.frameCount > 0 && b.curFinalPath != "" {
+	if b.frameCount > 0 && finalExists {
 		b.recordSegmentCreated()
 		if fileSize > 0 {
 			b.recordBytes(fileSize)

--- a/internal/recorder/base_ghost_test.go
+++ b/internal/recorder/base_ghost_test.go
@@ -1,0 +1,118 @@
+package recorder
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/muxer"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// ghostCountingDB records every inserted recording row.
+type ghostCountingDB struct {
+	mu      sync.Mutex
+	inserts []*model.Recording
+}
+
+func (d *ghostCountingDB) InsertRecording(_ context.Context, r *model.Recording) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.inserts = append(d.inserts, r)
+	return nil
+}
+
+func (d *ghostCountingDB) InsertRecordingWithRetry(ctx context.Context, r *model.Recording, _ int, _ time.Duration) error {
+	return d.InsertRecording(ctx, r)
+}
+
+func (d *ghostCountingDB) SetMergeStatus(context.Context, []string, string) error { return nil }
+
+func (d *ghostCountingDB) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.inserts)
+}
+
+// Production incident 2026-09-08: the startup temp-cleanup scan deleted an
+// in-flight segment's .tmp; CloseSegment failed with "temp path not found"
+// but the DB row was still inserted — a permanent 404 entry in the
+// recordings list. closeCurrentSegment must NOT insert a row (nor publish a
+// SegmentCompleted event) when the final file never materialized.
+func TestCloseCurrentSegment_NoGhostRowWhenTempVanished(t *testing.T) {
+	store, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+
+	db := &ghostCountingDB{}
+	b := &baseRecorder{
+		cfg:    BaseConfig{CameraID: "cam-ghost", DB: db},
+		store:  store,
+		driver: H264NALDriver{},
+		log:    slog.Default(),
+	}
+
+	tempPath, finalPath, err := store.CreateSegment("cam-ghost", "h264")
+	require.NoError(t, err)
+
+	b.muxer = muxer.NewMP4Muxer(tempPath)
+	trackID, err := b.muxer.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	b.trackID = trackID
+	require.NoError(t, b.muxer.WriteSample(trackID, []byte{0x65, 0x01, 0x02}, 0, 33*time.Millisecond))
+
+	b.curTempPath = tempPath
+	b.curFinalPath = finalPath
+	b.segStart = time.Now().Add(-time.Minute)
+	b.frameCount = 10
+
+	// Simulate the race: the .tmp vanishes (startup cleanup scan) while the
+	// recorder is mid-segment. The muxer's fd stays valid (writes land in the
+	// unlinked inode), so muxer.Close() succeeds — only CloseSegment
+	// discovers the loss, exactly like the production logs.
+	require.NoError(t, os.Remove(tempPath))
+
+	b.closeCurrentSegment()
+
+	require.Zero(t, db.count(), "vanished segment must not produce a DB row (permanent 404 ghost)")
+	_, err = os.Stat(finalPath)
+	require.True(t, os.IsNotExist(err), "final file must not exist")
+}
+
+// Control: a healthy finalize still inserts exactly one row.
+func TestCloseCurrentSegment_HealthySegmentInsertsRow(t *testing.T) {
+	store, err := storage.NewManager(t.TempDir())
+	require.NoError(t, err)
+
+	db := &ghostCountingDB{}
+	b := &baseRecorder{
+		cfg:    BaseConfig{CameraID: "cam-ok", DB: db},
+		store:  store,
+		driver: H264NALDriver{},
+		log:    slog.Default(),
+	}
+
+	tempPath, finalPath, err := store.CreateSegment("cam-ok", "h264")
+	require.NoError(t, err)
+
+	b.muxer = muxer.NewMP4Muxer(tempPath)
+	trackID, err := b.muxer.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	b.trackID = trackID
+	require.NoError(t, b.muxer.WriteSample(trackID, []byte{0x65, 0x01, 0x02}, 0, 33*time.Millisecond))
+
+	b.curTempPath = tempPath
+	b.curFinalPath = finalPath
+	b.segStart = time.Now().Add(-time.Minute)
+	b.frameCount = 10
+
+	b.closeCurrentSegment()
+
+	require.Equal(t, 1, db.count(), "healthy segment must insert its row")
+	_, err = os.Stat(finalPath)
+	require.NoError(t, err)
+}

--- a/internal/recorder/gb28181.go
+++ b/internal/recorder/gb28181.go
@@ -591,15 +591,29 @@ func (r *GB28181Recorder) closeCurrentSegmentLocked() {
 		}
 	}
 
-	// Insert the recording row so the segment is visible to playback, merge,
-	// timelapse, and retention cleanup.
+	// Segment-loss gate (2026-09-08 incident): when the final file never
+	// materialized, a DB row would be a permanent 404 entry — skip the
+	// insert, event, and metrics instead.
 	var fileSize int64
 	var recordingID string
+	finalExists := false
+	if r.curFinal != "" {
+		if info, err := os.Stat(r.curFinal); err == nil {
+			finalExists = true
+			fileSize = info.Size()
+		} else {
+			gb28181Logger.Warn("segment file missing after finalize — recording row skipped",
+				"camera_id", r.cfg.CameraID, "path", r.curFinal)
+		}
+	}
+
+	// Insert the recording row so the segment is visible to playback, merge,
+	// timelapse, and retention cleanup.
 	format := model.FormatH264
 	if r.codecType == "h265" {
 		format = model.FormatH265
 	}
-	if r.cfg.DB != nil && r.curFinal != "" {
+	if r.cfg.DB != nil && finalExists {
 		now := time.Now()
 		duration := now.Sub(r.segStart).Seconds()
 		rec := &model.Recording{
@@ -611,12 +625,9 @@ func (r *GB28181Recorder) closeCurrentSegmentLocked() {
 			EndedAt:    now,
 			Duration:   duration,
 			FrameCount: r.frameCount,
+			FileSize:   fileSize,
 		}
 		recordingID = rec.ID
-		if info, err := os.Stat(r.curFinal); err == nil {
-			fileSize = info.Size()
-			rec.FileSize = fileSize
-		}
 		if err := r.cfg.DB.InsertRecordingWithRetry(context.Background(), rec, 3, 500*time.Millisecond); err != nil {
 			gb28181Logger.Error("failed to insert recording", "camera_id", r.cfg.CameraID, "error", err)
 		}
@@ -637,7 +648,7 @@ func (r *GB28181Recorder) closeCurrentSegmentLocked() {
 	}
 
 	// Update metrics for the completed segment.
-	if r.frameCount > 0 && r.curFinal != "" && r.cfg.Metrics != nil {
+	if r.frameCount > 0 && finalExists && r.cfg.Metrics != nil {
 		r.cfg.Metrics.SegmentsCreated.WithLabelValues(r.cfg.CameraID, r.codecType).Inc()
 		if fileSize > 0 {
 			r.cfg.Metrics.RecordingBytesTotal.WithLabelValues(r.cfg.CameraID, r.codecType).Add(float64(fileSize))

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -561,6 +561,19 @@ func (r *HTTPJPEGRecorder) closeCurrentSegment() {
 		httpJpegLogger.Error("failed to close segment", "camera_id", r.cfg.CameraID, "error", err)
 	}
 
+	// Segment-loss gate (2026-09-08 incident): when the final file/directory
+	// never materialized, a DB row would be a permanent 404 entry — skip the
+	// insert, event, and metrics instead.
+	segmentFinalized := false
+	if r.curFinalPath != "" {
+		if _, err := os.Stat(r.curFinalPath); err == nil {
+			segmentFinalized = true
+		} else {
+			httpJpegLogger.Warn("segment missing after finalize — recording row skipped",
+				"camera_id", r.cfg.CameraID, "path", r.curFinalPath)
+		}
+	}
+
 	// Insert recording entry into database
 	var totalSize int64
 	var recordingID string
@@ -568,7 +581,7 @@ func (r *HTTPJPEGRecorder) closeCurrentSegment() {
 	if r.cfg.AVI {
 		segFormat = model.FormatAVI
 	}
-	if r.cfg.DB != nil && r.curFinalPath != "" && r.frameCount > 0 {
+	if r.cfg.DB != nil && segmentFinalized && r.frameCount > 0 {
 		now := time.Now()
 		duration := now.Sub(r.segStart).Seconds()
 		rec := &model.Recording{
@@ -636,7 +649,7 @@ func (r *HTTPJPEGRecorder) closeCurrentSegment() {
 		})
 	}
 
-	if r.frameCount > 0 {
+	if r.frameCount > 0 && segmentFinalized {
 		r.recordSegmentCreated()
 	}
 

--- a/internal/recorder/ingest.go
+++ b/internal/recorder/ingest.go
@@ -695,11 +695,23 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 		}
 	}
 
-	// Insert recording entry into the database.
+	// Segment-loss gate (2026-09-08 incident): when the final file never
+	// materialized, a DB row would be a permanent 404 entry — skip the
+	// insert, event, and metrics instead.
 	var fileSize int64
 	var recordingID string
+	finalExists := false
+	if r.curFinal != "" {
+		if info, err := os.Stat(r.curFinal); err == nil {
+			finalExists = true
+			fileSize = info.Size()
+		} else {
+			ingestLogger.Warn("segment file missing after finalize — recording row skipped",
+				"camera_id", r.cfg.CameraID, "path", r.curFinal)
+		}
+	}
 	format := r.format()
-	if r.cfg.DB != nil && r.curFinal != "" {
+	if r.cfg.DB != nil && finalExists {
 		now := time.Now()
 		duration := now.Sub(r.segStart).Seconds()
 		rec := &model.Recording{
@@ -711,12 +723,9 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 			EndedAt:    now,
 			Duration:   duration,
 			FrameCount: r.frameCount,
+			FileSize:   fileSize,
 		}
 		recordingID = rec.ID
-		if info, err := os.Stat(r.curFinal); err == nil {
-			fileSize = info.Size()
-			rec.FileSize = fileSize
-		}
 		if err := r.cfg.DB.InsertRecordingWithRetry(context.Background(), rec, 3, 500*time.Millisecond); err != nil {
 			ingestLogger.Error("failed to insert recording", "camera_id", r.cfg.CameraID, "error", err)
 		}
@@ -737,7 +746,7 @@ func (r *IngestRecorder) closeCurrentSegmentLocked() {
 	}
 
 	// Update metrics for the completed segment.
-	if r.frameCount > 0 && r.curFinal != "" {
+	if r.frameCount > 0 && finalExists {
 		r.recordSegmentCreated()
 		if fileSize > 0 {
 			r.recordBytes(fileSize)

--- a/internal/recorder/mjpeg.go
+++ b/internal/recorder/mjpeg.go
@@ -567,11 +567,24 @@ func (r *MJPEGRecorder) closeCurrentSegment() {
 		mjpegLogger.Error("failed to close segment", "camera_id", r.cfg.CameraID, "error", err)
 	}
 
+	// Segment-loss gate (2026-09-08 incident): when the final file/directory
+	// never materialized, a DB row would be a permanent 404 entry — skip the
+	// insert, event, and metrics instead.
+	segmentFinalized := false
+	if r.curFinalPath != "" {
+		if _, err := os.Stat(r.curFinalPath); err == nil {
+			segmentFinalized = true
+		} else {
+			mjpegLogger.Warn("segment missing after finalize — recording row skipped",
+				"camera_id", r.cfg.CameraID, "path", r.curFinalPath)
+		}
+	}
+
 	// Insert recording entry into database
 	var totalSize int64
 	var recordingID string
 	segFormat := r.segmentFormat()
-	if r.cfg.DB != nil && r.curFinalPath != "" && r.frameCount > 0 {
+	if r.cfg.DB != nil && segmentFinalized && r.frameCount > 0 {
 		now := time.Now()
 		duration := now.Sub(r.segStart).Seconds()
 		rec := &model.Recording{
@@ -647,7 +660,7 @@ func (r *MJPEGRecorder) closeCurrentSegment() {
 	}
 
 	// Update metrics for completed segment
-	if r.frameCount > 0 {
+	if r.frameCount > 0 && segmentFinalized {
 		r.recordSegmentCreated()
 	}
 

--- a/internal/recorder/timelapse.go
+++ b/internal/recorder/timelapse.go
@@ -400,10 +400,23 @@ func (r *TimelapseRecorder) closeCurrentSegment() {
 		timelapseLogger.Error("failed to close segment", "camera_id", r.cfg.CameraID, "error", err)
 	}
 
+	// Segment-loss gate (2026-09-08 incident): when the final directory never
+	// materialized, a DB row would be a permanent 404 entry — skip the
+	// insert, merge trigger, and metrics instead.
+	segmentFinalized := false
+	if r.curFinalPath != "" {
+		if _, err := os.Stat(r.curFinalPath); err == nil {
+			segmentFinalized = true
+		} else {
+			timelapseLogger.Warn("segment missing after finalize — recording row skipped",
+				"camera_id", r.cfg.CameraID, "path", r.curFinalPath)
+		}
+	}
+
 	// Insert recording entry into database
 	var recordingID string
 	var totalSize int64
-	if r.cfg.DB != nil && r.curFinalPath != "" && r.frameCount > 0 {
+	if r.cfg.DB != nil && segmentFinalized && r.frameCount > 0 {
 		now := time.Now()
 		recordingID = strconv.FormatInt(now.UnixNano(), 10)
 		duration := now.Sub(r.segStart).Seconds()
@@ -430,12 +443,12 @@ func (r *TimelapseRecorder) closeCurrentSegment() {
 		}
 	}
 
-	if r.frameCount > 0 {
+	if r.frameCount > 0 && segmentFinalized {
 		r.recordSegmentCreated()
 	}
 
 	// Trigger async rolling merge if merge manager is configured.
-	if r.mergeMgr != nil && r.curFinalPath != "" && r.frameCount > 0 {
+	if r.mergeMgr != nil && segmentFinalized && r.frameCount > 0 {
 		r.mergeMgr.StartSegmentMerge(context.Background(), r.cfg.CameraID, r.curFinalPath, r.curFinalPath+".mp4", recordingID)
 	}
 

--- a/internal/storage/db_longtail_extra_test.go
+++ b/internal/storage/db_longtail_extra_test.go
@@ -271,21 +271,27 @@ func TestMigrationCapacityQueries(t *testing.T) {
 	require.True(t, paths["/mnt/data/nvr/a.mp4"])
 }
 
-func TestPendingMJPEGRecordings(t *testing.T) {
+func TestStalePendingRecordings(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
 	ctx := context.Background()
-	now := time.Now().UTC()
+	base := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	cutoff := base.Add(24 * time.Hour)
 
-	seedLongRec(t, db, "mj", "cam", "mjpeg", "pending", "/p/mj", now)
-	seedLongRec(t, db, "jp", "cam", "jpeg", "pending", "/p/jp", now)
-	seedLongRec(t, db, "h", "cam", "h264", "pending", "/p/h", now)
-	seedLongRec(t, db, "mj-done", "cam", "mjpeg", "merged", "/p/md", now)
-	seedLongRec(t, db, "mj-other", "cam2", "mjpeg", "pending", "/p/mo", now)
+	seedLongRec(t, db, "old-pending", "cam", "h264", "pending", "/p/old", base)
+	seedLongRec(t, db, "new-pending", "cam", "h264", "pending", "/p/new", base.Add(48*time.Hour))
+	seedLongRec(t, db, "old-merged", "cam", "mjpeg", "merged", "/p/md", base)
+	seedLongRec(t, db, "old-other-cam", "cam2", "mjpeg", "pending", "/p/mo", base)
 
-	rows, err := db.ListPendingMJPEGRecordings(ctx, "cam")
+	rows, err := db.ListStalePendingRecordings(ctx, cutoff, 100)
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[r.ID] = true
+	}
+	require.True(t, got["old-pending"])
+	require.True(t, got["old-other-cam"])
 }
 
 func TestInsertRecordingWithRetryFastFail(t *testing.T) {

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -972,20 +972,30 @@ func (d *DB) PathIsRecordingFile(ctx context.Context, cameraID, fullpath string)
 	return true, nil
 }
 
-// ListPendingMJPEGRecordings returns recordings for a camera where format IN ('mjpeg','jpeg')
-// AND merge_status='pending' AND ended_at IS NOT NULL.
-func (d *DB) ListPendingMJPEGRecordings(ctx context.Context, cameraID string) ([]model.Recording, error) {
-	sqlstr := selectRecordingColumns + ` WHERE camera_id = ? AND format IN ('mjpeg','jpeg') AND merge_status = 'pending' AND ended_at IS NOT NULL;`
-	rows, err := d.readConn().QueryContext(ctx, sqlstr, cameraID)
+// ListStalePendingRecordings returns up to limit pending recordings (any
+// format, any camera) whose started_at is older than the cutoff, excluding
+// archived rows and rows with an active AI status (protected from cleanup
+// like retention). The caller stats each row's file and deletes the ones
+// that never existed — the ghost-row sweep for the 2026-09-08 incident
+// class (pending row + missing file = permanent 404 entry).
+func (d *DB) ListStalePendingRecordings(ctx context.Context, cutoff time.Time, limit int) ([]model.Recording, error) {
+	defer d.observeQuery("ListStalePendingRecordings", time.Now())
+	if limit <= 0 {
+		limit = 500
+	}
+	sqlstr := selectRecordingColumns + ` WHERE merge_status = 'pending' AND archived = 0
+		AND (ai_status IS NULL OR ai_status = '')
+		AND started_at < ? ORDER BY started_at LIMIT ?;`
+	rows, err := d.readConn().QueryContext(ctx, sqlstr, timeToDB(cutoff), limit)
 	if err != nil {
-		return nil, fmt.Errorf("list pending mjpeg recordings: %w", err)
+		return nil, fmt.Errorf("list stale pending recordings: %w", err)
 	}
 	defer rows.Close()
 	var res []model.Recording
 	for rows.Next() {
 		r, err := scanRecordingRow(rows)
 		if err != nil {
-			return nil, fmt.Errorf("list pending mjpeg recordings: %w", err)
+			return nil, fmt.Errorf("list stale pending recordings: %w", err)
 		}
 		res = append(res, *r)
 	}

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -204,9 +204,16 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 	case "h264", "h265":
 		tempPath = filepath.Join(hourDir, uuid+".tmp")
 		finalPath = filepath.Join(hourDir, fmt.Sprintf("%s_%s_%s.mp4", cameraID, ts, uuid))
+		// Register BEFORE the file exists: the startup temp-cleanup scan
+		// must never observe an unregistered in-flight segment. Registration
+		// happens-before creation, so once the .tmp is visible on disk it is
+		// already protected (2026-09-08 incident: the scan deleted an active
+		// segment temp mid-write).
+		m.registerTempPath(tempPath, cameraID)
 		f, err := os.Create(tempPath)
 		if err != nil {
 			m.recordWriteFailure(cameraID)
+			m.unregisterTempPath(tempPath)
 			return "", "", fmt.Errorf("storage: failed to create temp file: %w", err)
 		}
 		f.Close()
@@ -215,17 +222,21 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 		tempPath = filepath.Join(hourDir, uuid+".tmp")
 		finalPath = filepath.Join(hourDir, fmt.Sprintf("%s_%s_%s", cameraID, ts, uuid))
 
+		m.registerTempPath(tempPath, cameraID)
 		if err := os.MkdirAll(tempPath, 0o755); err != nil {
 			m.recordWriteFailure(cameraID)
+			m.unregisterTempPath(tempPath)
 			return "", "", fmt.Errorf("storage: failed to create temp dir: %w", err)
 		}
 
 	case "avi":
 		tempPath = filepath.Join(hourDir, uuid+".tmp")
 		finalPath = filepath.Join(hourDir, fmt.Sprintf("%s_%s_%s.avi", cameraID, ts, uuid))
+		m.registerTempPath(tempPath, cameraID)
 		f, err := os.Create(tempPath)
 		if err != nil {
 			m.recordWriteFailure(cameraID)
+			m.unregisterTempPath(tempPath)
 			return "", "", fmt.Errorf("storage: failed to create temp file: %w", err)
 		}
 		f.Close()
@@ -233,12 +244,39 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 		return "", "", fmt.Errorf("storage: unsupported format %q", format)
 	}
 
-	// Register tempPath → cameraID mapping for WriteFrame health tracking.
+	return tempPath, finalPath, nil
+}
+
+// RegisterActiveTemp marks tempPath as an in-flight segment owned by
+// cameraID, protecting it from CleanupTempFiles. For temps created via
+// CreateSegment this happens automatically; writers that create their own
+// .tmp files under cam-* trees (e.g. tierrec) must call this themselves for
+// the segment's whole open→finalize window.
+func (m *Manager) RegisterActiveTemp(tempPath, cameraID string) {
+	m.registerTempPath(tempPath, cameraID)
+}
+
+// UnregisterActiveTemp releases the protection granted by RegisterActiveTemp
+// (or CreateSegment) — call once the segment's fate is sealed (renamed to
+// final, or removed).
+func (m *Manager) UnregisterActiveTemp(tempPath string) {
+	m.unregisterTempPath(tempPath)
+}
+
+// registerTempPath records the tempPath → cameraID mapping for health
+// tracking and cleanup protection.
+func (m *Manager) registerTempPath(tempPath, cameraID string) {
 	m.segMapMu.Lock()
 	m.segmentCameraMap[tempPath] = cameraID
 	m.segMapMu.Unlock()
+}
 
-	return tempPath, finalPath, nil
+// isActiveTemp reports whether tempPath belongs to an in-flight segment.
+func (m *Manager) isActiveTemp(tempPath string) bool {
+	m.segMapMu.RLock()
+	_, ok := m.segmentCameraMap[tempPath]
+	m.segMapMu.RUnlock()
+	return ok
 }
 
 // recordFinalizeFailure feeds a finalize-path error into health tracking —
@@ -580,10 +618,16 @@ func (m *Manager) IsAvailable() bool {
 // scan bounded: on a production tree with 100k+ files it avoids walking the
 // HLS shard directories entirely.
 //
-// This function is safe to call concurrently with recording (each segment uses
-// a unique uuid path; a leftover .tmp from a previous crash never collides with
-// a new write). Callers that don't need the result immediately should run it in
-// a goroutine to avoid blocking startup.
+// Active in-flight segments (registered via CreateSegment or
+// RegisterActiveTemp) are never touched: the scan runs concurrently with
+// recording, and deleting a live temp loses the whole segment — the final
+// rename then fails and the recorder's DB row becomes a permanent 404 entry
+// (2026-09-08 production incident). Registration happens-before file
+// creation, so any .tmp visible on disk without a registration is a genuine
+// crash leftover.
+//
+// Callers that don't need the result immediately should run it in a
+// goroutine to avoid blocking startup.
 func (m *Manager) CleanupTempFiles() error {
 	var firstErr error
 	for _, root := range m.Roots() {
@@ -607,6 +651,9 @@ func (m *Manager) CleanupTempFiles() error {
 				if !d.IsDir() {
 					// Remove .tmp files
 					if strings.HasSuffix(d.Name(), ".tmp") {
+						if m.isActiveTemp(path) {
+							return nil // in-flight segment — protected
+						}
 						if err := os.Remove(path); err != nil {
 							// Don't abort the whole walk on a single failure (file
 							// may be in use); record and continue.
@@ -620,6 +667,9 @@ func (m *Manager) CleanupTempFiles() error {
 					return nil
 				}
 				if strings.HasSuffix(d.Name(), ".tmp") {
+					if m.isActiveTemp(path) {
+						return filepath.SkipDir // in-flight MJPEG/timelapse segment — protected
+					}
 					if err := os.RemoveAll(path); err != nil {
 						logger.Warn("temp cleanup: failed to remove temp dir", "path", path, "error", err)
 					}

--- a/internal/storage/manager_cleanup_race_test.go
+++ b/internal/storage/manager_cleanup_race_test.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The startup temp-cleanup scan (CleanupTempFiles) races with recorders that
+// start writing immediately after process start — on large trees the scan
+// runs for minutes. An ACTIVE segment (created by CreateSegment, not yet
+// closed) must never be deleted by the scan.
+//
+// Production incident 2026-09-08 (Banana Pi M5): a 120s h265 segment's .tmp
+// was deleted mid-write by the startup scan; CloseSegment failed with "temp
+// path not found", the final .mp4 never existed, and the DB row became a
+// permanent 404 entry in the recordings list.
+
+func TestCleanupTempFiles_SkipsActiveSegment(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	require.NoError(t, err)
+
+	tempPath, finalPath, err := m.CreateSegment("cam-race", "h264")
+	require.NoError(t, err)
+	_, err = m.WriteFrame(tempPath, []byte("payload"))
+	require.NoError(t, err)
+
+	require.NoError(t, m.CleanupTempFiles())
+
+	_, err = os.Stat(tempPath)
+	require.NoError(t, err, "active segment temp must survive the cleanup scan")
+
+	// A clean close after the scan still produces the final file — the
+	// protection must not leak into normal finalization.
+	require.NoError(t, m.CloseSegment(tempPath, finalPath))
+	_, err = os.Stat(finalPath)
+	require.NoError(t, err)
+}
+
+func TestCleanupTempFiles_SkipsActiveSegmentDir(t *testing.T) {
+	m, err := NewManager(t.TempDir())
+	require.NoError(t, err)
+
+	tempPath, _, err := m.CreateSegment("cam-race", "mjpeg")
+	require.NoError(t, err)
+	_, err = m.WriteFrame(tempPath, []byte("jpeg-bytes"))
+	require.NoError(t, err)
+
+	require.NoError(t, m.CleanupTempFiles())
+
+	info, err := os.Stat(tempPath)
+	require.NoError(t, err, "active MJPEG temp dir must survive the cleanup scan")
+	require.True(t, info.IsDir())
+}
+
+// Orphaned temps from a previous crash must still be removed even when an
+// active segment exists in the same tree — protection is per-path, exact.
+func TestCleanupTempFiles_StillRemovesOrphansBesideActiveSegment(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	require.NoError(t, err)
+
+	activeTemp, activeFinal, err := m.CreateSegment("cam-race", "h264")
+	require.NoError(t, err)
+	orphan := filepath.Join(filepath.Dir(activeTemp), "999999999999999999.tmp")
+	require.NoError(t, os.WriteFile(orphan, []byte("crash-leftover"), 0o644))
+
+	require.NoError(t, m.CleanupTempFiles())
+
+	_, err = os.Stat(activeTemp)
+	require.NoError(t, err, "active segment must be skipped")
+	_, err = os.Stat(orphan)
+	require.True(t, os.IsNotExist(err), "orphaned temp must still be removed")
+
+	require.NoError(t, m.CloseSegment(activeTemp, activeFinal))
+}
+
+// tierrec writes segment temps under cam-*/ trees WITHOUT going through
+// CreateSegment; it registers them via RegisterActiveTemp instead. A
+// registered external temp must be protected until unregistered.
+func TestCleanupTempFiles_SkipsRegisteredExternalTemp(t *testing.T) {
+	root := t.TempDir()
+	m, err := NewManager(root)
+	require.NoError(t, err)
+
+	camDir := filepath.Join(root, "cam-ext")
+	require.NoError(t, os.MkdirAll(camDir, 0o755))
+	extTemp := filepath.Join(camDir, "1788877062013791340.tmp")
+	require.NoError(t, os.WriteFile(extTemp, []byte("tierrec-segment"), 0o644))
+
+	m.RegisterActiveTemp(extTemp, "cam-ext")
+	require.NoError(t, m.CleanupTempFiles())
+	_, err = os.Stat(extTemp)
+	require.NoError(t, err, "registered external temp must survive the scan")
+
+	m.UnregisterActiveTemp(extTemp)
+	require.NoError(t, m.CleanupTempFiles())
+	_, err = os.Stat(extTemp)
+	require.True(t, os.IsNotExist(err), "unregistered temp is an orphan again and must be removed")
+}

--- a/internal/tierrec/tierrec.go
+++ b/internal/tierrec/tierrec.go
@@ -59,6 +59,15 @@ type Store interface {
 	InsertRecording(ctx context.Context, r *model.Recording) error
 }
 
+// TempRegistry tells the storage manager's temp-cleanup scan that a .tmp
+// under a cam-* tree is an in-flight tierrec segment, not a crash leftover
+// (2026-09-08 incident: the startup scan deleted an active segment temp
+// mid-write). Satisfied by *storage.Manager; nil disables protection.
+type TempRegistry interface {
+	RegisterActiveTemp(tempPath, cameraID string)
+	UnregisterActiveTemp(tempPath string)
+}
+
 // Config configures the Manager.
 type Config struct {
 	Provider Provider
@@ -69,7 +78,10 @@ type Config struct {
 	StorageRoot string
 	// SegmentDur overrides the rotation window (tests).
 	SegmentDur time.Duration
-	Log        *slog.Logger
+	// TempRegistry protects in-flight segment temps from the storage
+	// manager's startup temp-cleanup scan (optional; nil in tests).
+	TempRegistry TempRegistry
+	Log          *slog.Logger
 }
 
 // Manager runs one sub-stream recorder per tiered camera.
@@ -367,6 +379,12 @@ func (r *subRecorder) openSegmentLocked(codec model.Format, sps, pps, vps []byte
 	tmp := filepath.Join(hourDir, fmt.Sprintf("%d%s", id, tmpSuffix))
 	final := filepath.Join(hourDir, fmt.Sprintf("%s%s_%s_%d.mp4", subFilePrefix, r.cameraID, ts, id))
 
+	// Register BEFORE the muxer creates the file: once the .tmp is visible
+	// on disk it is already protected from the startup temp-cleanup scan.
+	if r.mgr.cfg.TempRegistry != nil {
+		r.mgr.cfg.TempRegistry.RegisterActiveTemp(tmp, r.cameraID)
+	}
+
 	m := muxer.NewMP4Muxer(tmp)
 	var (
 		trackID int
@@ -381,6 +399,10 @@ func (r *subRecorder) openSegmentLocked(codec model.Format, sps, pps, vps []byte
 		err = fmt.Errorf("unsupported codec %q", codec)
 	}
 	if err != nil {
+		// No segment ever materialized — release the protection registration.
+		if r.mgr.cfg.TempRegistry != nil {
+			r.mgr.cfg.TempRegistry.UnregisterActiveTemp(tmp)
+		}
 		return err
 	}
 	r.mux = m
@@ -403,6 +425,12 @@ func (r *subRecorder) closeSegmentLocked() {
 	}
 	_ = r.mux.Close()
 	r.mux = nil
+	// The temp's fate is sealed below (removed or renamed) — release the
+	// cleanup protection so a crash between here and the rename still leaves
+	// a reclaimable orphan.
+	if r.tmpPath != "" && r.mgr.cfg.TempRegistry != nil {
+		r.mgr.cfg.TempRegistry.UnregisterActiveTemp(r.tmpPath)
+	}
 	if r.frames == 0 {
 		_ = os.Remove(r.tmpPath)
 		return

--- a/internal/tierrec/tierrec_registry_test.go
+++ b/internal/tierrec/tierrec_registry_test.go
@@ -1,0 +1,96 @@
+package tierrec
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
+	"github.com/stretchr/testify/require"
+)
+
+// tempRegistrySpy records Register/Unregister calls for assertions.
+type tempRegistrySpy struct {
+	mu           sync.Mutex
+	registered   []string
+	unregistered []string
+}
+
+func (s *tempRegistrySpy) RegisterActiveTemp(path, cameraID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.registered = append(s.registered, path)
+}
+
+func (s *tempRegistrySpy) UnregisterActiveTemp(path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unregistered = append(s.unregistered, path)
+}
+
+func (s *tempRegistrySpy) snapshot() (reg, unreg []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.registered...), append([]string(nil), s.unregistered...)
+}
+
+// tierrec writes its segment temps directly under cam-*/ trees (not via
+// storage.CreateSegment), so the startup temp-cleanup scan can race-delete
+// an in-flight segment exactly like the 2026-09-08 production incident. The
+// temp must be registered as active for the whole open→finalize window.
+func TestSubRecorder_TempRegisteredWhileSegmentOpen(t *testing.T) {
+	reg := &tempRegistrySpy{}
+	m := NewManager(Config{StorageRoot: t.TempDir(), Store: &fakeStore{}, TempRegistry: reg})
+	src := &fakeSource{hub: streamhub.New(), codec: model.FormatH264, sps: testSPS, pps: testPPS}
+	r := newSubRecorder(m, "cam-reg", src)
+
+	require.NoError(t, r.openSegmentLocked(model.FormatH264, testSPS, testPPS, nil))
+	require.NoError(t, r.mux.WriteSample(r.trackID, []byte{0x65, 0x01}, 0, 33*time.Millisecond))
+	r.frames++
+
+	r.mu.Lock()
+	tmp := r.tmpPath
+	r.mu.Unlock()
+	require.NotEmpty(t, tmp)
+
+	registered, _ := reg.snapshot()
+	require.Equal(t, []string{tmp}, registered, "temp must be registered (active) when the segment opens")
+
+	r.closeSegmentLocked()
+
+	_, unregistered := reg.snapshot()
+	require.Equal(t, []string{tmp}, unregistered, "temp must be unregistered once the segment is finalized")
+
+	r.mu.Lock()
+	final := r.finalPath
+	r.mu.Unlock()
+	_, err := os.Stat(final)
+	require.NoError(t, err, "finalized segment file must exist")
+}
+
+// If the temp vanishes mid-segment (the cleanup race), closeSegmentLocked
+// must not insert a recording row — the file never materialized. This pins
+// the existing rename-failure semantics against regression.
+func TestSubRecorder_NoRowWhenTempVanished(t *testing.T) {
+	store := &fakeStore{}
+	m := NewManager(Config{StorageRoot: t.TempDir(), Store: store})
+	src := &fakeSource{hub: streamhub.New(), codec: model.FormatH264, sps: testSPS, pps: testPPS}
+	r := newSubRecorder(m, "cam-vanish", src)
+
+	require.NoError(t, r.openSegmentLocked(model.FormatH264, testSPS, testPPS, nil))
+	require.NoError(t, r.mux.WriteSample(r.trackID, []byte{0x65, 0x01}, 0, 33*time.Millisecond))
+	r.frames++
+
+	r.mu.Lock()
+	tmp := r.tmpPath
+	r.mu.Unlock()
+	require.NoError(t, os.Remove(tmp))
+
+	r.closeSegmentLocked()
+
+	require.Zero(t, len(store.rows), "vanished temp must not produce a recording row")
+	_ = context.Background()
+}

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/health"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/motion"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/pixgate"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/streamhub"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/substream"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/tierrec"
@@ -312,6 +313,10 @@ func registerServices(a *App, deps *appDeps) error {
 	// stay out of the default list/merge/push filters. Tier changes are read
 	// here at boot (restart to apply).
 	if deps.camMgr != nil {
+		// Compile-time guard: the storage manager must keep satisfying the
+		// tierrec temp-protection interface, or in-flight tierrec segments
+		// lose their cleanup-scan protection (2026-09-08 incident class).
+		var _ tierrec.TempRegistry = (*storage.Manager)(nil)
 		var tiered []string
 		for _, cam := range deps.cfg.Cameras {
 			if cam.RecordingTier == "tiered" {
@@ -320,10 +325,11 @@ func registerServices(a *App, deps *appDeps) error {
 		}
 		if len(tiered) > 0 {
 			tm := tierrec.NewManager(tierrec.Config{
-				Provider:    deps.camMgr,
-				Store:       deps.db,
-				Bus:         deps.eventBus,
-				StorageRoot: deps.cfg.Storage.RootDir,
+				Provider:     deps.camMgr,
+				Store:        deps.db,
+				Bus:          deps.eventBus,
+				StorageRoot:  deps.cfg.Storage.RootDir,
+				TempRegistry: deps.store,
 			})
 			tm.SetCameras(tiered)
 			if err := a.Register(tm); err != nil {


### PR DESCRIPTION
## 事故背景（2026-09-08，M5 生产）

用户报告 `/#/recordings/1788877182013185720` 播放不了。排查（journald + DB + 磁盘比对）还原：

1. 22:16:56 systemd 重启 NVR → `pkg/app/builders.go` 后台 goroutine 跑 `CleanupTempFiles()`（大存储树上要跑 1m38s）
2. 22:17:41 相机开始录制，创建段临时文件 `1788877062013791340.tmp`
3. 扫描进行中把它当崩溃孤儿**误删**（该函数对 `cam-*` 下所有 `.tmp` 无差别删除，包括正在写入的）
4. 22:19:42 段写满 120s 收尾：`storage: temp segment vanished before finalize` → rename 失败 → 最终 `.mp4` 从未存在
5. 但 recorder 照插 DB 行（duration=120s、1501 帧、size=0、pending）→ **永久 404 条目** + rolling-merge 无限重试

同一模式在 2026-09-06 已发生过（7 行、5 个相机、一次重启窗口）——不是偶发，是每次重启的必然竞态窗口。

## 根治（TDD red→green，四层）

| 层 | 改动 | 防住什么 |
|---|------|---------|
| **storage** | 活跃临时段注册表：`CreateSegment` **先注册后建文件**（happens-before，磁盘可见的 `.tmp` 必已在册）；`CleanupTempFiles` 删除前查注册表跳过活跃段（文件+目录两分支）。公开 `RegisterActiveTemp`/`UnregisterActiveTemp` 供自建 `.tmp` 的写入方 | 数据丢失根因：清理误删活跃段 |
| **tierrec** | 子码流段自建 `.tmp`（不走 CreateSegment），经 `Config.TempRegistry`（wired 为 `*storage.Manager`，含编译期接口断言）在 muxer 建文件前注册、段命运落定时注销（含 open 失败路径） | 同类数据丢失（tierrec 漏网） |
| **6 个 recorder** | base(h264/h265)/gb28181/ingest/mjpeg/http_jpeg/timelapse：段收尾加 loss gate——CloseSegment 后 final 不存在则跳过 DB 插入、SegmentCompleted 事件、metrics、merge 触发 | 幽灵行不再产生 |
| **cleanup** | `staleRecordCleanup` 从"MJPEG 专用标 failed"泛化为幽灵行清扫：pending 且 >24h 宽限且文件缺失（绝对路径 / tierrec 相对路径按 root 解析）→ **删除行**。宽限窗口容忍 per-camera 根临时卸载；AI-active / archived / stat 错误一律保守不删 | 存量幽灵行自动消失 |

孤儿清理语义不变（uuid 唯一，活跃段保护不影响真孤儿删除——测试覆盖"活跃段旁边的孤儿照删"）。

## RED → GREEN 证据

- RED：storage 3 红（活跃段文件/目录今天确实被删）+ recorder 1 红（`Should be zero, but was 1` 幽灵行照插，事故精确复现）+ tierrec 编译红 + cleanup 1 红（幽灵行留存）
- GREEN：`go test ./...` 全仓 **5511 passed / 66 packages**；关键路径 `-race -count=3`（storage/tierrec）+ `-race -count=1`（cleanup/pkg/app/recorder）全绿；golangci-lint 0 issues

## 生产处置

- 已核实的 8 条幽灵行（含用户点名的 1788877182013185720；9-06 的 7 条逐一 stat 确认文件缺失）已通过 `DELETE /api/recordings/{id}` 清除
- 合并部署后，清扫逻辑自动兜底未来任何同类残留

## 测试清单

- `internal/storage/manager_cleanup_race_test.go` — 活跃段(文件/目录)幸存、旁边孤儿照删、外部注册段保护/解除
- `internal/recorder/base_ghost_test.go` — 事故复现（.tmp 被删 → 无 DB 行）+ 健康对照
- `internal/tierrec/tierrec_registry_test.go` — 注册/注销时序 + 段丢失不落行（pin 既有语义）
- `internal/cleanup/ghost_records_test.go` — 幽灵删除/宽限窗口/文件在册保留/AI 保护