### PR TITLE
fix(api): revoke all same-name API keys; reject duplicate active names (#705)

### DIFF
--- a/internal/api/handlers_apikey_test.go
+++ b/internal/api/handlers_apikey_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
@@ -96,4 +97,76 @@ func TestBuildAPIKeyInfoNoStore(t *testing.T) {
 	require.Equal(t, false, info[0]["revoked"])
 	_, hasLastUsed := info[0]["last_used"]
 	require.False(t, hasLastUsed, "no store wired → no last_used field")
+}
+
+// mintExpectStatus posts a generate request and returns (key, statusCode).
+func mintExpectStatus(t *testing.T, h *Handler, name string) (string, int) {
+	t.Helper()
+	b, _ := json.Marshal(map[string]string{"name": name})
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/api-keys", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	h.handleGenerateAPIKey(rec, req)
+	var resp struct {
+		Key string `json:"key"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	return resp.Key, rec.Code
+}
+
+// Duplicate ACTIVE names are rejected at mint time (409) — a name that only
+// exists in revoked history can be reused for re-pairing (#705).
+func TestGenerateAPIKeyRejectsDuplicateActiveName(t *testing.T) {
+	t.Parallel()
+	h, _ := setupAPIKeyTestHandler(t)
+
+	_, code := mintExpectStatus(t, h, "dad-phone")
+	require.Equal(t, http.StatusCreated, code)
+
+	_, code = mintExpectStatus(t, h, "dad-phone")
+	require.Equal(t, http.StatusConflict, code, "duplicate active name must be rejected")
+
+	// Re-using the name after revocation is the re-pairing flow — allowed.
+	deleteRevokeKey(t, h, "dad-phone")
+	_, code = mintExpectStatus(t, h, "dad-phone")
+	require.Equal(t, http.StatusCreated, code, "revoked name must be reusable")
+}
+
+// Revoke-by-name must mark ALL entries with that name — legacy/restored configs
+// can carry duplicates, and stopping at the first match left the newer key
+// authorized while reporting success (#705).
+func TestRevokeAPIKeyMarksAllDuplicates(t *testing.T) {
+	t.Parallel()
+	h, keyStore := setupAPIKeyTestHandler(t)
+
+	// Simulate a restored config with two active entries sharing a name.
+	h.config.APIKeys = []config.APIKeyConfig{
+		{Key: "mbv_" + strings.Repeat("a", 40), Name: "tablet"},
+		{Key: "mbv_" + strings.Repeat("b", 40), Name: "tablet"},
+	}
+	h.syncAPIKeyStore()
+	_, ok := keyStore.Lookup("mbv_" + strings.Repeat("a", 40))
+	require.True(t, ok)
+
+	r := chi.NewRouter()
+	r.Delete("/api/settings/api-keys/{name}", h.handleRevokeAPIKey)
+	req := httptest.NewRequest(http.MethodDelete, "/api/settings/api-keys/tablet", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Status string `json:"status"`
+		Count  int    `json:"count"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "revoked", resp.Status)
+	require.Equal(t, 2, resp.Count, "both duplicate entries must be revoked")
+
+	for _, k := range h.config.APIKeys {
+		require.True(t, k.Revoked, "config entry %s must be revoked", k.Name)
+	}
+	_, ok = keyStore.Lookup("mbv_" + strings.Repeat("a", 40))
+	require.False(t, ok, "first duplicate must stop authenticating")
+	_, ok = keyStore.Lookup("mbv_" + strings.Repeat("b", 40))
+	require.False(t, ok, "second duplicate must stop authenticating")
 }

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -574,6 +574,16 @@ func (h *Handler) handleGenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 		name = "mibeevision"
 	}
 
+	// Reject duplicate ACTIVE names (#705): two live entries sharing a name make
+	// revoke-by-name ambiguous and the settings list confusing. Names that exist
+	// only in revoked history stay reusable (re-pairing flow).
+	for _, existing := range h.config.APIKeys {
+		if existing.Name == name && !existing.Revoked {
+			WriteError(w, http.StatusConflict, "an active API key with this name already exists")
+			return
+		}
+	}
+
 	key := middleware.GenerateAPIKey()
 	h.config.APIKeys = append(h.config.APIKeys, config.APIKeyConfig{
 		Key:  key,
@@ -610,15 +620,17 @@ func (h *Handler) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	found := false
+	// Mark ALL entries with the matching name (#705): restored/legacy configs can
+	// carry duplicates, and stopping at the first match left the newer key
+	// authorized while reporting success.
+	count := 0
 	for i := range h.config.APIKeys {
 		if h.config.APIKeys[i].Name == name {
 			h.config.APIKeys[i].Revoked = true
-			found = true
-			break
+			count++
 		}
 	}
-	if !found {
+	if count == 0 {
 		WriteError(w, http.StatusNotFound, "API key not found")
 		return
 	}
@@ -629,6 +641,6 @@ func (h *Handler) handleRevokeAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 	h.syncAPIKeyStore()
 
-	logger.Info("API key revoked", "name", name)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+	logger.Info("API key revoked", "name", name, "count", count)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "revoked", "count": count})
 }


### PR DESCRIPTION
Two live-verified holes in the API-key lifecycle:

1. `DELETE /api/settings/api-keys/{name}` stopped at the first matching entry — restored/legacy configs carrying duplicates left the newer key authorized while reporting success. Now marks every matching entry and returns `{"status":"revoked","count":N}`.
2. `POST /api/settings/api-keys` minted unlimited same-name actives, making revoke-by-name ambiguous and the settings list confusing. Now 409 on a duplicate ACTIVE name; revoked-only names stay reusable (re-pairing flow, per #335 device-token UX).

M5 verified: mint→409→revoke(count)→re-mint 201.