### PR TITLE
feat(stream): API-key-authenticated HLS playlists issue the stream cookie (#706)

### DIFF
--- a/internal/api/handlers_hls.go
+++ b/internal/api/handlers_hls.go
@@ -185,13 +185,36 @@ func (h *Handler) handleHLSStream(w http.ResponseWriter, r *http.Request) {
 // for an HLS playlist (path ends in .m3u8) and was authenticated with a
 // session token. A freshly-renewed token (X-Renewed-Token) takes precedence
 // so the cookie outlives the original token's remaining lifetime.
+// API-key callers (#706) get the same channel with the key itself as the
+// cookie value: relative segment URLs do not inherit the playlist's
+// ?api_key= query, and players like iOS AVPlayer cannot attach headers to
+// every segment request. The value is only echoed when the auth middleware
+// actually validated the key (IsAPIKeyAuthenticated), and the cookie stays
+// scoped to this camera's subtree + GET/HEAD media fetches — no more power
+// than the ?api_key= playlist URL already granted.
 func setStreamCookieOnPlaylist(w http.ResponseWriter, r *http.Request, cameraID string) {
 	if !strings.HasSuffix(r.URL.Path, ".m3u8") {
 		return
 	}
 	tok := middleware.SessionTokenFromRequest(r)
 	if tok == "" {
-		return // BasicAuth/API-key callers: nothing to hand out
+		if !middleware.IsAPIKeyAuthenticated(r.Context()) {
+			return // BasicAuth/unauthenticated callers: nothing to hand out
+		}
+		key := middleware.APIKeyFromRequest(r)
+		if key == "" {
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     middleware.StreamCookieName,
+			Value:    key,
+			Path:     "/api/cameras/" + cameraID + "/",
+			MaxAge:   int(middleware.StreamCookieAPIKeyTTL.Seconds()),
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   r.TLS != nil,
+		})
+		return
 	}
 	if renewed := w.Header().Get(middleware.RenewedTokenHeader); renewed != "" {
 		tok = renewed

--- a/internal/api/hls_cookie_test.go
+++ b/internal/api/hls_cookie_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/stretchr/testify/require"
 )
@@ -61,5 +63,56 @@ func TestSetStreamCookieOnPlaylist(t *testing.T) {
 		cookies := rr.Result().Cookies()
 		require.Len(t, cookies, 1)
 		require.Equal(t, fresh, cookies[0].Value, "cookie must carry the freshly-renewed token")
+	})
+}
+
+// API-key callers get the same stream-cookie channel as session-token callers
+// (#706): playlist authenticated with ?api_key= (or Bearer mbv_) hands the
+// player a cookie so relative segment URLs — which do NOT inherit the query
+// per RFC 3986 — can authenticate. iOS AVPlayer is the motivating client.
+func TestSetStreamCookieOnPlaylistAPIKey(t *testing.T) {
+	t.Parallel()
+
+	mkAPIKeyReq := func(path string, ctxOK bool) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, path+"?api_key=mbv_"+strings.Repeat("a", 40), nil)
+		if ctxOK {
+			r = r.WithContext(middleware.WithAPIKeyName(r.Context(), "dad-phone"))
+		}
+		return r
+	}
+
+	t.Run("api-key playlist sets cookie carrying the key", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		setStreamCookieOnPlaylist(rr, mkAPIKeyReq("/api/cameras/cam-1/stream/index.m3u8", true), "cam-1")
+
+		cookies := rr.Result().Cookies()
+		require.Len(t, cookies, 1)
+		c := cookies[0]
+		require.Equal(t, middleware.StreamCookieName, c.Name)
+		require.Equal(t, "mbv_"+strings.Repeat("a", 40), c.Value)
+		require.Equal(t, "/api/cameras/cam-1/", c.Path)
+		require.Equal(t, int(middleware.StreamCookieAPIKeyTTL.Seconds()), c.MaxAge,
+			"api-key cookie is session-scale, not forever")
+		require.True(t, c.HttpOnly)
+		require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+	})
+
+	t.Run("api_key in URL but NOT validated must not mint a cookie", func(t *testing.T) {
+		// Echoing unvalidated key material into a cookie would persist a
+		// possibly-invalid credential beyond the single request.
+		rr := httptest.NewRecorder()
+		setStreamCookieOnPlaylist(rr, mkAPIKeyReq("/api/cameras/cam-1/stream/index.m3u8", false), "cam-1")
+		require.Empty(t, rr.Result().Cookies())
+	})
+
+	t.Run("session token still wins over api key", func(t *testing.T) {
+		token, _ := middleware.SignSessionToken("admin", "$2a$10$somehash", time.Now())
+		r := mkAPIKeyReq("/api/cameras/cam-1/stream/index.m3u8", true)
+		r.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		setStreamCookieOnPlaylist(rr, r, "cam-1")
+		cookies := rr.Result().Cookies()
+		require.Len(t, cookies, 1)
+		require.Equal(t, token, cookies[0].Value)
 	})
 }

--- a/internal/api/hls_cookie_test.go
+++ b/internal/api/hls_cookie_test.go
@@ -3,10 +3,9 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
-
-	"strings"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/stretchr/testify/require"

--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -88,6 +88,12 @@ func (s *APIKeyStore) LastUsed() map[string]time.Time {
 	return out
 }
 
+// StreamCookieAPIKeyTTL bounds the lifetime of an API-key-valued stream cookie
+// (#706). Unlike session tokens, API keys themselves do not expire — the cookie
+// must. One viewing session's worth; playlist fetches re-issue it continuously,
+// so a live player never notices, while a forgotten cookie dies on its own.
+const StreamCookieAPIKeyTTL = time.Hour
+
 // APIKeyAuthMiddleware validates Bearer tokens with the "mbv_" prefix against
 // the live API key store. It runs alongside BasicAuth — if the request has a
 // Bearer token, API Key auth is attempted first; otherwise BasicAuth handles
@@ -109,7 +115,20 @@ func APIKeyAuthMiddleware(store *APIKeyStore, next http.Handler) http.Handler {
 			// a failed Bearer match, so query-param-only requests never
 			// authenticated.
 			token = qk
-		} else {
+		} else if streamCookieEligible(r) {
+			// The mbs_session stream cookie may carry an API key for media
+			// fetches (#706): players that cannot attach headers per request
+			// (iOS AVPlayer on HLS segments) got the cookie from an
+			// api-key-authenticated playlist response. Only mbv_-shaped values
+			// take this path — mbs_ session values fall through untouched to
+			// the session middleware. The GET/HEAD + media-extension gate is
+			// the same one that governs session-token cookies, so the cookie
+			// can never authorize anything but read-only media fetches.
+			if c, err := r.Cookie(StreamCookieName); err == nil && strings.HasPrefix(c.Value, APIKeyPrefix) {
+				token = c.Value
+			}
+		}
+		if token == "" {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -148,6 +167,23 @@ func WithAPIKeyName(ctx context.Context, name string) context.Context {
 // IsAPIKeyAuthenticated reports whether the request was authenticated via API Key.
 func IsAPIKeyAuthenticated(ctx context.Context) bool {
 	return APIKeyNameFromContext(ctx) != ""
+}
+
+// APIKeyFromRequest returns the raw mbv_ key the request presented, from the
+// Bearer header or the ?api_key= query — mirroring the two extraction paths of
+// APIKeyAuthMiddleware. Callers must ALSO check IsAPIKeyAuthenticated before
+// trusting the value: presence in the request proves nothing, only the
+// middleware's store lookup does (#706: the playlist handler refuses to echo
+// an unvalidated key into a cookie).
+func APIKeyFromRequest(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer "+APIKeyPrefix) {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	if qk := r.URL.Query().Get("api_key"); strings.HasPrefix(qk, APIKeyPrefix) {
+		return qk
+	}
+	return ""
 }
 
 // GenerateAPIKey creates a new random API key with the mbv_ prefix.

--- a/internal/middleware/apikey_cookie_test.go
+++ b/internal/middleware/apikey_cookie_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The stream cookie (mbs_session) may also carry an API key for media
+// fetches (#706): the eligibility gate (GET/HEAD + media extension) is shared
+// with the session-token cookie path, and only mbv_-prefixed cookie values are
+// routed into API-key validation — an mbs_ value falls through untouched.
+func TestAPIKeyStreamCookie(t *testing.T) {
+	t.Parallel()
+	store := NewAPIKeyStore()
+	validKey := APIKeyPrefix + strings.Repeat("k", 40)
+	store.SetKeys(map[string]string{validKey: "dad-phone"})
+
+	serve := func(method, target string, cookie *http.Cookie) (int, bool) {
+		var authed bool
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authed = IsAPIKeyAuthenticated(r.Context())
+		})
+		handler := APIKeyAuthMiddleware(store, next)
+		req := httptest.NewRequest(method, target, nil)
+		if cookie != nil {
+			req.AddCookie(cookie)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code, authed
+	}
+
+	valid := &http.Cookie{Name: StreamCookieName, Value: validKey}
+
+	code, authed := serve(http.MethodGet, "/api/cameras/cam-1/stream/seg-4.ts", valid)
+	require.Equal(t, http.StatusOK, code)
+	require.True(t, authed, "segment fetch via api-key cookie must authenticate")
+
+	code, authed = serve(http.MethodGet, "/api/cameras/cam-1/stream/index.m3u8", valid)
+	require.Equal(t, http.StatusOK, code)
+	require.True(t, authed, "playlist fetch via api-key cookie must authenticate")
+
+	// Non-media path: the cookie must not authenticate (falls through to the
+	// next middleware, e.g. session/BasicAuth, with no api-key context).
+	_, authed = serve(http.MethodGet, "/api/recordings", valid)
+	require.False(t, authed, "cookie must not authenticate non-media API paths")
+
+	// POST to a media path is also outside the gate.
+	_, authed = serve(http.MethodPost, "/api/cameras/cam-1/stream/seg-4.ts", valid)
+	require.False(t, authed, "POST must not authenticate via cookie")
+
+	// Unknown/revoked key in the cookie → explicit 401 (the key IS mbv_-shaped,
+	// so it claims our auth path and fails it, rather than falling through).
+	code, _ = serve(http.MethodGet, "/api/cameras/cam-1/stream/seg-4.ts",
+		&http.Cookie{Name: StreamCookieName, Value: APIKeyPrefix + strings.Repeat("x", 40)})
+	require.Equal(t, http.StatusUnauthorized, code)
+
+	// mbs_ session tokens in the cookie are NOT API-key middleware's business.
+	sess := &http.Cookie{Name: StreamCookieName, Value: "mbs_abc"}
+	code, authed = serve(http.MethodGet, "/api/cameras/cam-1/stream/seg-4.ts", sess)
+	require.Equal(t, http.StatusOK, code, "mbs_ cookie falls through, next handler still runs")
+	require.False(t, authed, "mbs_ cookie must fall through to the session middleware")
+}


### PR DESCRIPTION
API-key callers (`?api_key=mbv_…`, the #335 per-device-token pattern) could fetch an HLS playlist but never its segments: relative segment URLs do not inherit the playlist query (RFC 3986) and `setStreamCookieOnPlaylist` only served session-token callers. iOS + H.265 (no WebRTC) was the hardest-hit combination — AVPlayer cannot reliably attach headers to segment requests, cookies are its only stable channel.

Approach A from the issue — reuse the existing cookie machinery:

- Playlist handler issues `mbs_session` carrying the **validated** API key (1h TTL, re-issued on every playlist poll; never echoes unvalidated key material).
- `APIKeyAuthMiddleware` accepts `mbv_`-valued stream cookies strictly under the existing GET/HEAD + media-extension gate — the cookie can never authorize anything but read-only media fetches. `mbs_` values fall through untouched to the session middleware. Revoked keys 401 on the next segment request (store lookup).

M5 verified live: playlist → `Set-Cookie mbs_session=mbv_…` (HttpOnly/Lax/Path-scoped) → segment with cookie ONLY 200 (252KB), no credentials 401, garbage key 401.

Closes #706.