### PR TITLE
fix(recorder): honor Retry-After on 503 for the HTTP MJPEG puller (#711)

### DIFF
--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -359,7 +359,10 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("http status %d", resp.StatusCode), false
+		return &HTTPStatusError{
+			Code:       resp.StatusCode,
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+		}, false
 	}
 
 	ct := resp.Header.Get("Content-Type")
@@ -735,4 +738,31 @@ func readUntilBoundary(reader *bufio.Reader, buf *bytes.Buffer, boundary []byte)
 			return data, nil
 		}
 	}
+}
+
+// HTTPStatusError is a non-200 stream response. RetryAfter carries the
+// server's Retry-After hint when present (seconds form): the mibee_cam
+// anti-hammer guard sends the remaining cooldown on 503 so clients can wait
+// out the window instead of re-triggering its renewal (#711).
+type HTTPStatusError struct {
+	Code       int
+	RetryAfter time.Duration
+}
+
+func (e *HTTPStatusError) Error() string { return fmt.Sprintf("http status %d", e.Code) }
+
+// RetryAfterHint exposes the cooldown for the reconnect loop (longer wins).
+func (e *HTTPStatusError) RetryAfterHint() time.Duration { return e.RetryAfter }
+
+// parseRetryAfter parses the delta-seconds form of Retry-After. The HTTP-date
+// form is treated as absent — no known camera firmware uses it.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
 }

--- a/internal/recorder/reconnect.go
+++ b/internal/recorder/reconnect.go
@@ -2,6 +2,7 @@ package recorder
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -53,6 +54,29 @@ func nextBackoff(retryCount int, storageFailed bool, floor time.Duration) time.D
 	return b
 }
 
+// retryAfterCap bounds how long a server-advertised Retry-After may pause the
+// reconnect loop: the camera guard's cooldown caps at 300s, but a hostile or
+// buggy value must not silence a camera for hours.
+const retryAfterCap = 10 * time.Minute
+
+// backoffFor is nextBackoff plus the Retry-After escalation (#711): when the
+// connect error carries a server-advertised cooldown (camera anti-hammer 503
+// + Retry-After), waiting ANY less renews the camera-side window — the two
+// backoff systems interlock into a permanent 503. Longer wins, capped.
+func backoffFor(err error, retryCount int, storageFailed bool, floor time.Duration) time.Duration {
+	b := nextBackoff(retryCount, storageFailed, floor)
+	var hint interface{ RetryAfterHint() time.Duration }
+	if errors.As(err, &hint) {
+		if ra := hint.RetryAfterHint(); ra > b {
+			if ra > retryAfterCap {
+				ra = retryAfterCap
+			}
+			b = ra
+		}
+	}
+	return b
+}
+
 // runReconnectLoop is the shared auto-reconnect cycle: call Connect, on
 // failure sleep with tiered backoff + jitter (storage failures get the flat
 // storage backoff), transition to StatusReconnecting, and retry until ctx is
@@ -74,7 +98,7 @@ func runReconnectLoop(ctx context.Context, d reconnectDeps) {
 		}
 		retryCount++
 		storageFailed := isStorageFailed(d.Store, d.CameraID)
-		backoff := nextBackoff(retryCount, storageFailed, d.MinBackoff)
+		backoff := backoffFor(err, retryCount, storageFailed, d.MinBackoff)
 		if d.Metrics != nil {
 			d.Metrics.CameraReconnectBackoffSeconds.WithLabelValues(d.CameraID).Set(backoff.Seconds())
 		}

--- a/internal/recorder/reconnect_test.go
+++ b/internal/recorder/reconnect_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
 )
 
 // runReconnectLoopHarness wires runReconnectLoop to record every observable
@@ -229,4 +231,94 @@ func TestRunReconnectLoopAppliesMinBackoff(t *testing.T) {
 	if gap := attempts[1].Sub(attempts[0]); gap < 2500*time.Millisecond {
 		t.Fatalf("inter-attempt gap must respect the 2.5s floor, got %s", gap)
 	}
+}
+
+// TestHTTPStatusErrorRetryAfter (#711): the camera-side anti-hammer guard
+// answers 503 with a Retry-After header (remaining cooldown seconds). The
+// reconnect loop must wait that long — longer wins over the ladder/floor —
+// or the two backoff systems interlock into a permanent 503 (their window
+// renews on ANY rehit; our ladder caps at 60s < their 300s window).
+func TestHTTPStatusErrorRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parseRetryAfter seconds form", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, 40*time.Second, parseRetryAfter("40"))
+		require.Equal(t, time.Second, parseRetryAfter("1"))
+		require.Zero(t, parseRetryAfter(""))
+		require.Zero(t, parseRetryAfter("next tuesday"))
+		// HTTP-date form is not used by the camera firmware — treated as absent.
+		require.Zero(t, parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT"))
+	})
+
+	t.Run("backoffFor honors Retry-After over ladder and floor", func(t *testing.T) {
+		t.Parallel()
+		err := &HTTPStatusError{Code: http.StatusServiceUnavailable, RetryAfter: 300 * time.Second}
+		for range 10 {
+			b := backoffFor(err, 1, false, 5*time.Second)
+			require.GreaterOrEqual(t, b, 300*time.Second, "Retry-After must win over ladder+floor")
+		}
+		// Longer ladder (60s tier) still raised to the hint.
+		require.GreaterOrEqual(t, backoffFor(err, 99, false, 0), 300*time.Second)
+	})
+
+	t.Run("backoffFor caps hostile Retry-After", func(t *testing.T) {
+		t.Parallel()
+		err := &HTTPStatusError{Code: http.StatusServiceUnavailable, RetryAfter: 24 * time.Hour}
+		require.LessOrEqual(t, backoffFor(err, 1, false, 0), retryAfterCap)
+	})
+
+	t.Run("plain errors keep the ladder", func(t *testing.T) {
+		t.Parallel()
+		require.Less(t, backoffFor(errors.New("dial fail"), 1, false, 0), 2*time.Second)
+	})
+
+	t.Run("loop waits out the advertised cooldown", func(t *testing.T) {
+		t.Parallel()
+		var mu sync.Mutex
+		attempts := make([]time.Time, 0, 2)
+		h := &runReconnectLoopHarness{
+			connect: func(int) (error, bool) {
+				mu.Lock()
+				attempts = append(attempts, time.Now())
+				mu.Unlock()
+				return &HTTPStatusError{Code: http.StatusServiceUnavailable, RetryAfter: 2 * time.Second}, false
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			runReconnectLoop(ctx, reconnectDeps{
+				CameraID:    "test-cam",
+				Log:         slog.Default(),
+				Connect:     h.Connect,
+				RecordError: h.RecordError,
+				SetStatus:   h.SetStatus,
+				MinBackoff:  50 * time.Millisecond,
+			})
+		}()
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			mu.Lock()
+			n := len(attempts)
+			mu.Unlock()
+			if n >= 2 {
+				cancel()
+				break
+			}
+			if time.Now().After(deadline) {
+				cancel()
+				t.Fatal("second connect attempt never happened")
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		<-done
+		mu.Lock()
+		defer mu.Unlock()
+		if gap := attempts[1].Sub(attempts[0]); gap < 2*time.Second {
+			t.Fatalf("inter-attempt gap must respect Retry-After 2s, got %s", gap)
+		}
+	})
 }


### PR DESCRIPTION
Camera-team follow-up from the backoff-floor fix (#712): the anti-hammer guard answers 503 with `Retry-After: <remaining cooldown>`, and its window RENEWS on any rehit. Our reconnect ladder caps at 60s (+1s jitter) — below the camera's 300s window — so two correct-in-isolation backoff systems interlocked into a **permanent 503** (`attempt=1` forever, 拒计数 20901+ on .139).

- `connectAndStream` returns `*HTTPStatusError` carrying the parsed Retry-After (delta-seconds form).
- `backoffFor` waits the advertised cooldown when it exceeds ladder+floor (longer wins), capped at 10m against hostile values.

M5 field-verified on the two guarded MiBeeCams: `cam-121f81b1` 503 → `backoff=5m1s` (camera-advertised ~300s — unreachable via the ladder), `cam-56643269` → 11s (its shorter window). After the wait the next dial lands outside the window and connects.

Part of #711 (the MJPEG interlock half; the Pull-Point MotionAlarm feature rides separately).