### PR TITLE
feat(onvif): camera-side MotionAlarm trigger via Pull-Point subscription (#711)

### DIFF
--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -390,9 +390,9 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		RecordingMode *string `json:"recording_mode"`
 		RecordingTier *string `json:"recording_tier"`
 		// Motion signal source (#711): ""/"nvr" or "camera:onvif".
-		MotionSource *string `json:"motion_source"`
-		Pixgate       *config.CameraPixgateConfig     `json:"pixgate"`
-		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
+		MotionSource *string                         `json:"motion_source"`
+		Pixgate      *config.CameraPixgateConfig     `json:"pixgate"`
+		Adaptive     *config.AdaptiveRecordingConfig `json:"adaptive"`
 		// Audio trigger (#478): loudness input for adaptive recording.
 		AudioTrigger *config.CameraAudioTriggerConfig `json:"audio_trigger"`
 		// Push/ingest fields (SRT/RTMP)

--- a/internal/api/handlers_camera.go
+++ b/internal/api/handlers_camera.go
@@ -87,6 +87,7 @@ func injectYAMLConfigFields(row *storage.CameraRow, cfg *config.Config) {
 		row.RecordingSchedule = cam.RecordingSchedule
 		row.RecordingMode = cam.RecordingMode
 		row.RecordingTier = cam.RecordingTier
+		row.MotionSource = cam.MotionSource
 		row.Pixgate = cam.Pixgate
 		row.Adaptive = cam.Adaptive
 		if cam.Protocol == "gb28181" {
@@ -386,8 +387,10 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		RecordingSchedule *config.ScheduleConfig `json:"recording_schedule"`
 		// Recording mode (#435): ""/"continuous" or "adaptive" (+ tuning).
 		// Validated at this boundary with the startup rules (#402 class).
-		RecordingMode *string                         `json:"recording_mode"`
-		RecordingTier *string                         `json:"recording_tier"`
+		RecordingMode *string `json:"recording_mode"`
+		RecordingTier *string `json:"recording_tier"`
+		// Motion signal source (#711): ""/"nvr" or "camera:onvif".
+		MotionSource *string `json:"motion_source"`
 		Pixgate       *config.CameraPixgateConfig     `json:"pixgate"`
 		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
 		// Audio trigger (#478): loudness input for adaptive recording.
@@ -494,6 +497,7 @@ func (h *Handler) handleUpdateCamera(w http.ResponseWriter, r *http.Request) {
 		RecordingSchedule:      body.RecordingSchedule,
 		RecordingMode:          body.RecordingMode,
 		RecordingTier:          body.RecordingTier,
+		MotionSource:           body.MotionSource,
 		Pixgate:                body.Pixgate,
 		Adaptive:               body.Adaptive,
 		AudioTrigger:           body.AudioTrigger,
@@ -781,6 +785,10 @@ func (h *Handler) registerCameraRoutes(r chi.Router) {
 			// classifier running outside the NVR (or a test) forces a
 			// timelapse→normal transition with the usual GOP + audio back-fill.
 			r.Post("/adaptive/trigger", h.handleAdaptiveTrigger)
+			// Camera-side ONVIF motion subscription diagnostics (#711): the
+			// "订阅挂了 or 相机没事件" discriminator for the camera form's
+			// status line.
+			r.Get("/onvif-events", h.handleONVIFEventsStatus)
 			// Xiaomi-specific PTZ and device info endpoints
 			r.Route("/xiaomi", func(r chi.Router) {
 				r.Post("/ptz/move", h.handleXiaomiPTZMove)

--- a/internal/api/handlers_camera_create.go
+++ b/internal/api/handlers_camera_create.go
@@ -94,8 +94,8 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		// Recording mode (#435): ""/"continuous" or "adaptive" (+ tuning).
 		RecordingMode string `json:"recording_mode"`
 		// Motion signal source (#711): ""/"nvr" or "camera:onvif".
-		MotionSource string `json:"motion_source"`
-		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
+		MotionSource string                          `json:"motion_source"`
+		Adaptive     *config.AdaptiveRecordingConfig `json:"adaptive"`
 		// Audio trigger (#478): loudness input for adaptive recording.
 		AudioTrigger *config.CameraAudioTriggerConfig `json:"audio_trigger"`
 		// Push/ingest fields (SRT/RTMP)

--- a/internal/api/handlers_camera_create.go
+++ b/internal/api/handlers_camera_create.go
@@ -92,7 +92,9 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		// Cascade tier: forward the sub-stream instead of main (#512).
 		CascadeSubStream bool `json:"cascade_sub_stream"`
 		// Recording mode (#435): ""/"continuous" or "adaptive" (+ tuning).
-		RecordingMode string                          `json:"recording_mode"`
+		RecordingMode string `json:"recording_mode"`
+		// Motion signal source (#711): ""/"nvr" or "camera:onvif".
+		MotionSource string `json:"motion_source"`
 		Adaptive      *config.AdaptiveRecordingConfig `json:"adaptive"`
 		// Audio trigger (#478): loudness input for adaptive recording.
 		AudioTrigger *config.CameraAudioTriggerConfig `json:"audio_trigger"`
@@ -320,6 +322,7 @@ func (h *Handler) handleCreateCamera(w http.ResponseWriter, r *http.Request) {
 		CascadeEnabled:    body.CascadeEnabled,
 		CascadeSubStream:  body.CascadeSubStream,
 		RecordingMode:     body.RecordingMode,
+		MotionSource:      body.MotionSource,
 		Adaptive:          body.Adaptive,
 		AudioTrigger:      body.AudioTrigger,
 		StreamKey:         body.StreamKey,

--- a/internal/api/handlers_camera_lifecycle.go
+++ b/internal/api/handlers_camera_lifecycle.go
@@ -209,3 +209,16 @@ func (h *Handler) handleAdaptiveTrigger(w http.ResponseWriter, r *http.Request) 
 		"hold", hold.String(), "dbfs", body.DBFS)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "triggered"})
 }
+
+// handleONVIFEventsStatus reports the camera-side ONVIF event subscription
+// diagnostics (#711): subscribed/state, event counters, last event and last
+// error — enough to tell "the camera emits nothing" from "the subscription
+// died" at a glance.
+func (h *Handler) handleONVIFEventsStatus(w http.ResponseWriter, r *http.Request) {
+	if h.camMgr == nil {
+		WriteError(w, http.StatusInternalServerError, "camera manager not available")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	writeJSON(w, http.StatusOK, h.camMgr.ONVIFEventsStatus(id))
+}

--- a/internal/camera/crud.go
+++ b/internal/camera/crud.go
@@ -237,6 +237,10 @@ func tryFillStableIDFromONVIFWithClient(ctx context.Context, cam *config.CameraC
 // RemoveCamera removes a camera from the manager, stops its recorder, and removes it from config.
 // Does NOT delete the camera record from the database.
 func (cm *CameraManager) RemoveCamera(ctx context.Context, cameraID string) error {
+	// Drop the camera-side ONVIF event subscription (#711) first — it survives
+	// recorder teardown by design and must not outlive the camera itself.
+	_ = cm.UnsubscribeONVIFEvents(ctx, cameraID)
+
 	// Snapshot the recorder + hub + aux components (lock-free / auxMu) so we can
 	// stop them OUTSIDE any lock after the config/snapshot removal, AND restore
 	// them on a persistConfig rollback.
@@ -644,6 +648,9 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 	if updates.RecordingTier != nil {
 		cam.RecordingTier = *updates.RecordingTier
 	}
+	if updates.MotionSource != nil {
+		cam.MotionSource = *updates.MotionSource
+	}
 	if updates.Pixgate != nil {
 		cam.Pixgate = updates.Pixgate
 	}
@@ -784,6 +791,11 @@ func (cm *CameraManager) UpdateCamera(ctx context.Context, cameraID string, upda
 	if hasSchedule {
 		cm.startRecordingScheduleMonitor(context.Background(), cameraID)
 	}
+
+	// Reconcile the camera-side ONVIF motion subscription with the (possibly
+	// changed) motion_source (#711). Async like the relay reconcile above —
+	// Subscribe dials the camera.
+	go cm.EnsureMotionSubscription(context.Background(), camCopy)
 
 	// Return a snapshot — we no longer hold configMu, so returning the live
 	// pointer into cm.cfg.Cameras would race with concurrent mutations.

--- a/internal/camera/lifecycle.go
+++ b/internal/camera/lifecycle.go
@@ -139,6 +139,12 @@ func (cm *CameraManager) Start(ctx context.Context) error {
 			}
 		}
 	}
+	// Camera-side ONVIF motion subscriptions (#711): async like the relay
+	// replay below — Subscribe dials the camera and must not delay boot.
+	for _, cam := range cm.cfg.Cameras {
+		c := cam
+		go cm.EnsureMotionSubscription(ctx, c)
+	}
 	// Start recording schedule monitors for cameras with a recording_schedule configured.
 	for _, cam := range cm.cfg.Cameras {
 		if cam.RecordingSchedule != nil && len(cam.RecordingSchedule.TimeRanges) > 0 {
@@ -211,6 +217,9 @@ func (cm *CameraManager) Stop() error {
 		return fmt.Errorf("camera manager: %d recorder(s) failed to stop", len(errs))
 	}
 
+	// Tear down camera-side ONVIF event subscriptions (#711) before dropping
+	// the shared ONVIF clients they ride on.
+	cm.StopAllONVIFEvents(context.Background())
 	cm.closeAllONVIFClients()
 
 	// Stop all timelapse schedule monitors

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -180,9 +180,9 @@ type CameraManager struct {
 	// eventSubscriberFactory overrides subscriber construction (test seam
 	// for the #711 motion wiring; nil = per-camera ONVIF client path).
 	eventSubscriberFactory func(ctx context.Context, cameraID string, cb onvif.EventCallback) (onvif.EventSubscriber, error)
-	deviceInfoCache  map[string]*onvif.DeviceInfo        // camera_id → cached device info
-	deviceInfoMu     sync.RWMutex                        // protects deviceInfoCache
-	eventBus         *event.EventBus                     // event bus for publishing segment events
+	deviceInfoCache        map[string]*onvif.DeviceInfo // camera_id → cached device info
+	deviceInfoMu           sync.RWMutex                 // protects deviceInfoCache
+	eventBus               *event.EventBus              // event bus for publishing segment events
 	// relayMgr (optional) is notified when a camera's push-out targets change so
 	// the relay engine can reconcile. Interface-typed to avoid a camera<->relay
 	// import cycle.

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -84,6 +84,10 @@ type CameraUpdate struct {
 	// (#637): ""/"single" or "tiered". nil = unchanged. Tier changes are read
 	// by the tiered-recording service — applies on NVR restart.
 	RecordingTier *string
+	// MotionSource (#711): ""/"nvr" (NVR-side detectors) or "camera:onvif"
+	// (subscribe to the camera's Pull-Point MotionAlarm events). nil =
+	// unchanged; the subscription reconciles immediately (no restart).
+	MotionSource *string
 	// Pixgate arms the pixel-domain fine gate (#636). nil = unchanged;
 	// applies on NVR restart (the service reads config at boot).
 	Pixgate  *config.CameraPixgateConfig
@@ -166,6 +170,12 @@ type CameraManager struct {
 	errorDetails     map[string]*model.CameraErrorDetail // cameraID → latest error detail
 	errorDetailsMu   sync.RWMutex                        // protects errorDetails
 	eventSubscribers map[string]onvif.EventSubscriber    // camera_id → event subscriber
+	// motionAction is the shared trigger-dispatcher entry (#711) used for
+	// camera-side ONVIF MotionAlarm events; nil = motion actions dropped.
+	motionAction func(cameraID, action string)
+	// eventSubscriberFactory overrides subscriber construction (test seam
+	// for the #711 motion wiring; nil = per-camera ONVIF client path).
+	eventSubscriberFactory func(ctx context.Context, cameraID string, cb onvif.EventCallback) (onvif.EventSubscriber, error)
 	deviceInfoCache  map[string]*onvif.DeviceInfo        // camera_id → cached device info
 	deviceInfoMu     sync.RWMutex                        // protects deviceInfoCache
 	eventBus         *event.EventBus                     // event bus for publishing segment events

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -170,6 +170,10 @@ type CameraManager struct {
 	errorDetails     map[string]*model.CameraErrorDetail // cameraID → latest error detail
 	errorDetailsMu   sync.RWMutex                        // protects errorDetails
 	eventSubscribers map[string]onvif.EventSubscriber    // camera_id → event subscriber
+	// motionSubErrors remembers the last camera:onvif subscription failure
+	// per camera (#711) — a failed subscriber is discarded, but the UI
+	// diagnostics must still say "device does not implement events".
+	motionSubErrors map[string]string
 	// motionAction is the shared trigger-dispatcher entry (#711) used for
 	// camera-side ONVIF MotionAlarm events; nil = motion actions dropped.
 	motionAction func(cameraID, action string)
@@ -263,6 +267,7 @@ func NewCameraManager(cfg *config.Config, store *storage.Manager, db *storage.DB
 		errorDetails:       make(map[string]*model.CameraErrorDetail),
 		onvifClients:       make(map[string]*onvif.Client),
 		eventSubscribers:   make(map[string]onvif.EventSubscriber),
+		motionSubErrors:    make(map[string]string),
 		deviceInfoCache:    make(map[string]*onvif.DeviceInfo),
 		hubFlushLast:       make(map[string][2]int64),
 		hubBytesLast:       make(map[string]int64),

--- a/internal/camera/motion_events.go
+++ b/internal/camera/motion_events.go
@@ -1,0 +1,194 @@
+package camera
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+)
+
+// Camera-side motion events (#711): a camera with motion_source: camera:onvif
+// runs a Pull-Point subscription against its ONVIF event service. Received
+// events are (a) republished to the SSE event bus under onvif.* topics (the
+// web UI's ONVIF events panel), and (b) MotionAlarm State=true drives the
+// recorder: the shared trigger dispatcher action surface (record — identical
+// semantics to the MQTT/webhook triggers) plus, for adaptive cameras, a
+// timelapse exit with reason=onvif_motion (the same path as the audio and
+// pixel triggers). State=false intentionally triggers nothing: the adaptive
+// gate's calm logic re-enters timelapse on its own, and a dispatcher "stop"
+// would kill recording sessions other sources started.
+//
+// mibee_cam contract notes pinned here (v1.5 §13): single-subscription model
+// (a new CreatePullPointSubscription replaces the old one — later client
+// wins), TerminationTime granted at 1h with 120s no-pull expiry (the
+// subscriber's supervised loop rebuilds), per-subscription queue depth 12 with
+// drop-oldest overflow (events lost while the NVR is down are NOT replayed —
+// recording decisions must not depend on backfill).
+
+// motionTriggerHold is how long a confirmed MotionAlarm defers timelapse
+// re-entry on adaptive cameras: bridges inter-poll gaps and the occasional
+// dropped clear, without pinning the camera in full-rate forever.
+const motionTriggerHold = 10 * time.Second
+
+// onvifEventTopic maps a device topic ("tns1:VideoSource/MotionAlarm") to the
+// event-bus topic ("onvif.motionalarm") the SSE feed and the web UI's
+// ONVIFEvents panel consume (they match the "onvif." prefix).
+func onvifEventTopic(deviceTopic string) string {
+	leaf := deviceTopic
+	if idx := strings.LastIndex(leaf, "/"); idx >= 0 {
+		leaf = leaf[idx+1:]
+	}
+	// Strip a trailing namespace prefix ("tns1:Device" → "device") — the
+	// leaf after the last ":" is the event name.
+	if idx := strings.LastIndex(leaf, ":"); idx >= 0 {
+		leaf = leaf[idx+1:]
+	}
+	leaf = strings.ToLower(strings.TrimSpace(leaf))
+	if leaf == "" {
+		return ""
+	}
+	return "onvif." + leaf
+}
+
+// motionTriggerable is the recorder surface a MotionAlarm drives (satisfied by
+// *recorder.ONVIFRecorder via delegate forwarding; interface-local so the
+// camera package does not import recorder).
+type motionTriggerable interface {
+	MotionTriggerEvent(at time.Time, hold time.Duration) error
+}
+
+// SetMotionActionHandler wires the shared trigger dispatcher (the same
+// mqtt.NewActionDispatcher instance the MQTT and webhook triggers use). Called
+// from pkg/app wiring after the dispatcher is built — the camera manager owns
+// the recorders, the dispatcher owns the camera manager, so the handler is
+// injected rather than constructed here.
+func (cm *CameraManager) SetMotionActionHandler(h func(cameraID, action string)) {
+	cm.motionAction = h
+}
+
+// SetEventSubscriberFactory overrides how ONVIF event subscribers are built
+// (test seam; production path goes through the per-camera ONVIF client).
+func (cm *CameraManager) SetEventSubscriberFactory(f func(ctx context.Context, cameraID string, cb onvif.EventCallback) (onvif.EventSubscriber, error)) {
+	cm.eventSubscriberFactory = f
+}
+
+// EnsureMotionSubscription reconciles the camera's Pull-Point subscription
+// with its motion_source setting: subscribe when camera:onvif is active on an
+// ONVIF camera, tear down otherwise. Idempotent — called at boot, after
+// camera updates, and after archive/restore.
+func (cm *CameraManager) EnsureMotionSubscription(ctx context.Context, cam config.CameraConfig) {
+	want := cam.MotionSource == config.MotionSourceCameraONVIF &&
+		cam.Protocol == string(model.ProtoONVIF) &&
+		cam.ActivationState != "pending_activation"
+
+	cm.onvifMu.Lock()
+	_, exists := cm.eventSubscribers[cam.ID]
+	factory := cm.eventSubscriberFactory
+	cm.onvifMu.Unlock()
+
+	if !want {
+		if exists {
+			_ = cm.UnsubscribeONVIFEvents(ctx, cam.ID)
+		}
+		return
+	}
+	if exists {
+		return
+	}
+
+	cameraID := cam.ID
+	cb := func(evt onvif.ONVIFEvent) { cm.onONVIFEvent(cameraID, evt) }
+
+	if factory != nil {
+		sub, err := factory(ctx, cameraID, cb)
+		if err != nil {
+			logger.Warn("camera:onvif motion subscription failed",
+				"camera_id", cameraID, "error", err)
+			return
+		}
+		if err := sub.Subscribe(ctx, cameraID); err != nil {
+			logger.Info("camera:onvif motion subscription not established",
+				"camera_id", cameraID, "error", err)
+			return
+		}
+		cm.onvifMu.Lock()
+		cm.eventSubscribers[cameraID] = sub
+		cm.onvifMu.Unlock()
+		logger.Info("subscribed to camera-side ONVIF motion events", "camera_id", cameraID)
+		return
+	}
+
+	// Production path: per-camera ONVIF client → subscriber. 1s poll keeps
+	// trigger latency low (mibee_cam contract suggests 0.5–1s; the 120s
+	// device-side expiry gives huge headroom).
+	if err := cm.SubscribeONVIFEvents(ctx, cameraID, cb, onvif.WithPollInterval(time.Second)); err != nil {
+		logger.Info("camera:onvif motion subscription not established",
+			"camera_id", cameraID, "error", err)
+	}
+}
+
+// ONVIFEventsStatus reports the per-camera subscription diagnostics.
+func (cm *CameraManager) ONVIFEventsStatus(cameraID string) onvif.EventSubscriptionStatus {
+	cm.onvifMu.Lock()
+	sub := cm.eventSubscribers[cameraID]
+	cm.onvifMu.Unlock()
+	if sub == nil {
+		return onvif.EventSubscriptionStatus{}
+	}
+	return sub.Status(cameraID)
+}
+
+// onONVIFEvent is the per-camera callback for every event the PullPoint
+// subscription delivers: SSE republish + MotionAlarm handling.
+func (cm *CameraManager) onONVIFEvent(cameraID string, evt onvif.ONVIFEvent) {
+	// (a) Republish under onvif.* for the SSE feed / UI events panel.
+	if topic := onvifEventTopic(evt.Topic); topic != "" && cm.eventBus != nil {
+		payload := map[string]any{
+			"camera_id": cameraID,
+			"topic":     evt.Topic,
+			"timestamp": evt.Timestamp,
+			"data":      evt.Data,
+		}
+		if cam := cm.snapshotConfig(cameraID); cam != nil {
+			payload["camera_name"] = cam.Name
+		}
+		cm.eventBus.Publish(context.Background(), topic, payload)
+	}
+
+	// (b) MotionAlarm → recorder.
+	ma, ok := onvif.ParseMotionAlarm(evt)
+	if !ok {
+		return
+	}
+	if !ma.Active {
+		// Clears trigger nothing (see file comment); logged for arrival-rate
+		// diagnosis — the 12-deep device queue drops oldest, so a clear can
+		// also arrive without its pairing true.
+		logger.Debug("onvif motion cleared", "camera_id", cameraID,
+			"source", ma.Source, "score", ma.Score)
+		return
+	}
+
+	logger.Info("onvif motion alarm",
+		"camera_id", cameraID, "source", ma.Source, "score", ma.Score)
+
+	// Same action surface as the MQTT (#660) and webhook (#709) triggers.
+	if cm.motionAction != nil {
+		cm.motionAction(cameraID, "record")
+	}
+
+	// Adaptive cameras: exit timelapse now (GOP + pre-capture backfill), the
+	// natural "有人才拍摄" path — the gate re-enters timelapse via its calm
+	// logic once motion stops.
+	if rec := cm.GetRecorder(cameraID); rec != nil {
+		if trig, ok := rec.(motionTriggerable); ok {
+			if err := trig.MotionTriggerEvent(time.Now(), motionTriggerHold); err != nil {
+				logger.Debug("onvif motion trigger not applied (not adaptive)",
+					"camera_id", cameraID, "error", err)
+			}
+		}
+	}
+}

--- a/internal/camera/motion_events.go
+++ b/internal/camera/motion_events.go
@@ -89,10 +89,24 @@ func (cm *CameraManager) EnsureMotionSubscription(ctx context.Context, cam confi
 	factory := cm.eventSubscriberFactory
 	cm.onvifMu.Unlock()
 
+	// Remember the last subscription outcome so the diagnostics endpoint can
+	// tell "device does not implement events" from "never attempted" even
+	// though a failed subscriber is discarded (its tombstone dies with it).
+	recordOutcome := func(err error) {
+		cm.onvifMu.Lock()
+		if err != nil {
+			cm.motionSubErrors[cam.ID] = err.Error()
+		} else {
+			delete(cm.motionSubErrors, cam.ID)
+		}
+		cm.onvifMu.Unlock()
+	}
+
 	if !want {
 		if exists {
 			_ = cm.UnsubscribeONVIFEvents(ctx, cam.ID)
 		}
+		recordOutcome(nil)
 		return
 	}
 	if exists {
@@ -105,11 +119,13 @@ func (cm *CameraManager) EnsureMotionSubscription(ctx context.Context, cam confi
 	if factory != nil {
 		sub, err := factory(ctx, cameraID, cb)
 		if err != nil {
+			recordOutcome(err)
 			logger.Warn("camera:onvif motion subscription failed",
 				"camera_id", cameraID, "error", err)
 			return
 		}
 		if err := sub.Subscribe(ctx, cameraID); err != nil {
+			recordOutcome(err)
 			logger.Info("camera:onvif motion subscription not established",
 				"camera_id", cameraID, "error", err)
 			return
@@ -117,6 +133,7 @@ func (cm *CameraManager) EnsureMotionSubscription(ctx context.Context, cam confi
 		cm.onvifMu.Lock()
 		cm.eventSubscribers[cameraID] = sub
 		cm.onvifMu.Unlock()
+		recordOutcome(nil)
 		logger.Info("subscribed to camera-side ONVIF motion events", "camera_id", cameraID)
 		return
 	}
@@ -125,18 +142,31 @@ func (cm *CameraManager) EnsureMotionSubscription(ctx context.Context, cam confi
 	// trigger latency low (mibee_cam contract suggests 0.5–1s; the 120s
 	// device-side expiry gives huge headroom).
 	if err := cm.SubscribeONVIFEvents(ctx, cameraID, cb, onvif.WithPollInterval(time.Second)); err != nil {
+		recordOutcome(err)
 		logger.Info("camera:onvif motion subscription not established",
 			"camera_id", cameraID, "error", err)
+		return
 	}
+	recordOutcome(nil)
 }
 
 // ONVIFEventsStatus reports the per-camera subscription diagnostics.
 func (cm *CameraManager) ONVIFEventsStatus(cameraID string) onvif.EventSubscriptionStatus {
 	cm.onvifMu.Lock()
 	sub := cm.eventSubscribers[cameraID]
+	lastErr := cm.motionSubErrors[cameraID]
 	cm.onvifMu.Unlock()
 	if sub == nil {
-		return onvif.EventSubscriptionStatus{}
+		st := onvif.EventSubscriptionStatus{}
+		if lastErr != "" {
+			st.LastError = lastErr
+			if onvif.IsEventsNotSupported(lastErr) {
+				st.State = onvif.StateUnsupported
+			} else {
+				st.State = onvif.StateResubscribing
+			}
+		}
+		return st
 	}
 	return sub.Status(cameraID)
 }

--- a/internal/camera/motion_events_test.go
+++ b/internal/camera/motion_events_test.go
@@ -151,3 +151,21 @@ func TestONVIFEventsStatusEmpty(t *testing.T) {
 	require.False(t, st.Subscribed)
 	require.Empty(t, st.State)
 }
+
+// A failed subscription is discarded with its subscriber — the manager-level
+// error memory must still surface "unsupported" / "resubscribing" in the
+// diagnostics so the UI can tell a dead subscription from a never-attempted
+// one (#711).
+func TestONVIFEventsStatusRemembersFailure(t *testing.T) {
+	t.Parallel()
+	cm := NewCameraManager(testConfig(), nil, nil, "")
+
+	cm.onvifMu.Lock()
+	cm.motionSubErrors["cam-x"] = "onvif: device does not support event pull-point subscription: Action not supported"
+	cm.motionSubErrors["cam-y"] = "dial tcp timeout"
+	cm.onvifMu.Unlock()
+
+	require.Equal(t, onvif.StateUnsupported, cm.ONVIFEventsStatus("cam-x").State)
+	require.NotEmpty(t, cm.ONVIFEventsStatus("cam-x").LastError)
+	require.Equal(t, onvif.StateResubscribing, cm.ONVIFEventsStatus("cam-y").State)
+}

--- a/internal/camera/motion_events_test.go
+++ b/internal/camera/motion_events_test.go
@@ -1,0 +1,153 @@
+package camera
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/onvif"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnvifEventTopicMapping(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "onvif.motionalarm", onvifEventTopic("tns1:VideoSource/MotionAlarm"))
+	require.Equal(t, "onvif.tamper", onvifEventTopic("tns1:Device/Tamper"))
+	require.Equal(t, "", onvifEventTopic("tns1:"))
+	require.Equal(t, "", onvifEventTopic(""))
+}
+
+// fakeMotionRecorder satisfies the recorder registry for onONVIFEvent.
+type fakeMotionRecorder struct {
+	motionCalls int
+	lastHold    time.Duration
+}
+
+func (f *fakeMotionRecorder) Start(ctx context.Context) error  { return nil }
+func (f *fakeMotionRecorder) Stop() error                      { return nil }
+func (f *fakeMotionRecorder) Status() model.RecorderStatus     { return model.StatusRecording }
+func (f *fakeMotionRecorder) MotionTriggerEvent(at time.Time, hold time.Duration) error {
+	f.motionCalls++
+	f.lastHold = hold
+	return nil
+}
+
+func TestOnMotionEventDispatchesPublishesAndTriggers(t *testing.T) {
+	t.Parallel()
+	bus := event.NewEventBus(16)
+	cfg := testConfig()
+	cfg.Cameras = []config.CameraConfig{{
+		ID: "cam-m", Name: "门口", Protocol: "onvif",
+		MotionSource: config.MotionSourceCameraONVIF,
+	}}
+	cm := NewCameraManager(cfg, nil, nil, "")
+	cm.eventBus = bus
+
+	rec := &fakeMotionRecorder{}
+	cm.apply(func(s *snapshot) *snapshot {
+		s.recorders["cam-m"] = rec
+		return s
+	})
+
+	var actionCam, action string
+	cm.SetMotionActionHandler(func(cameraID, act string) { actionCam, action = cameraID, act })
+
+	ch := make(chan event.Event, 8)
+	require.NoError(t, bus.SubscribeByPrefix("onvif.", ch, 16))
+
+	// MotionAlarm true → SSE publish + dispatcher record + adaptive trigger.
+	cm.onONVIFEvent("cam-m", onvif.ONVIFEvent{
+		Topic: "tns1:VideoSource/MotionAlarm",
+		Data:  map[string]any{"State": "true", "Score": "73", "source.Source": "CSI"},
+	})
+
+	require.Equal(t, "cam-m", actionCam)
+	require.Equal(t, "record", action)
+	require.Equal(t, 1, rec.motionCalls)
+	require.Equal(t, motionTriggerHold, rec.lastHold)
+
+	evt := <-ch
+	require.Equal(t, "onvif.motionalarm", evt.Topic)
+	payload, ok := evt.Data.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "cam-m", payload["camera_id"])
+	require.Equal(t, "门口", payload["camera_name"])
+	data := payload["data"].(map[string]any)
+	require.Equal(t, "true", data["State"])
+	require.Equal(t, "73", data["Score"])
+
+	// Clear event → published to SSE but triggers NOTHING.
+	action = ""
+	cm.onONVIFEvent("cam-m", onvif.ONVIFEvent{
+		Topic: "tns1:VideoSource/MotionAlarm",
+		Data:  map[string]any{"State": "false"},
+	})
+	require.Equal(t, "", action, "clear must not dispatch a stop")
+	require.Equal(t, 1, rec.motionCalls)
+	<-ch
+
+	// Non-motion ONVIF topic → SSE publish only.
+	cm.onONVIFEvent("cam-m", onvif.ONVIFEvent{
+		Topic: "tns1:Device/Tamper",
+		Data:  map[string]any{"State": "true"},
+	})
+	require.Equal(t, "", action)
+	require.Equal(t, 1, rec.motionCalls, "non-motion topics must not trigger")
+	<-ch
+}
+
+func TestEnsureMotionSubscriptionGating(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig()
+	cm := NewCameraManager(cfg, nil, nil, "")
+
+	var factoryCalls int
+	sub := &onvif.MockEventSubscriber{}
+	cm.SetEventSubscriberFactory(func(ctx context.Context, cameraID string, cb onvif.EventCallback) (onvif.EventSubscriber, error) {
+		factoryCalls++
+		return sub, nil
+	})
+
+	onvifCam := config.CameraConfig{ID: "cam-o", Protocol: "onvif", MotionSource: config.MotionSourceCameraONVIF}
+	httpCam := config.CameraConfig{ID: "cam-h", Protocol: "http", MotionSource: config.MotionSourceCameraONVIF}
+	plainCam := config.CameraConfig{ID: "cam-p", Protocol: "onvif"}
+
+	// Non-onvif protocol: no subscription even with the flag set.
+	cm.EnsureMotionSubscription(context.Background(), httpCam)
+	require.Equal(t, 0, factoryCalls)
+
+	// Default (no motion_source): no subscription.
+	cm.EnsureMotionSubscription(context.Background(), plainCam)
+	require.Equal(t, 0, factoryCalls)
+
+	// onvif + camera:onvif: subscribed once.
+	cm.EnsureMotionSubscription(context.Background(), onvifCam)
+	require.Equal(t, 1, factoryCalls)
+	require.True(t, cm.ONVIFEventsStatus("cam-o").Subscribed)
+
+	// Reconcile again: no duplicate.
+	cm.EnsureMotionSubscription(context.Background(), onvifCam)
+	require.Equal(t, 1, factoryCalls)
+
+	// Switching back to nvr tears it down.
+	off := onvifCam
+	off.MotionSource = ""
+	cm.EnsureMotionSubscription(context.Background(), off)
+	cm.onvifMu.Lock()
+	_, exists := cm.eventSubscribers["cam-o"]
+	cm.onvifMu.Unlock()
+	require.False(t, exists, "motion_source=nvr must tear the subscription down")
+	require.Equal(t, 1, sub.UnsubscribeCalls)
+}
+
+func TestONVIFEventsStatusEmpty(t *testing.T) {
+	t.Parallel()
+	cm := NewCameraManager(testConfig(), nil, nil, "")
+	st := cm.ONVIFEventsStatus("nope")
+	require.False(t, st.Subscribed)
+	require.Empty(t, st.State)
+}

--- a/internal/camera/motion_events_test.go
+++ b/internal/camera/motion_events_test.go
@@ -27,9 +27,9 @@ type fakeMotionRecorder struct {
 	lastHold    time.Duration
 }
 
-func (f *fakeMotionRecorder) Start(ctx context.Context) error  { return nil }
-func (f *fakeMotionRecorder) Stop() error                      { return nil }
-func (f *fakeMotionRecorder) Status() model.RecorderStatus     { return model.StatusRecording }
+func (f *fakeMotionRecorder) Start(ctx context.Context) error { return nil }
+func (f *fakeMotionRecorder) Stop() error                     { return nil }
+func (f *fakeMotionRecorder) Status() model.RecorderStatus    { return model.StatusRecording }
 func (f *fakeMotionRecorder) MotionTriggerEvent(at time.Time, hold time.Duration) error {
 	f.motionCalls++
 	f.lastHold = hold

--- a/internal/camera/onvif_client.go
+++ b/internal/camera/onvif_client.go
@@ -230,7 +230,7 @@ func intPtrOrZero(i *int) int {
 // SubscribeONVIFEvents subscribes to PullPoint events for the given camera.
 // The eventCallback is invoked when events are received.
 // Returns error if camera is not found, not ONVIF, or subscription fails.
-func (cm *CameraManager) SubscribeONVIFEvents(ctx context.Context, cameraID string, eventCallback onvif.EventCallback) error {
+func (cm *CameraManager) SubscribeONVIFEvents(ctx context.Context, cameraID string, eventCallback onvif.EventCallback, opts ...onvif.EventSubscriberOption) error {
 	client, err := cm.getOrCreateONVIFClient(ctx, cameraID)
 	if err != nil {
 		return err
@@ -243,7 +243,7 @@ func (cm *CameraManager) SubscribeONVIFEvents(ctx context.Context, cameraID stri
 		return nil // Already subscribed
 	}
 
-	sub := client.NewEventSubscriber(onvif.WithEventCallback(eventCallback))
+	sub := client.NewEventSubscriber(append([]onvif.EventSubscriberOption{onvif.WithEventCallback(eventCallback)}, opts...)...)
 	if sub == nil {
 		return fmt.Errorf("camera %q: failed to create event subscriber", cameraID)
 	}

--- a/internal/config/config_camera.go
+++ b/internal/config/config_camera.go
@@ -97,6 +97,15 @@ type CameraConfig struct {
 	// Issue #36.
 	RecordingEnabled *bool `yaml:"recording_enabled,omitempty" json:"recording_enabled,omitempty"`
 
+	// MotionSource selects where the camera's motion signal comes from
+	// (#711): "" | "nvr" — the NVR's own detectors (adaptive spikes, pixgate;
+	// the default, current behavior). "camera:onvif" — subscribe to the
+	// camera's ONVIF Pull-Point event service; tns1:VideoSource/MotionAlarm
+	// events (mibee_cam WiFi-CSI contract v1.5 §13, or a standard camera's
+	// motion detection) drive the recorder via the shared trigger surface and
+	// exit adaptive timelapse with reason=onvif_motion. ONVIF protocol only.
+	MotionSource string `yaml:"motion_source,omitempty" json:"motion_source,omitempty"`
+
 	// RecordingMode selects the write-density strategy (issue #435):
 	//   "" | "continuous" — record every frame (default, current behavior)
 	//   "adaptive"        — dynamic timelapse: while the compressed-domain

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1800,3 +1800,33 @@ func TestMQTTStatusEventsConfig(t *testing.T) {
 	cfg.ApplyDefaults()
 	require.False(t, cfg.MQTT.StatusEvents, "default mqtt.status_events should be false")
 }
+
+// TestValidateCameraMotionSource (#711): the motion-source allowlist plus the
+// protocol gate for camera:onvif.
+func TestValidateCameraMotionSource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		source  string
+		proto   string
+		wantErr bool
+	}{
+		{"empty defaults to nvr", "", "onvif", false},
+		{"explicit nvr", "nvr", "onvif", false},
+		{"camera:onvif on onvif camera", "camera:onvif", "onvif", false},
+		{"camera:onvif on rtsp camera rejected", "camera:onvif", "rtsp", true},
+		{"camera:onvif on http camera rejected", "camera:onvif", "http", true},
+		{"garbage value rejected", "camera:csi", "onvif", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cam := CameraConfig{ID: "cam-1", Protocol: tc.proto, MotionSource: tc.source}
+			err := ValidateCameraRecordingMode(cam)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -777,11 +777,23 @@ func validatePortRange(r string) error {
 	return nil
 }
 
+// MotionSourceCameraONVIF selects the camera-side ONVIF Pull-Point
+// MotionAlarm subscription as this camera's motion signal (#711).
+const MotionSourceCameraONVIF = "camera:onvif"
+
 // ValidateCameraRecordingMode checks one camera's recording_mode + adaptive
 // tuning block (issue #435) + audio_trigger block (issue #478). Shared by the
 // startup config validation and the camera create/update API boundaries so an
 // invalid value is rejected at the wire instead of bricking the next restart.
 func ValidateCameraRecordingMode(cam CameraConfig) error {
+	switch cam.MotionSource {
+	case "", "nvr", MotionSourceCameraONVIF:
+	default:
+		return fmt.Errorf("cameras.%s.motion_source must be \"nvr\" or \"camera:onvif\" (got %q)", cam.ID, cam.MotionSource)
+	}
+	if cam.MotionSource == MotionSourceCameraONVIF && cam.Protocol != "onvif" {
+		return fmt.Errorf("cameras.%s.motion_source=camera:onvif requires an onvif protocol camera (got %q)", cam.ID, cam.Protocol)
+	}
 	switch cam.RecordingMode {
 	case "", "continuous", "adaptive":
 	default:

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -22,6 +22,14 @@ var eventLogger = slogx.Component("onvif-events")
 // repeatedly attempting a subscription that will never succeed.
 var ErrEventsNotSupported = errors.New("onvif: device does not support event pull-point subscription")
 
+// IsEventsNotSupportedError reports whether an error string (e.g. a recorded
+// last-subscription failure) represents the device rejecting event
+// subscription as unimplemented — the camera-manager diagnostics use it to
+// label a camera "unsupported" without re-probing it.
+func IsEventsNotSupported(errOrMsg string) bool {
+	return isEventsNotSupportedError(errors.New(errOrMsg))
+}
+
 // isEventsNotSupportedError reports whether err represents the device rejecting
 // event subscription as unimplemented. Devices phrase this variously:
 // "Action Not Implemented", "ActionNotSupported", "NotImplemented", etc.

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -255,8 +255,8 @@ func (e *EventSubscriberImpl) createSubscriptionLocked(ctx context.Context, came
 			eventLogger.Info("device does not support ONVIF events; skipping subscription",
 				"camera_id", cameraID, "error", err)
 			e.subscriptions[cameraID] = &pullPointSubscription{
-				active:  false,
-				state:   StateUnsupported,
+				active:    false,
+				state:     StateUnsupported,
 				lastError: err.Error(),
 			}
 			return nil, fmt.Errorf("%w (camera %q): %w", ErrEventsNotSupported, cameraID, err)
@@ -377,14 +377,14 @@ func (e *EventSubscriberImpl) SetEventCallback(cb EventCallback) {
 
 // EventSubscriptionStatus is the per-camera subscription diagnostic snapshot.
 type EventSubscriptionStatus struct {
-	Subscribed           bool      `json:"subscribed"`
-	State                string    `json:"state"`
-	SubscriptionRef      string    `json:"subscription_ref,omitempty"`
-	TerminationTime      time.Time `json:"termination_time,omitempty"`
-	PollInterval         string    `json:"poll_interval,omitempty"`
-	EventCount           int64     `json:"event_count"`
-	LastEventAt          time.Time `json:"last_event_at,omitempty"`
-	LastError            string    `json:"last_error,omitempty"`
+	Subscribed            bool      `json:"subscribed"`
+	State                 string    `json:"state"`
+	SubscriptionRef       string    `json:"subscription_ref,omitempty"`
+	TerminationTime       time.Time `json:"termination_time,omitempty"`
+	PollInterval          string    `json:"poll_interval,omitempty"`
+	EventCount            int64     `json:"event_count"`
+	LastEventAt           time.Time `json:"last_event_at,omitempty"`
+	LastError             string    `json:"last_error,omitempty"`
 	ConsecutivePollErrors int       `json:"consecutive_poll_errors"`
 }
 

--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -48,18 +48,53 @@ const DefaultMessageLimit = 10
 // DefaultSubscriptionDuration is the requested PullPoint subscription lifetime.
 const DefaultSubscriptionDuration = 24 * time.Hour
 
-// SubscriptionRenewBefore is how long before expiry to attempt renewal.
+// SubscriptionRenewBefore is the upper bound on how much remaining lifetime
+// triggers a renewal. The effective threshold is min(this, half the GRANTED
+// lifetime): devices that grant short terms regardless of the request (the
+// mibee_cam contract grants exactly 1h) must not renew on every poll tick.
 const SubscriptionRenewBefore = 1 * time.Hour
+
+// terminalPollFailures is how many consecutive failed PullMessages calls
+// presume the subscription dead (expired after a 120s no-pull window,
+// SubscriptionReferenceDereferenced, device reboot) and trigger a rebuild.
+// Devices that long-poll block up to PullTimeout per call, so this bound also
+// caps the time-to-recovery.
+const terminalPollFailures = 5
+
+// Resubscribe backoff bounds: start at resubscribeMinBackoff, double per
+// failure, capped at resubscribeMaxBackoff.
+const (
+	resubscribeMinBackoff = 5 * time.Second
+	resubscribeMaxBackoff = 60 * time.Second
+)
+
+// Subscription states reported by Status.
+const (
+	StateActive        = "active"
+	StateResubscribing = "resubscribing"
+	StateUnsupported   = "unsupported"
+)
 
 // EventCallback is a function that receives parsed ONVIF events.
 // The camera manager wires this to publish events to the EventBus.
 type EventCallback func(event ONVIFEvent)
 
+// eventsAPI is the events-service surface EventSubscriberImpl drives.
+// Satisfied by the onvif-go events service; a narrow interface keeps the
+// subscription lifecycle unit-testable with an in-memory fake.
+type eventsAPI interface {
+	CreatePullPointSubscription(ctx context.Context, filter string, initialTerminationTime *time.Duration, subscriptionPolicy string) (*onvifgo.PullPointSubscription, error)
+	PullMessages(ctx context.Context, subscriptionReference string, timeout time.Duration, messageLimit int) ([]onvifgo.NotificationMessage, error)
+	RenewSubscription(ctx context.Context, subscriptionReference string, terminationTime time.Duration) (time.Time, time.Time, error)
+	Unsubscribe(ctx context.Context, subscriptionReference string) error
+}
+
 // EventSubscriberImpl manages PullPoint subscriptions and event polling
 // for a single ONVIF device. It wraps an onvif-go Client and handles
-// the full subscription lifecycle: create, poll, renew, unsubscribe.
+// the full subscription lifecycle: create, poll, renew, resubscribe on
+// terminal failures, unsubscribe.
 type EventSubscriberImpl struct {
-	client *onvifgo.Client
+	events eventsAPI
 
 	mu            sync.Mutex
 	subscriptions map[string]*pullPointSubscription // cameraID → subscription
@@ -70,18 +105,30 @@ type EventSubscriberImpl struct {
 	pullTimeout   time.Duration // SOAP timeout for PullMessages
 	messageLimit  int           // max messages per PullMessages call
 	subDuration   time.Duration // requested subscription lifetime
+	resubBackoff  time.Duration // initial rebuild backoff (doubles to max)
 }
 
 type pullPointSubscription struct {
 	subscriptionRef string    // PullPoint subscription reference URL
 	terminationTime time.Time // subscription expiry time
-	active          bool      // whether the polling goroutine is running
+	grantedDur      time.Duration
+	active          bool   // whether the polling goroutine is running
+	state           string // active | resubscribing | unsupported (diagnostics)
+	eventCount      int64
+	lastEventAt     time.Time
+	lastError       string
+	pollErrs        int
 }
 
 // NewEventSubscriber creates an EventSubscriber backed by an onvif-go client.
 func NewEventSubscriber(client *onvifgo.Client, opts ...EventSubscriberOption) *EventSubscriberImpl {
+	return newEventSubscriber(client.Events(), opts...)
+}
+
+// newEventSubscriber builds the subscriber around an eventsAPI — the test seam.
+func newEventSubscriber(svc eventsAPI, opts ...EventSubscriberOption) *EventSubscriberImpl {
 	es := &EventSubscriberImpl{
-		client:        client,
+		events:        svc,
 		subscriptions: make(map[string]*pullPointSubscription),
 		stopCh:        make(map[string]chan struct{}),
 		pollInterval:  DefaultPollInterval,
@@ -105,56 +152,70 @@ func WithEventCallback(cb EventCallback) EventSubscriberOption {
 	}
 }
 
-// withPollInterval sets the polling interval between PullMessages calls.
-func withPollInterval(d time.Duration) EventSubscriberOption {
+// WithPollInterval sets the polling interval between PullMessages calls. The
+// mibee_cam contract suggests 0.5–1s for motion-trigger use; the default 5s is
+// compliant (the device only expires a subscription after 120s without a
+// pull) but adds that much trigger latency.
+func WithPollInterval(d time.Duration) EventSubscriberOption {
 	return func(es *EventSubscriberImpl) {
-		es.pollInterval = d
+		if d > 0 {
+			es.pollInterval = d
+		}
 	}
 }
 
-// withPullTimeout sets the SOAP timeout for PullMessages requests.
-func withPullTimeout(d time.Duration) EventSubscriberOption {
+// WithPullTimeout sets the SOAP timeout for PullMessages requests.
+func WithPullTimeout(d time.Duration) EventSubscriberOption {
 	return func(es *EventSubscriberImpl) {
 		es.pullTimeout = d
 	}
 }
 
-// withSubscriptionDuration sets the requested PullPoint subscription lifetime.
-func withSubscriptionDuration(d time.Duration) EventSubscriberOption {
+// WithSubscriptionDuration sets the requested PullPoint subscription lifetime.
+func WithSubscriptionDuration(d time.Duration) EventSubscriberOption {
 	return func(es *EventSubscriberImpl) {
 		es.subDuration = d
 	}
 }
 
+// withResubscribeBackoff overrides the initial rebuild backoff (test seam for
+// fast loops; production keeps resubscribeMinBackoff).
+func withResubscribeBackoff(d time.Duration) EventSubscriberOption {
+	return func(es *EventSubscriberImpl) {
+		if d > 0 {
+			es.resubBackoff = d
+		}
+	}
+}
+
+// renewThreshold is the remaining-lifetime threshold that triggers renewal:
+// half the granted duration, clamped to [2×pollInterval, SubscriptionRenewBefore].
+func renewThreshold(grantedDur, pollInterval time.Duration) time.Duration {
+	th := grantedDur / 2
+	if th > SubscriptionRenewBefore {
+		th = SubscriptionRenewBefore
+	}
+	if minTh := 2 * pollInterval; th < minTh {
+		th = minTh
+	}
+	return th
+}
+
 // Subscribe creates a PullPoint subscription for the camera and starts
 // background polling. Safe to call multiple times — returns nil if already
-// subscribed.
+// subscribed (including the "unsupported" tombstone, so unsupported devices
+// are not re-probed on every reconcile).
 func (e *EventSubscriberImpl) Subscribe(ctx context.Context, cameraID string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	if _, exists := e.subscriptions[cameraID]; exists {
-		return nil // Already subscribed
+		return nil // Already subscribed (or tombstoned as unsupported)
 	}
 
-	// Create PullPoint subscription via onvif-go
-	sub, err := e.client.Events().CreatePullPointSubscription(ctx, "", &e.subDuration, "")
+	ps, err := e.createSubscriptionLocked(ctx, cameraID)
 	if err != nil {
-		// Some cameras advertise the event service in GetCapabilities but reject
-		// the actual subscription as unimplemented. Surface a sentinel so callers
-		// can cache the negative result rather than retrying forever.
-		if isEventsNotSupportedError(err) {
-			eventLogger.Info("device does not support ONVIF events; skipping subscription",
-				"camera_id", cameraID, "error", err)
-			return fmt.Errorf("%w (camera %q): %w", ErrEventsNotSupported, cameraID, err)
-		}
-		return fmt.Errorf("onvif: create PullPoint subscription for camera %q: %w", cameraID, err)
-	}
-
-	ps := &pullPointSubscription{
-		subscriptionRef: sub.SubscriptionReference,
-		terminationTime: sub.TerminationTime,
-		active:          true,
+		return err
 	}
 	e.subscriptions[cameraID] = ps
 
@@ -163,13 +224,53 @@ func (e *EventSubscriberImpl) Subscribe(ctx context.Context, cameraID string) er
 
 	eventLogger.Info("created PullPoint subscription",
 		"camera_id", cameraID,
-		"subscription_ref", sub.SubscriptionReference,
-		"termination", sub.TerminationTime)
+		"subscription_ref", ps.subscriptionRef,
+		"granted", ps.grantedDur.String(),
+		"termination", ps.terminationTime)
 
-	// Start background polling goroutine
-	go e.publishEvents(context.Background(), cameraID, ps, stopCh)
+	// Start the supervised polling goroutine. context.Background(): the loop
+	// owns its per-call timeouts and is stopped via stopCh (Unsubscribe).
+	go e.run(cameraID, stopCh)
 
 	return nil
+}
+
+// createSubscriptionLocked performs one CreatePullPointSubscription call and
+// returns the resulting pullPointSubscription. Caller holds e.mu.
+func (e *EventSubscriberImpl) createSubscriptionLocked(ctx context.Context, cameraID string) (*pullPointSubscription, error) {
+	sub, err := e.events.CreatePullPointSubscription(ctx, "", &e.subDuration, "")
+	if err != nil {
+		// Some cameras advertise the event service in GetCapabilities but reject
+		// the actual subscription as unimplemented. Tombstone the camera so
+		// callers stop probing instead of retrying forever.
+		if isEventsNotSupportedError(err) {
+			eventLogger.Info("device does not support ONVIF events; skipping subscription",
+				"camera_id", cameraID, "error", err)
+			e.subscriptions[cameraID] = &pullPointSubscription{
+				active:  false,
+				state:   StateUnsupported,
+				lastError: err.Error(),
+			}
+			return nil, fmt.Errorf("%w (camera %q): %w", ErrEventsNotSupported, cameraID, err)
+		}
+		return nil, fmt.Errorf("onvif: create PullPoint subscription for camera %q: %w", cameraID, err)
+	}
+
+	term := sub.TerminationTime
+	if term.IsZero() {
+		term = time.Now().Add(e.subDuration)
+	}
+	granted := time.Until(term)
+	if granted <= 0 {
+		granted = e.subDuration
+	}
+	return &pullPointSubscription{
+		subscriptionRef: sub.SubscriptionReference,
+		terminationTime: term,
+		grantedDur:      granted,
+		active:          true,
+		state:           StateActive,
+	}, nil
 }
 
 // Unsubscribe terminates the PullPoint subscription for the camera and
@@ -183,7 +284,7 @@ func (e *EventSubscriberImpl) Unsubscribe(ctx context.Context, cameraID string) 
 		return nil // Not subscribed
 	}
 
-	// Signal polling goroutine to stop
+	// Signal the run goroutine to stop, then let it drain.
 	if stopCh, ok := e.stopCh[cameraID]; ok {
 		close(stopCh)
 		delete(e.stopCh, cameraID)
@@ -191,9 +292,9 @@ func (e *EventSubscriberImpl) Unsubscribe(ctx context.Context, cameraID string) 
 
 	ps.active = false
 
-	// Unsubscribe via onvif-go (fire-and-forget on error, nil client means test mode)
-	if e.client != nil {
-		if err := e.client.Events().Unsubscribe(ctx, ps.subscriptionRef); err != nil {
+	// Unsubscribe via onvif-go (fire-and-forget on error; nil service = test mode)
+	if e.events != nil && ps.subscriptionRef != "" {
+		if err := e.events.Unsubscribe(ctx, ps.subscriptionRef); err != nil {
 			eventLogger.Warn("failed to unsubscribe from PullPoint",
 				"camera_id", cameraID,
 				"subscription_ref", ps.subscriptionRef,
@@ -223,6 +324,28 @@ func (e *EventSubscriberImpl) IsSubscribed(cameraID string) bool {
 	return exists && ps.active
 }
 
+// Status reports the subscription diagnostics for a camera — the "订阅挂了 or
+// 相机没事件" discriminator for the UI diagnostics line.
+func (e *EventSubscriberImpl) Status(cameraID string) EventSubscriptionStatus {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ps, exists := e.subscriptions[cameraID]
+	st := EventSubscriptionStatus{State: ""}
+	if !exists {
+		return st
+	}
+	st.Subscribed = ps.active
+	st.State = ps.state
+	st.SubscriptionRef = ps.subscriptionRef
+	st.TerminationTime = ps.terminationTime
+	st.EventCount = ps.eventCount
+	st.LastEventAt = ps.lastEventAt
+	st.LastError = ps.lastError
+	st.ConsecutivePollErrors = ps.pollErrs
+	st.PollInterval = e.pollInterval.String()
+	return st
+}
+
 // StopAll unsubscribes from all cameras and stops all polling goroutines.
 func (e *EventSubscriberImpl) StopAll(ctx context.Context) {
 	e.mu.Lock()
@@ -244,89 +367,257 @@ func (e *EventSubscriberImpl) SetEventCallback(cb EventCallback) {
 	e.eventCallback = cb
 }
 
-// publishEvents polls the PullPoint subscription and publishes events.
-// This runs as a background goroutine until the stop channel is closed or
-// context is cancelled.
-func (e *EventSubscriberImpl) publishEvents(ctx context.Context, cameraID string, ps *pullPointSubscription, stopCh <-chan struct{}) {
+// EventSubscriptionStatus is the per-camera subscription diagnostic snapshot.
+type EventSubscriptionStatus struct {
+	Subscribed           bool      `json:"subscribed"`
+	State                string    `json:"state"`
+	SubscriptionRef      string    `json:"subscription_ref,omitempty"`
+	TerminationTime      time.Time `json:"termination_time,omitempty"`
+	PollInterval         string    `json:"poll_interval,omitempty"`
+	EventCount           int64     `json:"event_count"`
+	LastEventAt          time.Time `json:"last_event_at,omitempty"`
+	LastError            string    `json:"last_error,omitempty"`
+	ConsecutivePollErrors int       `json:"consecutive_poll_errors"`
+}
+
+// run is the supervised polling loop for one camera: poll until a terminal
+// condition, then rebuild the subscription with backoff. Terminal-but-curable
+// conditions (expiry, dereference, device reboot) loop forever; only
+// "device does not implement events" (tombstone) and stopCh end the loop.
+func (e *EventSubscriberImpl) run(cameraID string, stopCh <-chan struct{}) {
+	backoff := e.resubBackoff
+	if backoff <= 0 {
+		backoff = resubscribeMinBackoff
+	}
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		ps := e.subLocked(cameraID)
+		if ps == nil {
+			return // Unsubscribe removed us
+		}
+		if ps.state == StateUnsupported {
+			return // tombstone — never retry
+		}
+		if !ps.active || ps.state != StateActive {
+			// Rebuild path: create a fresh subscription (the device's
+			// single-subscription model means the new create replaces any
+			// stale server-side state — later client wins).
+			newPS, err := e.rebuildSubscription(cameraID, ps)
+			if err != nil {
+				if errors.Is(err, ErrEventsNotSupported) {
+					return
+				}
+				if !sleepInterruptible(stopCh, backoff) {
+					return
+				}
+				backoff = min(backoff*2, resubscribeMaxBackoff)
+				continue
+			}
+			ps = newPS
+			backoff = resubscribeMinBackoff
+		}
+
+		if !e.pollLoop(cameraID, ps, stopCh) {
+			return // stopCh closed
+		}
+		// pollLoop hit a terminal condition — brief backoff, then rebuild.
+		e.setPS(cameraID, func(p *pullPointSubscription) { p.active = false; p.state = StateResubscribing })
+		if !sleepInterruptible(stopCh, backoff) {
+			return
+		}
+		backoff = min(backoff*2, resubscribeMaxBackoff)
+	}
+}
+
+// rebuildSubscription tears down the current subscription server-side and
+// installs a fresh one in the registry (keeping the same stop channel).
+func (e *EventSubscriberImpl) rebuildSubscription(cameraID string, old *pullPointSubscription) (*pullPointSubscription, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if old.subscriptionRef != "" && e.events != nil {
+		_ = e.events.Unsubscribe(ctx, old.subscriptionRef) // best-effort; refs are usually already dead
+	}
+	var fresh *pullPointSubscription
+	e.mu.Lock()
+	err := func() error {
+		var cerr error
+		fresh, cerr = e.createSubscriptionLocked(ctx, cameraID)
+		return cerr
+	}()
+	if err != nil {
+		e.mu.Unlock()
+		e.setPS(cameraID, func(p *pullPointSubscription) { p.lastError = err.Error() })
+		return nil, err
+	}
+	e.subscriptions[cameraID] = fresh
+	e.mu.Unlock()
+	eventLogger.Info("rebuilt PullPoint subscription",
+		"camera_id", cameraID, "subscription_ref", fresh.subscriptionRef,
+		"granted", fresh.grantedDur.String())
+	return fresh, nil
+}
+
+// pollLoop ticks PullMessages until a terminal condition (subscription expired
+// or terminalPollFailures consecutive errors) or stop. Returns false only when
+// stopCh closed; true means "resubscribe and continue".
+func (e *EventSubscriberImpl) pollLoop(cameraID string, ps *pullPointSubscription, stopCh <-chan struct{}) bool {
 	ticker := time.NewTicker(e.pollInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-stopCh:
-			return
-		case <-ctx.Done():
-			return
+			return false
 		case <-ticker.C:
-			if !e.pollAndPublish(ctx, cameraID, ps) {
-				// Subscription may have expired or been terminated
-				return
+		}
+
+		// Renewal check: renew before the term lapses. An already-expired
+		// term is NOT terminal by itself — devices with loose expiry may still
+		// honor a Renew (and the pre-#711 behavior relied on that); the ref
+		// is only presumed dead when pulls keep failing (below).
+		if remaining := time.Until(e.termOf(cameraID)); remaining < renewThreshold(e.grantedOf(cameraID), e.pollInterval) {
+			if !e.renewSubscription(cameraID) {
+				e.setPS(cameraID, func(p *pullPointSubscription) { p.pollErrs++ })
+			}
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), e.pullTimeout+10*time.Second)
+		messages, err := e.events.PullMessages(ctx, e.refOf(cameraID), e.pullTimeout, e.messageLimit)
+		cancel()
+		if err != nil {
+			e.setPS(cameraID, func(p *pullPointSubscription) {
+				p.pollErrs++
+				p.lastError = err.Error()
+			})
+			if e.pollErrsOf(cameraID) >= terminalPollFailures {
+				eventLogger.Warn("PullMessages failing repeatedly; rebuilding subscription",
+					"camera_id", cameraID, "consecutive_errors", e.pollErrsOf(cameraID))
+				return true
+			}
+			continue
+		}
+
+		e.setPS(cameraID, func(p *pullPointSubscription) { p.pollErrs = 0 })
+
+		for _, msg := range messages {
+			event := parseNotificationMessage(msg, cameraID)
+			if event.Topic == "" {
+				continue // Skip messages without topics
+			}
+
+			e.setPS(cameraID, func(p *pullPointSubscription) {
+				p.eventCount++
+				p.lastEventAt = event.Timestamp
+			})
+
+			e.mu.Lock()
+			callback := e.eventCallback
+			e.mu.Unlock()
+			if callback != nil {
+				callback(event)
 			}
 		}
 	}
 }
 
-// pollAndPublish performs a single PullMessages call and publishes results.
-// Returns false if the subscription should be terminated.
-func (e *EventSubscriberImpl) pollAndPublish(ctx context.Context, cameraID string, ps *pullPointSubscription) bool {
-	// Check subscription renewal
-	if time.Until(ps.terminationTime) < SubscriptionRenewBefore {
-		if !e.renewSubscription(ctx, cameraID, ps) {
-			eventLogger.Warn("subscription renewal failed, stopping polling",
-				"camera_id", cameraID)
-			ps.active = false
-			return false
-		}
+// renewSubscription attempts to renew the PullPoint subscription before expiry.
+func (e *EventSubscriberImpl) renewSubscription(cameraID string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	ref := e.refOf(cameraID)
+	if ref == "" {
+		return false
 	}
-
-	// Pull messages from the subscription
-	messages, err := e.client.Events().PullMessages(ctx, ps.subscriptionRef, e.pullTimeout, e.messageLimit)
+	_, newTerm, err := e.events.RenewSubscription(ctx, ref, e.subDuration)
 	if err != nil {
-		eventLogger.Warn("PullMessages failed",
-			"camera_id", cameraID,
-			"error", err)
-		return true // Continue polling — transient errors
+		eventLogger.Warn("failed to renew PullPoint subscription",
+			"camera_id", cameraID, "error", err)
+		e.setPS(cameraID, func(p *pullPointSubscription) { p.lastError = err.Error() })
+		return false
 	}
-
-	// Parse and publish events
-	e.mu.Lock()
-	callback := e.eventCallback
-	e.mu.Unlock()
-
-	for _, msg := range messages {
-		event := parseNotificationMessage(msg, cameraID)
-		if event.Topic == "" {
-			continue // Skip messages without topics
-		}
-
-		if callback != nil {
-			callback(event)
-		}
-
-		eventLogger.Debug("received ONVIF event",
-			"camera_id", cameraID,
-			"topic", event.Topic,
-			"timestamp", event.Timestamp)
+	if newTerm.IsZero() {
+		newTerm = time.Now().Add(e.subDuration)
 	}
-
+	granted := time.Until(newTerm)
+	if granted <= 0 {
+		granted = e.subDuration
+	}
+	e.setPS(cameraID, func(p *pullPointSubscription) {
+		p.terminationTime = newTerm
+		p.grantedDur = granted
+	})
+	eventLogger.Debug("renewed PullPoint subscription",
+		"camera_id", cameraID, "new_termination", newTerm)
 	return true
 }
 
-// renewSubscription attempts to renew the PullPoint subscription before expiry.
-func (e *EventSubscriberImpl) renewSubscription(ctx context.Context, cameraID string, ps *pullPointSubscription) bool {
-	_, newTermination, err := e.client.Events().RenewSubscription(ctx, ps.subscriptionRef, e.subDuration)
-	if err != nil {
-		eventLogger.Warn("failed to renew PullPoint subscription",
-			"camera_id", cameraID,
-			"error", err)
-		return false
-	}
+// --- small guarded accessors so the poll loop never holds e.mu across I/O ---
 
-	ps.terminationTime = newTermination
-	eventLogger.Info("renewed PullPoint subscription",
-		"camera_id", cameraID,
-		"new_termination", newTermination)
-	return true
+func (e *EventSubscriberImpl) subLocked(cameraID string) *pullPointSubscription {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.subscriptions[cameraID]
+}
+
+func (e *EventSubscriberImpl) setPS(cameraID string, fn func(p *pullPointSubscription)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.subscriptions[cameraID]; ok {
+		fn(p)
+	}
+}
+
+func (e *EventSubscriberImpl) refOf(cameraID string) string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.subscriptions[cameraID]; ok {
+		return p.subscriptionRef
+	}
+	return ""
+}
+
+func (e *EventSubscriberImpl) termOf(cameraID string) time.Time {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.subscriptions[cameraID]; ok {
+		return p.terminationTime
+	}
+	return time.Time{}
+}
+
+func (e *EventSubscriberImpl) grantedOf(cameraID string) time.Duration {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.subscriptions[cameraID]; ok {
+		return p.grantedDur
+	}
+	return e.subDuration
+}
+
+func (e *EventSubscriberImpl) pollErrsOf(cameraID string) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if p, ok := e.subscriptions[cameraID]; ok {
+		return p.pollErrs
+	}
+	return 0
+}
+
+// sleepInterruptible waits d, returning false if stopCh closed first.
+func sleepInterruptible(stopCh <-chan struct{}, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-stopCh:
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // parseNotificationMessage converts an onvif-go NotificationMessage to an ONVIFEvent.

--- a/internal/onvif/events_extra_test.go
+++ b/internal/onvif/events_extra_test.go
@@ -94,8 +94,8 @@ func TestEventSubscriberLifecycle(t *testing.T) {
 	// which lacks IsSubscribed) — same construction path the wrapper takes.
 	sub := NewEventSubscriber(client.client,
 		WithEventCallback(func(e ONVIFEvent) { eventsCh <- e }),
-		withPollInterval(30*time.Millisecond),
-		withPullTimeout(500*time.Millisecond),
+		WithPollInterval(30*time.Millisecond),
+		WithPullTimeout(500*time.Millisecond),
 	)
 	require.NotNil(t, sub)
 	require.False(t, sub.IsSubscribed("cam-1"))
@@ -146,7 +146,7 @@ func TestEventSubscriberSubscribeError(t *testing.T) {
 	client := NewClient(srv.URL, "admin", "pw")
 	require.NoError(t, client.Connect(context.Background()))
 
-	sub := NewEventSubscriber(client.client, withPollInterval(10*time.Millisecond))
+	sub := NewEventSubscriber(client.client, WithPollInterval(10*time.Millisecond))
 	err := sub.Subscribe(context.Background(), "cam-err")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "PullPoint subscription")
@@ -164,7 +164,7 @@ func TestEventSubscriberRenewalLoop(t *testing.T) {
 	eventsCh := make(chan ONVIFEvent, 4)
 	sub := NewEventSubscriber(client.client,
 		WithEventCallback(func(e ONVIFEvent) { eventsCh <- e }),
-		withPollInterval(20*time.Millisecond),
+		WithPollInterval(20*time.Millisecond),
 	)
 	require.NoError(t, sub.Subscribe(context.Background(), "cam-renew"))
 

--- a/internal/onvif/events_lifecycle_test.go
+++ b/internal/onvif/events_lifecycle_test.go
@@ -1,0 +1,193 @@
+package onvif
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	onvifgo "github.com/mickeyzzc/onvif-go/v2/onvif"
+	"github.com/stretchr/testify/require"
+)
+
+// motionMsg builds a MotionAlarm notification like the mibee_cam contract
+// emits (Source=CSI, Data State + Score).
+func motionMsg(state string, score string) onvifgo.NotificationMessage {
+	return onvifgo.NotificationMessage{
+		Topic: "tns1:VideoSource/MotionAlarm",
+		Message: onvifgo.EventMessage{
+			UtcTime: time.Now().UTC(),
+			Source:  []onvifgo.SimpleItem{{Name: "Source", Value: "CSI"}},
+			Data: []onvifgo.SimpleItem{
+				{Name: "State", Value: state},
+				{Name: "Score", Value: score},
+			},
+		},
+	}
+}
+
+// TestSubscriberDeliversEventsAndRenewsShortGrants: a device granting a short
+// term (mibee_cam grants 1h; 30min here to keep the test fast) must renew on
+// a sane cadence — the pre-#711 code renewed when < SubscriptionRenewBefore
+// (1h) remained, i.e. on EVERY poll tick for such devices.
+func TestSubscriberDeliversEventsAndRenewsShortGrants(t *testing.T) {
+	mock := &mockEventClient{
+		createPullPointFn: func(ctx context.Context, filter string, tt *time.Duration, policy string) (*onvifgo.PullPointSubscription, error) {
+			return &onvifgo.PullPointSubscription{
+				SubscriptionReference: "http://mock/sub/1",
+				CurrentTime:           time.Now(),
+				// Short grant (250ms): the renew threshold (max(grant/2, 2×poll))
+				// falls inside the test window, so renewal fires early.
+				TerminationTime: time.Now().Add(250 * time.Millisecond),
+			}, nil
+		},
+		pullMessagesFn: func(ctx context.Context, ref string, timeout time.Duration, limit int) ([]onvifgo.NotificationMessage, error) {
+			return []onvifgo.NotificationMessage{motionMsg("true", "87")}, nil
+		},
+		renewFn: func(ctx context.Context, ref string, d time.Duration) (time.Time, time.Time, error) {
+			// Renewal extends far out so it happens exactly once.
+			return time.Now(), time.Now().Add(10 * time.Minute), nil
+		},
+	}
+
+	var mu sync.Mutex
+	var received []ONVIFEvent
+	es := helperNewEventSubscriberWithMock(mock,
+		WithEventCallback(func(evt ONVIFEvent) { mu.Lock(); received = append(received, evt); mu.Unlock() }),
+		WithPollInterval(40*time.Millisecond),
+	)
+
+	require.NoError(t, es.Subscribe(context.Background(), "cam-1"))
+	defer es.StopAll(context.Background())
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.renewCalls.Load() >= 1 {
+			mu.Lock()
+			n := len(received)
+			mu.Unlock()
+			if n >= 2 {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, mock.renewCalls.Load(), int32(1),
+		"short-granted subscription must renew when < half the grant remains")
+	mu.Lock()
+	require.GreaterOrEqual(t, len(received), 2, "events must flow to the callback")
+	require.Equal(t, "tns1:VideoSource/MotionAlarm", received[0].Topic)
+	require.Equal(t, "87", received[0].Data["Score"])
+	mu.Unlock()
+
+	st := es.Status("cam-1")
+	require.True(t, st.Subscribed)
+	require.Equal(t, StateActive, st.State)
+	require.GreaterOrEqual(t, st.EventCount, int64(2))
+	require.False(t, st.LastEventAt.IsZero())
+}
+
+// TestSubscriberResubscribesAfterTerminalPollFailures: a subscription whose
+// PullMessages keep failing (expired / SubscriptionReferenceDereferenced /
+// device reboot) must be REBUILT, not polled forever — the pre-#711 loop
+// logged a warning per tick for eternity.
+func TestSubscriberResubscribesAfterTerminalPollFailures(t *testing.T) {
+	mock := &mockEventClient{
+		pullMessagesFn: func(ctx context.Context, ref string, timeout time.Duration, limit int) ([]onvifgo.NotificationMessage, error) {
+			return nil, errors.New("SubscriptionReferenceDereferenced")
+		},
+	}
+	es := helperNewEventSubscriberWithMock(mock, WithPollInterval(20*time.Millisecond))
+	require.NoError(t, es.Subscribe(context.Background(), "cam-1"))
+	defer es.StopAll(context.Background())
+
+	// 5 consecutive failures per cycle (terminalPollFailures) + rebuild.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.subscribeCalls.Load() >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.GreaterOrEqual(t, mock.subscribeCalls.Load(), int32(2),
+		"a dead subscription must be rebuilt, not polled forever")
+	require.True(t, es.IsSubscribed("cam-1"))
+}
+
+// TestSubscriberUnsupportedTombstone: a device answering "Action Not
+// Implemented" must not be re-probed by an internal retry loop.
+func TestSubscriberUnsupportedTombstone(t *testing.T) {
+	var calls int32
+	mock := &mockEventClient{
+		createPullPointFn: func(ctx context.Context, filter string, tt *time.Duration, policy string) (*onvifgo.PullPointSubscription, error) {
+			calls++
+			return nil, errors.New("SOAP fault: Action Not Implemented")
+		},
+	}
+	es := helperNewEventSubscriberWithMock(mock, WithPollInterval(20*time.Millisecond))
+
+	err := es.Subscribe(context.Background(), "cam-1")
+	require.ErrorIs(t, err, ErrEventsNotSupported)
+	require.False(t, es.IsSubscribed("cam-1"))
+
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, int32(1), calls, "no background retry loop for unsupported devices")
+	require.Equal(t, StateUnsupported, es.Status("cam-1").State)
+
+	// A repeat Subscribe (reconcile path) no-ops on the tombstone.
+	require.NoError(t, es.Subscribe(context.Background(), "cam-1"))
+	require.Equal(t, int32(1), calls)
+}
+
+// TestSubscriberStatusReportsLastError: transient poll errors surface in the
+// diagnostics without killing the subscription.
+func TestSubscriberStatusReportsLastError(t *testing.T) {
+	var fail bool
+	var mu sync.Mutex
+	mock := &mockEventClient{
+		pullMessagesFn: func(ctx context.Context, ref string, timeout time.Duration, limit int) ([]onvifgo.NotificationMessage, error) {
+			mu.Lock()
+			f := fail
+			mu.Unlock()
+			if f {
+				return nil, errors.New("temporary network hiccup")
+			}
+			return nil, nil
+		},
+	}
+	es := helperNewEventSubscriberWithMock(mock, WithPollInterval(20*time.Millisecond))
+	require.NoError(t, es.Subscribe(context.Background(), "cam-1"))
+	defer es.StopAll(context.Background())
+
+	mu.Lock()
+	fail = true
+	mu.Unlock()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if es.Status("cam-1").LastError != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NotEmpty(t, es.Status("cam-1").LastError)
+	require.True(t, es.IsSubscribed("cam-1"), "transient errors must not tear the subscription down")
+	require.GreaterOrEqual(t, es.Status("cam-1").ConsecutivePollErrors, 1)
+}
+
+func TestRenewThreshold(t *testing.T) {
+	// 24h grant → capped at SubscriptionRenewBefore (1h).
+	require.Equal(t, SubscriptionRenewBefore, renewThreshold(24*time.Hour, 5*time.Second))
+	// 1h grant (mibee_cam) → half: 30min.
+	require.Equal(t, 30*time.Minute, renewThreshold(time.Hour, 5*time.Second))
+	// Tiny grant → floored at 2× poll interval.
+	require.Equal(t, 2*time.Second, renewThreshold(500*time.Millisecond, time.Second))
+}
+
+func TestWithPollIntervalExported(t *testing.T) {
+	es := newEventSubscriber(nil, WithPollInterval(time.Second))
+	require.Equal(t, time.Second, es.pollInterval)
+	// Non-positive is ignored (default retained).
+	es = newEventSubscriber(nil, WithPollInterval(0))
+	require.Equal(t, DefaultPollInterval, es.pollInterval)
+}

--- a/internal/onvif/events_test.go
+++ b/internal/onvif/events_test.go
@@ -64,23 +64,20 @@ func (m *mockEventClient) RenewSubscription(ctx context.Context, subscriptionRef
 	return time.Now(), time.Now().Add(24 * time.Hour), nil
 }
 
-// helperNewEventSubscriberWithMock creates an EventSubscriberImpl with a mock client
-// that bypasses the *onvifgo.Client requirement.
+// helperNewEventSubscriberWithMock creates an EventSubscriberImpl driven by an
+// in-memory fake of the events service (the eventsAPI seam). Defaults are
+// applied BEFORE the caller's options so explicit opts win. A nil mock is
+// replaced by an empty one — a typed-nil interface would panic on method call.
 func helperNewEventSubscriberWithMock(mock *mockEventClient, opts ...EventSubscriberOption) *EventSubscriberImpl {
-	// We can't pass mock directly since it's not *onvifgo.Client.
-	// Instead, we create the struct directly.
-	es := &EventSubscriberImpl{
-		subscriptions: make(map[string]*pullPointSubscription),
-		stopCh:        make(map[string]chan struct{}),
-		pollInterval:  100 * time.Millisecond, // Fast for tests
-		pullTimeout:   1 * time.Second,
-		messageLimit:  10,
-		subDuration:   1 * time.Hour,
+	if mock == nil {
+		mock = &mockEventClient{}
 	}
-	for _, opt := range opts {
-		opt(es)
-	}
-	return es
+	all := append([]EventSubscriberOption{
+		WithPullTimeout(1 * time.Second),
+		WithSubscriptionDuration(1 * time.Hour),
+		withResubscribeBackoff(30 * time.Millisecond),
+	}, opts...)
+	return newEventSubscriber(mock, all...)
 }
 
 // --- Tests ---
@@ -110,9 +107,9 @@ func TestNewEventSubscriber_WithOptions(t *testing.T) {
 	es := helperNewEventSubscriberWithMock(
 		nil,
 		WithEventCallback(cb),
-		withPollInterval(2*time.Second),
-		withPullTimeout(10*time.Second),
-		withSubscriptionDuration(12*time.Hour),
+		WithPollInterval(2*time.Second),
+		WithPullTimeout(10*time.Second),
+		WithSubscriptionDuration(12*time.Hour),
 	)
 
 	require.NotNil(t, es)
@@ -311,7 +308,7 @@ func TestEventSubscriberImpl_EventCallbackReceivesEvents(t *testing.T) {
 	es := helperNewEventSubscriberWithMock(
 		nil,
 		WithEventCallback(cb),
-		withPollInterval(50*time.Millisecond),
+		WithPollInterval(50*time.Millisecond),
 	)
 
 	es.mu.Lock()

--- a/internal/onvif/interfaces.go
+++ b/internal/onvif/interfaces.go
@@ -54,6 +54,9 @@ type EventSubscriber interface {
 	Subscribe(ctx context.Context, cameraID string) error
 	Unsubscribe(ctx context.Context, cameraID string) error
 	GetEventMessages(ctx context.Context) ([]ONVIFEvent, error)
+	// Status reports per-camera subscription diagnostics (the "订阅挂了 or
+	// 相机没事件" discriminator for the UI diagnostics line, #711).
+	Status(cameraID string) EventSubscriptionStatus
 }
 
 // DeviceManager manages device-level operations on an ONVIF device.

--- a/internal/onvif/mocks.go
+++ b/internal/onvif/mocks.go
@@ -299,6 +299,10 @@ func (m *MockEventSubscriber) GetEventMessages(ctx context.Context) ([]ONVIFEven
 	return m.Events, m.Error
 }
 
+func (m *MockEventSubscriber) Status(cameraID string) EventSubscriptionStatus {
+	return EventSubscriptionStatus{Subscribed: m.SubscribeCalls > m.UnsubscribeCalls, State: StateActive}
+}
+
 var _ EventSubscriber = (*MockEventSubscriber)(nil)
 
 // MockDeviceManager is a testable DeviceManager.

--- a/internal/onvif/motion.go
+++ b/internal/onvif/motion.go
@@ -1,0 +1,47 @@
+package onvif
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MotionAlarm is a parsed tns1:VideoSource/MotionAlarm notification.
+//
+// mibee_cam family contract v1.5 §13: Source=CSI (WiFi-CSI motion sensing —
+// works with the MJPEG push in parallel, independent of light), Data carries
+// State ("true" = motion entered / "false" = cleared) and an optional Score
+// in 0–100. Standard ONVIF cameras emit the same topic with
+// Source=VideoSourceToken and Data State only.
+type MotionAlarm struct {
+	Active bool
+	Score  float64 // 0–100; 0 when the device omits it
+	Source string  // e.g. "CSI", "VideoSourceToken"
+}
+
+// ParseMotionAlarm extracts a MotionAlarm from a parsed ONVIF event. Returns
+// false for non-MotionAlarm topics or a missing/unparseable State item — the
+// camera-side queue (12 deep, drop-oldest) only makes the true/clear pairing
+// best-effort, so callers must tolerate clears that never arrive.
+func ParseMotionAlarm(evt ONVIFEvent) (MotionAlarm, bool) {
+	if !strings.Contains(strings.ToLower(evt.Topic), "motionalarm") {
+		return MotionAlarm{}, false
+	}
+	rawState, ok := evt.Data["State"].(string)
+	if !ok {
+		return MotionAlarm{}, false
+	}
+	active, err := strconv.ParseBool(strings.TrimSpace(rawState))
+	if err != nil {
+		return MotionAlarm{}, false
+	}
+	ma := MotionAlarm{Active: active}
+	if s, ok := evt.Data["Score"].(string); ok {
+		if f, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
+			ma.Score = f
+		}
+	}
+	if s, ok := evt.Data["source.Source"].(string); ok {
+		ma.Source = s
+	}
+	return ma, true
+}

--- a/internal/onvif/motion_test.go
+++ b/internal/onvif/motion_test.go
@@ -1,0 +1,79 @@
+package onvif
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMotionAlarm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mibee_cam CSI payload", func(t *testing.T) {
+		ma, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data: map[string]any{
+				"State":        "true",
+				"Score":        "87",
+				"source.Source": "CSI",
+			},
+		})
+		require.True(t, ok)
+		require.True(t, ma.Active)
+		require.Equal(t, 87.0, ma.Score)
+		require.Equal(t, "CSI", ma.Source)
+	})
+
+	t.Run("clear event", func(t *testing.T) {
+		ma, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data:  map[string]any{"State": "false"},
+		})
+		require.True(t, ok)
+		require.False(t, ma.Active)
+	})
+
+	t.Run("standard camera without score", func(t *testing.T) {
+		ma, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data:  map[string]any{"State": "true", "source.Source": "VideoSourceToken"},
+		})
+		require.True(t, ok)
+		require.True(t, ma.Active)
+		require.Zero(t, ma.Score)
+	})
+
+	t.Run("non-motion topic rejected", func(t *testing.T) {
+		_, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:Device/Humidity",
+			Data:  map[string]any{"State": "true"},
+		})
+		require.False(t, ok)
+	})
+
+	t.Run("missing state rejected", func(t *testing.T) {
+		_, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data:  map[string]any{"Score": "50"},
+		})
+		require.False(t, ok)
+	})
+
+	t.Run("garbage state rejected", func(t *testing.T) {
+		_, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data:  map[string]any{"State": "maybe"},
+		})
+		require.False(t, ok)
+	})
+
+	t.Run("garbage score tolerated", func(t *testing.T) {
+		ma, ok := ParseMotionAlarm(ONVIFEvent{
+			Topic: "tns1:VideoSource/MotionAlarm",
+			Data:  map[string]any{"State": "true", "Score": "high"},
+		})
+		require.True(t, ok)
+		require.True(t, ma.Active)
+		require.Zero(t, ma.Score)
+	})
+}

--- a/internal/onvif/motion_test.go
+++ b/internal/onvif/motion_test.go
@@ -13,8 +13,8 @@ func TestParseMotionAlarm(t *testing.T) {
 		ma, ok := ParseMotionAlarm(ONVIFEvent{
 			Topic: "tns1:VideoSource/MotionAlarm",
 			Data: map[string]any{
-				"State":        "true",
-				"Score":        "87",
+				"State":         "true",
+				"Score":         "87",
 				"source.Source": "CSI",
 			},
 		})

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -863,6 +863,17 @@ func (b *baseRecorder) PixelTriggerEvent(at time.Time, hold time.Duration) error
 	return nil
 }
 
+// MotionTriggerEvent injects a camera-side ONVIF MotionAlarm confirmation
+// (issue #711): same exit path as the audio/pixel triggers, attributed
+// reason=onvif_motion so field data can attribute exits correctly.
+func (b *baseRecorder) MotionTriggerEvent(at time.Time, hold time.Duration) error {
+	if b.adaptive == nil {
+		return fmt.Errorf("camera %s is not in adaptive recording mode", b.cfg.CameraID)
+	}
+	b.adaptive.audioLoudSrc(at, hold, "onvif_motion")
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Segment lifecycle (shared)
 // ---------------------------------------------------------------------------

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -344,6 +344,22 @@ func (r *ONVIFRecorder) PixelTriggerEvent(at time.Time, hold time.Duration) erro
 	return trig.PixelTriggerEvent(at, hold)
 }
 
+// MotionTriggerEvent forwards a camera-side ONVIF MotionAlarm confirmation
+// (#711) to the current delegate (same forwarding pattern as AudioTriggerEvent).
+func (r *ONVIFRecorder) MotionTriggerEvent(at time.Time, hold time.Duration) error {
+	d := r.Delegate()
+	if d == nil {
+		return fmt.Errorf("camera %s has no active stream delegate", r.cfg.CameraID)
+	}
+	trig, ok := d.(interface {
+		MotionTriggerEvent(at time.Time, hold time.Duration) error
+	})
+	if !ok {
+		return fmt.Errorf("camera %s does not support motion triggers (codec delegate without adaptive gate)", r.cfg.CameraID)
+	}
+	return trig.MotionTriggerEvent(at, hold)
+}
+
 // detectEncoding determines the stream encoding in priority order:
 //  1. RTSP DESCRIBE probe (authoritative — what the stream actually carries)
 //  2. Manual config (StreamEncoding field) — fallback when DESCRIBE is unavailable

--- a/internal/storage/db_camera.go
+++ b/internal/storage/db_camera.go
@@ -83,6 +83,9 @@ type CameraRow struct {
 	// drops to sparse keyframes while the compressed-domain activity signal
 	// stays calm. Adaptive holds its tuning knobs (nil = recorder defaults).
 	RecordingMode string `json:"recording_mode,omitempty"`
+	// MotionSource selects the camera's motion signal (#711): ""/"nvr" or
+	// "camera:onvif" (Pull-Point MotionAlarm subscription).
+	MotionSource string `json:"motion_source,omitempty"`
 	// RecordingTier marks the dual-stream tier (#637): ""/"single" or "tiered"
 	// (continuous sub-stream recording). Read by the tiered-recording service;
 	// changes apply on NVR restart.

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -893,6 +893,9 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	handler.SetSnapshotCapturer(snapCapturer)
 	// Shared trigger dispatcher (MQTT + webhook, #709).
 	handler.SetTriggerDispatcher(triggerDispatcher)
+	// Camera-side ONVIF MotionAlarm events ride the same action surface
+	// (#711) — record triggers behave identically to MQTT/webhook.
+	deps.camMgr.SetMotionActionHandler(triggerDispatcher)
 	api.SetAPIMetrics(m)
 	if deps.rollingMergeMgr != nil {
 		handler.SetTimelapseMergeMgr(deps.rollingMergeMgr)

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -213,6 +213,9 @@ export interface CreateCameraRequest {
   vision_targets?: string[];
   // Recording mode (#435). Omit = continuous.
   recording_mode?: string;
+  /** Motion signal source (#711): "nvr" (default) or "camera:onvif"
+   *  (Pull-Point MotionAlarm subscription). */
+  motion_source?: string;
   recording_tier?: string;
   adaptive?: AdaptiveRecordingConfig;
   // Loudness trigger for adaptive recording (#478); only effective with
@@ -268,6 +271,9 @@ export interface UpdateCameraRequest {
   vision_targets?: string[];
   // Recording mode (#435). Omit = unchanged. Changing it restarts the recorder.
   recording_mode?: string;
+  /** Motion signal source (#711): "nvr" (default) or "camera:onvif".
+   *  Reconciles immediately (no restart). */
+  motion_source?: string;
   recording_tier?: string;
   adaptive?: AdaptiveRecordingConfig;
   // Loudness trigger for adaptive recording (#478); only effective with

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -47,6 +47,7 @@
     import ImagingPanel from '$lib/components/ImagingPanel.svelte';
     import PresetManager from '$lib/components/PresetManager.svelte';
     import ONVIFEvents from '$lib/components/ONVIFEvents.svelte';
+  import MotionSubscriptionStatus from '$lib/components/MotionSubscriptionStatus.svelte';
     import DeviceManagement from '$lib/components/DeviceManagement.svelte';
     import { startBackfill, getUntranscodedRecordingCount } from '$lib/api/transcoding';
     import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
@@ -105,6 +106,7 @@
   // drops to sparse keyframes while the compressed-domain activity signal
   // stays calm and returns to full recording on activity.
   let formRecordingMode = $state<'continuous' | 'adaptive'>('continuous');
+  let formMotionSource = $state<'nvr' | 'camera:onvif'>('nvr');
   let formAdaptiveCalmThreshold = $state('');
   let formAdaptiveTimelapseInterval = $state('');
   let formAdaptiveSpikeFactor = $state('');
@@ -426,6 +428,7 @@ let validationErrors = $state<Record<string, string>>({});
     formCascadeEnabled = camera.cascade_enabled ?? true;
     formCascadeSubStream = camera.cascade_sub_stream ?? false;
     formRecordingMode = camera.recording_mode === 'adaptive' ? 'adaptive' : 'continuous';
+    formMotionSource = camera.motion_source === 'camera:onvif' ? 'camera:onvif' : 'nvr';
     formAdaptiveCalmThreshold = camera.adaptive?.calm_threshold ?? '';
     formAdaptiveTimelapseInterval = camera.adaptive?.timelapse_interval ?? '';
     formAdaptiveSpikeFactor = camera.adaptive?.spike_factor ? String(camera.adaptive.spike_factor) : '';
@@ -801,6 +804,7 @@ async function performCameraSave() {
             cascade_enabled: formCascadeEnabled,
             cascade_sub_stream: formCascadeSubStream,
             recording_mode: formRecordingMode,
+            motion_source: formProtocol === 'onvif' ? formMotionSource : undefined,
             recording_tier: formRecordingTier,
             adaptive: buildAdaptivePayload(),
             audio_trigger: buildAudioTriggerPayload(),
@@ -874,6 +878,7 @@ async function performCameraSave() {
             cascade_enabled: formCascadeEnabled,
             cascade_sub_stream: formCascadeSubStream,
             recording_mode: formRecordingMode,
+            motion_source: formProtocol === 'onvif' ? formMotionSource : undefined,
             recording_tier: formRecordingTier,
             adaptive: buildAdaptivePayload(),
             audio_trigger: buildAudioTriggerPayload(),
@@ -1071,6 +1076,23 @@ async function performCameraSave() {
           {formRecordingMode === 'adaptive' ? t('cameras.recordingModeAdaptiveHint') : t('cameras.recordingModeHint')}
         </p>
       </div>
+      {#if formProtocol === 'onvif'}
+        <!-- Motion source (#711): NVR-side detectors or the camera's own
+             Pull-Point MotionAlarm subscription (mibee_cam WiFi-CSI). -->
+        <div>
+          <label for="cam-motion-source" class="input-label">{t('cameras.motionSource')}</label>
+          <select id="cam-motion-source" class="input" bind:value={formMotionSource}>
+            <option value="nvr">{t('cameras.motionSourceNvr')}</option>
+            <option value="camera:onvif">{t('cameras.motionSourceCamera')}</option>
+          </select>
+          <p class="text-xs th-text-muted mt-1">
+            {formMotionSource === 'camera:onvif' ? t('cameras.motionSourceCameraHint') : t('cameras.motionSourceNvrHint')}
+          </p>
+          {#if formMotionSource === 'camera:onvif' && editingCamera}
+            <MotionSubscriptionStatus cameraId={editingCamera.id} />
+          {/if}
+        </div>
+      {/if}
       {#if formProtocol !== 'srt' && formProtocol !== 'rtmp' && formProtocol !== 'whip'}
         <!-- Recording tier (#637): tiered adds a continuous sub-stream channel -->
         <div>

--- a/web/src/lib/components/CameraForm.svelte
+++ b/web/src/lib/components/CameraForm.svelte
@@ -1062,20 +1062,6 @@ async function performCameraSave() {
         {t('cameras.recordingEnabled')}
       </label>
     </div>
-    {#if !formRecordingEnabled}
-      <p class="text-xs th-text-muted -mt-1">{t('cameras.recordingDisabledHint')}</p>
-    {:else if formEncoding === 'h264' || formEncoding === 'h265'}
-      <!-- Recording mode (#435): continuous or adaptive (motion-aware sparse) -->
-      <div>
-        <label for="cam-recording-mode" class="input-label">{t('cameras.recordingMode')}</label>
-        <select id="cam-recording-mode" class="input" bind:value={formRecordingMode}>
-          <option value="continuous">{t('cameras.recordingModeContinuous')}</option>
-          <option value="adaptive">{t('cameras.recordingModeAdaptive')}</option>
-        </select>
-        <p class="text-xs th-text-muted mt-1">
-          {formRecordingMode === 'adaptive' ? t('cameras.recordingModeAdaptiveHint') : t('cameras.recordingModeHint')}
-        </p>
-      </div>
       {#if formProtocol === 'onvif'}
         <!-- Motion source (#711): NVR-side detectors or the camera's own
              Pull-Point MotionAlarm subscription (mibee_cam WiFi-CSI). -->
@@ -1093,6 +1079,20 @@ async function performCameraSave() {
           {/if}
         </div>
       {/if}
+    {#if !formRecordingEnabled}
+      <p class="text-xs th-text-muted -mt-1">{t('cameras.recordingDisabledHint')}</p>
+    {:else if formEncoding === 'h264' || formEncoding === 'h265'}
+      <!-- Recording mode (#435): continuous or adaptive (motion-aware sparse) -->
+      <div>
+        <label for="cam-recording-mode" class="input-label">{t('cameras.recordingMode')}</label>
+        <select id="cam-recording-mode" class="input" bind:value={formRecordingMode}>
+          <option value="continuous">{t('cameras.recordingModeContinuous')}</option>
+          <option value="adaptive">{t('cameras.recordingModeAdaptive')}</option>
+        </select>
+        <p class="text-xs th-text-muted mt-1">
+          {formRecordingMode === 'adaptive' ? t('cameras.recordingModeAdaptiveHint') : t('cameras.recordingModeHint')}
+        </p>
+      </div>
       {#if formProtocol !== 'srt' && formProtocol !== 'rtmp' && formProtocol !== 'whip'}
         <!-- Recording tier (#637): tiered adds a continuous sub-stream channel -->
         <div>

--- a/web/src/lib/components/MotionSubscriptionStatus.svelte
+++ b/web/src/lib/components/MotionSubscriptionStatus.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { API_BASE, getAuthHeader } from '$lib/api';
+  import { t } from '$lib/i18n';
+
+  interface Props {
+    cameraId: string;
+  }
+
+  let { cameraId }: Props = $props();
+
+  interface SubStatus {
+    subscribed?: boolean;
+    state?: string;
+    event_count?: number;
+    last_event_at?: string;
+    last_error?: string;
+    consecutive_poll_errors?: number;
+  }
+
+  let status = $state<SubStatus | null>(null);
+
+  onMount(() => {
+    let stopped = false;
+    const load = async () => {
+      try {
+        const resp = await fetch(`${API_BASE}/cameras/${encodeURIComponent(cameraId)}/onvif-events`, {
+          headers: { ...getAuthHeader() }
+        });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (!stopped) status = data;
+      } catch {
+        // transient — next poll retries
+      }
+    };
+    load();
+    const timer = setInterval(load, 15_000);
+    return () => {
+      stopped = true;
+      clearInterval(timer);
+    };
+  });
+
+  let stateLabel = $derived.by(() => {
+    if (!status) return t('cameras.motionSubLoading');
+    if (status.state === 'active') return t('cameras.motionSubActive');
+    if (status.state === 'resubscribing') return t('cameras.motionSubResubscribing');
+    if (status.state === 'unsupported') return t('cameras.motionSubUnsupported');
+    return t('cameras.motionSubIdle');
+  });
+
+  let lastEvent = $derived.by(() => {
+    if (!status?.last_event_at) return '';
+    const d = new Date(status.last_event_at);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleTimeString();
+  });
+</script>
+
+<p class="text-xs th-text-muted mt-1 flex flex-wrap items-center gap-x-2">
+  <span>{t('cameras.motionSubState')}: {stateLabel}</span>
+  {#if status?.state === 'active'}
+    <span>· {t('cameras.motionSubEvents')}: {status.event_count ?? 0}</span>
+    {#if lastEvent}
+      <span>· {t('cameras.motionSubLastEvent')}: {lastEvent}</span>
+    {/if}
+  {/if}
+  {#if status?.last_error}
+    <span class="text-amber-500" title={status.last_error}>
+      · {t('cameras.motionSubError')}: {status.last_error.slice(0, 80)}
+    </span>
+  {/if}
+</p>

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1906,5 +1906,19 @@
   "cameras.visionRoutingHint": "Choose which vision instances receive this camera's recordings; unchecked = all enabled instances.",
   "cameras.visionRoutingDisabled": "disabled",
   "aiEvents.sourceFilter": "Source instance",
-  "aiEvents.allSources": "All sources"
+  "aiEvents.allSources": "All sources",
+  "cameras.motionSource": "Motion detection source",
+  "cameras.motionSourceNvr": "NVR-side detection",
+  "cameras.motionSourceCamera": "Camera-side (ONVIF events)",
+  "cameras.motionSourceNvrHint": "The NVR detects activity from the video stream itself (adaptive compressed-domain signal / pixel gate).",
+  "cameras.motionSourceCameraHint": "Subscribe to the camera's ONVIF MotionAlarm events (e.g. mibee_cam WiFi-CSI): motion immediately triggers recording / exits timelapse.",
+  "cameras.motionSubState": "Subscription",
+  "cameras.motionSubLoading": "querying…",
+  "cameras.motionSubActive": "active",
+  "cameras.motionSubResubscribing": "resubscribing",
+  "cameras.motionSubUnsupported": "unsupported by device",
+  "cameras.motionSubIdle": "not subscribed",
+  "cameras.motionSubEvents": "events",
+  "cameras.motionSubLastEvent": "last event",
+  "cameras.motionSubError": "last error"
 }

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1905,5 +1905,19 @@
   "cameras.visionRoutingHint": "选择该摄像头的录像推送给哪些 Vision 实例;不勾选 = 全部启用实例。",
   "cameras.visionRoutingDisabled": "已停用",
   "aiEvents.sourceFilter": "来源实例",
-  "aiEvents.allSources": "全部来源"
+  "aiEvents.allSources": "全部来源",
+  "cameras.motionSource": "运动侦测来源",
+  "cameras.motionSourceNvr": "NVR 侧侦测",
+  "cameras.motionSourceCamera": "相机侧侦测（ONVIF 事件）",
+  "cameras.motionSourceNvrHint": "NVR 从视频流自行侦测活动（自适应压缩域信号 / 像素门控）。",
+  "cameras.motionSourceCameraHint": "订阅相机的 ONVIF MotionAlarm 事件（如 mibee_cam 的 WiFi CSI 感知）：有人活动时立即触发录像 / 退出延时模式。",
+  "cameras.motionSubState": "订阅",
+  "cameras.motionSubLoading": "查询中…",
+  "cameras.motionSubActive": "正常",
+  "cameras.motionSubResubscribing": "重建中",
+  "cameras.motionSubUnsupported": "设备不支持",
+  "cameras.motionSubIdle": "未订阅",
+  "cameras.motionSubEvents": "已收事件",
+  "cameras.motionSubLastEvent": "最近事件",
+  "cameras.motionSubError": "最近错误"
 }


### PR DESCRIPTION
The main feature of #711: 相机侧运动事件触发采集. Cameras with `motion_source: camera:onvif` run a supervised Pull-Point subscription against their ONVIF event service (mibee_cam WiFi-CSI contract v1.5 §13, or any standard camera's motion detection).

**Event flow** — MotionAlarm `State=true` drives:
- the shared trigger dispatcher action surface (`record` — identical semantics to MQTT #660 / webhook #709), and
- for adaptive cameras, a timelapse exit with `reason=onvif_motion` (same GOP + pre-capture backfill path as the audio/pixel triggers) — the natural 有人才拍摄 loop: the gate re-enters timelapse via its calm logic once motion stops.
- `State=false` intentionally triggers nothing (a dispatcher stop would kill sessions other sources started; dropped clears are tolerated per the 12-deep drop-oldest queue).
- Every event republishes under `onvif.*` on the event bus → the existing ONVIFEvents SSE panel lights up.

**Subscription lifecycle** (was: a 2024-era dead-wiring subscription that never recovered from expiry):
- renewal at `min(granted/2, 1h)` remaining — short-granting devices (mibee_cam grants exactly 1h) no longer renew every poll tick;
- rebuild with backoff after 5 consecutive poll failures (expiry / SubscriptionReferenceDereferenced / reboot);
- unsupported devices tombstone (single probe, no retry storm);
- per-camera diagnostics (`GET /api/cameras/{id}/onvif-events`) — the 订阅挂了 vs 相机没事件 discriminator;
- contract points pinned in code comments: single-subscription later-wins, 120s no-pull expiry, queue depth 12 drop-oldest, no replay.

**Config/UI**: camera-level `motion_source` (validated allowlist + onvif-protocol gate, create/update API, CameraRow), CameraForm dropdown (zh/en) + live subscription status line, works for live-only cameras too.

M5 field-verified: PUT motion_source → reconcile → real camera (视通 V4.0) answers "Action not supported" → clean tombstone, status endpoint reports `state: unsupported` + the fault, config round-trips restarts, UI dropdown + status line render with the persisted value. Full lifecycle covered by unit tests against a fake SOAP service; real-device acceptance on n16r8/seeed boards pending camera-team firmware availability (their boards flash next cycle).

Score→motion_score per-segment merge deliberately deferred: needs an aggregation design (map camera events onto covering segments) — tracked in the issue.