### PR TITLE
feat(cam-compat): route trt:* SOAP to advertised media endpoint + adopt probed MJPEG connection (#723)

### DIFF
--- a/internal/onvif/client.go
+++ b/internal/onvif/client.go
@@ -30,6 +30,12 @@ type Client struct {
 
 	cachedCapabilities *DeviceCapabilitiesDetailed
 	capsMu             sync.Mutex
+
+	// mediaRoute is the advertised media XAddr for trt:* raw SOAP, resolved
+	// once via GetServices (#723). Guarded by mu — getRawStreamURI callers
+	// already hold it.
+	mediaRoute         string
+	mediaRouteResolved bool
 }
 
 // NewClient creates a new ONVIF client for a specific device.
@@ -180,6 +186,8 @@ func (c *Client) GetStreamURIWithProtocol(ctx context.Context, profileToken, pro
 
 // getRawStreamURI sends a raw SOAP GetStreamUri request and parses the response.
 // This works around XML namespace parsing issues in onvif-go with some devices.
+// The request is routed to the device's advertised media endpoint when one is
+// known (#723): minimal devices reject trt:* on device_service.
 func (c *Client) getRawStreamURI(ctx context.Context, profileToken, protocol string) (string, error) {
 	soapBody := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
@@ -198,7 +206,28 @@ func (c *Client) getRawStreamURI(ctx context.Context, profileToken, protocol str
   </s:Body>
 </s:Envelope>`, protocol, profileToken)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, strings.NewReader(soapBody))
+	// Resolve the media endpoint, best-effort: a definitive "no media
+	// advertised" is cached; transport errors are retried on the next raw
+	// media call. On failure we keep the legacy device-endpoint behavior
+	// (strict devices fault trt:* there, and callers fall back to other
+	// transports).
+	if c.mediaRoute == "" && !c.mediaRouteResolved {
+		if m, err := resolveMediaEndpoint(ctx, c.endpoint); err != nil {
+			logger.Debug("GetServices media endpoint resolution failed, using device endpoint", "device", c.endpoint, "error", err)
+		} else {
+			c.mediaRouteResolved = true
+			if m != "" {
+				c.mediaRoute = m
+				logger.Info("routing media SOAP actions to advertised media endpoint", "device", c.endpoint, "media", m)
+			}
+		}
+	}
+	endpoint := c.endpoint
+	if c.mediaRoute != "" {
+		endpoint = c.mediaRoute
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(soapBody))
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}

--- a/internal/onvif/client_media_route_test.go
+++ b/internal/onvif/client_media_route_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+
+// Raw-SOAP media routing (#723): trt:* requests must go to the media endpoint
+// the device advertises via GetServices. Minimal devices (ESP32 MiBeeCam)
+// fault media actions on device_service, so the NVR's raw GetStreamUri path
+// has to follow the advertisement instead of posting to the device endpoint.
+
+package onvif
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const soapFaultMediaUnsupported = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <s:Fault>
+      <s:Code><s:Value>s:Sender</s:Value><s:Subcode><s:Value>ter:ActionNotSupported</s:Value></s:Subcode></s:Code>
+      <s:Reason><s:Text xml:lang="en">Unsupported device action</s:Text></s:Reason>
+    </s:Fault>
+  </s:Body>
+</s:Envelope>`
+
+// mediaRouteServer is an ONVIF device that hosts the media service on a
+// distinct path: GetServices on device_service advertises the media XAddr,
+// and media actions are only answered there (device_service faults them —
+// the behavior the ESP32 MiBeeCam firmware shows).
+type mediaRouteServer struct {
+	srv        *httptest.Server
+	mediaXAddr atomic.Value // string
+
+	getServices        atomic.Int32
+	mediaHits          atomic.Int32 // GetStreamUri requests that correctly reached media_service
+	deviceMediaRequest atomic.Int32 // GetStreamUri requests that reached device_service
+
+	getServicesFails    bool // serve 500 for GetServices (fallback scenario)
+	answerMediaOnDevice bool // tolerant device: answer trt:* on device_service too
+}
+
+func newMediaRouteServer(t *testing.T) *mediaRouteServer {
+	t.Helper()
+	m := &mediaRouteServer{}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	m.srv = &httptest.Server{
+		Listener: ln,
+		Config:   &http.Server{Handler: http.HandlerFunc(m.serve)},
+	}
+	m.srv.Start()
+	t.Cleanup(m.srv.Close)
+	m.mediaXAddr.Store("http://" + ln.Addr().String() + "/onvif/media_service")
+	return m
+}
+
+func (m *mediaRouteServer) deviceEndpoint() string {
+	return "http://" + m.srv.Listener.Addr().String() + "/onvif/device_service"
+}
+
+func (m *mediaRouteServer) serve(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	b := string(body)
+	w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+
+	if strings.HasSuffix(r.URL.Path, "/onvif/media_service") {
+		if strings.Contains(b, "GetStreamUri") {
+			m.mediaHits.Add(1)
+			fmt.Fprint(w, soapGetStreamURIResponse)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, soapFaultResponse)
+		return
+	}
+
+	// device_service
+	switch {
+	case strings.Contains(b, "GetServices"):
+		m.getServices.Add(1)
+		if m.getServicesFails {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, soapFaultResponse)
+			return
+		}
+		fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body>
+    <tcr:GetServicesResponse xmlns:tcr="http://www.onvif.org/ver10/device/wsdl">
+      <tcr:Service><tcr:Namespace>http://www.onvif.org/ver10/device/wsdl</tcr:Namespace><tcr:XAddr>%s</tcr:XAddr></tcr:Service>
+      <tcr:Service><tcr:Namespace>http://www.onvif.org/ver10/media/wsdl</tcr:Namespace><tcr:XAddr>%s</tcr:XAddr></tcr:Service>
+    </tcr:GetServicesResponse>
+  </s:Body>
+</s:Envelope>`, m.deviceEndpoint(), m.mediaXAddr.Load().(string))
+	case strings.Contains(b, "GetStreamUri"):
+		m.deviceMediaRequest.Add(1)
+		if m.answerMediaOnDevice {
+			fmt.Fprint(w, soapGetStreamURIResponse)
+			return
+		}
+		fmt.Fprint(w, soapFaultMediaUnsupported)
+	case strings.Contains(b, "GetCapabilities"):
+		fmt.Fprint(w, soapGetCapabilitiesResponse)
+	case strings.Contains(b, "GetSystemDateAndTime"):
+		fmt.Fprint(w, soapSystemDateAndTime(time.Now()))
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, soapFaultResponse)
+	}
+}
+
+func TestGetStreamURIWithProtocolRoutesToMediaEndpoint(t *testing.T) {
+	m := newMediaRouteServer(t)
+	client := NewClient(m.deviceEndpoint(), "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	info, err := client.GetStreamURIWithProtocol(context.Background(), "profile_1", "HTTP")
+	require.NoError(t, err)
+	require.Equal(t, "rtsp://192.168.1.100:554/stream1", info.URI)
+
+	require.Equal(t, int32(1), m.mediaHits.Load(), "GetStreamUri must land on media_service")
+	require.Equal(t, int32(0), m.deviceMediaRequest.Load(), "GetStreamUri must not hit device_service")
+	require.GreaterOrEqual(t, m.getServices.Load(), int32(1), "routing must consult GetServices")
+
+	// Second call reuses the cached route without a fresh GetServices.
+	_, err = client.GetStreamURIWithProtocol(context.Background(), "profile_1", "RTSP")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), m.mediaHits.Load())
+	require.Equal(t, int32(1), m.getServices.Load())
+}
+
+func TestMediaRouteStaleHostIsRewritten(t *testing.T) {
+	m := newMediaRouteServer(t)
+	// Advertise the media XAddr with a stale host (camera roamed): the route
+	// must be rewritten to the device endpoint's host, not dialed as-is.
+	advertised, ok := m.mediaXAddr.Load().(string)
+	require.True(t, ok)
+	u, err := url.Parse(advertised)
+	require.NoError(t, err)
+	u.Host = "192.0.2.99" + portSuffix(u)
+	m.mediaXAddr.Store(u.String())
+
+	client := NewClient(m.deviceEndpoint(), "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	info, err := client.GetStreamURIWithProtocol(context.Background(), "profile_1", "HTTP")
+	require.NoError(t, err)
+	require.Equal(t, "rtsp://192.168.1.100:554/stream1", info.URI)
+	require.Equal(t, int32(1), m.mediaHits.Load(), "rewritten route must reach the real server")
+	require.Equal(t, int32(0), m.deviceMediaRequest.Load())
+}
+
+func TestMediaRouteFallsBackToDeviceEndpointWhenUnadvertised(t *testing.T) {
+	m := newMediaRouteServer(t)
+	m.getServicesFails = true    // device has no usable GetServices
+	m.answerMediaOnDevice = true // …and tolerates trt:* on device_service
+
+	client := NewClient(m.deviceEndpoint(), "admin", "pw")
+	require.NoError(t, client.Connect(context.Background()))
+
+	info, err := client.GetStreamURIWithProtocol(context.Background(), "profile_1", "HTTP")
+	require.NoError(t, err)
+	require.Equal(t, "rtsp://192.168.1.100:554/stream1", info.URI)
+	require.Equal(t, int32(0), m.mediaHits.Load())
+	require.Equal(t, int32(1), m.deviceMediaRequest.Load())
+	require.Empty(t, client.mediaRoute, "failed resolution must not be cached as a route")
+
+	// A failed resolution is retried on the next raw media call (transient
+	// GetServices errors are not treated as a definitive absence).
+	_, err = client.GetStreamURIWithProtocol(context.Background(), "profile_1", "RTSP")
+	require.NoError(t, err)
+	require.Equal(t, int32(2), m.getServices.Load())
+	require.Equal(t, int32(2), m.deviceMediaRequest.Load())
+}
+
+func TestResolveMediaEndpointPicksVer20WhenVer10Missing(t *testing.T) {
+	var mediaHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "GetServices") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		mediaHits.Add(1)
+		fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">
+  <s:Body><GetServicesResponse xmlns="http://www.onvif.org/ver10/device/wsdl">
+    <Service><Namespace>http://www.onvif.org/ver20/media/wsdl</Namespace><XAddr>http://%s/onvif/media2</XAddr></Service>
+  </GetServicesResponse></s:Body>
+</s:Envelope>`, r.Host)
+		w.Header().Set("Content-Type", "application/soap+xml")
+	}))
+	t.Cleanup(srv.Close)
+
+	got, err := resolveMediaEndpoint(context.Background(), srv.URL+"/onvif/device_service")
+	require.NoError(t, err)
+	require.Equal(t, "http://"+srv.Listener.Addr().String()+"/onvif/media2", got)
+}
+
+func TestRewriteStaleHost(t *testing.T) {
+	cases := []struct {
+		name   string
+		xaddr  string
+		device string
+		want   string
+	}{
+		{"same host untouched", "http://1.2.3.4:80/onvif/media_service", "http://1.2.3.4:80/onvif/device_service", "http://1.2.3.4:80/onvif/media_service"},
+		{"stale host rewritten", "http://192.0.2.99:80/onvif/media_service", "http://10.0.0.7:80/onvif/device_service", "http://10.0.0.7:80/onvif/media_service"},
+		{"unparseable xaddr untouched", "::::", "http://10.0.0.7:80/onvif/device_service", "::::"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, rewriteStaleHost(tc.xaddr, tc.device))
+		})
+	}
+}
+
+// portSuffix returns ":port" (empty when the URL has no explicit port).
+func portSuffix(u *url.URL) string {
+	if u.Port() == "" {
+		return ""
+	}
+	return ":" + u.Port()
+}

--- a/internal/onvif/media_route.go
+++ b/internal/onvif/media_route.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+package onvif
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ONVIF service namespaces whose SOAP actions must be routed away from the
+// device service endpoint (#723): trt:* (media) belongs at the media XAddr the
+// device advertises. Minimal implementations (ESP32 MiBeeCam firmware) answer
+// "Unsupported device action" when trt:* lands on device_service, so raw-SOAP
+// media calls must follow the advertisement instead of relying on fallbacks.
+const (
+	nsMediaVer10 = "http://www.onvif.org/ver10/media/wsdl"
+	nsMediaVer20 = "http://www.onvif.org/ver20/media/wsdl"
+)
+
+const soapGetServices = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"
+ xmlns:tds="http://www.onvif.org/ver10/device/wsdl">
+  <s:Body>
+    <tds:GetServices>
+      <tds:IncludeCapability>false</tds:IncludeCapability>
+    </tds:GetServices>
+  </s:Body>
+</s:Envelope>`
+
+// fetchServiceXAddrs asks the device service which endpoints host which
+// namespaces and returns a namespace → XAddr map.
+func fetchServiceXAddrs(ctx context.Context, deviceEndpoint string) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, deviceEndpoint, strings.NewReader(soapGetServices))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/soap+xml")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Body struct {
+			GetServicesResponse struct {
+				Service []struct {
+					Namespace string `xml:"Namespace"`
+					XAddr     string `xml:"XAddr"`
+				} `xml:"Service"`
+			} `xml:"GetServicesResponse"`
+		} `xml:"Body"`
+	}
+	if err := xml.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	xaddrs := make(map[string]string, len(envelope.Body.GetServicesResponse.Service))
+	for _, svc := range envelope.Body.GetServicesResponse.Service {
+		if svc.Namespace != "" && svc.XAddr != "" {
+			xaddrs[svc.Namespace] = svc.XAddr
+		}
+	}
+	if len(xaddrs) == 0 {
+		return nil, fmt.Errorf("no services advertised")
+	}
+	return xaddrs, nil
+}
+
+// resolveMediaEndpoint returns the advertised media-service XAddr, rewritten
+// to the device endpoint's host when the advertisement is stale (camera roamed
+// to a new address; mirrors the library's fixServiceURL). Empty string means
+// nothing usable was advertised — callers keep the device endpoint.
+func resolveMediaEndpoint(ctx context.Context, deviceEndpoint string) (string, error) {
+	xaddrs, err := fetchServiceXAddrs(ctx, deviceEndpoint)
+	if err != nil {
+		return "", err
+	}
+	advertised := xaddrs[nsMediaVer10]
+	if advertised == "" {
+		advertised = xaddrs[nsMediaVer20]
+	}
+	if advertised == "" {
+		return "", nil
+	}
+	return rewriteStaleHost(advertised, deviceEndpoint), nil
+}
+
+// rewriteStaleHost swaps the XAddr's host for the device endpoint's host when
+// the two disagree, keeping the advertised scheme and path.
+func rewriteStaleHost(xaddr, deviceEndpoint string) string {
+	xu, err := url.Parse(xaddr)
+	if err != nil || xu.Host == "" {
+		return xaddr
+	}
+	du, err := url.Parse(deviceEndpoint)
+	if err != nil || du.Host == "" || du.Host == xu.Host {
+		return xaddr
+	}
+	xu.Host = du.Host
+	return xu.String()
+}

--- a/internal/recorder/http_jpeg.go
+++ b/internal/recorder/http_jpeg.go
@@ -62,6 +62,14 @@ type HTTPJPEGRecorder struct {
 	done         chan struct{}
 	watchdogDone chan struct{}
 
+	// adoptedResp/adoptedCancel hold a probe's already-open MJPEG response
+	// (#723): the ONVIF recorder probes candidate URLs before handing over,
+	// and re-dialing the just-probed URL trips ESP32 anti-hammer guards
+	// (<5s between connections arms them). Consumed by the first
+	// connectAndStream; later reconnects dial normally. Guarded by mu.
+	adoptedResp   *http.Response
+	adoptedCancel context.CancelFunc
+
 	lastFrameTime   atomic.Int64 // Unix timestamp of last received frame
 	curTempPath     string
 	curFinalPath    string
@@ -253,6 +261,7 @@ func (r *HTTPJPEGRecorder) Stop() error {
 	if r.watchdogDone != nil {
 		<-r.watchdogDone
 	}
+	r.discardAdoptedStream() // covers never-started recorders holding an adopted probe
 	r.decActive()
 	return nil
 }
@@ -273,6 +282,7 @@ func (r *HTTPJPEGRecorder) run(ctx context.Context) {
 	defer close(r.done)
 	defer r.setStatus(model.StatusStopped)
 	defer r.closeCurrentSegment()
+	defer r.discardAdoptedStream()
 
 	runReconnectLoop(ctx, reconnectDeps{
 		CameraID: r.cfg.CameraID,
@@ -333,6 +343,38 @@ func (r *HTTPJPEGRecorder) idleWatchdog(ctx context.Context) {
 	}
 }
 
+// AdoptStream hands the recorder an already-open MJPEG response — typically
+// the ONVIF recorder's probe connection — so the first stream cycle continues
+// it instead of re-dialing the URL (#723: two TCP connects within the ESP32
+// anti-hammer window arm the device's guard). The cancel func releases the
+// detached request context once the response is done.
+func (r *HTTPJPEGRecorder) AdoptStream(resp *http.Response, cancel context.CancelFunc) {
+	if resp == nil {
+		return
+	}
+	r.mu.Lock()
+	r.adoptedResp = resp
+	r.adoptedCancel = cancel
+	r.mu.Unlock()
+}
+
+// discardAdoptedStream closes a never-consumed adopted response (recorder
+// stopped before the first connect cycle ran).
+func (r *HTTPJPEGRecorder) discardAdoptedStream() {
+	r.mu.Lock()
+	resp := r.adoptedResp
+	cancel := r.adoptedCancel
+	r.adoptedResp = nil
+	r.adoptedCancel = nil
+	r.mu.Unlock()
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if cancel != nil {
+		cancel()
+	}
+}
+
 // connectAndStream opens an HTTP connection to the MJPEG stream and parses frames.
 func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 	defer func() {
@@ -343,18 +385,35 @@ func (r *HTTPJPEGRecorder) connectAndStream(ctx context.Context) (error, bool) {
 		}
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.cfg.URL, nil)
-	if err != nil {
-		return fmt.Errorf("create request: %w", err), false
-	}
-	if r.cfg.Username != "" {
-		req.SetBasicAuth(r.cfg.Username, r.cfg.Password)
-	}
+	// Prefer an adopted probe connection (#723): continuing it avoids a
+	// second TCP dial within the device's anti-hammer window. Consumed once;
+	// reconnects after this stream ends dial normally (through the ≥5s
+	// reconnect floor).
+	r.mu.Lock()
+	resp := r.adoptedResp
+	adoptedCancel := r.adoptedCancel
+	r.adoptedResp = nil
+	r.adoptedCancel = nil
+	r.mu.Unlock()
+	if resp != nil {
+		httpJpegLogger.Info("continuing probed MJPEG connection", "camera_id", r.cfg.CameraID, "url", r.cfg.URL)
+		if adoptedCancel != nil {
+			defer adoptedCancel()
+		}
+	} else {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.cfg.URL, nil)
+		if err != nil {
+			return fmt.Errorf("create request: %w", err), false
+		}
+		if r.cfg.Username != "" {
+			req.SetBasicAuth(r.cfg.Username, r.cfg.Password)
+		}
 
-	httpJpegLogger.Info("connecting to MJPEG stream", "camera_id", r.cfg.CameraID, "url", r.cfg.URL)
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("http connect: %w", err), false
+		httpJpegLogger.Info("connecting to MJPEG stream", "camera_id", r.cfg.CameraID, "url", r.cfg.URL)
+		resp, err = r.client.Do(req)
+		if err != nil {
+			return fmt.Errorf("http connect: %w", err), false
+		}
 	}
 	defer resp.Body.Close()
 

--- a/internal/recorder/http_jpeg_adopt_test.go
+++ b/internal/recorder/http_jpeg_adopt_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+
+// Probe-connection adoption (#723): the ONVIF recorder probes MJPEG candidate
+// URLs before handing over to the HTTP-JPEG recorder; on ESP32-class devices
+// with anti-hammer guards, re-dialing the just-probed URL within the guard
+// window (<5s between connections) arms the guard. The probe's open response
+// must therefore become the recorder's stream connection — one TCP dial total.
+
+package recorder
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// adoptTestJPEG carries valid JPEG magic bytes (SOI + EOI) so the recorder's
+// frame validation accepts it.
+var adoptTestJPEG = []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x04, 0xFF, 0xD9}
+
+func TestHTTPJPEGRecorderAdoptsProbedConnection(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=frame")
+		w.WriteHeader(http.StatusOK)
+		for range 400 {
+			fmt.Fprintf(w, "--frame\r\nContent-Length: %d\r\n\r\n", len(adoptTestJPEG))
+			_, _ = w.Write(adoptTestJPEG)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// The ONVIF probe flow: header-only wait on a detached context.
+	probeClient := &http.Client{Timeout: 0, Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, probeCancel, err := probeMJPEGHeaders(context.Background(), probeClient, srv.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, int32(1), requests.Load(), "the probe must be the only dial so far")
+
+	recordDisabled := false // live-only: exercise the frame path, skip segment I/O
+	rec := NewHTTPJPEGRecorder(HTTPJPEGConfig{
+		CameraID:      "adopt-cam",
+		URL:           srv.URL,
+		RecordEnabled: &recordDisabled,
+	}, &mockSegmentStore{})
+	rec.AdoptStream(resp, probeCancel)
+
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		stop()
+		_ = rec.Stop()
+	})
+	require.NoError(t, rec.Start(ctx))
+
+	require.Eventually(t, func() bool { return rec.LatestFrame() != nil },
+		5*time.Second, 50*time.Millisecond, "frames must flow over the adopted connection")
+
+	// The whole point (#723): the recorder must continue the probed
+	// connection instead of dialing the same URL again.
+	require.Equal(t, int32(1), requests.Load(), "recorder must not re-dial the just-probed URL")
+}
+
+func TestHTTPJPEGRecorderWithoutAdoptionDialsItself(t *testing.T) {
+	// Control: with no adopted response the recorder dials normally.
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=frame")
+		w.WriteHeader(http.StatusOK)
+		for range 400 {
+			fmt.Fprintf(w, "--frame\r\nContent-Length: %d\r\n\r\n", len(adoptTestJPEG))
+			_, _ = w.Write(adoptTestJPEG)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	recordDisabled := false
+	rec := NewHTTPJPEGRecorder(HTTPJPEGConfig{
+		CameraID:      "dial-cam",
+		URL:           srv.URL,
+		RecordEnabled: &recordDisabled,
+	}, &mockSegmentStore{})
+
+	ctx, stop := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		stop()
+		_ = rec.Stop()
+	})
+	require.NoError(t, rec.Start(ctx))
+
+	require.Eventually(t, func() bool { return rec.LatestFrame() != nil }, 5*time.Second, 50*time.Millisecond)
+	require.Equal(t, int32(1), requests.Load(), "unadopted recorder dials exactly once itself")
+}
+
+func TestProbeMJPEGHeadersTimeoutCancelsRequest(t *testing.T) {
+	// Server that accepts the connection but never answers: the probe must
+	// give up after its header-wait budget and cancel the request, leaving
+	// no adopted response behind.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // hang until the client goes away
+	}))
+	t.Cleanup(srv.Close)
+
+	probeClient := &http.Client{Timeout: 0, Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, cancel, err := probeMJPEGHeaders(context.Background(), probeClient, srv.URL)
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Nil(t, cancel, "on failure the cancel func is consumed internally")
+	require.Contains(t, err.Error(), "timed out")
+}
+
+func TestProbeMJPEGHeadersCallerCancelReturnsPromptly(t *testing.T) {
+	// Caller aborts mid-probe: the probe must surface the caller's error
+	// immediately, never hand out an adopted response, and never hang. Whether
+	// the detached dial completes underneath is a race — either way nothing is
+	// returned to the caller.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary=frame")
+		w.WriteHeader(http.StatusOK)
+		<-r.Context().Done() // hold the stream open until the client goes away
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already-expired caller context
+
+	probeClient := &http.Client{Timeout: 0, Transport: &http.Transport{DisableKeepAlives: true}}
+	resp, probeCancel, err := probeMJPEGHeaders(ctx, probeClient, srv.URL)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, resp, "cancelled probe must not hand out a response")
+	require.Nil(t, probeCancel, "cancelled probe must not hand out a cancel func")
+}

--- a/internal/recorder/onvif.go
+++ b/internal/recorder/onvif.go
@@ -612,10 +612,62 @@ func probeRTSPEncodingFor(rtspURL, username, password string) string {
 
 // probeHTTPMJPEG probes the ONVIF device for an HTTP MJPEG stream by trying
 // candidate URLs and checking for multipart/x-mixed-replace Content-Type.
-func (r *ONVIFRecorder) probeHTTPMJPEG(ctx context.Context) (string, error) {
+// probeMJPEGHeaders dials testURL and waits for the response headers only.
+// The request runs on a context detached from the caller so that a hit can be
+// adopted by the recorder as its live stream connection (#723: re-dialing the
+// just-probed URL within the device's anti-hammer window arms its guard). On
+// timeout or caller cancellation the detached request is cancelled and its
+// response, if any, is closed.
+func probeMJPEGHeaders(ctx context.Context, client *http.Client, testURL string) (*http.Response, context.CancelFunc, error) {
+	detached, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(detached, http.MethodGet, testURL, nil)
+	if err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Connection", "close")
+	req.Close = true
+
+	type probeResult struct {
+		resp *http.Response
+		err  error
+	}
+	ch := make(chan probeResult, 1)
+	go func() {
+		resp, err := client.Do(req) //nolint:bodyclose // ownership transfers via the channel: caller adopts or closes
+		ch <- probeResult{resp, err}
+	}()
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			cancel()
+			return nil, nil, r.err
+		}
+		return r.resp, cancel, nil
+	case <-timer.C:
+		cancel()
+		if r := <-ch; r.resp != nil {
+			_ = r.resp.Body.Close()
+		}
+		return nil, nil, fmt.Errorf("probe timed out waiting for response headers")
+	case <-ctx.Done():
+		cancel()
+		go func() {
+			if r := <-ch; r.resp != nil {
+				_ = r.resp.Body.Close()
+			}
+		}()
+		return nil, nil, ctx.Err()
+	}
+}
+
+func (r *ONVIFRecorder) probeHTTPMJPEG(ctx context.Context) (string, *http.Response, context.CancelFunc, error) {
 	onvifURL, err := url.Parse(r.cfg.ONVIFEndpoint)
 	if err != nil {
-		return "", fmt.Errorf("parse ONVIF endpoint: %w", err)
+		return "", nil, nil, fmt.Errorf("parse ONVIF endpoint: %w", err)
 	}
 
 	// Extract path from rtspURL (e.g., /stream from rtsp://host:554/stream)
@@ -647,11 +699,12 @@ func (r *ONVIFRecorder) probeHTTPMJPEG(ctx context.Context) (string, error) {
 		"http://" + onvifURL.Host,
 	}
 
+	// Header-wait is bounded per candidate by probeMJPEGHeaders' timer, NOT a
+	// client Timeout — a hit is handed to the recorder as a live connection
+	// and must not carry a body-read deadline (#723).
 	client := &http.Client{
-		Timeout: 3 * time.Second,
-		Transport: &http.Transport{
-			DisableKeepAlives: true,
-		},
+		Timeout:   0,
+		Transport: &http.Transport{DisableKeepAlives: true},
 	}
 
 	onvifRecLogger.Info("probing HTTP MJPEG", "camera_id", r.cfg.CameraID, "bases", baseURLs, "candidates", candidates)
@@ -659,28 +712,23 @@ func (r *ONVIFRecorder) probeHTTPMJPEG(ctx context.Context) (string, error) {
 	for _, base := range baseURLs {
 		for _, path := range candidates {
 			testURL := base + path
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, testURL, nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Set("Connection", "close")
-			req.Close = true
-
-			resp, err := client.Do(req)
+			resp, probeCancel, err := probeMJPEGHeaders(ctx, client, testURL)
 			if err != nil {
 				onvifRecLogger.Debug("HTTP MJPEG probe candidate failed", "camera_id", r.cfg.CameraID, "url", testURL, "error", err)
 				continue
 			}
 			ct := resp.Header.Get("Content-Type")
-			resp.Body.Close()
-			onvifRecLogger.Debug("HTTP MJPEG probe response", "camera_id", r.cfg.CameraID, "url", testURL, "content_type", ct)
-			if strings.Contains(ct, "multipart/x-mixed-replace") {
-				onvifRecLogger.Info("HTTP MJPEG stream found", "camera_id", r.cfg.CameraID, "url", testURL)
-				return testURL, nil
+			if !strings.Contains(ct, "multipart/x-mixed-replace") {
+				_ = resp.Body.Close()
+				probeCancel()
+				onvifRecLogger.Debug("HTTP MJPEG probe response", "camera_id", r.cfg.CameraID, "url", testURL, "content_type", ct)
+				continue
 			}
+			onvifRecLogger.Info("HTTP MJPEG stream found", "camera_id", r.cfg.CameraID, "url", testURL)
+			return testURL, resp, probeCancel, nil
 		}
 	}
-	return "", fmt.Errorf("no MJPEG stream found at any candidate URL")
+	return "", nil, nil, fmt.Errorf("no MJPEG stream found at any candidate URL")
 }
 
 // guessMJPEGURL constructs a best-guess HTTP MJPEG URL from the ONVIF endpoint
@@ -764,7 +812,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 	case "JPEG":
 		// 1. Try cached HTTP MJPEG URL (caller holds mu, no need to re-lock)
 		if r.httpJPEGURL != "" {
-			return r.newHTTPJPEGRecorder(r.httpJPEGURL)
+			return r.newHTTPJPEGRecorder(r.httpJPEGURL, nil, nil)
 		}
 
 		// 2. Try ONVIF GetStreamUri with Protocol=HTTP.
@@ -781,7 +829,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 			} else if info != nil && strings.HasPrefix(info.URI, "http://") {
 				onvifRecLogger.Info("ONVIF returned HTTP stream URI", "camera_id", r.cfg.CameraID, "url", info.URI)
 				r.httpJPEGURL = info.URI
-				return r.newHTTPJPEGRecorder(info.URI)
+				return r.newHTTPJPEGRecorder(info.URI, nil, nil)
 			} else if info != nil {
 				onvifRecLogger.Debug("ONVIF HTTP protocol returned non-HTTP URI, ignoring", "camera_id", r.cfg.CameraID, "url", info.URI)
 			}
@@ -791,11 +839,14 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 		//    NOTE: ONVIF client may hold an active HTTP connection to the same
 		//    device (ESP32-S3 web servers often support only 1-2 concurrent
 		//    connections). The probe may fail due to connection exhaustion.
+		//    A hit hands its open response to the recorder (#723) so the
+		//    probe connection becomes the stream connection — re-dialing the
+		//    just-probed URL within the anti-hammer window arms the guard.
 		probeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if httpURL, err := r.probeHTTPMJPEG(probeCtx); err == nil {
+		if httpURL, resp, probeCancel, err := r.probeHTTPMJPEG(probeCtx); err == nil { //nolint:bodyclose // resp ownership moves into the recorder via newHTTPJPEGRecorder
 			r.httpJPEGURL = httpURL
-			return r.newHTTPJPEGRecorder(httpURL)
+			return r.newHTTPJPEGRecorder(httpURL, resp, probeCancel)
 		}
 
 		// 4. Probe failed (likely connection exhaustion on ESP32-S3).
@@ -804,7 +855,7 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 		guessURL := r.guessMJPEGURL()
 		onvifRecLogger.Info("HTTP MJPEG probe failed, using best-guess URL", "camera_id", r.cfg.CameraID, "url", guessURL)
 		r.httpJPEGURL = guessURL
-		return r.newHTTPJPEGRecorder(guessURL)
+		return r.newHTTPJPEGRecorder(guessURL, nil, nil)
 	default: // H264 or unknown
 		cfg := H264Config{
 			CameraID:             r.cfg.CameraID,
@@ -828,8 +879,10 @@ func (r *ONVIFRecorder) createDelegate(rtspURL string) model.Recorder {
 	}
 }
 
-// newHTTPJPEGRecorder creates an HTTPJPEGRecorder with the given URL.
-func (r *ONVIFRecorder) newHTTPJPEGRecorder(httpURL string) model.Recorder {
+// newHTTPJPEGRecorder creates an HTTPJPEGRecorder for the given URL. An
+// adopted response (non-nil) continues the probe's already-open connection
+// instead of re-dialing (#723).
+func (r *ONVIFRecorder) newHTTPJPEGRecorder(httpURL string, adopted *http.Response, adoptedCancel context.CancelFunc) model.Recorder {
 	cfg := HTTPJPEGConfig{
 		CameraID:      r.cfg.CameraID,
 		URL:           httpURL,
@@ -843,6 +896,9 @@ func (r *ONVIFRecorder) newHTTPJPEGRecorder(httpURL string) model.Recorder {
 	}
 	rec := NewHTTPJPEGRecorder(cfg, r.store, r.metrics)
 	rec.Hub = r.Hub
+	if adopted != nil {
+		rec.AdoptStream(adopted, adoptedCancel)
+	}
 	return rec
 }
 

--- a/internal/recorder/onvif_test.go
+++ b/internal/recorder/onvif_test.go
@@ -510,9 +510,12 @@ func TestONVIFRecorder_ProbeHTTPMJPEG_Success(t *testing.T) {
 	r.cfg.ONVIFEndpoint = server.URL + "/onvif/device_service"
 	r.rtspURL = "rtsp://192.168.1.100/stream"
 
-	url, err := r.probeHTTPMJPEG(context.Background())
+	url, resp, probeCancel, err := r.probeHTTPMJPEG(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, server.URL+"/stream", url)
+	require.NotNil(t, resp, "probe hit must return the open response for adoption (#723)")
+	_ = resp.Body.Close()
+	probeCancel()
 }
 
 func TestONVIFRecorder_ProbeHTTPMJPEG_FallbackPaths(t *testing.T) {
@@ -532,9 +535,11 @@ func TestONVIFRecorder_ProbeHTTPMJPEG_FallbackPaths(t *testing.T) {
 	r.cfg.ONVIFEndpoint = server.URL + "/onvif/device_service"
 	r.rtspURL = "rtsp://192.168.1.100/stream"
 
-	url, err := r.probeHTTPMJPEG(context.Background())
+	url, resp, probeCancel, err := r.probeHTTPMJPEG(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, server.URL+"/mjpeg", url)
+	_ = resp.Body.Close()
+	probeCancel()
 }
 
 func TestONVIFRecorder_ProbeHTTPMJPEG_NoStream(t *testing.T) {
@@ -549,7 +554,7 @@ func TestONVIFRecorder_ProbeHTTPMJPEG_NoStream(t *testing.T) {
 	r.cfg.ONVIFEndpoint = server.URL + "/onvif/device_service"
 	r.rtspURL = "rtsp://192.168.1.100/stream"
 
-	_, err := r.probeHTTPMJPEG(context.Background())
+	_, _, _, err := r.probeHTTPMJPEG(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no MJPEG stream found")
 }


### PR DESCRIPTION
Closes the two NVR-side code items of #723 (item 1, Retry-After honoring, already shipped in #720 and field-verified — see the issue comment).

## Item 2 — GetStreamUri must go to the media endpoint

**Root cause (reproduced against the live ai-thinker board .139):** the board advertises `media_service` in both GetCapabilities and GetServices, and the onvif-go v2 facade path already routes correctly. The misrouted call was the NVR's **own raw-SOAP path** — `GetStreamURIWithProtocol` (used by the ONVIF recorder's JPEG fallback chain) posts to `c.endpoint` = `device_service`, which the board correctly faults with *Unsupported device action*, forcing the fallback chain down to the direct-URL guess.

**Fix:** raw-SOAP media actions resolve the device's media XAddr via a GetServices probe (namespace map, ver10 → ver20), rewrite a stale advertised host to the device endpoint's host (mirrors the library's fixServiceURL), and post there. A definitive absence is cached; transport errors are retried on the next raw media call. Legacy behavior is otherwise unchanged (snapshot path already rides the library facade).

## Item 3 — 13ms double dial on stream start

**Root cause:** the JPEG fallback chain probed the MJPEG URL with `Connection: close`, discarded the connection on a hit, and the recorder immediately re-dialed the same URL — two TCP connects inside the ESP32 anti-hammer window, arming the guard.

**Fix:** the probe now waits for response headers on a context **detached** from the caller (3s header budget), and a hit is handed to the recorder as its live stream connection (`AdoptStream`), consumed by the first `connectAndStream` cycle. Reconnects after that stream ends dial normally through the ≥5s floor. With routing fixed, boards whose media service returns an http:// URI skip the probe entirely (one dial); boards that still need the probe pay one dial total.

## Tests (TDD)

- `internal/onvif/client_media_route_test.go` — path-aware fake device: GetStreamUri must land on media_service (never device_service), cached route (no second GetServices), stale-host rewrite, ver20 fallback, unadvertised→device-endpoint fallback with retry-not-cached semantics.
- `internal/recorder/http_jpeg_adopt_test.go` — probe+record opens **exactly one** connection; unadopted recorder dials once itself; header timeout cancels the detached request; caller cancel returns promptly with no adopted response.
- Updated existing probe tests for the new signature.

## M5 field verification (before PR, per process)

- `.139`/`.148` (ai-thinker / MiBeeCam boards): `routing media SOAP actions to advertised media endpoint … media=http://…/onvif/media_service` → `GetStreamURIWithProtocol response protocol=HTTP uri=http://…:81/stream` → direct pull, **no probe**.
- `.119`: probe fallback → `continuing probed MJPEG connection` in the same millisecond as the probe hit — single dial.
- 16 cams post-restart: 14 recording + 1 known source-side xiaomi outage; no new error classes post-deploy.