### PR TITLE
feat(pixgate): low-rate per-camera stats line for field visibility (#699)

### DIFF
--- a/internal/pixgate/pixgate.go
+++ b/internal/pixgate/pixgate.go
@@ -444,6 +444,11 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 	wasActive := false
 	wasSuppressed := false
 	backoff := time.Second
+	srcLabel := "hub"
+	if !useHub {
+		srcLabel = "rtsp"
+	}
+	var stats pixgateStats
 
 	sample := func(gray []byte) bool {
 		now := time.Now()
@@ -466,6 +471,16 @@ func (m *Manager) runCamera(ctx context.Context, cameraID string, cfg CameraConf
 			return ctx.Err() == nil
 		}
 		m.recordFG(cameraID, now, res.BlobAreaPct, !res.Flood && !res.Ghost)
+		if line, emit := stats.observe(now, res.BlobAreaPct, !res.Flood && !res.Ghost, res.Active); emit {
+			// #699 field visibility: the normal path is silent, which left
+			// TL-stuck cameras undiagnosable from the journal alone.
+			log.Info("pixgate stats",
+				"source", srcLabel,
+				"samples", line.Samples,
+				"valid", line.Valid,
+				"active", line.Active,
+				"last_area_pct", line.LastAreaPct)
+		}
 		if res.Ghost {
 			log.Info("pixgate: static foreground absorbed into background (ghost suppression)",
 				"area_pct", res.BlobAreaPct, "cx", res.CX, "cy", res.CY)

--- a/internal/pixgate/stats.go
+++ b/internal/pixgate/stats.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+
+package pixgate
+
+import "time"
+
+// statsInterval is how often the per-camera pixgate stats line is emitted
+// (#699): the sampler's normal path is silent by design (per-sample decision
+// logs were removed as noise), which left field diagnosis blind — a camera
+// stuck in TIMELAPSE through traffic had no journal evidence of whether the
+// sampler was running, how many samples validated, or what the last FG area
+// was. One INFO line per interval restores that visibility cheaply.
+const statsInterval = 60 * time.Second
+
+// pixgateStats accumulates sampler counters between stats emissions. Not
+// goroutine-safe: the sample callback that feeds it runs on one sampler
+// goroutine per camera.
+type pixgateStats struct {
+	lastEmit time.Time
+
+	samples     int // frames processed (excluding prime frames)
+	valid       int // samples that count as activity evidence
+	active      int // samples that confirmed activity (fired the trigger)
+	lastAreaPct float64
+}
+
+// pixgateStatsLine is the snapshot handed to the logger when the interval
+// elapses.
+type pixgateStatsLine struct {
+	Samples     int
+	Valid       int
+	Active      int
+	LastAreaPct float64
+}
+
+// observe records one processed sample and reports whether the interval
+// elapsed (only with actual samples — an idle camera doesn't spam zeros).
+func (s *pixgateStats) observe(now time.Time, areaPct float64, valid, active bool) (pixgateStatsLine, bool) {
+	s.samples++
+	if valid {
+		s.valid++
+	}
+	if active {
+		s.active++
+	}
+	s.lastAreaPct = areaPct
+	if !s.lastEmit.IsZero() && now.Sub(s.lastEmit) < statsInterval {
+		return pixgateStatsLine{}, false
+	}
+	line := pixgateStatsLine{
+		Samples:     s.samples,
+		Valid:       s.valid,
+		Active:      s.active,
+		LastAreaPct: s.lastAreaPct,
+	}
+	s.lastEmit = now
+	s.samples, s.valid, s.active = 0, 0, 0
+	return line, true
+}

--- a/internal/pixgate/stats_test.go
+++ b/internal/pixgate/stats_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+package pixgate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPixgateStatsEmitsPerInterval(t *testing.T) {
+	var s pixgateStats
+	start := time.Now()
+
+	// The first observed sample emits immediately — instant proof the
+	// sampler is live (#699: "is pixgate even running?" is the first field
+	// question) — and initializes the window.
+	first, emit := s.observe(start, 1.0, true, false)
+	require.True(t, emit)
+	require.Equal(t, 1, first.Samples)
+	require.Equal(t, 1, first.Valid)
+	require.Equal(t, 0, first.Active)
+	require.Equal(t, 1.0, first.LastAreaPct)
+
+	// Samples inside the window accumulate silently.
+	for i := 1; i <= 5; i++ {
+		line, emit := s.observe(start.Add(time.Duration(i)*time.Second), 2.0, true, i == 3)
+		require.False(t, emit)
+		require.Empty(t, line)
+	}
+
+	// Crossing the interval emits the accumulated counters and resets.
+	line, emit := s.observe(start.Add(statsInterval+time.Second), 3.5, true, true)
+	require.True(t, emit)
+	require.Equal(t, 6, line.Samples, "5 in-window samples + the crossing one")
+	require.Equal(t, 6, line.Valid)
+	require.Equal(t, 2, line.Active, "the i==3 sample and the crossing one")
+	require.Equal(t, 3.5, line.LastAreaPct)
+
+	// Counters reset after emission.
+	line2, emit := s.observe(start.Add(statsInterval+2*time.Second), 0.5, false, false)
+	require.False(t, emit)
+	require.Empty(t, line2)
+
+	line3, emit := s.observe(start.Add(2*statsInterval+2*time.Second), 0.5, false, false)
+	require.True(t, emit)
+	require.Equal(t, 2, line3.Samples, "post-reset window counts fresh samples only")
+	require.Equal(t, 0, line3.Valid)
+	require.Equal(t, 0, line3.Active)
+}


### PR DESCRIPTION
Implements #699's own suggestion 3: the pixgate sampler's normal path is silent by design (per-sample decision logs removed as noise in #685/#690), which left TL-stuck cameras undiagnosable from the journal — no evidence whether the sampler was running, how many samples validated, or what FG areas it saw.

One INFO line per 60s window per camera: `source` (hub|rtsp), `samples`, `valid`, `active`, `last_area_pct`. The first observed sample emits immediately ("is it even running" is the first field question).

## First field data from M5 (deployed before PR, per process)

```
06:34:04 pixgate stats camera_id=cam-5b24e253…(视通-9楼) source=hub samples=1  valid=1 active=0 last_area_pct=0.0052
06:35:08 pixgate stats camera_id=cam-5b24e253…                source=hub samples=22 valid=22 active=0 last_area_pct=0.0156
```

Two findings for the #699 diagnosis, quantified on day one:

1. **Effective sample rate ≈ 0.37fps, not the configured 1fps** (22 samples/min): the hub sampler delivers GOP keyframes in ~5s batches (#689), so the realized cadence is capped by the sub-stream's GOP (~2.7s), not `sample_fps`. This is hard evidence for the #689-batch suspicion in the issue — persist-confirmations have ~⅓ the expected chances per minute.
2. **FG blobs straddle the threshold**: `last_area_pct` fluctuates 0.005–0.016 (0.5%–1.6%) against `min_area_pct: 1.5` — borderline areas never string together the persist hits needed for an Active confirmation, matching "pixel exits never fire while byte-domain motion_score is 0.5+".

## Tests

`internal/pixgate/stats_test.go` — first-sample emission, silent accumulation inside the window, interval-crossing emission with reset, fresh-window counting. Full package green in WSL; golangci-lint clean.