### PR TITLE
feat(gb28181): bump gb28181-go to v0.7.x + wire UploadSnapShotFinished onto snapshot sessions (#708)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require go.uber.org/goleak v1.3.0
 require github.com/emmansun/gmsm v0.44.1
 
 require (
-	github.com/mickeyzzc/gb28181-go v0.6.1-0.20260908035749-1da718699599
+	github.com/mickeyzzc/gb28181-go v0.7.1-0.20260909044714-43f84652195d
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mickeyzzc/gb28181-go v0.6.1-0.20260908035749-1da718699599 h1:6YdlS1KgIAPqJyZ5XfgyS7CPWpVqhsL5uc0fWuQAGQ4=
-github.com/mickeyzzc/gb28181-go v0.6.1-0.20260908035749-1da718699599/go.mod h1:nfoCIOHiVAlgx7oUOGRF5YjX0Zv/3Rkwb4vC4y6BM+I=
+github.com/mickeyzzc/gb28181-go v0.7.1-0.20260909044714-43f84652195d h1:a9T0TLDNCmOUEEtG4usq8GneJBN38IAmZzwgu5hWMNQ=
+github.com/mickeyzzc/gb28181-go v0.7.1-0.20260909044714-43f84652195d/go.mod h1:nfoCIOHiVAlgx7oUOGRF5YjX0Zv/3Rkwb4vC4y6BM+I=
 github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2 h1:mbHQKNzFOWrSamcEuMEvqgSEUa79nMUntCFaW8XamvE=
 github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=

--- a/internal/gb28181/snapshot_sessions.go
+++ b/internal/gb28181/snapshot_sessions.go
@@ -9,7 +9,13 @@ import (
 	"time"
 
 	gbsip "github.com/mickeyzzc/gb28181-go/platform/sip"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/slogx"
 )
+
+// snapshotSessionsLogger is the component logger for the snapshot session
+// registry (component=gb28181-snapshot, matching the command sender).
+var snapshotSessionsLogger = slogx.Component("gb28181-snapshot")
 
 // GB/T 28181-2022 platform-side on-demand snapshot sessions (#708): the
 // platform sends DeviceControl(SnapShotCmd) with an UploadURL + SessionID;
@@ -246,19 +252,20 @@ func (m *SnapshotSessionManager) Receive(sessionID string, jpeg []byte) (string,
 // length; 0 = whole exchange failed per A.2.5.7). The session stays
 // registered (marked terminal) until Sweep evicts it, so a straggler upload
 // lands on ErrSnapshotSessionClosed rather than a misleading unknown-ID.
-func (m *SnapshotSessionManager) Finish(sessionID string, successCount int) {
+// Returns true when a live session was closed by this call.
+func (m *SnapshotSessionManager) Finish(sessionID string, successCount int) bool {
 	m.mu.Lock()
 	s, ok := m.sessions[sessionID]
 	if !ok {
 		m.mu.Unlock()
-		return
+		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	m.mu.Unlock()
 
 	if s.outcome != "" {
-		return
+		return false
 	}
 	switch {
 	case successCount <= 0:
@@ -268,6 +275,7 @@ func (m *SnapshotSessionManager) Finish(sessionID string, successCount int) {
 	default:
 		s.outcome = SnapshotPartial
 	}
+	return true
 }
 
 // SubscribeFinished wires the library's UploadSnapShotFinished notify
@@ -294,7 +302,12 @@ func (m *SnapshotSessionManager) SubscribeFinished(bus *gbsip.EventBus) {
 				if !valid {
 					continue
 				}
-				m.Finish(fin.SessionID, fin.SuccessCount)
+				if m.Finish(fin.SessionID, fin.SuccessCount) {
+					snapshotSessionsLogger.Info("snapshot session closed by device notify",
+						"session_id", fin.SessionID,
+						"device_id", fin.DeviceID,
+						"success_count", fin.SuccessCount)
+				}
 			}
 		}
 	}()

--- a/internal/gb28181/snapshot_sessions.go
+++ b/internal/gb28181/snapshot_sessions.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	gbsip "github.com/mickeyzzc/gb28181-go/platform/sip"
 )
 
 // GB/T 28181-2022 platform-side on-demand snapshot sessions (#708): the
@@ -266,6 +268,36 @@ func (m *SnapshotSessionManager) Finish(sessionID string, successCount int) {
 	default:
 		s.outcome = SnapshotPartial
 	}
+}
+
+// SubscribeFinished wires the library's UploadSnapShotFinished notify
+// (platform/sip event bus, topic gb28181.snapshot.finished — lib PR #54)
+// onto Finish: the device's own completion report closes the session
+// immediately instead of waiting out the TTL sweep (#708 loop closure).
+// The consumer goroutine unwinds with the manager's Stop.
+func (m *SnapshotSessionManager) SubscribeFinished(bus *gbsip.EventBus) {
+	if bus == nil {
+		return
+	}
+	ch := make(chan gbsip.Event, 16)
+	_ = bus.Subscribe(gbsip.TopicGB28181SnapshotFinished, ch, 16)
+	go func() {
+		for {
+			select {
+			case <-m.sweepStop:
+				return
+			case ev, ok := <-ch:
+				if !ok {
+					return
+				}
+				fin, valid := ev.Data.(gbsip.GB28181SnapshotFinishedEvent)
+				if !valid {
+					continue
+				}
+				m.Finish(fin.SessionID, fin.SuccessCount)
+			}
+		}
+	}()
 }
 
 // Sweep expires sessions past their deadline. Also evicts terminal sessions

--- a/internal/gb28181/snapshot_sessions_test.go
+++ b/internal/gb28181/snapshot_sessions_test.go
@@ -1,12 +1,14 @@
 package gb28181
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	gbsip "github.com/mickeyzzc/gb28181-go/platform/sip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,4 +164,41 @@ func TestSnapshotSessionManager_EventPayload(t *testing.T) {
 	require.Equal(t, "cam-gb", ev["camera_id"])
 	require.Equal(t, "gb28181", ev["trigger"])
 	require.True(t, strings.HasPrefix(fmt.Sprint(ev["file_path"]), "snapshots/cam-gb/"))
+}
+
+func TestSnapshotSessionManager_SubscribeFinished(t *testing.T) {
+	m, _, _, _ := newTestSnapshotManager(t)
+	sess, err := m.CreateSession("34020000011320000001", "34020000001320000002", "cam-gb", 2)
+	require.NoError(t, err)
+
+	bus := gbsip.NewEventBus(16)
+	m.SubscribeFinished(bus)
+
+	// The device's own completion notify (lib PR #54): 2 of 2 uploaded.
+	bus.Publish(context.Background(), gbsip.TopicGB28181SnapshotFinished, gbsip.GB28181SnapshotFinishedEvent{
+		DeviceID:     "34020000011320000001",
+		SessionID:    sess.ID,
+		FileIDs:      []string{"f1", "f2"},
+		SuccessCount: 2,
+	})
+	require.Eventually(t, func() bool { return sess.Outcome() == SnapshotComplete },
+		2*time.Second, 10*time.Millisecond)
+
+	// Stray/late notifies for unknown sessions and non-matching payloads are
+	// no-ops, not panics.
+	bus.Publish(context.Background(), gbsip.TopicGB28181SnapshotFinished,
+		gbsip.GB28181SnapshotFinishedEvent{SessionID: strings.Repeat("f", 32)})
+	bus.Publish(context.Background(), gbsip.TopicGB28181SnapshotFinished, "garbage")
+	time.Sleep(50 * time.Millisecond)
+
+	// Partial report maps to the partial outcome.
+	sess2, err := m.CreateSession("34020000011320000001", "34020000001320000002", "cam-gb", 2)
+	require.NoError(t, err)
+	bus.Publish(context.Background(), gbsip.TopicGB28181SnapshotFinished,
+		gbsip.GB28181SnapshotFinishedEvent{SessionID: sess2.ID, SuccessCount: 1})
+	require.Eventually(t, func() bool { return sess2.Outcome() == SnapshotPartial },
+		2*time.Second, 10*time.Millisecond)
+
+	// Stop unwinds the subscription goroutine.
+	m.Stop()
 }

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -741,6 +741,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	// ingest listeners (SRT) and before cleanup; registered as the "gb28181"
 	// service between srt and ws. The DeviceManager heartbeat checker is owned
 	// by the SIP server's service lifecycle.
+	var gbLibEvents *gbsip.EventBus // library event bus — also feeds the snapshot manager below
 	if cfg.GB28181.Enabled {
 		heartbeatInterval, err := time.ParseDuration(cfg.GB28181.HeartbeatInterval)
 		if err != nil {
@@ -766,7 +767,8 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		}
 		deps.gb28181Server = gbsip.NewServer(sipCfg, deps.gb28181DevMgr, deps.gb28181SessionMgr, gb28181.NewDeviceStore(deps.db))
 		// Alarm notifications surface on the event bus (SSE /api/events).
-		deps.gb28181Server.SetEventBus(gb28181.NewEventBridge(deps.eventBus))
+		gbLibEvents = gb28181.NewEventBridge(deps.eventBus)
+		deps.gb28181Server.SetEventBus(gbLibEvents)
 		slog.Info("GB28181 SIP server configured", "sip_listen", cfg.GB28181.SIPListen)
 	}
 
@@ -928,6 +930,10 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			}),
 		)
 		gbSnapMgr.Start()
+		// #708 loop closure: the device's UploadSnapShotFinished notify
+		// (gb28181-go PR #54) closes snapshot sessions on completion instead
+		// of timing out after the 30s TTL.
+		gbSnapMgr.SubscribeFinished(gbLibEvents)
 		handler.SetGB28181SnapshotManager(gbSnapMgr)
 		handler.SetGB28181Catalog(platform.NewCatalogController(deps.gb28181DevMgr, deps.gb28181Server))
 		handler.SetGB28181Inviter(deps.gb28181Server)


### PR DESCRIPTION
Closes the loop left open by #715: lib PR mickeyzzc/gb28181-go#54 merged (2026-09-09), so the device's `CmdUploadSnapShotFinished` notify now surfaces as `gb28181.snapshot.finished` on the platform/sip bus. `SnapshotSessionManager.SubscribeFinished` consumes it — SessionID/SuccessCount close the session immediately (complete/partial/failed per SnapShotList) instead of waiting out the 30s TTL sweep.

Pins `v0.7.1-0.20260909044714-43f84652195d` (post-v0.7.0 commit: v0.7.0 was tagged BEFORE #54 merged — verified by tag/commit list). Also picks up v0.7.0's platform hardening transparently: Config.Validate fail-fast, REGISTER retry backoff (cascade), DialContext migration — NVR code needed no adaptation (compiles/tests clean).

## Tests (TDD)

`TestSnapshotSessionManager_SubscribeFinished`: notify closes session complete; stray session / non-matching payload are no-ops; partial report maps to partial outcome; Stop unwinds the consumer. `Finish` now returns whether a live session was closed (observability: the notify handler logs `snapshot session closed by device notify`).

## M5 field verification (before PR, per process)

- Deployed; SIP server boots clean under the new lib's Config.Validate (no config failures, no panic); all 4 GB devices re-registered + cameras recording.
- **Full closure proven on the wire**: `POST /api/gb28181/channels/34020000001320000021/snapshot` → 202 (session 4ab49f0f…) → crafted device-side `UploadSnapShotFinished` MESSAGE (as mibee-rec from its registered host) → journal:
  ```
  gb28181: snapshot finished notify device=34020000001320000021 session=4ab49f0f… files=1
  snapshot session closed by device notify session_id=4ab49f0f… success_count=1 component=gb28181-snapshot
  ```
- Live mibee-rec (Rec-01, updated lib, registers from the notebook) currently **ignores SnapShotCmd** (no upload, no notify) — its firmware hasn't wired the capture path yet; the session correctly TTL-sweeps for it (pre-existing behavior, non-regression). Real-device acceptance (Hikvision/Dahua) still pending as in the issue.