### PR TITLE
chore(deps): bump onvif-go/v2 rc2 → v2.0.0-rc6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2
+	github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc6
 	github.com/miekg/dns v1.1.41 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1f
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mickeyzzc/gb28181-go v0.7.1-0.20260909044714-43f84652195d h1:a9T0TLDNCmOUEEtG4usq8GneJBN38IAmZzwgu5hWMNQ=
 github.com/mickeyzzc/gb28181-go v0.7.1-0.20260909044714-43f84652195d/go.mod h1:nfoCIOHiVAlgx7oUOGRF5YjX0Zv/3Rkwb4vC4y6BM+I=
-github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2 h1:mbHQKNzFOWrSamcEuMEvqgSEUa79nMUntCFaW8XamvE=
-github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc2/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
+github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc6 h1:AGDsmgSntxh1h/zAIJ4QcvhpFQUZF+P9yP32Rj9gKu8=
+github.com/mickeyzzc/onvif-go/v2 v2.0.0-rc6/go.mod h1:OmXWljqR4RIKMVVly/CxunWdyRCa4onMMGkt84SaQGQ=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
Protocol dependency refresh to match the library's enterprise-readiness release (companion to gb28181-go v0.7.x in #727).

Four rc's of changes (rc3→rc6: 110 files), NVR-relevant:
- **Bounded SOAP response bodies** (1MB limit) — hostile/broken devices can no longer OOM the client.
- **Auth-mode ladder infrastructure** (`WithAuthMode`/`WithAuthFallback`) + clock-skew/auth **diagnosis helpers** (`DiagnoseAuth`) — available for future NVR use, not wired here.
- Server-side hardening (embedding surface, Config.Validate, coverage gate) — not consumed by the NVR's client-only usage.

**Compatibility verified**: the client path the NVR uses is unchanged — events facade (`CreatePullPointSubscription`/`PullMessages`/`Renew`/`Unsubscribe` from #721), credential handling (empty credentials under digest still mean "no WS-Security header" = anonymous), and the raw-SOAP surface (`getRawStreamURI` media routing from #724). `internal/onvif` + `internal/camera` + `internal/recorder` test suites green against rc6 with zero code changes.

**M5 field verification** (cumulative binary with #727): all ONVIF cameras reconnect and record under rc6 — including the no-credential MiBeeCam boards (.139/.148/.119: connect + GetStreamURI + #724 media-endpoint routing all logged), GB channels unaffected; 15/16 recording with the 1 known source-side xiaomi outage unchanged; no new error classes.