### PR TITLE
fix(ui): recover gateway SSO session after backgrounded-window token expiry

### DIFF
--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1788646312116';
+const CACHE_VERSION = 'mibee-nvr-1788968904578';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { isAuthenticated, healthCheck } from '$lib/api';
+  import { isAuthenticated, healthCheck, tryGatewaySession } from '$lib/api';
   import { t } from '$lib/i18n';
   import { WifiOff } from 'lucide-svelte';
   // Route loader map — lazy loaded on demand
@@ -63,6 +63,19 @@
     } catch {
       // Health check failed — ignore, user stays on login page
     }
+  }
+
+  // Backgrounded-window expiry recovery: the 2h session token only renews
+  // on live requests, so a window hidden past its TTL (fnOS desktop app
+  // minimized overnight) wakes up unauthenticated and the route guard would
+  // dump the user at the login wall despite the gateway session being alive.
+  // On wake, silently re-run the gateway SSO bootstrap. No-op when already
+  // authenticated or after an explicit logout (flag inside tryGatewaySession).
+  function handleVisibilityWake() {
+    if (document.visibilityState !== 'visible' || isAuthenticated()) return;
+    void tryGatewaySession().then((ok) => {
+      if (ok && currentRoute === 'login') window.location.hash = '#/surveillance';
+    });
   }
 
 
@@ -236,6 +249,7 @@ function parseRoute(hash: string) {
     updateRoute();
     checkSetupRequired();
     window.addEventListener('hashchange', updateRoute);
+    document.addEventListener('visibilitychange', handleVisibilityWake);
 
     // Network detection
     isOffline = !navigator.onLine;
@@ -246,6 +260,7 @@ function parseRoute(hash: string) {
 
     return () => {
       window.removeEventListener('hashchange', updateRoute);
+      document.removeEventListener('visibilitychange', handleVisibilityWake);
       window.removeEventListener('offline', handleOffline);
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('nvr-api-offline', handleApiOffline);

--- a/web/src/__tests__/Login.test.ts
+++ b/web/src/__tests__/Login.test.ts
@@ -1,0 +1,68 @@
+import { render, cleanup, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { gatewayMock, authedMock } = vi.hoisted(() => ({
+  gatewayMock: vi.fn(),
+  authedMock: vi.fn(() => false),
+}));
+
+vi.mock('$lib/api', () => ({
+  login: vi.fn(),
+  isAuthenticated: () => authedMock(),
+  tryGatewaySession: () => gatewayMock(),
+}));
+
+import Login from '../routes/Login.svelte';
+
+// The login page doubles as the expiry-recovery path for backgrounded windows
+// (fnOS desktop app hidden past the 2h token TTL): on mount it retries the
+// gateway SSO bootstrap and bounces straight back into the app when the NAS
+// session is still alive, instead of demanding credentials from an SSO user.
+
+beforeEach(() => {
+  window.location.hash = '';
+  localStorage.clear();
+  sessionStorage.clear();
+  // jsdom has no matchMedia; ThemeToggle queries prefers-color-scheme.
+  vi.stubGlobal('matchMedia', vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })));
+  gatewayMock.mockReset();
+  authedMock.mockReset().mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe('Login gateway SSO recovery', () => {
+  it('re-mints via gateway SSO on mount and returns to the app', async () => {
+    gatewayMock.mockResolvedValue(true);
+    render(Login);
+    await waitFor(() => expect(window.location.hash).toBe('#/surveillance'));
+    expect(gatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays on the form when the gateway refuses (direct-port deployments)', async () => {
+    gatewayMock.mockResolvedValue(false);
+    render(Login);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(window.location.hash).not.toBe('#/surveillance');
+    expect(document.querySelector('input[type="password"]')).toBeTruthy();
+  });
+
+  it('does not attempt SSO when already authenticated', async () => {
+    authedMock.mockReturnValue(true);
+    render(Login);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(gatewayMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/__tests__/auth-session.test.ts
+++ b/web/src/lib/__tests__/auth-session.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { storeToken, getToken, logout, clearToken, tryGatewaySession } from '$lib/api';
+
+// Backgrounded-window expiry (fnOS desktop app, >2h hidden — no requests, no
+// sliding renewal) must be recoverable by re-running the gateway SSO bootstrap
+// — but an explicit logout must NOT be bounced straight back in.
+
+function fetchOk(body: Record<string, unknown>) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('explicit-logout guard', () => {
+  it('logout() arms the logged-out flag', () => {
+    storeToken('mbs_t1');
+    logout();
+    expect(sessionStorage.getItem('mibee_nvr_logged_out')).toBe('1');
+    expect(getToken()).toBeNull();
+  });
+
+  it('tryGatewaySession skips the network entirely after an explicit logout', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    logout();
+    await expect(tryGatewaySession()).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(getToken()).toBeNull();
+  });
+
+  it('storeToken clears the flag (any successful mint = logged back in)', () => {
+    logout();
+    expect(sessionStorage.getItem('mibee_nvr_logged_out')).toBe('1');
+    storeToken('mbs_t2');
+    expect(sessionStorage.getItem('mibee_nvr_logged_out')).toBeNull();
+    expect(getToken()).toBe('mbs_t2');
+  });
+
+  it('clearToken alone does NOT clear the flag (only a real mint does)', () => {
+    logout();
+    clearToken();
+    expect(sessionStorage.getItem('mibee_nvr_logged_out')).toBe('1');
+  });
+});
+
+describe('gateway SSO re-mint (expiry recovery)', () => {
+  it('mints and stores a fresh token when the gateway answers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      fetchOk({ status: 'ok', token: 'mbs_fresh', expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(tryGatewaySession()).resolves.toBe(true);
+    expect(getToken()).toBe('mbs_fresh');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hit the network when a valid token is already stored', async () => {
+    storeToken('mbs_live', new Date(Date.now() + 3600_000).toISOString());
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(tryGatewaySession()).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false without storing anything when the gateway refuses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401 } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(tryGatewaySession()).resolves.toBe(false);
+    expect(getToken()).toBeNull();
+  });
+});

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -19,6 +19,15 @@ import { APP_BASE } from '$lib/base-path';
 const TOKEN_KEY = 'mibee_nvr_token';
 // Renewed-token response header (must match internal/middleware/token.go).
 const RENEWED_TOKEN_HEADER = 'X-Renewed-Token';
+// sessionStorage flag marking an EXPLICIT logout. The token TTL is 2h with
+// sliding renewal only on live requests, so a window backgrounded past the TTL
+// (e.g. the fnOS desktop app minimized overnight) wakes up unauthenticated and
+// must re-mint via gateway SSO instead of hitting the login wall. An explicit
+// logout must NOT be auto-bounced back in by that recovery path — the flag
+// says "the user chose to leave" and survives reloads within the window
+// (sessionStorage), while a fresh window/app relaunch starts clean and resumes
+// SSO as before.
+const LOGOUT_FLAG = 'mibee_nvr_logged_out';
 
 export interface AuthCredentials {
   username: string;
@@ -118,6 +127,9 @@ export function storeToken(token: string, expiresAtIso?: string): void {
   }
   const session: StoredSession = { token, expiresAt };
   localStorage.setItem(TOKEN_KEY, JSON.stringify(session));
+  // Any successful token mint means the user is (back) in — drop the explicit
+  // logout marker so wake-up SSO recovery resumes for this window.
+  sessionStorage.removeItem(LOGOUT_FLAG);
 }
 
 // Get the raw session token, or null if absent/expired. Expired tokens are
@@ -392,6 +404,7 @@ export async function login(username: string, password: string, signal?: AbortSi
 
 // Logout
 export function logout(): void {
+  sessionStorage.setItem(LOGOUT_FLAG, '1');
   clearToken();
   window.location.hash = '#/login';
 }
@@ -407,6 +420,10 @@ export function logout(): void {
 // the synchronous isAuthenticated() route gate sees the stored token.
 export async function tryGatewaySession(): Promise<boolean> {
   if (getToken()) return true;
+  // Explicit logout wins over gateway SSO: never bounce the user straight
+  // back into a session they chose to end. The flag is cleared by the next
+  // successful storeToken (manual login) and by a fresh window (sessionStorage).
+  if (sessionStorage.getItem(LOGOUT_FLAG)) return false;
   try {
     const response = await fetch(`${API_BASE}/auth/gateway-session`, {
       signal: AbortSignal.timeout(5000),

--- a/web/src/routes/Login.svelte
+++ b/web/src/routes/Login.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { login, isAuthenticated } from '$lib/api';
+  import { onMount } from 'svelte';
+  import { login, isAuthenticated, tryGatewaySession } from '$lib/api';
   import ThemeToggle from '../components/ThemeToggle.svelte';
   import LanguageSwitcher from '../components/LanguageSwitcher.svelte';
   import { t } from '$lib/i18n';
@@ -19,6 +20,20 @@
   if (isAuthenticated()) {
     window.location.hash = '#/surveillance';
   }
+
+  // Landing here with a dead token is the backgrounded-window expiry path
+  // (window hidden past the 2h TTL → no sliding renewal → route guard dumps
+  // the user at this wall). Behind the fnOS gateway the NAS session is still
+  // valid — re-mint and go straight back in instead of demanding credentials
+  // the SSO user never has. Direct-port deployments 401 the endpoint and
+  // show the form as before; an explicit logout is respected via the
+  // logged-out flag inside tryGatewaySession.
+  onMount(() => {
+    if (isAuthenticated()) return;
+    void tryGatewaySession().then((ok) => {
+      if (ok) window.location.hash = '#/surveillance';
+    });
+  });
 
   function validateUsername() {
     if (!username.trim()) {


### PR DESCRIPTION
Fixes #729

## 问题
fnOS 桌面应用窗口放后台超过 token TTL（2h）再打开：后台期间无请求 → 滑动续期从未发生 → token 过期 → SPA 路由守卫（纯本地 `isAuthenticated()`）把用户扔到登录墙。SSO 用户没有 NVR 凭据，只能强制退出应用（fresh boot SSO）恢复。

后端无责：实测过期后经网关身份的 API 全部 200；`/api/auth/gateway-session` 按需重铸立即可用。

## 修复（纯 SPA，3 处小改）
| 文件 | 改动 |
|---|---|
| `web/src/App.svelte` | `visibilitychange`→visible 且会话已死 → 静默重跑 `tryGatewaySession()`；守卫已停在登录页则弹回应用 |
| `web/src/routes/Login.svelte` | 挂载时会话已死 → 重试一次网关 SSO；直连端口 401 → 照旧显示表单 |
| `web/src/lib/api/client.ts` | 主动登出置 sessionStorage 旗标抑制恢复路径；成功铸 token 清旗标；新窗口恢复 SSO 不变 |

## 测试
- **新增 10 个 vitest**（TDD：先红后绿）：`auth-session.test.ts` 7（登出旗标语义 + 重铸行为）+`Login.test.ts` 3（挂载自动 SSO/拒绝留表单/已认证不发请求）。全套 **601/601 绿**。
- **实机双端验证**（部署后浏览器探针 `tmp-probe/token_wake_{repro,verify}.py`）：
  - 修复前复现（R4S）：过期后导航必落登录墙 7/7。
  - 修复后 R4S fnOS 网关：SSO 启动 / 唤醒重铸（ttl 恢复 119.9min）/ 登录页挂载自动恢复 / 登出旗标（唤醒不弹回 + 重载不自动 SSO）/ 宫格渲染 **9/9**。
  - 修复后 M5 直连：表单登录 / 登出 / 过期停在登录页（无网关可救，符合预期）**3/3**。
- M5 现运行 `v0.12.0-48-tokenwake-1`（备份 bak-0909-tokenwake），R4S overlay 同二进制（md5 95076a4f）。

## 登出语义变化（有意）
此前 fnOS 下「退出登录后刷新页面」会被启动 SSO 自动弹回（登出形同虚设）；现在 sessionStorage 旗标使登出在窗口生命周期内保持，强制退出/新窗口后恢复 SSO。直连端口行为不变。