### PR TITLE
fix(onvif): read subscription lifecycle fields under lock in run()

### DIFF
--- a/internal/onvif/events.go
+++ b/internal/onvif/events.go
@@ -408,15 +408,22 @@ func (e *EventSubscriberImpl) run(cameraID string, stopCh <-chan struct{}) {
 		if ps == nil {
 			return // Unsubscribe removed us
 		}
-		if ps.state == StateUnsupported {
+		// Lifecycle fields must be read as a locked snapshot: Unsubscribe()
+		// and setPS mutate them under e.mu, and reading them on the raw
+		// pointer raced with Unsubscribe (CI -race catch, 2026-09-09).
+		state, active, ok := e.lifecycleOf(cameraID)
+		if !ok {
+			return // Unsubscribe removed us between the two lookups
+		}
+		if state == StateUnsupported {
 			return // tombstone — never retry
 		}
-		if !ps.active || ps.state != StateActive {
+		if !active || state != StateActive {
 			// Rebuild path: create a fresh subscription (the device's
 			// single-subscription model means the new create replaces any
-			// stale server-side state — later client wins).
-			newPS, err := e.rebuildSubscription(cameraID, ps)
-			if err != nil {
+			// stale server-side state — later client wins). The old pointer
+			// is only read for its immutable subscriptionRef.
+			if err := e.rebuildSubscription(cameraID, ps); err != nil {
 				if errors.Is(err, ErrEventsNotSupported) {
 					return
 				}
@@ -426,11 +433,10 @@ func (e *EventSubscriberImpl) run(cameraID string, stopCh <-chan struct{}) {
 				backoff = min(backoff*2, resubscribeMaxBackoff)
 				continue
 			}
-			ps = newPS
 			backoff = resubscribeMinBackoff
 		}
 
-		if !e.pollLoop(cameraID, ps, stopCh) {
+		if !e.pollLoop(cameraID, stopCh) {
 			return // stopCh closed
 		}
 		// pollLoop hit a terminal condition — brief backoff, then rebuild.
@@ -444,7 +450,7 @@ func (e *EventSubscriberImpl) run(cameraID string, stopCh <-chan struct{}) {
 
 // rebuildSubscription tears down the current subscription server-side and
 // installs a fresh one in the registry (keeping the same stop channel).
-func (e *EventSubscriberImpl) rebuildSubscription(cameraID string, old *pullPointSubscription) (*pullPointSubscription, error) {
+func (e *EventSubscriberImpl) rebuildSubscription(cameraID string, old *pullPointSubscription) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if old.subscriptionRef != "" && e.events != nil {
@@ -460,20 +466,21 @@ func (e *EventSubscriberImpl) rebuildSubscription(cameraID string, old *pullPoin
 	if err != nil {
 		e.mu.Unlock()
 		e.setPS(cameraID, func(p *pullPointSubscription) { p.lastError = err.Error() })
-		return nil, err
+		return err
 	}
 	e.subscriptions[cameraID] = fresh
 	e.mu.Unlock()
 	eventLogger.Info("rebuilt PullPoint subscription",
 		"camera_id", cameraID, "subscription_ref", fresh.subscriptionRef,
 		"granted", fresh.grantedDur.String())
-	return fresh, nil
+	return nil
 }
 
 // pollLoop ticks PullMessages until a terminal condition (subscription expired
 // or terminalPollFailures consecutive errors) or stop. Returns false only when
-// stopCh closed; true means "resubscribe and continue".
-func (e *EventSubscriberImpl) pollLoop(cameraID string, ps *pullPointSubscription, stopCh <-chan struct{}) bool {
+// stopCh closed; true means "resubscribe and continue". All subscription-state
+// access goes through the locked *Of/setPS helpers — never a raw pointer.
+func (e *EventSubscriberImpl) pollLoop(cameraID string, stopCh <-chan struct{}) bool {
 	ticker := time.NewTicker(e.pollInterval)
 	defer ticker.Stop()
 
@@ -570,6 +577,20 @@ func (e *EventSubscriberImpl) subLocked(cameraID string) *pullPointSubscription 
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.subscriptions[cameraID]
+}
+
+// lifecycleOf returns a lock-consistent snapshot of the subscription's
+// decision fields. run() must use this instead of reading ps.state/ps.active
+// on the raw pointer: Unsubscribe() and setPS mutate those fields under e.mu
+// (reading them unlocked raced with Unsubscribe — CI -race catch, 2026-09-09).
+func (e *EventSubscriberImpl) lifecycleOf(cameraID string) (state string, active bool, ok bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	ps, exists := e.subscriptions[cameraID]
+	if !exists {
+		return "", false, false
+	}
+	return ps.state, ps.active, true
 }
 
 func (e *EventSubscriberImpl) setPS(cameraID string, fn func(p *pullPointSubscription)) {

--- a/internal/onvif/events_test.go
+++ b/internal/onvif/events_test.go
@@ -341,3 +341,32 @@ func TestEventSubscriberImplImplementsEventSubscriber(t *testing.T) {
 	// Compile-time check: EventSubscriberImpl must implement EventSubscriber
 	var _ EventSubscriber = (*EventSubscriberImpl)(nil)
 }
+
+// TestEventSubscriberImpl_RunLifecycleReadsUnderLock is the regression test
+// for the CI -race catch (2026-09-09, PR #730 run): run() read ps.active /
+// ps.state on the raw subscription pointer while Unsubscribe() wrote them
+// under e.mu. Failing polls drive pollLoop to its terminal condition every
+// few milliseconds, so run() re-reads the lifecycle fields each cycle; the
+// Subscribe/Unsubscribe churn from this goroutine supplies the concurrent
+// writer. Under -race the old unlocked reads trip the detector quickly.
+func TestEventSubscriberImpl_RunLifecycleReadsUnderLock(t *testing.T) {
+	mock := &mockEventClient{
+		pullMessagesFn: func(_ context.Context, _ string, _ time.Duration, _ int) ([]onvifgo.NotificationMessage, error) {
+			return nil, fmt.Errorf("poll boom")
+		},
+	}
+	sub := helperNewEventSubscriberWithMock(mock,
+		WithPollInterval(time.Millisecond),
+		withResubscribeBackoff(time.Millisecond),
+	)
+	defer sub.StopAll(context.Background())
+
+	const cam = "cam-race"
+	for i := range 100 {
+		require.NoError(t, sub.Subscribe(context.Background(), cam))
+		// Vary the unsubscribe offset across the ~2ms poll-terminal cycle so
+		// the write collides with run()'s loop-top reads at some phase.
+		time.Sleep(time.Duration(i%4) * time.Millisecond)
+		require.NoError(t, sub.Unsubscribe(context.Background(), cam))
+	}
+}


### PR DESCRIPTION
## 问题
CI `-race` 在 PR #730 的 test job 摄到 main 上的预存数据竞争（`internal/camera` 四个测试报 "race detected"）：

```
Write at 0x... by goroutine: EventSubscriberImpl.Unsubscribe()  events.go:301  (ps.active = false, 持 e.mu)
Previous read:              EventSubscriberImpl.run()          events.go:414  (ps.active, 无锁 —— subLocked 返回裸指针后直接读)
```

`pollLoop` 本身守纪律（全部经锁内 `*Of`/`setPS` 助手），唯一的无锁读者是 `run()` 循环顶对 `ps.state`/`ps.active` 的判断。

## 修复
- `run()` 改经 `lifecycleOf()` 取锁一致的 `(state, active, ok)` 快照；裸指针仅保留给 `rebuildSubscription` 读不可变的 `subscriptionRef`。
- `pollLoop` 去掉从未使用的 `ps` 参数；`rebuildSubscription` 只返回 `error`（唯一调用方从未用其返回指针）——均单调用方内部方法。

## 测试（TDD）
- 新增 `TestEventSubscriberImpl_RunLifecycleReadsUnderLock`：失败 poll 以 ~2ms 周期驱动 `run()` 反复读生命周期字段 + 测试 goroutine 锤 Subscribe/Unsubscribe——**修复前 0.2s 内即触发 detector（本地复现）**，修复后 `-count=3` 干净。
- `internal/onvif` + `internal/camera` 全量 `-race` 绿（CI 摄到竞争的正是 camera 包）。

## 实机
M5 + R4S 已部署 `v0.12.0-48-tokenwake-2`（含本修复；M5 备份 bak-0910-prerace）：ONVIF events 订阅路径真机正常（不支持 PullPoint 的设备正确走 tombstone），重启后相机恢复 14 recording，错误仅已知项（小米 CS2 闪断/MiBeeCam 防锤）。