### PR TITLE
feat(timelapse): working MJPEG dual-mode timelapse + batched canvas playback

### DIFF
--- a/docs/en/timelapse.md
+++ b/docs/en/timelapse.md
@@ -54,6 +54,32 @@ cameras:
       merge_output_fps: 30
 ```
 
+### MJPEG / HTTP-JPEG Cameras (ESP32-class)
+
+MJPEG cameras with recording enabled (`recording_enabled`) also support dual-mode timelapse: the periodic merge samples JPEG frames directly from the recording segment directories at `interval` (this path previously produced nothing for MJPEG cameras). Disconnect fragments don't matter — sampling is continuous across segments in absolute time and gaps are skipped automatically.
+
+```yaml
+cameras:
+  - name: "MiBeeCam"
+    protocol: "onvif"
+    encoding: "jpeg"
+    url: "http://192.168.63.148/onvif/device_service"
+    recording_enabled: true
+
+    timelapse:
+      enabled: true
+      interval: "30s"                        # sampling: one frame every 30s (default)
+      merge_duration: "natural-day"          # one timelapse per calendar day
+      merge_output_fps: 30                   # output playback fps (24h ≈ 96s video)
+      delete_recordings_after_merge: true    # delete source recordings after merge (optional)
+```
+
+Notes:
+
+- **`interval` is the timelapse compression knob**: output duration ≈ window ÷ interval × (1 / `merge_output_fps`). This semantics applies uniformly to dual-mode cameras of every format.
+- **`delete_recordings_after_merge`** (default false): after a successful periodic merge, the source video recordings inside the window are deleted, truly reducing the file count. Recordings being processed by MiBeeVision are skipped; nothing is ever deleted when the merge fails. `delete_original` only removes timelapse frame directories — the two are independent.
+- Historical days can be backfilled with `POST /api/timelapse/{cameraId}/merge?date=YYYY-MM-DD&duration=natural-day`.
+
 ### Standalone Timelapse Configuration
 
 Create dedicated timelapse cameras with separate RTSP sources:

--- a/docs/zh/timelapse.md
+++ b/docs/zh/timelapse.md
@@ -54,6 +54,32 @@ cameras:
       output_fps: 30
 ```
 
+### MJPEG / HTTP-JPEG 摄像头（ESP32 类）
+
+开启录像（`recording_enabled`）的 MJPEG 相机同样支持双模延时：周期合并会直接从录像段目录里按 `interval` 采样 JPEG 帧（此前该路径对 MJPEG 相机无效）。断连碎片不影响采样——按绝对时间跨段连续采样，空洞自动跳过。
+
+```yaml
+cameras:
+  - name: "MiBeeCam"
+    protocol: "onvif"
+    encoding: "jpeg"
+    url: "http://192.168.63.148/onvif/device_service"
+    recording_enabled: true
+
+    timelapse:
+      enabled: true
+      interval: "30s"                        # 采样间隔：每 30s 取 1 帧（默认 30s）
+      merge_duration: "natural-day"          # 每个自然日一条延时视频
+      merge_output_fps: 30                   # 输出回放帧率（24h ≈ 96 秒视频）
+      delete_recordings_after_merge: true    # 合并成功后删除窗口内源录像段（可选）
+```
+
+要点：
+
+- **`interval` 是延时压缩旋钮**：输出时长 ≈ 窗口时长 ÷ interval × (1 / `merge_output_fps`)。所有格式的双模相机统一使用该语义。
+- **`delete_recordings_after_merge`**（默认 false）：周期合并成功后删除窗口内源录像段，真正减少文件数。AI 处理中的录像会跳过；合并失败绝不删除。`delete_original` 只删 timelapse 帧目录，两者互不影响。
+- 历史日期可用 `POST /api/timelapse/{cameraId}/merge?date=YYYY-MM-DD&duration=natural-day` 补跑。
+
 ### 独立延时摄影配置
 
 创建带有独立 RTSP 源的专用延时摄影摄像头：

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -181,6 +181,11 @@ type Handler struct {
 	visionCoordinator *vision.Coordinator
 	apiKeyStore       *middleware.APIKeyStore
 	whipServer        *whip.Server
+	// timelapseSourceDeleter backs the opt-in delete_recordings_after_merge
+	// behavior in manual merges. Wired post-construction
+	// (SetTimelapseSourceDeleter) because the cleanup manager is built after
+	// the handler in app assembly; nil = deletion disabled.
+	timelapseSourceDeleter timelapse.SourceRecordingDeleter
 	// frameListCache memoizes sorted file-name listings for MJPEG/timelapse frame
 	// directories so repeated ?frame=N / list-frames requests don't os.ReadDir + sort
 	// the whole directory on every hit. Keyed by dir path; invalidated by mtime + TTL.
@@ -570,6 +575,44 @@ func (h *Handler) SetAPIKeyStore(s *middleware.APIKeyStore) {
 // SetAIHandler sets the AI handler on the Handler.
 func (h *Handler) SetAIHandler(ah *AIHandler) {
 	h.aiHandler = ah
+}
+
+// SetTimelapseSourceDeleter wires the deleter used by the opt-in
+// delete_recordings_after_merge behavior in manual merges. Wired
+// post-construction because the cleanup manager is built after the handler
+// in app assembly.
+func (h *Handler) SetTimelapseSourceDeleter(d timelapse.SourceRecordingDeleter) {
+	h.timelapseSourceDeleter = d
+}
+
+// HasTimelapseSourceDeleter reports whether the timelapse source deleter is
+// wired. Exposed for wiring regression tests.
+func (h *Handler) HasTimelapseSourceDeleter() bool {
+	return h.timelapseSourceDeleter != nil
+}
+
+// timelapseExtractionInterval returns the camera's timelapse.interval for
+// recording→timelapse frame sampling (manual merges; default 30s).
+func (h *Handler) timelapseExtractionInterval(cameraID string) time.Duration {
+	if h.camMgr != nil {
+		if cam := h.camMgr.GetCameraConfig(cameraID); cam != nil && cam.Timelapse != nil {
+			if d, err := time.ParseDuration(cam.Timelapse.Interval); err == nil && d > 0 {
+				return d
+			}
+		}
+	}
+	return 30 * time.Second
+}
+
+// timelapseDeleteAfterMerge reports the camera's delete_recordings_after_merge
+// flag for manual merges (default false).
+func (h *Handler) timelapseDeleteAfterMerge(cameraID string) bool {
+	if h.camMgr != nil {
+		if cam := h.camMgr.GetCameraConfig(cameraID); cam != nil && cam.Timelapse != nil {
+			return cam.Timelapse.DeleteRecordingsAfterMerge
+		}
+	}
+	return false
 }
 
 // SetRelayManager wires the relay manager for the relay-presets endpoints.

--- a/internal/api/handlers_frame_batch.go
+++ b/internal/api/handlers_frame_batch.go
@@ -1,0 +1,261 @@
+// Frame-batch endpoints: one multipart/mixed HTTP response carries a batch of
+// JPEG frames, replacing the per-frame GET hot path of the JPEG cycler for
+// MJPEG playback (merged timelapse outputs + raw recording dirs + AVI files).
+// The frontend streams the response and decodes parts as Blobs — N frames per
+// request instead of N requests.
+package api
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/merge"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	frameBatchDefaultLimit = 120
+	frameBatchMaxLimit     = 240
+)
+
+// parseFrameBatchParams parses ?offset=&limit= for the frame-batch endpoints.
+// Defaults: offset 0, limit 120. limit is clamped to frameBatchMaxLimit;
+// offset<0 / limit<=0 / non-numeric values are rejected.
+func parseFrameBatchParams(r *http.Request) (offset, limit int, err error) {
+	if s := r.URL.Query().Get("offset"); s != "" {
+		v, perr := strconv.Atoi(s)
+		if perr != nil || v < 0 {
+			return 0, 0, fmt.Errorf("invalid offset %q", s)
+		}
+		offset = v
+	}
+	limit = frameBatchDefaultLimit
+	if s := r.URL.Query().Get("limit"); s != "" {
+		v, perr := strconv.Atoi(s)
+		if perr != nil || v <= 0 {
+			return 0, 0, fmt.Errorf("invalid limit %q", s)
+		}
+		if v > frameBatchMaxLimit {
+			v = frameBatchMaxLimit
+		}
+		limit = v
+	}
+	return offset, limit, nil
+}
+
+// writeFrameBatch streams a multipart/mixed batch of frames [offset,
+// offset+limit) as JPEG parts. count is clamped to the available range; an
+// out-of-range offset yields an empty (but valid) multipart body so players
+// stop cleanly. emit writes the i-th frame as one part.
+func (h *Handler) writeFrameBatch(w http.ResponseWriter, total, offset, limit int, emit func(i int, mw *multipart.Writer) error) {
+	count := limit
+	if offset+count > total {
+		count = total - offset
+	}
+	if count < 0 {
+		count = 0
+	}
+
+	mw := multipart.NewWriter(w)
+	w.Header().Set("Content-Type", "multipart/mixed; boundary="+mw.Boundary())
+	w.Header().Set("X-Frame-Total", strconv.Itoa(total))
+	w.Header().Set("X-Frame-Offset", strconv.Itoa(offset))
+	w.Header().Set("X-Frame-Count", strconv.Itoa(count))
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+
+	if count == 0 {
+		_ = mw.Close()
+		return
+	}
+	for i := offset; i < offset+count; i++ {
+		if err := emit(i, mw); err != nil {
+			// Status already sent — abort the batch mid-stream; the player
+			// sees a truncated part count and refetches the tail if needed.
+			logger.Warn("frame batch: emit failed", "index", i, "error", err)
+			break
+		}
+	}
+	_ = mw.Close()
+}
+
+// writeJPEGPartHeader creates one image/jpeg part. Callers write the payload.
+func writeJPEGPartHeader(mw *multipart.Writer, index int) (io.Writer, error) {
+	hdr := textproto.MIMEHeader{}
+	hdr.Set("Content-Type", "image/jpeg")
+	hdr.Set("X-Frame-Index", strconv.Itoa(index))
+	return mw.CreatePart(hdr)
+}
+
+// handleTimelapseMergeFrames handles GET /api/timelapse/merges/{id}/frames.
+// Slices JPEG frames out of an MJPEG (mjpa) periodic-merge output via the
+// pure-Go MP4 sample table (merge.ParseSegment → stsz/stco), streaming one
+// multipart part per frame. Only for codec=mjpeg merges — h264/h265 outputs
+// play natively via <video>.
+func (h *Handler) handleTimelapseMergeFrames(w http.ResponseWriter, r *http.Request) {
+	if h.db == nil {
+		WriteError(w, http.StatusInternalServerError, "database not available")
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id <= 0 {
+		WriteError(w, http.StatusBadRequest, "invalid merge id")
+		return
+	}
+	m, err := h.db.GetTimelapseMerge(r.Context(), id)
+	if err != nil || m == nil {
+		WriteError(w, http.StatusNotFound, "timelapse merge not found")
+		return
+	}
+	if m.Status != model.TimelapseMergeStatusCompleted || m.OutputPath == "" {
+		WriteError(w, http.StatusNotFound, "timelapse merge output not available")
+		return
+	}
+	if m.Codec != "" && m.Codec != model.TimelapseMergeCodecMJPEG {
+		WriteError(w, http.StatusNotFound, "frame batches only available for MJPEG merges")
+		return
+	}
+	if _, err := os.Stat(m.OutputPath); err != nil {
+		WriteError(w, http.StatusNotFound, "timelapse merge output file not available")
+		return
+	}
+	offset, limit, err := parseFrameBatchParams(r)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	seg, err := merge.ParseSegment(m.OutputPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "failed to index merge output frames")
+		return
+	}
+
+	f, err := os.Open(m.OutputPath)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "failed to open merge output")
+		return
+	}
+	defer f.Close()
+
+	if m.FPS > 0 {
+		w.Header().Set("X-Frame-Fps", strconv.Itoa(m.FPS))
+	}
+	h.writeFrameBatch(w, len(seg.Samples), offset, limit, func(i int, mw *multipart.Writer) error {
+		s := seg.Samples[i]
+		part, err := writeJPEGPartHeader(mw, i)
+		if err != nil {
+			return err
+		}
+		buf := make([]byte, s.Size)
+		if _, err := f.ReadAt(buf, s.Offset); err != nil {
+			return fmt.Errorf("read sample %d: %w", i, err)
+		}
+		_, err = part.Write(buf)
+		return err
+	})
+}
+
+// handleTimelapseFramesBatch handles GET /api/recordings/{id}/timelapse-frames/batch.
+// Serves a multipart/mixed JPEG batch from an MJPEG/timelapse recording
+// directory (timestamped .jpg files, cached listing) or an AVI recording
+// (frames indexed via the AVI movi chunk index).
+func (h *Handler) handleTimelapseFramesBatch(w http.ResponseWriter, r *http.Request) {
+	if h.db == nil {
+		WriteError(w, http.StatusInternalServerError, "database not available")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	rec, err := h.db.GetRecording(r.Context(), id)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "failed to get recording")
+		return
+	}
+	if rec == nil {
+		WriteError(w, http.StatusNotFound, "recording not found")
+		return
+	}
+
+	switch rec.Format {
+	case model.FormatMJPEG, model.FormatTimelapse:
+		h.handleFramesBatchDir(w, r, rec)
+	case model.FormatAVI:
+		h.handleFramesBatchAVI(w, r, rec)
+	default:
+		WriteError(w, http.StatusNotFound, "not a timelapse or MJPEG recording")
+	}
+}
+
+// handleFramesBatchDir streams a JPEG batch from an MJPEG/timelapse directory.
+func (h *Handler) handleFramesBatchDir(w http.ResponseWriter, r *http.Request, rec *model.Recording) {
+	offset, limit, err := parseFrameBatchParams(r)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	names, err := h.sortedImageFiles(rec.FilePath)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, "timelapse directory not found")
+		return
+	}
+	h.writeFrameBatch(w, len(names), offset, limit, func(i int, mw *multipart.Writer) error {
+		part, err := writeJPEGPartHeader(mw, i)
+		if err != nil {
+			return err
+		}
+		f, err := os.Open(filepath.Join(rec.FilePath, names[i]))
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(part, f)
+		return err
+	})
+}
+
+// handleFramesBatchAVI streams a JPEG batch from an AVI recording using the
+// demuxer's video frame index (one seek + copy per frame, no full demux).
+func (h *Handler) handleFramesBatchAVI(w http.ResponseWriter, r *http.Request, rec *model.Recording) {
+	offset, limit, err := parseFrameBatchParams(r)
+	if err != nil {
+		WriteError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	f, err := os.Open(rec.FilePath)
+	if err != nil {
+		WriteError(w, http.StatusNotFound, "AVI file not found")
+		return
+	}
+	defer f.Close()
+
+	dmx, err := avi.NewDemuxer(f)
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "parse AVI: "+err.Error())
+		return
+	}
+	entries, err := dmx.VideoFrameIndex()
+	if err != nil {
+		WriteError(w, http.StatusInternalServerError, "index AVI frames: "+err.Error())
+		return
+	}
+
+	h.writeFrameBatch(w, len(entries), offset, limit, func(i int, mw *multipart.Writer) error {
+		part, err := writeJPEGPartHeader(mw, i)
+		if err != nil {
+			return err
+		}
+		if _, err := f.Seek(entries[i].Offset, io.SeekStart); err != nil {
+			return err
+		}
+		_, err = io.CopyN(part, f, int64(entries[i].Size))
+		return err
+	})
+}

--- a/internal/api/handlers_frame_batch_test.go
+++ b/internal/api/handlers_frame_batch_test.go
@@ -1,0 +1,288 @@
+// Multipart frame-batch endpoint tests: one HTTP request returns a batch of
+// JPEG frames for MJPEG playback (merged timelapse outputs + raw recording
+// directories + AVI files), replacing the per-frame GET cycler hot path.
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMJPAMergeFixture merges n distinct minimal JPEGs into a real mjpa MP4
+// via the production GoMerger and returns its path plus the source frame bytes.
+func buildMJPAMergeFixture(t *testing.T, dir string, n int) (string, [][]byte) {
+	t.Helper()
+	framesDir := filepath.Join(dir, "frames")
+	if err := os.MkdirAll(framesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	frames := make([][]byte, n)
+	for i := range n {
+		frames[i] = []byte{0xFF, 0xD8, 0xFF, byte(0xA0 + i), byte(i), 0xFF, 0xD9}
+		if err := os.WriteFile(filepath.Join(framesDir, fmt.Sprintf("frame_%06d.jpg", i+1)), frames[i], 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := filepath.Join(dir, "periodic_test.mp4")
+	_, err := timelapse.NewGoMerger().Merge(context.Background(), framesDir, out, 10)
+	require.NoError(t, err, "GoMerger must produce a real mjpa MP4 for the fixture")
+	return out, frames
+}
+
+// parseMultipartParts decodes a multipart/mixed response body into parts.
+func parseMultipartParts(t *testing.T, resp *http.Response, body []byte) [][]byte {
+	t.Helper()
+	ct := resp.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(ct)
+	require.NoError(t, err)
+	require.Equal(t, "multipart/mixed", mediaType)
+	mr := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+	var parts [][]byte
+	for {
+		p, err := mr.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		data, err := io.ReadAll(p)
+		require.NoError(t, err)
+		parts = append(parts, data)
+	}
+	return parts
+}
+
+func TestHandleTimelapseMergeFrames_MultipartBatch(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	outPath, frames := buildMJPAMergeFixture(t, dir, 5)
+
+	windowStart := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	id, err := db.InsertTimelapseMerge(context.Background(), &model.TimelapseMerge{
+		CameraID: "cam-a", WindowStart: windowStart, WindowEnd: windowStart.Add(24 * time.Hour),
+		DurationLabel: "natural-day", OutputPath: outPath, Codec: model.TimelapseMergeCodecMJPEG,
+		FPS: 10, FrameCount: 5, Status: model.TimelapseMergeStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	resp := doRequest(t, h.Routes(), "GET", fmt.Sprintf("/api/timelapse/merges/%d/frames?offset=1&limit=2", id), nil, "", "")
+	require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+
+	require.Equal(t, "5", resp.Header().Get("X-Frame-Total"))
+	require.Equal(t, "1", resp.Header().Get("X-Frame-Offset"))
+	require.Equal(t, "2", resp.Header().Get("X-Frame-Count"))
+	require.Equal(t, "10", resp.Header().Get("X-Frame-Fps"))
+
+	parts := parseMultipartParts(t, resp.Result(), resp.Body.Bytes())
+	require.Len(t, parts, 2)
+	require.Equal(t, frames[1], parts[0], "offset=1 must return the 2nd frame")
+	require.Equal(t, frames[2], parts[1])
+}
+
+func TestHandleTimelapseMergeFrames_EmptyTail(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	outPath, _ := buildMJPAMergeFixture(t, dir, 3)
+
+	windowStart := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	id, err := db.InsertTimelapseMerge(context.Background(), &model.TimelapseMerge{
+		CameraID: "cam-a", WindowStart: windowStart, WindowEnd: windowStart.Add(24 * time.Hour),
+		DurationLabel: "natural-day", OutputPath: outPath, Codec: model.TimelapseMergeCodecMJPEG,
+		FPS: 10, FrameCount: 3, Status: model.TimelapseMergeStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	// Offset beyond the end → 200 with an EMPTY batch (player stops cleanly).
+	resp := doRequest(t, h.Routes(), "GET", fmt.Sprintf("/api/timelapse/merges/%d/frames?offset=99", id), nil, "", "")
+	require.Equal(t, 200, resp.Code)
+	require.Equal(t, "3", resp.Header().Get("X-Frame-Total"))
+	require.Equal(t, "0", resp.Header().Get("X-Frame-Count"))
+	parts := parseMultipartParts(t, resp.Result(), resp.Body.Bytes())
+	require.Empty(t, parts)
+}
+
+func TestHandleTimelapseMergeFrames_H264Rejected(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	windowStart := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	id, err := db.InsertTimelapseMerge(context.Background(), &model.TimelapseMerge{
+		CameraID: "cam-a", WindowStart: windowStart, WindowEnd: windowStart.Add(24 * time.Hour),
+		DurationLabel: "natural-day", OutputPath: "/tmp/x.mp4", Codec: model.TimelapseMergeCodecH264,
+		FPS: 30, Status: model.TimelapseMergeStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	resp := doRequest(t, h.Routes(), "GET", fmt.Sprintf("/api/timelapse/merges/%d/frames", id), nil, "", "")
+	require.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestHandleTimelapseMergeFrames_LimitClamped(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	outPath, frames := buildMJPAMergeFixture(t, dir, 5)
+
+	windowStart := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	id, err := db.InsertTimelapseMerge(context.Background(), &model.TimelapseMerge{
+		CameraID: "cam-a", WindowStart: windowStart, WindowEnd: windowStart.Add(24 * time.Hour),
+		DurationLabel: "natural-day", OutputPath: outPath, Codec: model.TimelapseMergeCodecMJPEG,
+		FPS: 10, FrameCount: 5, Status: model.TimelapseMergeStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	// limit=9999 clamps to the 5 available frames.
+	resp := doRequest(t, h.Routes(), "GET", fmt.Sprintf("/api/timelapse/merges/%d/frames?limit=9999", id), nil, "", "")
+	require.Equal(t, 200, resp.Code)
+	require.Equal(t, "5", resp.Header().Get("X-Frame-Count"))
+	parts := parseMultipartParts(t, resp.Result(), resp.Body.Bytes())
+	require.Len(t, parts, 5)
+	require.Equal(t, frames[0], parts[0])
+}
+
+// --- Recordings batch endpoint (mjpeg/timelapse dirs + AVI) ---
+
+func TestHandleTimelapseFramesBatch_MJPEGDir(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "seg")
+	if err := os.MkdirAll(segDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Timestamped names like storage.Manager.WriteFrame produces.
+	base := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+	frames := make([][]byte, 4)
+	names := make([]string, 4)
+	for i := range 4 {
+		frames[i] = []byte{0xFF, 0xD8, byte(0xB0 + i), 0xFF, 0xD9}
+		names[i] = base.Add(time.Duration(i)*time.Second).Format("20060102_150405.000") + ".jpg"
+		if err := os.WriteFile(filepath.Join(segDir, names[i]), frames[i], 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := &model.Recording{
+		ID: "rec-batch-1", CameraID: "cam-a", FilePath: segDir, Format: model.FormatMJPEG,
+		StartedAt: base, EndedAt: base.Add(4 * time.Second), Duration: 4,
+	}
+	require.NoError(t, db.InsertRecording(context.Background(), rec))
+
+	resp := doRequest(t, h.Routes(), "GET", "/api/recordings/rec-batch-1/timelapse-frames/batch?offset=1&limit=2", nil, "", "")
+	require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+	require.Equal(t, "4", resp.Header().Get("X-Frame-Total"))
+	require.Equal(t, "1", resp.Header().Get("X-Frame-Offset"))
+	require.Equal(t, "2", resp.Header().Get("X-Frame-Count"))
+
+	parts := parseMultipartParts(t, resp.Result(), resp.Body.Bytes())
+	require.Len(t, parts, 2)
+	require.Equal(t, frames[1], parts[0])
+	require.Equal(t, frames[2], parts[1])
+}
+
+func TestHandleTimelapseFramesBatch_AVI(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	aviPath := filepath.Join(dir, "rec.avi")
+	frames := make([][]byte, 3)
+	{
+		var buf bytes.Buffer
+		m := avi.NewVideoOnlyMuxer(&buf, 64, 48)
+		for i := range 3 {
+			frames[i] = []byte{0xFF, 0xD8, 0xFF, byte(0xC0 + i), 0xFF, 0xD9}
+			require.NoError(t, m.WriteVideo(frames[i], int64(i)*33333))
+		}
+		require.NoError(t, m.Close())
+		require.NoError(t, os.WriteFile(aviPath, buf.Bytes(), 0o644))
+	}
+
+	started := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "rec-avi-1", CameraID: "cam-a", FilePath: aviPath, Format: model.FormatAVI,
+		StartedAt: started, EndedAt: started.Add(time.Second), Duration: 1,
+	}))
+
+	resp := doRequest(t, h.Routes(), "GET", "/api/recordings/rec-avi-1/timelapse-frames/batch", nil, "", "")
+	require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+	require.Equal(t, "3", resp.Header().Get("X-Frame-Total"))
+
+	parts := parseMultipartParts(t, resp.Result(), resp.Body.Bytes())
+	require.Len(t, parts, 3)
+	// AVI chunks store the exact JPEG bytes written via WriteVideo.
+	require.Equal(t, frames[0], parts[0])
+	require.Equal(t, frames[2], parts[2])
+}
+
+func TestHandleTimelapseFramesBatch_NotFound(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	// Missing recording.
+	resp := doRequest(t, h.Routes(), "GET", "/api/recordings/nope/timelapse-frames/batch", nil, "", "")
+	require.Equal(t, http.StatusNotFound, resp.Code)
+
+	// Wrong format (h264 recording) → 404, not 500.
+	started := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "rec-h264", CameraID: "cam-a", FilePath: "/tmp/nope.mp4", Format: model.FormatH264,
+		StartedAt: started, EndedAt: started.Add(time.Second), Duration: 1,
+	}))
+	resp = doRequest(t, h.Routes(), "GET", "/api/recordings/rec-h264/timelapse-frames/batch", nil, "", "")
+	require.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+// TestHandleTimelapseFramesBatch_BadParams verifies invalid query params are
+// rejected rather than panicking.
+func TestHandleTimelapseFramesBatch_BadParams(t *testing.T) {
+	db, store := setupTestDB(t)
+	defer db.Close()
+	h := TestHandler(db, store)
+
+	dir := t.TempDir()
+	segDir := filepath.Join(dir, "seg")
+	if err := os.MkdirAll(segDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(segDir, "20260909_100000.000.jpg"), []byte{0xFF, 0xD8, 0xFF, 0xD9}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "rec-bad", CameraID: "cam-a", FilePath: segDir, Format: model.FormatMJPEG,
+		StartedAt: started, EndedAt: started.Add(time.Second), Duration: 1,
+	}))
+
+	for _, q := range []string{"offset=-5", "limit=0", "offset=abc", "limit=xyz"} {
+		resp := doRequest(t, h.Routes(), "GET", "/api/recordings/rec-bad/timelapse-frames/batch?"+q, nil, "", "")
+		require.Equal(t, http.StatusBadRequest, resp.Code, "query %q", q)
+	}
+}

--- a/internal/api/handlers_recording.go
+++ b/internal/api/handlers_recording.go
@@ -615,6 +615,8 @@ func (h *Handler) registerRecordingRoutes(r chi.Router) {
 			r.Get("/frames", h.handleListFrames)
 			r.Get("/playback", h.handlePlayback)
 			r.Get("/timelapse-frames", h.handleTimelapseFrames)
+			// Batch endpoint registered BEFORE the {filename} wildcard.
+			r.Get("/timelapse-frames/batch", h.handleTimelapseFramesBatch)
 			r.Get("/timelapse-frames/{filename}", h.handleTimelapseFrame)
 			r.Post("/retry-merge", h.handleRetryTimelapseMerge)
 		})

--- a/internal/api/handlers_timelapse.go
+++ b/internal/api/handlers_timelapse.go
@@ -42,15 +42,16 @@ func (h *Handler) handleGetCameraTimelapse(w http.ResponseWriter, r *http.Reques
 	// Return timelapse config (nil means disabled/no config)
 	if tl == nil {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"enabled":          false,
-			"interval":         "30s",
-			"frame_source":     "auto",
-			"paused":           false,
-			"delete_original":  false,
-			"merge_output_fps": 30,
-			"merge_mode":       "auto",
-			"daily_merge":      true,
-			"merge_duration":   "natural-day",
+			"enabled":                       false,
+			"interval":                      "30s",
+			"frame_source":                  "auto",
+			"paused":                        false,
+			"delete_original":               false,
+			"delete_recordings_after_merge": false,
+			"merge_output_fps":              30,
+			"merge_mode":                    "auto",
+			"daily_merge":                   true,
+			"merge_duration":                "natural-day",
 		})
 		return
 	}
@@ -453,7 +454,10 @@ func (h *Handler) handleTimelapseMergeWithDuration(w http.ResponseWriter, r *htt
 		}),
 		timelapse.WithRetainIntermediateMP4(retainMP4),
 		timelapse.WithIntermediateMP4Pruner(h.db),
+		timelapse.WithExtractionInterval(h.timelapseExtractionInterval(cameraID)),
+		timelapse.WithDeleteRecordingsAfterMerge(h.timelapseDeleteAfterMerge(cameraID)),
 	)
+	mgr.SetSourceRecordingDeleter(h.timelapseSourceDeleter)
 
 	// Run the merge on a Handler-tracked goroutine (mergeWg + mergeCtx) so
 	// Handler.Close can cancel + join it during shutdown. Previously this used
@@ -867,7 +871,10 @@ func (h *Handler) handleTimelapseBatchMerge(w http.ResponseWriter, r *http.Reque
 			timelapse.WithDurationLabel(body.Duration),
 			timelapse.WithRetainIntermediateMP4(retainMP4),
 			timelapse.WithIntermediateMP4Pruner(h.db),
+			timelapse.WithExtractionInterval(h.timelapseExtractionInterval(cameraID)),
+			timelapse.WithDeleteRecordingsAfterMerge(h.timelapseDeleteAfterMerge(cameraID)),
 		)
+		mgr.SetSourceRecordingDeleter(h.timelapseSourceDeleter)
 
 		// Launch merge in background (Handler-tracked so Close can join it).
 		h.startMergeGoroutine(func(ctx context.Context) {
@@ -1055,6 +1062,7 @@ func (h *Handler) registerTimelapseRoutes(r chi.Router) {
 	r.Get("/api/timelapse/merges", h.handleListTimelapseMerges)
 	r.Get("/api/timelapse/merges/{id}", h.handleGetTimelapseMerge)
 	r.Get("/api/timelapse/merges/{id}/download", h.handleDownloadTimelapseMerge)
+	r.Get("/api/timelapse/merges/{id}/frames", h.handleTimelapseMergeFrames)
 	r.Delete("/api/timelapse/merges/{id}", h.handleDeleteTimelapseMerge)
 	r.Post("/api/timelapse/{id}/merge", h.handleTimelapseMerge)
 	r.Delete("/api/timelapse/{id}/merge", h.handleTimelapseMergeCancel)

--- a/internal/config/config_timelapse.go
+++ b/internal/config/config_timelapse.go
@@ -44,6 +44,14 @@ type CameraTimelapseConfig struct {
 	// raw frame directories (frame_*.h264 / .h265 / .jpg) are always preserved
 	// regardless of this flag — only the rolling-merge .mp4 outputs are pruned.
 	RetainIntermediateMP4 *bool `yaml:"retain_intermediate_mp4,omitempty" json:"retain_intermediate_mp4,omitempty"`
+	// DeleteRecordingsAfterMerge deletes the source video recordings (DB rows
+	// + files) in the merge window after a periodic merge has successfully
+	// folded their frames into a timelapse output. Opt-in, default false —
+	// distinct from DeleteOriginal (which only removes timelapse frame dirs).
+	// Useful for fragment-heavy cameras (MJPEG/HTTP-JPEG) where the timelapse
+	// output replaces the raw segments. Recordings being processed by
+	// MiBeeVision are always skipped. Never applied when the merge failed.
+	DeleteRecordingsAfterMerge bool `yaml:"delete_recordings_after_merge,omitempty" json:"delete_recordings_after_merge,omitempty"`
 }
 
 // RetainIntermediateMP4Value returns the effective bool value of

--- a/internal/config/config_timelapse_test.go
+++ b/internal/config/config_timelapse_test.go
@@ -480,3 +480,26 @@ func TestTimelapseConfig_DeprecatedFieldsIgnored(t *testing.T) {
 	err := Validate(cfg)
 	require.NoError(t, err)
 }
+
+func TestTimelapseConfig_DeleteRecordingsAfterMerge(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{Cameras: []CameraConfig{
+		{
+			ID: "cam1", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://192.168.1.10/stream",
+			Timelapse: &CameraTimelapseConfig{
+				Enabled:                    true,
+				DeleteRecordingsAfterMerge: true,
+			},
+		},
+		{
+			ID: "cam2", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://192.168.1.11/stream",
+			Timelapse: &CameraTimelapseConfig{
+				Enabled: true,
+			},
+		},
+	}}
+	cfg.ApplyDefaults()
+	require.NoError(t, Validate(cfg))
+	require.True(t, cfg.Cameras[0].Timelapse.DeleteRecordingsAfterMerge)
+	require.False(t, cfg.Cameras[1].Timelapse.DeleteRecordingsAfterMerge) // opt-in, default false
+}

--- a/internal/middleware/compress.go
+++ b/internal/middleware/compress.go
@@ -123,6 +123,7 @@ func shouldSkipCompression(contentType string) bool {
 	case strings.HasPrefix(ct, "video/"),
 		strings.HasPrefix(ct, "image/"),
 		strings.HasPrefix(ct, "audio/"),
+		strings.HasPrefix(ct, "multipart/"), // JPEG frame batches — already-compressed payloads; the frontend streams the raw parts
 		ct == "application/zip",
 		ct == "application/gzip",
 		ct == "application/x-gzip",

--- a/internal/timelapse/frame_extractor.go
+++ b/internal/timelapse/frame_extractor.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/avi"
@@ -69,44 +71,127 @@ func (e *RecordingFrameExtractor) ExtractFrames(
 		return e.extractMP4(filePath, false, interval, outputDir)
 	case model.FormatH265:
 		return e.extractMP4(filePath, true, interval, outputDir)
+	case model.FormatMJPEG:
+		return e.extractMJPEGDirRelative(filePath, interval, outputDir)
 	default:
 		return 0, fmt.Errorf("unsupported format: %q", format)
 	}
 }
 
-// extractAVI reads video chunks from an AVI file and extracts JPEG frames at
-// the given interval. Uses the AVI demuxer's dwMicroSecPerFrame to map chunk
-// positions to timestamps.
-func (e *RecordingFrameExtractor) extractAVI(filePath string, interval time.Duration, outputDir string) (int, error) {
+// FrameSampler tracks the next absolute sampling target across recordings
+// within one merge window. Sampling is anchored to the previously taken frame
+// (next = ts + interval), so a long gap never produces a catch-up burst — the
+// first frame after a gap is taken immediately and the cadence restarts from
+// there. Not safe for concurrent use.
+type FrameSampler struct {
+	interval time.Duration
+	next     time.Time
+	end      time.Time // zero value = unbounded
+}
+
+// NewFrameSampler creates a sampler for a merge window [windowStart, windowEnd).
+// windowEnd may be zero for an unbounded window.
+func NewFrameSampler(interval time.Duration, windowStart, windowEnd time.Time) *FrameSampler {
+	return &FrameSampler{interval: interval, next: windowStart, end: windowEnd}
+}
+
+// ShouldTake reports whether a frame with the given absolute timestamp should
+// be extracted, advancing the sampler when it is.
+func (s *FrameSampler) ShouldTake(ts time.Time) bool {
+	if !s.end.IsZero() && !ts.Before(s.end) {
+		return false
+	}
+	if ts.Before(s.next) {
+		return false
+	}
+	s.next = ts.Add(s.interval)
+	return true
+}
+
+// ExtractWindowFrames extracts frames from one recording using absolute-time
+// sampling against a shared FrameSampler, continuing frame numbering from
+// startIndex (the first written file is frame_{startIndex+1}). This is the
+// fragmented-camera path: multiple recordings in one window share one sampler
+// and one output directory without overwriting each other.
+//
+// recStart is the recording's absolute start time (DB started_at); PTS within
+// the recording are offset by it. MJPEG directories carry absolute wall-clock
+// timestamps in their frame filenames, so recStart is ignored for them.
+//
+// A recording that contributes zero frames (e.g. a disconnect fragment shorter
+// than the sampling interval) is NOT an error — (0, nil) is returned.
+func (e *RecordingFrameExtractor) ExtractWindowFrames(
+	recPath string,
+	format model.Format,
+	recStart time.Time,
+	sampler *FrameSampler,
+	startIndex int,
+	outputDir string,
+) (int, error) {
+	if format == "" {
+		return 0, fmt.Errorf("format is required")
+	}
+	if sampler == nil {
+		return 0, fmt.Errorf("sampler is required")
+	}
+
+	switch format {
+	case model.FormatMJPEG:
+		return e.extractMJPEGDirWindow(recPath, sampler, startIndex, outputDir)
+	case model.FormatAVI:
+		return e.extractAVIWindow(recPath, recStart, sampler, startIndex, outputDir)
+	case model.FormatH264:
+		return e.extractMP4Window(recPath, false, recStart, sampler, startIndex, outputDir)
+	case model.FormatH265:
+		return e.extractMP4Window(recPath, true, recStart, sampler, startIndex, outputDir)
+	default:
+		return 0, fmt.Errorf("unsupported format: %q", format)
+	}
+}
+
+// aviVideoFrame is one AVI video chunk with its PTS in microseconds.
+type aviVideoFrame struct {
+	pts  int64 // microseconds
+	data []byte
+}
+
+// collectAVIFrames reads all video chunks from an AVI file, returning them in
+// stream order plus the demuxer's dwMicroSecPerFrame.
+func collectAVIFrames(filePath string) ([]aviVideoFrame, int64, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
-		return 0, fmt.Errorf("open AVI: %w", err)
+		return nil, 0, fmt.Errorf("open AVI: %w", err)
 	}
 	defer f.Close()
 
 	d, err := avi.NewDemuxer(f)
 	if err != nil {
-		return 0, fmt.Errorf("AVI demuxer: %w", err)
+		return nil, 0, fmt.Errorf("AVI demuxer: %w", err)
 	}
 
-	// Collect all video chunks with their PTS (microseconds).
-	type videoFrame struct {
-		pts  int64 // microseconds
-		data []byte
-	}
-	var frames []videoFrame
-
+	var frames []aviVideoFrame
 	for {
 		chunk, err := d.NextChunk()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return 0, fmt.Errorf("read AVI chunk: %w", err)
+			return nil, 0, fmt.Errorf("read AVI chunk: %w", err)
 		}
 		if chunk.Type == avi.ChunkVideo {
-			frames = append(frames, videoFrame{pts: chunk.PTS, data: chunk.Data})
+			frames = append(frames, aviVideoFrame{pts: chunk.PTS, data: chunk.Data})
 		}
+	}
+	return frames, int64(d.MicroSecPerFrame()), nil
+}
+
+// extractAVI reads video chunks from an AVI file and extracts JPEG frames at
+// the given interval. Uses the AVI demuxer's dwMicroSecPerFrame to map chunk
+// positions to timestamps.
+func (e *RecordingFrameExtractor) extractAVI(filePath string, interval time.Duration, outputDir string) (int, error) {
+	frames, microSecPerFrame, err := collectAVIFrames(filePath)
+	if err != nil {
+		return 0, err
 	}
 
 	if len(frames) == 0 {
@@ -114,7 +199,7 @@ func (e *RecordingFrameExtractor) extractAVI(filePath string, interval time.Dura
 	}
 
 	// Total duration: last frame's PTS + one frame interval.
-	totalDurUs := frames[len(frames)-1].pts + int64(d.MicroSecPerFrame())
+	totalDurUs := frames[len(frames)-1].pts + microSecPerFrame
 	totalDur := time.Duration(totalDurUs) * time.Microsecond
 
 	if interval > totalDur {
@@ -150,41 +235,176 @@ func (e *RecordingFrameExtractor) extractAVI(filePath string, interval time.Dura
 	return extracted, nil
 }
 
-// extractMP4 extracts keyframes from an H264 or H265 MP4 file at the given
-// interval. Uses merge.ParseSegment to get sample metadata and keyframe
-// detection, then reads only the selected sample data via ReadAt.
-//
-// Output frames are self-contained Annex-B NAL streams with parameter sets
-// prepended from the codec config, compatible with H264GoMerger/H265GoMerger.
-func (e *RecordingFrameExtractor) extractMP4(filePath string, isH265 bool, interval time.Duration, outputDir string) (int, error) {
+// extractAVIWindow is the window-sampling variant of extractAVI: frame PTS are
+// offset by recStart into absolute time and tested against the shared sampler.
+// Zero extracted frames is not an error (short fragment).
+func (e *RecordingFrameExtractor) extractAVIWindow(recPath string, recStart time.Time, sampler *FrameSampler, startIndex int, outputDir string) (int, error) {
+	frames, _, err := collectAVIFrames(recPath)
+	if err != nil {
+		return 0, err
+	}
+	if len(frames) == 0 {
+		return 0, fmt.Errorf("no video frames in AVI")
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return 0, fmt.Errorf("create output dir: %w", err)
+	}
+
+	var extracted int
+	for _, fr := range frames {
+		abs := recStart.Add(time.Duration(fr.pts) * time.Microsecond)
+		if !sampler.ShouldTake(abs) {
+			continue
+		}
+		filename := fmt.Sprintf("frame_%06d.jpg", startIndex+extracted+1)
+		framePath := filepath.Join(outputDir, filename)
+		if err := os.WriteFile(framePath, fr.data, 0o644); err != nil {
+			return extracted, fmt.Errorf("write frame %d: %w", startIndex+extracted+1, err)
+		}
+		extracted++
+	}
+
+	return extracted, nil
+}
+
+// mjpegFrameFile is one timestamped JPEG inside an MJPEG recording directory.
+type mjpegFrameFile struct {
+	name string
+	ts   time.Time
+}
+
+// parseMJPEGFrameTime parses the storage layer's frame filename layout
+// ("20060102_150405.000", local wall clock) into an absolute time.
+func parseMJPEGFrameTime(name string) (time.Time, bool) {
+	base := strings.TrimSuffix(strings.TrimSuffix(name, ".jpg"), ".jpeg")
+	for _, layout := range []string{"20060102_150405.000", "20060102_150405"} {
+		if ts, err := time.ParseInLocation(layout, base, time.Local); err == nil {
+			return ts, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// listMJPEGFrames lists the JPEG frames of an MJPEG recording directory in
+// chronological order (timestamped names sort chronologically).
+func listMJPEGFrames(dirPath string) ([]mjpegFrameFile, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("read MJPEG dir: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(e.Name())
+		if strings.HasSuffix(lower, ".jpg") || strings.HasSuffix(lower, ".jpeg") {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no JPEG frames in MJPEG directory %s", dirPath)
+	}
+	sort.Strings(names)
+
+	frames := make([]mjpegFrameFile, 0, len(names))
+	for _, name := range names {
+		ts, ok := parseMJPEGFrameTime(name)
+		if !ok {
+			continue // non-timestamped stray file — skip defensively
+		}
+		frames = append(frames, mjpegFrameFile{name: name, ts: ts})
+	}
+	if len(frames) == 0 {
+		return nil, fmt.Errorf("no timestamped JPEG frames in MJPEG directory %s", dirPath)
+	}
+	return frames, nil
+}
+
+// writeSampledMJPEGFrames copies the sampled frames from dirPath into
+// outputDir with continuous numbering. Returns the number written.
+func writeSampledMJPEGFrames(dirPath string, frames []mjpegFrameFile, sampler *FrameSampler, startIndex int, outputDir string) (int, error) {
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return 0, fmt.Errorf("create output dir: %w", err)
+	}
+	var extracted int
+	for _, fr := range frames {
+		if !sampler.ShouldTake(fr.ts) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dirPath, fr.name))
+		if err != nil {
+			return extracted, fmt.Errorf("read frame %s: %w", fr.name, err)
+		}
+		filename := fmt.Sprintf("frame_%06d.jpg", startIndex+extracted+1)
+		if err := os.WriteFile(filepath.Join(outputDir, filename), data, 0o644); err != nil {
+			return extracted, fmt.Errorf("write frame %d: %w", startIndex+extracted+1, err)
+		}
+		extracted++
+	}
+	return extracted, nil
+}
+
+// extractMJPEGDirRelative is the legacy single-recording path: sampling is
+// anchored at the first frame's timestamp and steps by interval.
+func (e *RecordingFrameExtractor) extractMJPEGDirRelative(dirPath string, interval time.Duration, outputDir string) (int, error) {
+	frames, err := listMJPEGFrames(dirPath)
+	if err != nil {
+		return 0, err
+	}
+	sampler := NewFrameSampler(interval, frames[0].ts, time.Time{})
+	extracted, err := writeSampledMJPEGFrames(dirPath, frames, sampler, 0, outputDir)
+	if err != nil {
+		return extracted, err
+	}
+	if extracted == 0 {
+		return 0, fmt.Errorf("no frames extracted at interval %v", interval)
+	}
+	return extracted, nil
+}
+
+// extractMJPEGDirWindow is the window-sampling variant for MJPEG directories;
+// frame timestamps come from the filenames (absolute wall clock).
+func (e *RecordingFrameExtractor) extractMJPEGDirWindow(recPath string, sampler *FrameSampler, startIndex int, outputDir string) (int, error) {
+	frames, err := listMJPEGFrames(recPath)
+	if err != nil {
+		return 0, err
+	}
+	return writeSampledMJPEGFrames(recPath, frames, sampler, startIndex, outputDir)
+}
+
+// mp4SyncSample is a keyframe sample with its cumulative time in microseconds.
+type mp4SyncSample struct {
+	offset    int64
+	size      uint32
+	cumTimeUs int64
+}
+
+// collectMP4Syncs parses an H264/H265 MP4 and returns its keyframe samples
+// (with cumulative times), the codec parameter sets, and the total duration.
+func collectMP4Syncs(filePath string, isH265 bool) ([]mp4SyncSample, [][]byte, time.Duration, error) {
 	seg, err := merge.ParseSegment(filePath)
 	if err != nil {
-		return 0, fmt.Errorf("parse MP4: %w", err)
+		return nil, nil, 0, fmt.Errorf("parse MP4: %w", err)
 	}
 
 	if len(seg.Samples) == 0 {
-		return 0, fmt.Errorf("no samples in MP4")
+		return nil, nil, 0, fmt.Errorf("no samples in MP4")
 	}
 
 	// Collect parameter sets from codec config.
 	paramSets := collectParamSets(seg, isH265)
 	if len(paramSets) == 0 {
-		return 0, fmt.Errorf("no codec parameter sets found in MP4")
+		return nil, nil, 0, fmt.Errorf("no codec parameter sets found in MP4")
 	}
 
-	// Build a list of keyframe samples with cumulative time in microseconds.
-	type syncSample struct {
-		offset    int64
-		size      uint32
-		cumTimeUs int64
-	}
-	var syncs []syncSample
+	var syncs []mp4SyncSample
 	cumTimeUs := int64(0)
-
 	for _, s := range seg.Samples {
 		durUs := int64(s.Duration) * 1000000 / int64(seg.Timescale)
 		if s.IsKeyFrame {
-			syncs = append(syncs, syncSample{
+			syncs = append(syncs, mp4SyncSample{
 				offset:    s.Offset,
 				size:      s.Size,
 				cumTimeUs: cumTimeUs,
@@ -193,9 +413,22 @@ func (e *RecordingFrameExtractor) extractMP4(filePath string, isH265 bool, inter
 		cumTimeUs += durUs
 	}
 
-	totalDur := seg.TotalDuration
 	if len(syncs) == 0 {
-		return 0, fmt.Errorf("no keyframes in MP4")
+		return nil, nil, 0, fmt.Errorf("no keyframes in MP4")
+	}
+	return syncs, paramSets, seg.TotalDuration, nil
+}
+
+// extractMP4 extracts keyframes from an H264 or H265 MP4 file at the given
+// interval. Uses merge.ParseSegment to get sample metadata and keyframe
+// detection, then reads only the selected sample data via ReadAt.
+//
+// Output frames are self-contained Annex-B NAL streams with parameter sets
+// prepended from the codec config, compatible with H264GoMerger/H265GoMerger.
+func (e *RecordingFrameExtractor) extractMP4(filePath string, isH265 bool, interval time.Duration, outputDir string) (int, error) {
+	syncs, paramSets, totalDur, err := collectMP4Syncs(filePath, isH265)
+	if err != nil {
+		return 0, err
 	}
 
 	if interval > totalDur {
@@ -226,28 +459,76 @@ func (e *RecordingFrameExtractor) extractMP4(filePath string, isH265 bool, inter
 
 	for _, sync := range syncs {
 		if sync.cumTimeUs >= nextTargetUs {
-			// Read the sample data at its offset (length-prefixed NALUs).
-			sampleData := make([]byte, sync.size)
-			if _, err := f.ReadAt(sampleData, sync.offset); err != nil {
-				return extracted, fmt.Errorf("read sample at offset %d: %w", sync.offset, err)
+			extracted, err = writeSyncFrame(f, sync, paramSets, isH265, ext, outputDir, extracted, 0)
+			if err != nil {
+				return extracted, err
 			}
-
-			// Build Annex-B frame: parameter sets + sample NALUs (stripping
-			// duplicate param sets from the sample data).
-			frameData := buildAnnexBFrame(sampleData, paramSets, isH265)
-
-			filename := fmt.Sprintf("frame_%06d%s", extracted+1, ext)
-			framePath := filepath.Join(outputDir, filename)
-			if err := os.WriteFile(framePath, frameData, 0o644); err != nil {
-				return extracted, fmt.Errorf("write frame %d: %w", extracted+1, err)
-			}
-			extracted++
 			nextTargetUs += intervalUs
 		}
 	}
 
 	if extracted == 0 {
 		return 0, fmt.Errorf("no frames extracted at interval %v", interval)
+	}
+
+	return extracted, nil
+}
+
+// writeSyncFrame reads one keyframe sample and writes it as an Annex-B frame
+// file with the given absolute index (startIndex+ordinal+1).
+func writeSyncFrame(f *os.File, sync mp4SyncSample, paramSets [][]byte, isH265 bool, ext, outputDir string, ordinal, startIndex int) (int, error) {
+	// Read the sample data at its offset (length-prefixed NALUs).
+	sampleData := make([]byte, sync.size)
+	if _, err := f.ReadAt(sampleData, sync.offset); err != nil {
+		return ordinal, fmt.Errorf("read sample at offset %d: %w", sync.offset, err)
+	}
+
+	// Build Annex-B frame: parameter sets + sample NALUs (stripping
+	// duplicate param sets from the sample data).
+	frameData := buildAnnexBFrame(sampleData, paramSets, isH265)
+
+	filename := fmt.Sprintf("frame_%06d%s", startIndex+ordinal+1, ext)
+	framePath := filepath.Join(outputDir, filename)
+	if err := os.WriteFile(framePath, frameData, 0o644); err != nil {
+		return ordinal, fmt.Errorf("write frame %d: %w", startIndex+ordinal+1, err)
+	}
+	return ordinal + 1, nil
+}
+
+// extractMP4Window is the window-sampling variant of extractMP4: keyframe
+// cumulative times are offset by recStart into absolute time and tested
+// against the shared sampler. Zero extracted frames is not an error.
+func (e *RecordingFrameExtractor) extractMP4Window(recPath string, isH265 bool, recStart time.Time, sampler *FrameSampler, startIndex int, outputDir string) (int, error) {
+	syncs, paramSets, _, err := collectMP4Syncs(recPath, isH265)
+	if err != nil {
+		return 0, err
+	}
+
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return 0, fmt.Errorf("create output dir: %w", err)
+	}
+
+	f, err := os.Open(recPath)
+	if err != nil {
+		return 0, fmt.Errorf("open MP4: %w", err)
+	}
+	defer f.Close()
+
+	ext := ".h264"
+	if isH265 {
+		ext = ".h265"
+	}
+
+	var extracted int
+	for _, sync := range syncs {
+		abs := recStart.Add(time.Duration(sync.cumTimeUs) * time.Microsecond)
+		if !sampler.ShouldTake(abs) {
+			continue
+		}
+		extracted, err = writeSyncFrame(f, sync, paramSets, isH265, ext, outputDir, extracted, startIndex)
+		if err != nil {
+			return extracted, err
+		}
 	}
 
 	return extracted, nil

--- a/internal/timelapse/frame_extractor_test.go
+++ b/internal/timelapse/frame_extractor_test.go
@@ -1026,7 +1026,7 @@ func TestRecordingFrameExtractor_IntervalTooLarge(t *testing.T) {
 func TestRecordingFrameExtractor_InvalidFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 	extractor := NewRecordingFrameExtractor()
-	_, err := extractor.ExtractFrames("dummy", model.FormatMJPEG, time.Second, tmpDir)
+	_, err := extractor.ExtractFrames("dummy", model.Format("mpegts"), time.Second, tmpDir)
 	if err == nil {
 		t.Error("expected error for unsupported format, got nil")
 	}
@@ -1430,5 +1430,271 @@ func TestRecordingFrameExtractor_AVI_FrameCountPrecision(t *testing.T) {
 	expected := 20
 	if n < expected-1 || n > expected+1 {
 		t.Errorf("expected ~%d frames (tolerance ±1), got %d", expected, n)
+	}
+}
+
+// --- Test MJPEG directory frame extraction + window sampler ---
+
+// writeMJPEGDirFixture writes n timestamped JPEG frames into dir, one every
+// step starting at start (mirrors storage.Manager.WriteFrame naming:
+// local-time "20060102_150405.000.jpg"). base differentiates frame bytes
+// between recordings so overwrites are detectable.
+func writeMJPEGDirFixture(t *testing.T, dir string, start time.Time, n int, step time.Duration, base byte) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for i := range n {
+		ts := start.Add(time.Duration(i) * step)
+		name := ts.Format("20060102_150405.000") + ".jpg"
+		if err := os.WriteFile(filepath.Join(dir, name), buildTestJPEG(t, base+byte(i)), 0o644); err != nil {
+			t.Fatalf("write frame %s: %v", name, err)
+		}
+	}
+}
+
+// frameMarker extracts the per-frame marker byte written by buildTestJPEG.
+// The scan data starts right after the SOS header (0xFF 0xDA ... 14 bytes).
+func frameMarker(t *testing.T, path string) byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	idx := bytes.Index(data, []byte{0xFF, 0xDA})
+	if idx < 0 || idx+14 >= len(data) {
+		t.Fatalf("%s: SOS marker not found or truncated", path)
+	}
+	return data[idx+14]
+}
+
+func TestFrameSampler(t *testing.T) {
+	start := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+	end := start.Add(1 * time.Hour)
+	s := NewFrameSampler(10*time.Second, start, end)
+
+	// First frame at window start is taken.
+	if !s.ShouldTake(start) {
+		t.Error("frame at window start should be taken")
+	}
+	// Frame 5s later: next target is start+10s → skipped.
+	if s.ShouldTake(start.Add(5 * time.Second)) {
+		t.Error("frame 5s after taken frame should be skipped")
+	}
+	// Frame exactly at next target: taken.
+	if !s.ShouldTake(start.Add(10 * time.Second)) {
+		t.Error("frame at next target should be taken")
+	}
+	// Gap clamping: after a 5-minute outage the first returning frame is
+	// taken immediately (no catch-up burst), and the following 1s frame is not.
+	if !s.ShouldTake(start.Add(5 * time.Minute)) {
+		t.Error("first frame after a gap should be taken")
+	}
+	if s.ShouldTake(start.Add(5*time.Minute + time.Second)) {
+		t.Error("frame 1s after gap-recovery frame should be skipped")
+	}
+	// Beyond window end: never taken.
+	if s.ShouldTake(end.Add(5 * time.Second)) {
+		t.Error("frame beyond window end should be skipped")
+	}
+}
+
+func TestRecordingFrameExtractor_MJPEGDir_Legacy(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "seg_mjpeg")
+	outputDir := filepath.Join(tmpDir, "frames")
+
+	// 60 frames, one per second (mirrors a low-fps MJPEG camera segment).
+	start := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+	writeMJPEGDirFixture(t, dir, start, 60, time.Second, 0)
+
+	extractor := NewRecordingFrameExtractor()
+	n, err := extractor.ExtractFrames(dir, model.FormatMJPEG, 15*time.Second, outputDir)
+	if err != nil {
+		t.Fatalf("ExtractFrames failed: %v", err)
+	}
+	// Legacy relative sampling: first frame taken, then one per 15s → 0,15,30,45 = 4.
+	if n != 4 {
+		t.Errorf("expected 4 frames, got %d", n)
+	}
+	matches, _ := filepath.Glob(filepath.Join(outputDir, "frame_*.jpg"))
+	if len(matches) != 4 {
+		t.Errorf("expected 4 frame files, got %d", len(matches))
+	}
+}
+
+func TestRecordingFrameExtractor_MJPEGDir_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "empty_seg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	extractor := NewRecordingFrameExtractor()
+	_, err := extractor.ExtractFrames(dir, model.FormatMJPEG, time.Second, tmpDir)
+	if err == nil {
+		t.Error("expected error for MJPEG dir with no frames, got nil")
+	}
+}
+
+// TestRecordingFrameExtractor_MJPEGDir_Window is the core fragmented-camera
+// scenario: two short segments (disconnect in between) share one output dir,
+// one FrameSampler and continuing numbering — no overwrite, chronological
+// order, gap-aware sampling.
+func TestRecordingFrameExtractor_MJPEGDir_Window(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "frames")
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+	windowEnd := windowStart.Add(24 * time.Hour)
+
+	// Segment A: 60s @ 1fps starting at window start, marker bytes 0..59.
+	dirA := filepath.Join(tmpDir, "segA")
+	writeMJPEGDirFixture(t, dirA, windowStart, 60, time.Second, 0)
+	// Segment B after a 4-minute outage: 60s @ 1fps from 10:05, markers 100..159.
+	dirB := filepath.Join(tmpDir, "segB")
+	writeMJPEGDirFixture(t, dirB, windowStart.Add(5*time.Minute), 60, time.Second, 100)
+
+	extractor := NewRecordingFrameExtractor()
+	sampler := NewFrameSampler(10*time.Second, windowStart, windowEnd)
+
+	nA, err := extractor.ExtractWindowFrames(dirA, model.FormatMJPEG, windowStart, sampler, 0, outputDir)
+	if err != nil {
+		t.Fatalf("ExtractWindowFrames A failed: %v", err)
+	}
+	// A: targets 10:00:00, :10, :20, :30, :40, :50 → 6 frames.
+	if nA != 6 {
+		t.Errorf("segment A: expected 6 frames, got %d", nA)
+	}
+
+	nB, err := extractor.ExtractWindowFrames(dirB, model.FormatMJPEG, windowStart.Add(5*time.Minute), sampler, nA, outputDir)
+	if err != nil {
+		t.Fatalf("ExtractWindowFrames B failed: %v", err)
+	}
+	// B: gap-clamped — 10:05:00 taken immediately, then :10,:20,:30,:40,:50 → 6 frames.
+	if nB != 6 {
+		t.Errorf("segment B: expected 6 frames, got %d", nB)
+	}
+
+	total := nA + nB
+	matches, _ := filepath.Glob(filepath.Join(outputDir, "frame_*.jpg"))
+	if len(matches) != total {
+		t.Errorf("expected %d frame files, got %d", total, len(matches))
+	}
+
+	// No overwrite: frame_000006 is A's last sampled frame (10:00:50, marker 50),
+	// frame_000007 is B's first (10:05:00, marker 100).
+	if got := frameMarker(t, filepath.Join(outputDir, "frame_000006.jpg")); got != 50 {
+		t.Errorf("frame_000006 marker = %d, want 50 (segment A 10:00:50)", got)
+	}
+	if got := frameMarker(t, filepath.Join(outputDir, "frame_000007.jpg")); got != 100 {
+		t.Errorf("frame_000007 marker = %d, want 100 (segment B 10:05:00)", got)
+	}
+}
+
+// TestRecordingFrameExtractor_AVI_Window verifies window sampling +
+// startIndex continuation for AVI recordings (PTS offset by recording start).
+func TestRecordingFrameExtractor_AVI_Window(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "frames")
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	buildAVI := func(name string, frames int, base byte) string {
+		path := filepath.Join(tmpDir, name)
+		var buf bytes.Buffer
+		m := avi.NewVideoOnlyMuxer(&buf, 64, 48)
+		for i := range frames {
+			if err := m.WriteVideo(buildTestJPEG(t, base+byte(i)), int64(i)*100*1000); err != nil { // 10fps
+				t.Fatalf("WriteVideo %d: %v", i, err)
+			}
+		}
+		if err := m.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+			t.Fatalf("write AVI: %v", err)
+		}
+		return path
+	}
+
+	// Recording A: 100 frames. The AVI muxer pins dwMicroSecPerFrame=33333µs
+	// (30fps), so PTS = i*33.3ms → recording spans ~3.33s (markers 0..99).
+	aviA := buildAVI("a.avi", 100, 0)
+	// Recording B 2 minutes later (markers 100..199).
+	recBStart := windowStart.Add(2 * time.Minute)
+	aviB := buildAVI("b.avi", 100, 100)
+
+	extractor := NewRecordingFrameExtractor()
+	sampler := NewFrameSampler(time.Second, windowStart, windowStart.Add(time.Hour))
+
+	nA, err := extractor.ExtractWindowFrames(aviA, model.FormatAVI, windowStart, sampler, 0, outputDir)
+	if err != nil {
+		t.Fatalf("A failed: %v", err)
+	}
+	// A: absolute targets 10:00:00/01/02/03 → 4 frames.
+	if nA != 4 {
+		t.Errorf("A: expected 4 frames, got %d", nA)
+	}
+	nB, err := extractor.ExtractWindowFrames(aviB, model.FormatAVI, recBStart, sampler, nA, outputDir)
+	if err != nil {
+		t.Fatalf("B failed: %v", err)
+	}
+	// B: next target after A's last (10:00:03+1s) is long past — first frame at
+	// 10:02:00 taken, then :01/:02/:03 → 4 frames.
+	if nB != 4 {
+		t.Errorf("B: expected 4 frames, got %d", nB)
+	}
+
+	// Continuation: frame_000005 must be B's first frame (marker 100), proving
+	// no overwrite of A's frame_000005 slot... rather, that B starts at 5.
+	if got := frameMarker(t, filepath.Join(outputDir, "frame_000005.jpg")); got != 100 {
+		t.Errorf("frame_000005 marker = %d, want 100 (recording B first frame)", got)
+	}
+	matches, _ := filepath.Glob(filepath.Join(outputDir, "frame_*.jpg"))
+	if len(matches) != nA+nB {
+		t.Errorf("expected %d files, got %d", nA+nB, len(matches))
+	}
+}
+
+// TestRecordingFrameExtractor_H264_Window verifies window sampling + startIndex
+// continuation for H264 MP4 recordings.
+func TestRecordingFrameExtractor_H264_Window(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputDir := filepath.Join(tmpDir, "frames")
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	// 3 keyframes 1s apart (timescale 30 → duration 30 each).
+	samples := []testSample{
+		{data: buildH264IDRSample(), isKeyFrame: true, duration: 30},
+		{data: buildH264IDRSample(), isKeyFrame: true, duration: 30},
+		{data: buildH264IDRSample(), isKeyFrame: true, duration: 30},
+	}
+	mp4A := createTestMP4(t, tmpDir, "a.h264.mp4", false, samples, 30)
+	mp4B := createTestMP4(t, tmpDir, "b.h264.mp4", false, samples, 30)
+
+	extractor := NewRecordingFrameExtractor()
+	sampler := NewFrameSampler(2*time.Second, windowStart, windowStart.Add(time.Hour))
+
+	// A: targets 0s and 2s → frames 1 and 3 → 2 extracted.
+	nA, err := extractor.ExtractWindowFrames(mp4A, model.FormatH264, windowStart, sampler, 0, outputDir)
+	if err != nil {
+		t.Fatalf("A failed: %v", err)
+	}
+	if nA != 2 {
+		t.Errorf("A: expected 2 frames, got %d", nA)
+	}
+	// B starts 60s later: first frame taken (gap clamp) at rel 0s, rel 1s
+	// skipped, rel 2s taken → 2 extracted, numbering continues at 3.
+	recBStart := windowStart.Add(time.Minute)
+	nB, err := extractor.ExtractWindowFrames(mp4B, model.FormatH264, recBStart, sampler, nA, outputDir)
+	if err != nil {
+		t.Fatalf("B failed: %v", err)
+	}
+	if nB != 2 {
+		t.Errorf("B: expected 2 frames, got %d", nB)
+	}
+	for i := 1; i <= nA+nB; i++ {
+		name := filepath.Join(outputDir, fmt.Sprintf("frame_%06d.h264", i))
+		if _, err := os.Stat(name); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
 	}
 }

--- a/internal/timelapse/periodic_merge.go
+++ b/internal/timelapse/periodic_merge.go
@@ -102,6 +102,25 @@ type PeriodicMergeManager struct {
 	// (legacy callers / tests) — in that case the row uses duration.String().
 	durationLabel string
 
+	// extractionInterval is the per-camera timelapse.interval — how often a
+	// frame is sampled from source video recordings when recording_enabled=true.
+	// Zero/negative falls back to defaultExtractionInterval at the use site.
+	// This is the timelapse compression knob (30s default → 24h becomes ~96s
+	// of output at 30fps), NOT the output playback fps (m.fps).
+	extractionInterval time.Duration
+
+	// deleteRecordingsAfterMerge implements the per-camera
+	// delete_recordings_after_merge config: when true (and a sourceDeleter is
+	// wired), source video recordings are deleted after their frames have been
+	// successfully folded into a periodic-merge output. Never on merge failure.
+	deleteRecordingsAfterMerge bool
+
+	// sourceDeleter deletes source recordings (DB rows + disk files) for the
+	// deleteRecordingsAfterMerge behavior. nil = deletion disabled. Production
+	// wiring adapts cleanup.CleanupManager.BatchDeleteRecordingsWithFiles,
+	// which skips recordings being processed by MiBeeVision.
+	sourceDeleter SourceRecordingDeleter
+
 	// runCtx holds per-Run metadata (camera/window/label) that finalizeMerge
 	// needs to write the timelapse_merges DB row. Set at the top of Run under
 	// runCtxMu. Empty runCtx.cameraID signals "no DB recording" (legacy mode
@@ -124,10 +143,63 @@ type periodicRunContext struct {
 	durationLabel string
 }
 
+// SourceRecordingDeleter deletes source video recordings (DB rows + disk
+// files) after their frames have been folded into a periodic-merge output.
+// Implementations must skip recordings protected by MiBeeVision processing —
+// the production adapter wraps cleanup.CleanupManager.BatchDeleteRecordingsWithFiles.
+type SourceRecordingDeleter interface {
+	DeleteRecordings(ctx context.Context, recordings []model.Recording, reason string) ([]string, error)
+}
+
 // Option configures PeriodicMergeManager behavior.
 
 // Option configures PeriodicMergeManager behavior.
 type Option func(*PeriodicMergeManager)
+
+// WithExtractionInterval sets the frame-sampling interval used when extracting
+// timelapse frames from video recordings (per-camera timelapse.interval,
+// default 30s). Smaller interval → denser timelapse; this is independent of
+// the output playback fps.
+func WithExtractionInterval(d time.Duration) Option {
+	return func(m *PeriodicMergeManager) {
+		m.extractionInterval = d
+	}
+}
+
+// WithDeleteRecordingsAfterMerge enables the per-camera
+// delete_recordings_after_merge behavior: source video recordings in the
+// window are deleted after a successful periodic merge (opt-in, default off).
+// A source deleter must also be wired (SetSourceRecordingDeleter).
+func WithDeleteRecordingsAfterMerge(enabled bool) Option {
+	return func(m *PeriodicMergeManager) {
+		m.deleteRecordingsAfterMerge = enabled
+	}
+}
+
+// SetSourceRecordingDeleter wires the deleter used by
+// delete_recordings_after_merge. Wired post-construction because the cleanup
+// manager is built after the periodic-merge managers in app assembly.
+// Deletion runs only when BOTH the flag (WithDeleteRecordingsAfterMerge) and
+// this deleter are set.
+func (m *PeriodicMergeManager) SetSourceRecordingDeleter(d SourceRecordingDeleter) {
+	m.sourceDeleter = d
+}
+
+// ExtractionInterval returns the effective frame-sampling interval (the
+// configured timelapse.interval, or the 30s default when unset). Exposed for
+// wiring regression tests.
+func (m *PeriodicMergeManager) ExtractionInterval() time.Duration {
+	if m.extractionInterval <= 0 {
+		return defaultExtractionInterval
+	}
+	return m.extractionInterval
+}
+
+// HasSourceDeleter reports whether a source-recording deleter is wired.
+// Exposed for wiring regression tests.
+func (m *PeriodicMergeManager) HasSourceDeleter() bool {
+	return m.sourceDeleter != nil
+}
 
 // WithRecordingEnabledProvider sets a function that reports if a camera has
 // recording_enabled=true. When true, Run will extract frames from video
@@ -324,14 +396,16 @@ func (m *PeriodicMergeManager) Run(ctx context.Context, cameraID string, t time.
 	//   - MJPEG ✅ (same JPEG extraction as AVI)
 	//   - MPEG-TS ✗ (no moov/stss boxes, too expensive to probe)
 	recordingEnabled := m.recordingEnabledProvider != nil && m.recordingEnabledProvider(cameraID)
+	var extractedSources map[string][]model.Recording
 	if recordingEnabled {
-		videoSegs, dirs, err := m.extractRecordingFrames(ctx, cameraID, startTime, endTime)
+		videoSegs, dirs, sources, err := m.extractRecordingFrames(ctx, cameraID, startTime, endTime)
 		if err != nil {
 			slog.Warn("periodic merge: recording frame extraction failed",
 				"camera_id", cameraID, "error", err)
 		}
 		tmpDirs = append(tmpDirs, dirs...)
 		segments = append(segments, videoSegs...)
+		extractedSources = sources
 	}
 
 	// 2. Handle no segments.
@@ -348,8 +422,9 @@ func (m *PeriodicMergeManager) Run(ctx context.Context, cameraID string, t time.
 		// 3b. Per-codec merge: group segments by codec type and run separate
 		// pipelines to avoid mixing incompatible codecs (e.g. H264+H265)
 		// in a single merge output. Temporary directories are cleaned up
-		// via the deferred function above.
-		return m.runPerCodecMerge(ctx, segments, cameraID, windowLabel)
+		// via the deferred function above. extractedSources feeds the opt-in
+		// delete_recordings_after_merge cleanup per group.
+		return m.runPerCodecMerge(ctx, segments, extractedSources, cameraID, windowLabel)
 	}
 
 	// 3. Build output path.

--- a/internal/timelapse/periodic_merge_extract_test.go
+++ b/internal/timelapse/periodic_merge_extract_test.go
@@ -1,0 +1,256 @@
+// Periodic-merge recording-frame extraction tests: MJPEG directory support,
+// window sampling via WithExtractionInterval, and opt-in source-recording
+// deletion after a successful merge (delete_recordings_after_merge).
+package timelapse
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// fakeSourceDeleter records DeleteRecordings calls for assertions.
+type fakeSourceDeleter struct {
+	calls     [][]model.Recording
+	reasons   []string
+	returnIDs []string
+	err       error
+}
+
+func (f *fakeSourceDeleter) DeleteRecordings(_ context.Context, recordings []model.Recording, reason string) ([]string, error) {
+	f.calls = append(f.calls, recordings)
+	f.reasons = append(f.reasons, reason)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.returnIDs != nil {
+		return f.returnIDs, nil
+	}
+	ids := make([]string, len(recordings))
+	for i, r := range recordings {
+		ids[i] = r.ID
+	}
+	return ids, nil
+}
+
+func (f *fakeSourceDeleter) callCount() int { return len(f.calls) }
+
+func (f *fakeSourceDeleter) deletedIDs() []string {
+	var ids []string
+	for _, call := range f.calls {
+		for _, r := range call {
+			ids = append(ids, r.ID)
+		}
+	}
+	return ids
+}
+
+// TestExtractRecordingFrames_MJPEGDirs_JoinedGroup verifies that MJPEG
+// directory recordings are extracted into ONE suffix-less JPEG group with a
+// shared window sampler and continuing numbering (no frame_000001 overwrite).
+func TestExtractRecordingFrames_MJPEGDirs_JoinedGroup(t *testing.T) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	// Two fragmented MJPEG dirs: 60s @1fps each, 5 minutes apart.
+	dirA := filepath.Join(dataDir, "segA")
+	dirB := filepath.Join(dataDir, "segB")
+	writeMJPEGDirFixture(t, dirA, windowStart, 60, time.Second, 0)
+	writeMJPEGDirFixture(t, dirB, windowStart.Add(5*time.Minute), 60, time.Second, 100)
+
+	lister := &mockRecordingListerMultiFormat{
+		videoSegments: []model.Recording{
+			{ID: "vid-mjpeg-1", CameraID: cameraID, FilePath: dirA, Format: model.FormatMJPEG, StartedAt: windowStart},
+			{ID: "vid-mjpeg-2", CameraID: cameraID, FilePath: dirB, Format: model.FormatMJPEG, StartedAt: windowStart.Add(5 * time.Minute)},
+		},
+	}
+
+	mgr := NewPeriodicMergeManager(
+		lister, &mockMergeStatusUpdater{}, nil, 30, dataDir, 8*time.Hour, nil,
+		WithRecordingEnabledProvider(func(string) bool { return true }),
+		WithExtractionInterval(10*time.Second),
+	)
+
+	segments, tmpDirs, sources, err := mgr.extractRecordingFrames(context.Background(), cameraID, windowStart, windowStart.Add(8*time.Hour))
+	if err != nil {
+		t.Fatalf("extractRecordingFrames failed: %v", err)
+	}
+	if len(tmpDirs) == 0 {
+		t.Fatal("expected temp dirs to be returned for cleanup")
+	}
+	t.Cleanup(func() {
+		for _, d := range tmpDirs {
+			os.RemoveAll(d)
+		}
+	})
+
+	// Both MJPEG recordings land in ONE JPEG group (suffix-less output).
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 synthetic segment (single JPEG group), got %d", len(segments))
+	}
+	if segments[0].Format != model.FormatTimelapse {
+		t.Errorf("synthetic segment format = %q, want %q (joined JPEG group)", segments[0].Format, model.FormatTimelapse)
+	}
+
+	// 10s sampling across both dirs: 6 frames from A + 6 from B = 12.
+	matches, _ := filepath.Glob(filepath.Join(segments[0].FilePath, "frame_*.jpg"))
+	if len(matches) != 12 {
+		t.Errorf("expected 12 extracted frames, got %d", len(matches))
+	}
+
+	// Source IDs reported for the "jpeg" group.
+	jpegSources := sources["jpeg"]
+	if len(jpegSources) != 2 {
+		t.Fatalf("expected 2 source recordings in jpeg group, got %d", len(jpegSources))
+	}
+	if jpegSources[0].ID != "vid-mjpeg-1" || jpegSources[1].ID != "vid-mjpeg-2" {
+		t.Errorf("unexpected source order: [%s, %s]", jpegSources[0].ID, jpegSources[1].ID)
+	}
+}
+
+// TestExtractRecordingFrames_DefaultInterval verifies the extraction interval
+// falls back to 30s when WithExtractionInterval is not set.
+func TestExtractRecordingFrames_DefaultInterval(t *testing.T) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	// One MJPEG dir spanning 2 minutes @1fps (120 frames).
+	dir := filepath.Join(dataDir, "seg")
+	writeMJPEGDirFixture(t, dir, windowStart, 120, time.Second, 0)
+
+	lister := &mockRecordingListerMultiFormat{
+		videoSegments: []model.Recording{
+			{ID: "vid-1", CameraID: cameraID, FilePath: dir, Format: model.FormatMJPEG, StartedAt: windowStart},
+		},
+	}
+
+	mgr := NewPeriodicMergeManager(
+		lister, &mockMergeStatusUpdater{}, nil, 30, dataDir, 8*time.Hour, nil,
+		WithRecordingEnabledProvider(func(string) bool { return true }),
+		// No WithExtractionInterval → default 30s.
+	)
+
+	segments, tmpDirs, _, err := mgr.extractRecordingFrames(context.Background(), cameraID, windowStart, windowStart.Add(8*time.Hour))
+	if err != nil {
+		t.Fatalf("extractRecordingFrames failed: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, d := range tmpDirs {
+			os.RemoveAll(d)
+		}
+	})
+	if len(segments) != 1 {
+		t.Fatalf("expected 1 synthetic segment, got %d", len(segments))
+	}
+	// 30s sampling over a 2-minute dir: frames at 0,30,60,90 → 4.
+	matches, _ := filepath.Glob(filepath.Join(segments[0].FilePath, "frame_*.jpg"))
+	if len(matches) != 4 {
+		t.Errorf("expected 4 frames at default 30s interval, got %d", len(matches))
+	}
+}
+
+// TestPeriodicMerge_DeleteRecordingsAfterMerge verifies the opt-in
+// delete_recordings_after_merge behavior: after a successful merge the source
+// video recordings are handed to the deleter; with the flag off nothing is.
+func TestPeriodicMerge_DeleteRecordingsAfterMerge(t *testing.T) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	dirA := filepath.Join(dataDir, "segA")
+	dirB := filepath.Join(dataDir, "segB")
+	writeMJPEGDirFixture(t, dirA, windowStart, 60, time.Second, 0)
+	writeMJPEGDirFixture(t, dirB, windowStart.Add(5*time.Minute), 60, time.Second, 100)
+
+	newLister := func() *mockRecordingListerMultiFormat {
+		return &mockRecordingListerMultiFormat{
+			videoSegments: []model.Recording{
+				{ID: "vid-mjpeg-1", CameraID: cameraID, FilePath: dirA, Format: model.FormatMJPEG, StartedAt: windowStart},
+				{ID: "vid-mjpeg-2", CameraID: cameraID, FilePath: dirB, Format: model.FormatMJPEG, StartedAt: windowStart.Add(5 * time.Minute)},
+			},
+		}
+	}
+
+	run := func(deleteAfterMerge bool) *fakeSourceDeleter {
+		deleter := &fakeSourceDeleter{}
+		mgr := NewPeriodicMergeManager(
+			newLister(), newTrackDB(), NewGoMerger(), 30, dataDir, 8*time.Hour, nil,
+			WithRecordingEnabledProvider(func(string) bool { return true }),
+			WithExtractionInterval(10*time.Second),
+			WithDeleteRecordingsAfterMerge(deleteAfterMerge),
+		)
+		mgr.SetSourceRecordingDeleter(deleter)
+		if err := mgr.Run(context.Background(), cameraID, windowStart.Add(time.Minute)); err != nil {
+			t.Fatalf("Run failed: %v", err)
+		}
+		return deleter
+	}
+
+	// Flag ON → both source recordings deleted after the successful merge.
+	deleter := run(true)
+	if deleter.callCount() == 0 {
+		t.Fatal("expected DeleteRecordings to be called with flag on")
+	}
+	ids := deleter.deletedIDs()
+	if len(ids) != 2 || ids[0] != "vid-mjpeg-1" || ids[1] != "vid-mjpeg-2" {
+		t.Errorf("deleted IDs = %v, want [vid-mjpeg-1 vid-mjpeg-2]", ids)
+	}
+	if deleter.reasons[0] == "" {
+		t.Error("expected a deletion reason to be recorded")
+	}
+
+	// Flag OFF → no deletion.
+	deleterOff := run(false)
+	if deleterOff.callCount() != 0 {
+		t.Errorf("DeleteRecordings must not be called with flag off, got %d calls", deleterOff.callCount())
+	}
+}
+
+// TestPeriodicMerge_DeleteSkippedOnMergeFailure verifies sources survive a
+// failed merge (no data loss when no output was produced).
+func TestPeriodicMerge_DeleteSkippedOnMergeFailure(t *testing.T) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	dirA := filepath.Join(dataDir, "segA")
+	writeMJPEGDirFixture(t, dirA, windowStart, 60, time.Second, 0)
+
+	lister := &mockRecordingListerMultiFormat{
+		videoSegments: []model.Recording{
+			{ID: "vid-mjpeg-1", CameraID: cameraID, FilePath: dirA, Format: model.FormatMJPEG, StartedAt: windowStart},
+		},
+	}
+
+	deleter := &fakeSourceDeleter{}
+	mgr := NewPeriodicMergeManager(
+		lister, newTrackDB(), NewGoMerger(), 30, dataDir, 8*time.Hour, nil,
+		WithRecordingEnabledProvider(func(string) bool { return true }),
+		WithExtractionInterval(10*time.Second),
+		WithDeleteRecordingsAfterMerge(true),
+	)
+	mgr.SetSourceRecordingDeleter(deleter)
+
+	// Force merge failure: occupy the camera output directory path with a
+	// regular file so the merge's os.MkdirAll fails deterministically.
+	if err := os.WriteFile(filepath.Join(dataDir, cameraID), []byte("blocker"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run error is tolerated (same as production: scheduled path logs it).
+	_ = mgr.Run(context.Background(), cameraID, windowStart.Add(time.Minute))
+
+	if deleter.callCount() != 0 {
+		t.Errorf("DeleteRecordings must not be called when the merge failed, got %d calls", deleter.callCount())
+	}
+}

--- a/internal/timelapse/periodic_merge_probe.go
+++ b/internal/timelapse/periodic_merge_probe.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -156,28 +157,27 @@ func probeVideoFrameCount(ctx context.Context, filePath string) (int, error) {
 	return count, nil
 }
 
-// extractRecordingFrames queries video-format recordings in the merge window
-// and extracts frames into per-codec temporary directories. Returns synthetic
-// Recording entries for each codec group and the list of temp dirs to clean up.
-//
-// Supported formats for frame extraction:
-//   - H264 ✅ (keyframe-sync H.264 IDR samples from MP4)
-//   - H265 ✅ (IRAP NAL type 19/20 sync samples from MP4)
-//   - AVI ✅  (MJPEG JPEG frames via internal/avi demuxer)
-//   - MJPEG ✅ (same JPEG extraction as AVI)
-//   - MPEG-TS ✗ (no moov/stss boxes, too expensive to probe)
+// defaultExtractionInterval is the frame-sampling fallback when the camera's
+// timelapse.interval is not wired (legacy constructions / tests).
+const defaultExtractionInterval = 30 * time.Second
 
 // extractRecordingFrames queries video-format recordings in the merge window
-// and extracts frames into per-codec temporary directories. Returns synthetic
-// Recording entries for each codec group and the list of temp dirs to clean up.
+// and extracts frames into per-codec temporary directories using ONE shared
+// absolute-time FrameSampler per codec group — so fragmented recordings
+// (disconnect-heavy MJPEG cameras) sample continuously across segments without
+// overwriting each other's frame numbering.
+//
+// Returns synthetic Recording entries for each codec group, the temp dirs to
+// clean up, and the source recordings per codec group (used by the opt-in
+// delete_recordings_after_merge cleanup after a successful merge).
 //
 // Supported formats for frame extraction:
 //   - H264 ✅ (keyframe-sync H.264 IDR samples from MP4)
 //   - H265 ✅ (IRAP NAL type 19/20 sync samples from MP4)
 //   - AVI ✅  (MJPEG JPEG frames via internal/avi demuxer)
-//   - MJPEG ✅ (same JPEG extraction as AVI)
+//   - MJPEG ✅ (timestamped JPEG directory — frame times from filenames)
 //   - MPEG-TS ✗ (no moov/stss boxes, too expensive to probe)
-func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, cameraID string, startTime, endTime time.Time) ([]model.Recording, []string, error) {
+func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, cameraID string, startTime, endTime time.Time) ([]model.Recording, []string, map[string][]model.Recording, error) {
 	videoFormats := []model.Format{model.FormatH264, model.FormatH265, model.FormatAVI, model.FormatMJPEG}
 	recs, err := m.store.ListRecordings(ctx, model.RecordingFilter{
 		CameraID:  cameraID,
@@ -186,17 +186,22 @@ func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, camer
 		EndTime:   endTime,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("list video recordings: %w", err)
+		return nil, nil, nil, fmt.Errorf("list video recordings: %w", err)
 	}
 	if len(recs) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
-	// Map recording format to extraction codec (grouping key).
-	// MJPEG recordings produce JPEG frames like AVI.
+	// Chronological order is load-bearing: the shared sampler walks recordings
+	// in time order, and continuing frame numbering must not go backwards.
+	sort.Slice(recs, func(i, j int) bool { return recs[i].StartedAt.Before(recs[j].StartedAt) })
+
+	// MJPEG/AVI recordings both yield JPEG frames — join them into one
+	// suffix-less "jpeg" group (same mapping runPerCodecMerge applies to
+	// timelapse segments), so the output is periodic_<window>.mp4.
 	codecKey := func(f model.Format) model.Format {
-		if f == model.FormatMJPEG {
-			return model.FormatAVI // MJPEG → JPEG extraction like AVI
+		if f == model.FormatMJPEG || f == model.FormatAVI {
+			return model.FormatTimelapse
 		}
 		return f
 	}
@@ -209,33 +214,45 @@ func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, camer
 	}
 
 	extractor := NewRecordingFrameExtractor()
-	// Determine extraction interval based on FPS. At least 1 frame per recording.
-	interval := time.Second / time.Duration(m.fps)
+	// Sampling cadence = per-camera timelapse.interval (the timelapse
+	// compression knob), NOT 1/output-fps — sampling every frame would just
+	// copy the whole window instead of producing a timelapse.
+	interval := m.extractionInterval
 	if interval <= 0 {
-		interval = 100 * time.Millisecond // default 10fps
+		interval = defaultExtractionInterval
 	}
 
 	var segments []model.Recording
 	var tmpDirs []string
+	sourcesByGroup := make(map[string][]model.Recording)
 
-	for codec, recs := range codecRecordings {
+	for codec, codecRecs := range codecRecordings {
 		tmpDir, err := os.MkdirTemp("", fmt.Sprintf("periodic_extract_%s_*", codec))
 		if err != nil {
 			// Clean up previously created dirs on error.
 			for _, d := range tmpDirs {
 				os.RemoveAll(d)
 			}
-			return nil, nil, fmt.Errorf("create temp dir for %s: %w", codec, err)
+			return nil, nil, nil, fmt.Errorf("create temp dir for %s: %w", codec, err)
 		}
 		tmpDirs = append(tmpDirs, tmpDir)
 
-		for _, rec := range recs {
-			n, err := extractor.ExtractFrames(rec.FilePath, codec, interval, tmpDir)
+		// One shared window sampler + continuing frame index across ALL
+		// recordings in the group — fixes the frame_000001 overwrite that
+		// destroyed all but the last recording's frames.
+		sampler := NewFrameSampler(interval, startTime, endTime)
+		frameIdx := 0
+		groupSources := make([]model.Recording, 0, len(codecRecs))
+
+		for _, rec := range codecRecs {
+			n, err := extractor.ExtractWindowFrames(rec.FilePath, rec.Format, rec.StartedAt, sampler, frameIdx, tmpDir)
 			if err != nil {
 				slog.Warn("periodic merge: frame extraction failed, skipping recording",
 					"recording_id", rec.ID, "format", rec.Format, "error", err)
 				continue
 			}
+			frameIdx += n
+			groupSources = append(groupSources, rec)
 			slog.Debug("periodic merge: extracted frames from recording",
 				"recording_id", rec.ID, "format", rec.Format, "frames", n, "dir", tmpDir)
 		}
@@ -258,9 +275,10 @@ func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, camer
 			Format:      codec,
 			MergeStatus: "", // unmerged raw segment
 		})
+		sourcesByGroup[codecGroupName(codec)] = groupSources
 	}
 
-	return segments, tmpDirs, nil
+	return segments, tmpDirs, sourcesByGroup, nil
 }
 
 // runPerCodecMerge groups segments by codec type and runs a separate merge

--- a/internal/timelapse/periodic_merge_strategies.go
+++ b/internal/timelapse/periodic_merge_strategies.go
@@ -362,22 +362,24 @@ func (m *PeriodicMergeManager) goMergeSegments(ctx context.Context, segments []m
 //   - JPEG group: periodic_WINDOW.mp4
 //   - H264 group: periodic_WINDOW_h264.mp4
 //   - H265 group: periodic_WINDOW_h265.mp4
-func (m *PeriodicMergeManager) runPerCodecMerge(ctx context.Context, segments []model.Recording, cameraID, windowLabel string) error {
+//
+// extractedSources maps group name → source video recordings folded into that
+// group (from extractRecordingFrames); may be nil. When
+// delete_recordings_after_merge is enabled and a source deleter is wired, a
+// group's sources are deleted only after that group's merge succeeds.
+func (m *PeriodicMergeManager) runPerCodecMerge(ctx context.Context, segments []model.Recording, extractedSources map[string][]model.Recording, cameraID, windowLabel string) error {
 	// Map each segment to its codec group.
 	// Timelapse and MJPEG/AVI extracted frames are JPEG-based and can be grouped.
 	groups := make(map[string][]model.Recording)
 	for _, seg := range segments {
-		codec := string(seg.Format)
-		if codec == string(model.FormatTimelapse) || codec == "" {
-			codec = "jpeg" // timelapse JPEG frames
-		}
+		codec := codecGroupName(seg.Format)
 		groups[codec] = append(groups[codec], seg)
 	}
 
 	var lastErr error
 	for codec, segs := range groups {
 		suffix := ""
-		if codec != "jpeg" {
+		if codec != codecGroupJPEG {
 			suffix = "_" + codec
 		}
 		outputFilename := fmt.Sprintf("periodic_%s%s.mp4", windowLabel, suffix)
@@ -387,7 +389,40 @@ func (m *PeriodicMergeManager) runPerCodecMerge(ctx context.Context, segments []
 			slog.Warn("periodic merge: per-codec merge failed",
 				"codec", codec, "camera_id", cameraID, "error", err)
 			lastErr = err
+			continue
+		}
+
+		// Opt-in source cleanup: delete the group's source video recordings
+		// only after its output was produced. Never on failure — that would
+		// lose data with no timelapse to show for it.
+		if m.deleteRecordingsAfterMerge && m.sourceDeleter != nil {
+			if srcs := extractedSources[codec]; len(srcs) > 0 {
+				deleted, err := m.sourceDeleter.DeleteRecordings(ctx, srcs, "timelapse_source_merged")
+				if err != nil {
+					slog.Warn("periodic merge: source recording deletion failed",
+						"camera_id", cameraID, "count", len(srcs), "error", err)
+				} else {
+					slog.Info("periodic merge: deleted source recordings after merge",
+						"camera_id", cameraID, "codec", codec, "deleted", len(deleted))
+				}
+			}
 		}
 	}
 	return lastErr
+}
+
+// codecGroupJPEG is the suffix-less codec group name for JPEG-based output.
+const codecGroupJPEG = "jpeg"
+
+// codecGroupName maps a segment format to its codec group name. Timelapse,
+// MJPEG and AVI segments all carry JPEG frames and merge into one suffix-less
+// "jpeg" group (output periodic_<window>.mp4, codec "mjpeg" in the DB row);
+// other formats keep their suffixed groups.
+func codecGroupName(f model.Format) string {
+	switch f {
+	case model.FormatTimelapse, model.FormatMJPEG, model.FormatAVI, "":
+		return codecGroupJPEG
+	default:
+		return string(f)
+	}
 }

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -37,6 +37,7 @@ import (
 	authmw "github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/middleware/remotelog"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/migration"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/motion"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mqtt"
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/relay"
@@ -415,6 +416,13 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			if cam.Timelapse.MergeOutputFPS > 0 {
 				fps = cam.Timelapse.MergeOutputFPS
 			}
+			// Frame-sampling interval for recording→timelapse extraction
+			// (timelapse.interval, default 30s via ApplyDefaults). This is the
+			// timelapse compression knob, independent of the output fps above.
+			extractInterval := 30 * time.Second
+			if d, err := time.ParseDuration(cam.Timelapse.Interval); err == nil && d > 0 {
+				extractInterval = d
+			}
 			periodicMergeManagers[cam.ID] = timelapse.NewPeriodicMergeManager(
 				db, db, timelapse.NewGoMerger(), fps, periodicMergeDir, dur, appLoc,
 				timelapse.WithRecordingEnabledProvider(func(cameraID string) bool {
@@ -434,6 +442,8 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 				// merge folds them in, unless the camera opts to retain them.
 				timelapse.WithRetainIntermediateMP4(cam.Timelapse.RetainIntermediateMP4Value()),
 				timelapse.WithIntermediateMP4Pruner(db),
+				timelapse.WithExtractionInterval(extractInterval),
+				timelapse.WithDeleteRecordingsAfterMerge(cam.Timelapse.DeleteRecordingsAfterMerge),
 			)
 			mergeScheduler.AddOrUpdate(cam.ID, dur)
 			slog.Info(
@@ -443,6 +453,7 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			)
 		}
 	}
+	deps.periodicMergeManagers = periodicMergeManagers
 	mergeScheduler.SetRunFunc(func(ctx context.Context, cameraID string, refTime time.Time) error {
 		manager, ok := periodicMergeManagers[cameraID]
 		if !ok {
@@ -824,6 +835,16 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	deps.cleanupMgr = cleanupMgr
 	deps.archiveDeleter = cleanup.NewArchiveDeleter(db, store)
 
+	// Wire the opt-in delete_recordings_after_merge source deleter into the
+	// periodic-merge managers. The per-camera enable flags were applied at
+	// manager construction; the mechanism is wired here because the cleanup
+	// manager is built after them. BatchDeleteRecordingsWithFiles skips
+	// recordings being processed by MiBeeVision.
+	tlSourceDeleter := timelapseSourceDeleter{cm: cleanupMgr}
+	for _, mgr := range periodicMergeManagers {
+		mgr.SetSourceRecordingDeleter(tlSourceDeleter)
+	}
+
 	// Shared snapshot capturer (#657): FFmpeg-gated hub-IDR decode for
 	// H.264/H.265 cameras + device snapshot-URL fallback. Wired into the
 	// latest-frame API below and the MQTT snapshot runner (Step 9). Every
@@ -910,6 +931,9 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 	aiMgr := ai.NewManager(aiConfigFromConfig(cfg.AI), deps.eventBus)
 	ah := api.NewAIHandler(aiMgr, cfg, configPath)
 	handler.SetAIHandler(ah)
+	// Manual merges (POST /api/timelapse/{id}/merge, batch-merge) get the same
+	// opt-in delete_recordings_after_merge mechanism as the scheduled path.
+	handler.SetTimelapseSourceDeleter(tlSourceDeleter)
 	handler.SetRelayManager(relayMgr)
 	// Wire GB28181 PTZ controller (sends DeviceControl via the SIP server) when
 	// the GB28181 platform server is enabled.
@@ -1040,6 +1064,16 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		db.Close()
 	}
 	return deps, cleanup, nil
+}
+
+// timelapseSourceDeleter adapts cleanup.CleanupManager to the timelapse
+// package's SourceRecordingDeleter interface. Used by the opt-in
+// delete_recordings_after_merge behavior for periodic merges (scheduled path
+// and the API manual-merge path).
+type timelapseSourceDeleter struct{ cm *cleanup.CleanupManager }
+
+func (d timelapseSourceDeleter) DeleteRecordings(ctx context.Context, recordings []model.Recording, reason string) ([]string, error) {
+	return d.cm.BatchDeleteRecordingsWithFiles(ctx, recordings, reason)
 }
 
 // newGB28181SessionManager builds the media SessionManager from config. The

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -69,9 +69,10 @@ type appDeps struct {
 	transcodeMgr          *transcoding.TranscodeManager
 	rollingMergeMgr       *timelapse.RollingMergeManager // timelapse rolling merge (wired to API handler)
 	mergeScheduler        *timelapse.MergeScheduler
-	visionMgr             *vision.Coordinator // NVR→Vision push coordinator
-	motionAnalyzer        *motion.Analyzer    // offline motion-score service (issue #435)
-	pixgateMgr            *pixgate.Manager    // pixel-domain fine gate (issue #636)
+	periodicMergeManagers map[string]*timelapse.PeriodicMergeManager // per-camera (nil Timelapse = absent); asserted by wiring tests
+	visionMgr             *vision.Coordinator                        // NVR→Vision push coordinator
+	motionAnalyzer        *motion.Analyzer                           // offline motion-score service (issue #435)
+	pixgateMgr            *pixgate.Manager                           // pixel-domain fine gate (issue #636)
 
 	// Camera + health + relay
 	camMgr    *camera.CameraManager

--- a/pkg/app/timelapse_wiring_test.go
+++ b/pkg/app/timelapse_wiring_test.go
@@ -1,0 +1,70 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// TestBuildAppDeps_TimelapseExtractionWiring guards the recording→timelapse
+// wiring (same wiring-bug class as the #653 onAction=nil lesson):
+//   - the per-camera timelapse.interval must reach the periodic-merge manager
+//     (WithExtractionInterval) — without it, MJPEG dual-mode cameras sample at
+//     1/output-fps and the "timelapse" is a full-speed copy of the day;
+//   - the cleanup-backed source deleter must be wired into both the scheduled
+//     managers and the API handler, or opt-in delete_recordings_after_merge
+//     silently does nothing.
+func TestBuildAppDeps_TimelapseExtractionWiring(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+
+	// minimalConfig ships zero cameras — add one with a timelapse block
+	// carrying a non-default interval and the source-deletion flag on.
+	cfg.Cameras = append(cfg.Cameras, config.CameraConfig{
+		ID: "wiring-cam", Protocol: "rtsp", Encoding: "h264", URL: "rtsp://127.0.0.1:554/test",
+		Timelapse: &config.CameraTimelapseConfig{
+			Enabled:                    true,
+			Interval:                   "5s",
+			DeleteRecordingsAfterMerge: true,
+		},
+	})
+	camID := "wiring-cam"
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	mgr, ok := deps.periodicMergeManagers[camID]
+	if !ok {
+		t.Fatal("no periodic-merge manager built for camera with timelapse config")
+	}
+	if got := mgr.ExtractionInterval(); got != 5*time.Second {
+		t.Errorf("ExtractionInterval = %v, want 5s (timelapse.interval must be wired)", got)
+	}
+	if !mgr.HasSourceDeleter() {
+		t.Error("periodic-merge manager has no source deleter: delete_recordings_after_merge would silently do nothing")
+	}
+	if !deps.handler.HasTimelapseSourceDeleter() {
+		t.Error("api handler has no timelapse source deleter: manual merges cannot honor delete_recordings_after_merge")
+	}
+}
+
+// TestBuildAppDeps_TimelapseDefaults_NoConfig: a camera without a timelapse
+// block gets no periodic-merge manager (existing behavior preserved).
+func TestBuildAppDeps_TimelapseDefaults_NoConfig(t *testing.T) {
+	t.Helper()
+	cfg, configPath := minimalConfig(t)
+
+	deps, cleanup, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanup()
+
+	if len(deps.periodicMergeManagers) != 0 {
+		t.Errorf("expected 0 periodic-merge managers without timelapse config, got %d", len(deps.periodicMergeManagers))
+	}
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -197,7 +197,7 @@ function parseRoute(hash: string) {
       window.location.replace('#/dashboard/health');
     } else if (window.location.hash === '#/ai-events' || window.location.hash.startsWith('#/ai-events')) {
       window.location.replace('#/dashboard/ai');
-    } else if (window.location.hash === '#/timelapse' || window.location.hash.startsWith('#/timelapse')) {
+    } else if (window.location.hash === '#/timelapse' || window.location.hash.startsWith('#/timelapse/')) {
       window.location.replace('#/recordings');
     }
   }
@@ -226,7 +226,7 @@ function parseRoute(hash: string) {
       window.location.replace('#/dashboard/ai');
       return;
     }
-    if (hash === '#/timelapse' || hash.startsWith('#/timelapse')) {
+    if (hash === '#/timelapse' || hash.startsWith('#/timelapse/')) {
       window.location.replace('#/recordings');
       return;
     }

--- a/web/src/lib/api/cameras.ts
+++ b/web/src/lib/api/cameras.ts
@@ -1113,6 +1113,7 @@ export interface TimelapseConfig {
   schedule: ScheduleConfig | null;
   paused: boolean;
   delete_original: boolean;
+  delete_recordings_after_merge?: boolean;
   merge_enabled?: boolean;
   merge_mode?: string;
   daily_merge?: boolean;

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -177,6 +177,7 @@ export {
   setArchiveRetention,
   getArchiveCleanupStatus,
   getTimelapseFrames,
+  fetchRecordingFrameBatch,
   loadTimelapseFrameBlob,
   triggerTimelapseMerge,
   batchMergeTimelapse,
@@ -214,6 +215,7 @@ export {
   listTimelapseMerges,
   getTimelapseMerge,
   getTimelapseMergeDownloadUrl,
+  fetchTimelapseMergeFrameBatch,
   probeTimelapseMergeCodec,
   deleteTimelapseMerge,
 } from './timelapse-merges';

--- a/web/src/lib/api/recordings.ts
+++ b/web/src/lib/api/recordings.ts
@@ -2,6 +2,7 @@
  * Recording API — list, download, frames, stats, archives
  */
 import { apiRequest, apiRequestBlob, apiHeadHeader, getAuthHeader, API_BASE, ApiRequestError } from './client';
+import { fetchFrameBatch, type FrameBatch } from '$lib/multipart';
 
 // --- Types ---
 
@@ -374,6 +375,20 @@ export async function loadTimelapseFrameBlob(
 ): Promise<string> {
   const blob = await apiRequestBlob(`/recordings/${recordingId}/timelapse-frames/${filename}`, { signal });
   return URL.createObjectURL(blob);
+}
+
+/**
+ * Fetch a batch of JPEG frames for an MJPEG/timelapse/AVI recording as one
+ * multipart/mixed response (N frames per request — the smooth-playback path
+ * used by the canvas sequence player).
+ */
+export function fetchRecordingFrameBatch(
+  recordingId: string,
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<FrameBatch> {
+  return fetchFrameBatch(`/recordings/${recordingId}/timelapse-frames/batch`, offset, limit, signal);
 }
 export async function loadFrameBlob(recordingId: string, frameIndex: number, signal?: AbortSignal): Promise<string> {
   const blob = await apiRequestBlob(`/recordings/${recordingId}/download?frame=${frameIndex}`, { signal });

--- a/web/src/lib/api/timelapse-merges.ts
+++ b/web/src/lib/api/timelapse-merges.ts
@@ -7,6 +7,7 @@
  * (migration v28) so the frontend can discover, play, and delete them.
  */
 import { apiRequest, getAuthHeader, API_BASE, ApiRequestError } from './client';
+import { fetchFrameBatch, type FrameBatch } from '$lib/multipart';
 
 export interface TimelapseMerge {
   id: number;
@@ -76,6 +77,20 @@ export async function getTimelapseMerge(id: number | string, signal?: AbortSigna
  */
 export function getTimelapseMergeDownloadUrl(id: number | string): string {
   return `${API_BASE}/timelapse/merges/${id}/download`;
+}
+
+/**
+ * Fetch a batch of JPEG frames sliced from an MJPEG (mjpa) merge output as
+ * one multipart/mixed response. Used by the canvas sequence player for
+ * codec=mjpeg merges (browsers cannot decode mjpa via <video>).
+ */
+export function fetchTimelapseMergeFrameBatch(
+  id: number | string,
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<FrameBatch> {
+  return fetchFrameBatch(`/timelapse/merges/${id}/frames`, offset, limit, signal);
 }
 
 /**

--- a/web/src/lib/components/MjpegSequencePlayer.svelte
+++ b/web/src/lib/components/MjpegSequencePlayer.svelte
@@ -1,0 +1,323 @@
+<script lang="ts">
+  /**
+   * Canvas-based JPEG sequence player — the smooth-playback replacement for
+   * the per-frame-GET img cycler.
+   *
+   * - Fetches frames in multipart batches (BATCH frames per request) instead
+   *   of one HTTP GET per frame.
+   * - Decodes via createImageBitmap into a small LRU around the playhead and
+   *   renders with canvas.drawImage — no <img src> swaps, no opacity
+   *   transitions, no per-frame DOM churn → no flicker.
+   *   A late frame keeps the previous frame on screen instead of a spinner.
+   * - Pacing is a drift-corrected requestAnimationFrame accumulator — a
+   *   cache miss never stretches the frame interval (the old cycler armed
+   *   the next timeout only after the fetch resolved).
+   *
+   * `currentIndex`/`playing`/`speed` are bindable so hosts can drive the
+   * player with their own control bar (PlaybackPanel) or use the built-in
+   * minimal controls (TimelapseMergeDetail).
+   */
+  import { onMount } from 'svelte';
+  import { Play, Pause } from 'lucide-svelte';
+
+  interface Props {
+    /** Known total frame count; 0 = learn from the first batch response. */
+    frameCount?: number;
+    /** Base playback fps (recordings default 10; merges pass their row fps). */
+    fps?: number;
+    fetchBatch: (offset: number, limit: number, signal?: AbortSignal) => Promise<import('$lib/multipart').FrameBatch>;
+    currentIndex?: number;
+    playing?: boolean;
+    speed?: number;
+    loop?: boolean;
+    /** Render the built-in control bar (standalone usage). */
+    showControls?: boolean;
+    /** Optional per-frame timestamp label. */
+    frameTimestamp?: ((i: number) => string) | null;
+    onEnded?: () => void;
+    onError?: (message: string) => void;
+  }
+
+  let {
+    frameCount = 0,
+    fps = 10,
+    fetchBatch,
+    currentIndex = $bindable(0),
+    playing = $bindable(false),
+    speed = $bindable(1),
+    loop = false,
+    showControls = true,
+    frameTimestamp = null,
+    onEnded,
+    onError,
+  }: Props = $props();
+
+  const BATCH = 120;
+  const BLOB_CACHE_CAP = 600;
+  const BITMAP_WINDOW_BACK = 16;
+  const BITMAP_WINDOW_AHEAD = 32;
+
+  let canvas: HTMLCanvasElement | null = $state(null);
+  let total = $state(frameCount);
+  let ready = $state(false);
+  let errorMsg = $state('');
+
+  let blobCache = new Map<number, Blob>();
+  let bitmaps = new Map<number, ImageBitmap>();
+  const fetchedBatches = new Set<number>();
+  const inflightBatches = new Map<number, Promise<void>>();
+  let abort: AbortController | null = null;
+
+  // --- Batch fetching ------------------------------------------------------
+
+  function ensureBatch(batchStart: number): Promise<void> {
+    if (total > 0 && batchStart >= total) return Promise.resolve();
+    if (fetchedBatches.has(batchStart)) return Promise.resolve();
+    const existing = inflightBatches.get(batchStart);
+    if (existing) return existing;
+
+    const signal = abort?.signal;
+    const p = fetchBatch(batchStart, BATCH, signal)
+      .then((batch) => {
+        if (batch.total > 0 && batch.total !== total) total = batch.total;
+        batch.frames.forEach((blob, k) => {
+          blobCache.set(batch.offset + k, blob);
+        });
+        pruneBlobCache();
+        fetchedBatches.add(batchStart);
+        if (batch.frames.length < BATCH) fetchedBatches.add(batchStart + BATCH); // tail
+        // The current frame's data may just have arrived (drawCurrent bailed
+        // out when the blob was missing) — paint it now. Guarded against
+        // re-entry by drawCurrent itself.
+        void drawCurrent();
+      })
+      .catch((e) => {
+        if (signal?.aborted) return;
+        errorMsg = e instanceof Error ? e.message : String(e);
+        onError?.(errorMsg);
+      })
+      .finally(() => {
+        inflightBatches.delete(batchStart);
+      });
+    inflightBatches.set(batchStart, p);
+    return p;
+  }
+
+  function pruneBlobCache() {
+    if (blobCache.size <= BLOB_CACHE_CAP) return;
+    const keepFrom = Math.max(0, currentIndex - BLOB_CACHE_CAP / 2);
+    for (const k of [...blobCache.keys()].sort((a, b) => a - b)) {
+      if (blobCache.size <= BLOB_CACHE_CAP) break;
+      if (k < keepFrom) blobCache.delete(k);
+    }
+  }
+
+  function ensureAround(i: number) {
+    void ensureBatch(Math.floor(i / BATCH) * BATCH);
+    // Prefetch the next batch halfway through the current one so playback
+    // never catches up with the network on LAN.
+    if (i % BATCH >= BATCH * 0.5) void ensureBatch((Math.floor(i / BATCH) + 1) * BATCH);
+    pruneBitmaps(i);
+  }
+
+  function pruneBitmaps(center: number) {
+    for (const k of [...bitmaps.keys()]) {
+      if (k < center - BITMAP_WINDOW_BACK || k > center + BITMAP_WINDOW_AHEAD) {
+        bitmaps.get(k)?.close();
+        bitmaps.delete(k);
+      }
+    }
+  }
+
+  // --- Decode + draw -------------------------------------------------------
+
+  let drawing = false;
+  let redrawQueued = false;
+
+  async function ensureBitmap(i: number): Promise<ImageBitmap | null> {
+    const cached = bitmaps.get(i);
+    if (cached) return cached;
+    const blob = blobCache.get(i);
+    if (!blob) return null;
+    try {
+      const bmp = await createImageBitmap(blob);
+      // Playhead may have moved on while decoding — only cache if still wanted.
+      if (Math.abs(i - currentIndex) > BITMAP_WINDOW_AHEAD * 4) {
+        bmp.close();
+        return null;
+      }
+      bitmaps.set(i, bmp);
+      pruneBitmaps(currentIndex);
+      return bmp;
+    } catch {
+      blobCache.delete(i); // corrupt frame — refetch would give the same bytes
+      return null;
+    }
+  }
+
+  async function drawCurrent() {
+    if (drawing) {
+      redrawQueued = true;
+      return;
+    }
+    drawing = true;
+    try {
+      const idx = currentIndex;
+      const bmp = await ensureBitmap(idx);
+      if (!bmp) {
+        ensureAround(idx);
+        return;
+      }
+      if (canvas) {
+        if (canvas.width !== bmp.width || canvas.height !== bmp.height) {
+          canvas.width = bmp.width;
+          canvas.height = bmp.height;
+        }
+        canvas.getContext('2d')?.drawImage(bmp, 0, 0);
+      }
+      ready = true;
+    } finally {
+      drawing = false;
+      if (redrawQueued) {
+        redrawQueued = false;
+        void drawCurrent();
+      }
+    }
+  }
+
+  // --- Pacing --------------------------------------------------------------
+
+  let rafId = 0;
+  let lastTs = 0;
+  let acc = 0;
+
+  function frameTick(ts: number) {
+    if (!playing) {
+      rafId = 0;
+      lastTs = 0;
+      return;
+    }
+    if (lastTs === 0) lastTs = ts;
+    acc += (ts - lastTs) * speed;
+    lastTs = ts;
+    const interval = 1000 / Math.max(1, fps);
+    let steps = 0;
+    while (acc >= interval && steps < 10) {
+      acc -= interval;
+      steps++;
+      if (total > 0 && currentIndex < total - 1) {
+        currentIndex++;
+      } else if (loop && total > 0) {
+        currentIndex = 0;
+      } else {
+        // End of sequence: hold the last frame, stop, notify the host.
+        acc = 0;
+        playing = false;
+        lastTs = 0;
+        rafId = 0;
+        onEnded?.();
+        return;
+      }
+    }
+    rafId = requestAnimationFrame(frameTick);
+  }
+
+  $effect(() => {
+    if (playing && !rafId) rafId = requestAnimationFrame(frameTick);
+    return () => {
+      lastTs = 0;
+    };
+  });
+
+  // --- Reactions -----------------------------------------------------------
+
+  $effect(() => {
+    // Learn the total from the first batch when the host didn't know it.
+    if (total === 0) void ensureBatch(0);
+  });
+
+  $effect(() => {
+    // Clamp seeks to the known range.
+    if (total > 0 && currentIndex >= total) currentIndex = Math.max(0, total - 1);
+  });
+
+  $effect(() => {
+    currentIndex;
+    errorMsg = '';
+    ensureAround(currentIndex);
+    void drawCurrent();
+  });
+
+  onMount(() => {
+    abort = new AbortController();
+    ensureAround(0);
+    return () => {
+      abort?.abort();
+      if (rafId) cancelAnimationFrame(rafId);
+      rafId = 0;
+      for (const bmp of bitmaps.values()) bmp.close();
+      bitmaps.clear();
+      blobCache.clear();
+    };
+  });
+
+  function togglePlay() {
+    if (!playing && total > 0 && currentIndex >= total - 1) currentIndex = 0;
+    playing = !playing;
+  }
+
+  function cycleSpeed() {
+    speed = speed >= 8 ? 1 : speed * 2;
+  }
+
+  function fmtCounter(): string {
+    return total > 0 ? `${currentIndex + 1} / ${total}` : `${currentIndex + 1}`;
+  }
+</script>
+
+<div class="flex flex-col items-center w-full bg-black">
+  <div class="relative flex items-center justify-center w-full min-h-[200px] max-h-[75vh] overflow-hidden">
+    <canvas bind:this={canvas} class="max-w-full max-h-[75vh] object-contain" width="0" height="0"></canvas>
+    {#if !ready && !errorMsg}
+      <div class="absolute inset-0 flex items-center justify-center bg-black/40">
+        <div class="spinner spinner-lg"></div>
+      </div>
+    {/if}
+    {#if errorMsg}
+      <div class="absolute inset-0 flex items-center justify-center bg-black/60 p-4">
+        <p class="text-sm text-red-400 text-center">{errorMsg}</p>
+      </div>
+    {/if}
+  </div>
+
+  {#if showControls}
+    <div class="w-full flex items-center gap-3 px-3 py-2 th-bg-secondary border-t th-border text-sm">
+      <button
+        class="btn btn-sm btn-primary"
+        onclick={togglePlay}
+        disabled={total > 0 && total <= 1}
+        aria-label={playing ? 'pause' : 'play'}
+      >
+        {#if playing}
+          <Pause size={14} />
+        {:else}
+          <Play size={14} />
+        {/if}
+      </button>
+      <input
+        type="range"
+        class="flex-1 range range-sm range-primary"
+        min="0"
+        max={Math.max(0, total - 1)}
+        value={currentIndex}
+        oninput={(e) => (currentIndex = Number((e.target as HTMLInputElement).value))}
+        disabled={total <= 1}
+      />
+      <span class="tabular-nums th-text-secondary whitespace-nowrap">{fmtCounter()}</span>
+      <button class="btn btn-sm btn-ghost" onclick={cycleSpeed} disabled={total <= 1}>{speed}×</button>
+      {#if frameTimestamp}
+        <span class="th-text-tertiary whitespace-nowrap hidden sm:inline">{frameTimestamp(currentIndex)}</span>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/components/TimelapseConfigEditor.svelte
+++ b/web/src/lib/components/TimelapseConfigEditor.svelte
@@ -256,6 +256,21 @@
             <label for="timelapse-delete-original" class="th-text-secondary text-sm">{t('timelapse.deleteOriginal')}</label>
           </div>
 
+          <!-- Delete source recordings after periodic merge (opt-in) -->
+          <div class="flex items-center gap-2 md:col-span-2">
+            <input
+              id="timelapse-delete-recordings"
+              type="checkbox"
+              class="accent-[var(--color-accent)]"
+              checked={config.delete_recordings_after_merge}
+              onchange={(e) => updateField('delete_recordings_after_merge', (e.target as HTMLInputElement).checked)}
+            />
+            <label for="timelapse-delete-recordings" class="th-text-secondary text-sm">
+              {t('timelapse.deleteRecordingsAfterMerge')}
+              <span class="block text-xs th-text-tertiary">{t('timelapse.deleteRecordingsAfterMergeHint')}</span>
+            </label>
+          </div>
+
           <!-- Schedule Section -->
           <div class="md:col-span-2 border-t th-border pt-4 mt-2">
             <div class="flex items-center justify-between mb-3">

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1907,6 +1907,8 @@
   "cameras.visionRoutingDisabled": "disabled",
   "aiEvents.sourceFilter": "Source instance",
   "aiEvents.allSources": "All sources",
+  "timelapse.deleteRecordingsAfterMerge": "Delete source recordings after merge",
+  "timelapse.deleteRecordingsAfterMergeHint": "After a successful periodic merge, delete the source recordings in the window (AI-processing ones are skipped; never on failure). Great for fragment-heavy MJPEG cameras.",
   "cameras.motionSource": "Motion detection source",
   "cameras.motionSourceNvr": "NVR-side detection",
   "cameras.motionSourceCamera": "Camera-side (ONVIF events)",

--- a/web/src/lib/i18n/zh.json
+++ b/web/src/lib/i18n/zh.json
@@ -1906,6 +1906,8 @@
   "cameras.visionRoutingDisabled": "已停用",
   "aiEvents.sourceFilter": "来源实例",
   "aiEvents.allSources": "全部来源",
+  "timelapse.deleteRecordingsAfterMerge": "合并后删除源录像",
+  "timelapse.deleteRecordingsAfterMergeHint": "周期延时合并成功后删除窗口内源录像段（AI 处理中的跳过；合并失败不删）。适合碎片多的 MJPEG 相机减少文件数。",
   "cameras.motionSource": "运动侦测来源",
   "cameras.motionSourceNvr": "NVR 侧侦测",
   "cameras.motionSourceCamera": "相机侧侦测（ONVIF 事件）",

--- a/web/src/lib/multipart.test.ts
+++ b/web/src/lib/multipart.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { createMultipartPartParser, boundaryFromContentType } from './multipart';
+
+function enc(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const len = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(len);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/** Feed a multipart body through the parser in arbitrary chunk splits. */
+function parseChunked(body: string, boundary: string, splits: number[]): Uint8Array[] {
+  const parser = createMultipartPartParser(boundary);
+  const bytes = enc(body);
+  const parts: Uint8Array[] = [];
+  const cuts = [0, ...splits.filter((s) => s > 0 && s < bytes.length), bytes.length];
+  for (let i = 0; i < cuts.length - 1; i++) {
+    parts.push(...parser.push(bytes.slice(cuts[i], cuts[i + 1])));
+  }
+  parts.push(...parser.flush());
+  return parts;
+}
+
+describe('createMultipartPartParser', () => {
+  const boundary = 'mibeebatch123';
+  const body =
+    `--${boundary}\r\n` +
+    'Content-Type: image/jpeg\r\n' +
+    'X-Frame-Index: 0\r\n' +
+    '\r\n' +
+    '\xFF\xD8 frame zero \xFF\xD9' +
+    `\r\n--${boundary}\r\n` +
+    'Content-Type: image/jpeg\r\n' +
+    '\r\n' +
+    '\xFF\xD8 frame one \xFF\xD9' +
+    `\r\n--${boundary}--\r\n`;
+
+  it('parses all parts from a single chunk', () => {
+    const parts = parseChunked(body, boundary, []);
+    expect(parts).toHaveLength(2);
+    expect(new TextDecoder().decode(parts[0])).toBe('\xFF\xD8 frame zero \xFF\xD9');
+    expect(new TextDecoder().decode(parts[1])).toBe('\xFF\xD8 frame one \xFF\xD9');
+  });
+
+  it('parses parts when chunks split mid-delimiter and mid-payload', () => {
+    // Split at tricky offsets: inside the first boundary, inside a payload,
+    // and inside the closing delimiter.
+    const parts = parseChunked(body, boundary, [5, 12, 40, 70, body.length - 5]);
+    expect(parts).toHaveLength(2);
+    expect(new TextDecoder().decode(parts[0])).toBe('\xFF\xD8 frame zero \xFF\xD9');
+    expect(new TextDecoder().decode(parts[1])).toBe('\xFF\xD8 frame one \xFF\xD9');
+  });
+
+  it('returns empty for an empty batch (immediate closing delimiter)', () => {
+    const empty = `--${boundary}\r\n--${boundary}--\r\n`;
+    const parts = parseChunked(empty, boundary, []);
+    expect(parts).toHaveLength(0);
+  });
+
+  it('handles payload that itself contains boundary-like bytes after split', () => {
+    const tricky = `--${boundary}\r\nContent-Type: image/jpeg\r\n\r\nA--${boundary.slice(0, 4)}B\r\n--${boundary}--\r\n`;
+    const parts = parseChunked(tricky, boundary, [20]);
+    expect(parts).toHaveLength(1);
+    expect(new TextDecoder().decode(parts[0])).toBe(`A--${boundary.slice(0, 4)}B`);
+  });
+
+  it('is pure: same output regardless of chunking', () => {
+    const oneShot = concat(parseChunked(body, boundary, []));
+    const splattered = concat(parseChunked(body, boundary, [1, 3, 7, 11, 23, 37, 51, 67, 83, 97]));
+    expect(oneShot).toEqual(splattered);
+  });
+});
+
+describe('boundaryFromContentType', () => {
+  it('extracts boundary from a multipart/mixed content type', () => {
+    expect(boundaryFromContentType('multipart/mixed; boundary=abc123')).toBe('abc123');
+    expect(boundaryFromContentType('multipart/mixed; boundary="quoted-boundary"')).toBe('quoted-boundary');
+  });
+  it('returns null for non-multipart types', () => {
+    expect(boundaryFromContentType('application/json')).toBeNull();
+    expect(boundaryFromContentType('')).toBeNull();
+  });
+});

--- a/web/src/lib/multipart.ts
+++ b/web/src/lib/multipart.ts
@@ -1,0 +1,164 @@
+/**
+ * Streaming multipart/mixed parsing + frame-batch fetching.
+ *
+ * The backend serves JPEG frame batches as one multipart/mixed response
+ * (`GET .../frames?offset=&limit=`), replacing the per-frame GET hot path of
+ * the JPEG cycler. The parser below is a pure incremental byte scanner — feed
+ * it network chunks in any split, get complete part payloads out.
+ */
+import { API_BASE, ApiRequestError, getAuthHeader } from '$lib/api/client';
+
+/** Extracts the boundary parameter from a multipart Content-Type header. */
+export function boundaryFromContentType(contentType: string | null): string | null {
+  if (!contentType) return null;
+  if (!/^multipart\//i.test(contentType)) return null;
+  const m = /boundary="?([^";]+)"?/i.exec(contentType);
+  return m ? m[1] : null;
+}
+
+export interface MultipartPartParser {
+  /** Feed the next stream chunk; returns any part payloads that completed. */
+  push(chunk: Uint8Array): Uint8Array[];
+  /** Finalize the stream; returns any remaining complete parts. */
+  flush(): Uint8Array[];
+}
+
+/**
+ * Incremental multipart/mixed part-payload parser.
+ *
+ * Frame parts look like: `--B\r\n<headers>\r\n\r\n<payload>\r\n--B...`.
+ * The parser prepends a virtual CRLF so the delimiter `\r\n--B` matches
+ * uniformly at stream start. Payloads are returned as fresh copies; a false
+ * delimiter match inside a payload is possible in theory but the backend's
+ * hex boundaries make it negligible.
+ */
+export function createMultipartPartParser(boundary: string): MultipartPartParser {
+  const delimiter = new TextEncoder().encode(`\r\n--${boundary}`);
+  const headerEnd = new TextEncoder().encode('\r\n\r\n');
+  // Start with the virtual leading CRLF so the opening delimiter matches
+  // uniformly; trimmed as parts complete (buffer always starts at `\r\n--B`).
+  let buf = new Uint8Array(2); // \r\n
+  buf[0] = 13;
+  buf[1] = 10;
+
+  function indexOf(hay: Uint8Array, needle: Uint8Array, from: number): number {
+    outer: for (let i = from; i <= hay.length - needle.length; i++) {
+      for (let j = 0; j < needle.length; j++) {
+        if (hay[i + j] !== needle[j]) continue outer;
+      }
+      return i;
+    }
+    return -1;
+  }
+
+  function drain(): Uint8Array[] {
+    const parts: Uint8Array[] = [];
+    for (;;) {
+      // The buffer must begin with the current part's opening delimiter.
+      if (indexOf(buf, delimiter, 0) !== 0) return parts;
+      // Part headers live between the opening delimiter and the blank line.
+      const hIdx = indexOf(buf, headerEnd, delimiter.length);
+      if (hIdx < 0) return parts;
+      const payloadStart = hIdx + headerEnd.length;
+      // The payload ends at the NEXT delimiter (or the closing one).
+      const nextD = indexOf(buf, delimiter, payloadStart);
+      if (nextD < 0) return parts;
+      // Need the 2 bytes after the delimiter to tell next-part from closing.
+      const after = nextD + delimiter.length;
+      if (after + 2 > buf.length) return parts;
+      const isClosing = buf[after] === 45 /* - */ && buf[after + 1] === 45;
+      parts.push(buf.slice(payloadStart, nextD));
+      if (isClosing) {
+        buf = new Uint8Array(0);
+        return parts;
+      }
+      // Keep the delimiter: it is the NEXT part's opening. The buffer again
+      // starts at `\r\n--B` for the next iteration.
+      buf = buf.slice(nextD);
+    }
+  }
+
+  return {
+    push(chunk: Uint8Array): Uint8Array[] {
+      const nb = new Uint8Array(buf.length + chunk.length);
+      nb.set(buf);
+      nb.set(chunk, buf.length);
+      buf = nb;
+      return drain();
+    },
+    flush(): Uint8Array[] {
+      // A well-formed stream has no complete parts left after the closing
+      // delimiter; drain once more defensively for streams cut mid-batch.
+      return drain();
+    },
+  };
+}
+
+/** One batch of JPEG frames + range metadata from the response headers. */
+export interface FrameBatch {
+  frames: Blob[];
+  /** Total frames available (X-Frame-Total). */
+  total: number;
+  /** Absolute index of frames[0] (X-Frame-Offset). */
+  offset: number;
+  /** Playback fps hint from the merge row, when present (X-Frame-Fps). */
+  fps: number | null;
+}
+
+function intHeader(res: Response, name: string, fallback = 0): number {
+  const v = res.headers.get(name);
+  if (!v) return fallback;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Fetches a JPEG frame batch from a frame-batch endpoint (path relative to
+ * /api) and streams it into decoded Blobs. One request returns up to `limit`
+ * frames — the smooth-playback foundation (vs one GET per frame).
+ */
+export async function fetchFrameBatch(
+  endpoint: string,
+  offset: number,
+  limit: number,
+  signal?: AbortSignal,
+): Promise<FrameBatch> {
+  const url = `${API_BASE}${endpoint}?offset=${offset}&limit=${limit}`;
+  const headers: Record<string, string> = {};
+  const auth = getAuthHeader();
+  if (auth) headers['Authorization'] = auth;
+
+  const res = await fetch(url, {
+    headers,
+    signal: signal ?? AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new ApiRequestError(`frame batch request failed: HTTP ${res.status}`, 'HTTP_ERROR');
+  }
+  const boundary = boundaryFromContentType(res.headers.get('Content-Type'));
+  if (!boundary || !res.body) {
+    throw new ApiRequestError('frame batch: unexpected content type', 'BAD_CONTENT_TYPE');
+  }
+
+  const parser = createMultipartPartParser(boundary);
+  const reader = res.body.getReader();
+  const frames: Blob[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    for (const part of parser.push(value)) {
+      frames.push(new Blob([part], { type: 'image/jpeg' }));
+    }
+  }
+  for (const part of parser.flush()) {
+    frames.push(new Blob([part], { type: 'image/jpeg' }));
+  }
+
+  return {
+    frames,
+    total: intHeader(res, 'X-Frame-Total'),
+    offset: intHeader(res, 'X-Frame-Offset'),
+    fps: res.headers.get('X-Frame-Fps') ? intHeader(res, 'X-Frame-Fps') : null,
+  };
+}

--- a/web/src/routes/TimelapseMergeDetail.svelte
+++ b/web/src/routes/TimelapseMergeDetail.svelte
@@ -3,6 +3,7 @@
   import {
     getTimelapseMerge,
     getTimelapseMergeDownloadUrl,
+    fetchTimelapseMergeFrameBatch,
     deleteTimelapseMerge,
   } from '$lib/api';
   import type { TimelapseMerge } from '$lib/api';
@@ -13,6 +14,7 @@
   import { formatFileSize } from '$lib/format';
   import { AlertTriangle, ArrowLeft, Download, Trash2, RefreshCw, Loader2 } from 'lucide-svelte';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+  import MjpegSequencePlayer from '$lib/components/MjpegSequencePlayer.svelte';
 
   // Route prop — the numeric id of the timelapse_merge row.
   let { mergeId = '' } = $props();
@@ -175,8 +177,16 @@
 
         <!-- Player / status -->
         <div class="card border th-border overflow-hidden">
-            {#if merge.status === 'completed' && videoUrl}
-            {#if videoError === 'src_not_supported'}
+            {#if merge.status === 'completed' && (videoUrl || merge.codec === 'mjpeg')}
+            {#if merge.codec === 'mjpeg'}
+              <!-- MJPEG (mjpa) output: browsers can't decode it via <video> —
+                   play as a batched JPEG sequence on canvas instead. -->
+              <MjpegSequencePlayer
+                frameCount={merge.frame_count}
+                fps={merge.fps > 0 ? merge.fps : 30}
+                fetchBatch={(offset, limit, signal) => fetchTimelapseMergeFrameBatch(merge.id, offset, limit, signal)}
+              />
+            {:else if videoError === 'src_not_supported'}
               <div class="p-8 text-center">
                 <AlertTriangle size={40} class="mx-auto mb-3 th-color-warning" />
                 <p class="th-text-primary mb-2">{videoErrorMsg}</p>
@@ -288,11 +298,13 @@
   </main>
 </div>
 
-<ConfirmDialog
-  bind:open={deleteConfirm}
-  title={t('detail.delete')}
-  message={t('timelapseMerge.deleteConfirm')}
-  confirmLabel={t('detail.delete')}
-  cancelLabel={t('common.cancel')}
-  onConfirm={handleDelete}
-/>
+{#if deleteConfirm}
+  <ConfirmDialog
+    title={t('detail.delete')}
+    message={t('timelapseMerge.deleteConfirm')}
+    confirmText={t('detail.delete')}
+    cancelText={t('common.cancel')}
+    onconfirm={handleDelete}
+    oncancel={() => (deleteConfirm = false)}
+  />
+{/if}

--- a/web/src/routes/recordings/PlaybackPanel.svelte
+++ b/web/src/routes/recordings/PlaybackPanel.svelte
@@ -21,11 +21,12 @@
     clearMergedCodecCache,
     listRecordings,
     getTimelapseFrames,
-    loadTimelapseFrameBlob,
+    fetchRecordingFrameBatch,
     recordTimelineSeek,
   } from '$lib/api';
   import { AlertTriangle, HelpCircle, SkipForward, Loader2, RefreshCw, Play, Pause, ChevronLeft, ChevronRight } from 'lucide-svelte';
   import MjpegPlayer from '$lib/components/MjpegPlayer.svelte';
+  import MjpegSequencePlayer from '$lib/components/MjpegSequencePlayer.svelte';
   import { parseVodPlaylist, entryAt, nearestEntryByWallClock, mediaTimeFor, type VodEntry } from '$lib/vod-playlist';
   import { parseTimelineMap, wallToFileSec, fileToWallSec } from '$lib/timeline-map';
   import VideoPlaybackControls from '$lib/components/VideoPlaybackControls.svelte';
@@ -128,6 +129,9 @@
   let transcodePollTimer = $state<ReturnType<typeof setInterval> | null>(null);
 
   // --- Timelapse player state ---
+  // Frames are fetched + rendered by MjpegSequencePlayer (multipart batches on
+  // canvas); timelapseFrames is metadata only (count + per-frame timestamps
+  // for the timeline seek / timestamp display).
   let timelapseFrames = $state<TimelapseFrame[]>([]);
   let tlCurrentFrame = $state(0);
   let tlIsPlaying = $state(false);
@@ -135,20 +139,8 @@
   let tlLoading = $state(false);
   let tlError = $state('');
   const tlSpeeds = [1, 2, 4];
-  let tlPlayTimeout: ReturnType<typeof setTimeout> | null = null;
-  let tlBlobCache = $state<Map<number, string>>(new Map());
   let tlAbortController: AbortController | null = null;
   let tlLoop = $state(false);
-  let tlSeekLoading = $state(false);
-  let tlSeekTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  interface PrefetchedSegment {
-    recordingId: string;
-    frames: TimelapseFrame[];
-    blobCache: Map<number, string>;
-  }
-  let prefetchedNextSegment: PrefetchedSegment | null = null;
-  let prefetchingNextSegment = false;
 
   let formatLabel = $derived.by(() => {
     if (!recording) return '';
@@ -923,33 +915,23 @@
     if (transcodePollTimer) { clearInterval(transcodePollTimer); transcodePollTimer = null; }
   }
 
-  // --- Timelapse JPEG cycler ---
+  // --- Timelapse JPEG cycler (MjpegSequencePlayer-backed) ---
   async function initTimelapsePlayer() {
     tlLoading = true;
     tlError = '';
     tlIsPlaying = false;
     tlCurrentFrame = 0;
-    stopTimelapsePlayback();
     tlAbortController?.abort();
     tlAbortController = new AbortController();
     const signal = tlAbortController.signal;
-    tlBlobCache.forEach(url => URL.revokeObjectURL(url));
-    tlBlobCache = new Map();
-    prefetchedNextSegment = null;
-    prefetchingNextSegment = false;
     try {
       timelapseFrames = await getTimelapseFrames(currentId, signal);
-      if (timelapseFrames.length > 0) {
-        if (pendingTimelineSeekOffset != null) {
-          // Cross-segment timeline seek: land on the frame nearest the
-          // requested offset instead of the segment start.
-          const target = frameIndexAtOffset(pendingTimelineSeekOffset);
-          pendingTimelineSeekOffset = null;
-          tlSeek(target);
-        } else {
-          await ensureFrameCached(0, signal);
-        }
-        prefetchAhead(pendingTimelineSeekOffset == null ? 0 : tlCurrentFrame, signal);
+      if (timelapseFrames.length > 0 && pendingTimelineSeekOffset != null) {
+        // Cross-segment timeline seek: land on the frame nearest the
+        // requested offset instead of the segment start.
+        const target = frameIndexAtOffset(pendingTimelineSeekOffset);
+        pendingTimelineSeekOffset = null;
+        tlSeek(target);
       }
     } catch (e) {
       if (signal.aborted) return;
@@ -961,146 +943,25 @@
     }
   }
 
-  async function ensureFrameCached(index: number, signal?: AbortSignal) {
-    if (tlBlobCache.has(index) || !timelapseFrames[index]) return;
-    if (signal?.aborted) return;
-    try {
-      const blobUrl = await loadTimelapseFrameBlob(currentId, timelapseFrames[index].filename, signal);
-      if (signal?.aborted) return;
-      tlBlobCache.set(index, blobUrl);
-      if (tlBlobCache.size >= 500) {
-        const keys = [...tlBlobCache.keys()].sort((a, b) => a - b);
-        const toEvict = keys.slice(0, keys.length - 400);
-        for (const k of toEvict) {
-          const url = tlBlobCache.get(k);
-          if (url) URL.revokeObjectURL(url);
-          tlBlobCache.delete(k);
-        }
-      }
-    } catch (e) {
-      if (signal?.aborted) return;
-      console.warn('Failed to load timelapse frame:', index, e);
-    }
-  }
-
-  async function prefetchAhead(fromIndex: number, signal?: AbortSignal) {
-    const windowSize = 200;
-    const batchSize = 20;
-    const end = Math.min(fromIndex + windowSize, timelapseFrames.length);
-    for (let i = fromIndex; i < end; i += batchSize) {
-      if (signal?.aborted) return;
-      const batch = [];
-      for (let j = i; j < Math.min(i + batchSize, end); j++) {
-        if (!tlBlobCache.has(j)) batch.push(ensureFrameCached(j, signal));
-      }
-      await Promise.all(batch);
-    }
-  }
-
-  function stopTimelapsePlayback() {
-    if (tlPlayTimeout) { clearTimeout(tlPlayTimeout); tlPlayTimeout = null; }
-  }
-
-  function playNextFrame() {
-    if (!tlIsPlaying) return;
-    const signal = tlAbortController?.signal;
-    if (signal?.aborted) return;
-    const next = tlCurrentFrame + 1;
-
-    if (timelapseFrames.length > 0 && next >= timelapseFrames.length * 0.8 && !prefetchedNextSegment && !prefetchingNextSegment) {
-      prefetchNextSegmentFrames();
-    }
-
-    if (next >= timelapseFrames.length) {
-      if (tlLoop) {
-        tlCurrentFrame = 0;
-        tlPlayTimeout = setTimeout(playNextFrame, 50);
-        return;
-      }
-      // Seamless chain: if the next segment was prefetched, adopt its frames.
-      if (prefetchedNextSegment && prefetchedNextSegment.frames.length > 0) {
-        const pre = prefetchedNextSegment;
-        prefetchedNextSegment = null;
-        timelapseFrames = pre.frames;
-        tlBlobCache.forEach(url => URL.revokeObjectURL(url));
-        tlBlobCache = pre.blobCache;
-        tlCurrentFrame = 0;
-        clearMergedCodecCache(pre.recordingId);
-        // Claim the adopted segment BEFORE the host swaps the recording prop —
-        // the recording-change effect must skip so the adopted playback is not
-        // re-initialized (which would stomp the chain back to the old segment).
-        lastLoadedId = pre.recordingId;
-        // Reload the recording metadata in the background so the side panel /
-        // timeline update, without interrupting the cycler.
-        void getRecording(pre.recordingId).then(r => { if (r) oncrosssegment?.(r); });
-        const fps = 10 * tlSpeed;
-        const delay = Math.max(0, (1000 / fps) - 10);
-        tlPlayTimeout = setTimeout(playNextFrame, delay);
-        return;
-      }
-      // No prefetch → fall back to the host's next-segment navigation.
-      tlIsPlaying = false;
-      ongotonext();
-      return;
-    }
-    tlCurrentFrame = next;
-    const loadPromise = tlBlobCache.has(next) ? Promise.resolve() : ensureFrameCached(next, signal);
-    prefetchAhead(next + 1, signal);
-    loadPromise.then(() => {
-      if (signal?.aborted) return;
-      const fps = 10 * tlSpeed;
-      const delay = Math.max(0, (1000 / fps) - 10);
-      tlPlayTimeout = setTimeout(playNextFrame, delay);
-    });
-  }
-
-  async function prefetchNextSegmentFrames() {
-    if (!recording || prefetchedNextSegment || prefetchingNextSegment) return;
-    prefetchingNextSegment = true;
-    try {
-      const next = await loadNextRecording();
-      if (!next) return;
-      const frames = await getTimelapseFrames(next.id);
-      if (frames.length === 0) return;
-      const blobCache = new Map<number, string>();
-      const batchSize = Math.min(20, frames.length);
-      await Promise.all(
-        Array.from({ length: batchSize }, (_, i) =>
-          loadTimelapseFrameBlob(next.id, frames[i].filename)
-            .then(url => blobCache.set(i, url))
-            .catch(() => {})
-        )
-      );
-      prefetchedNextSegment = { recordingId: next.id, frames, blobCache };
-    } catch { /* silent */ } finally {
-      prefetchingNextSegment = false;
-    }
+  // The sequence player reports end-of-sequence; navigate to the next segment
+  // (batch fetching makes the transition one request, not N).
+  function handleSequenceEnded() {
+    ongotonext();
   }
 
   function tlTogglePlay() {
     if (tlIsPlaying) {
       tlIsPlaying = false;
-      stopTimelapsePlayback();
     } else {
       if (timelapseFrames.length === 0) return;
+      // Restart from the top when play is pressed at the end.
+      if (tlCurrentFrame >= timelapseFrames.length - 1) tlCurrentFrame = 0;
       tlIsPlaying = true;
-      stopTimelapsePlayback();
-      playNextFrame();
     }
   }
   function tlSetSpeed(speed: number) { tlSpeed = speed; }
   function tlSeek(index: number) {
-    const target = Math.max(0, Math.min(index, timelapseFrames.length - 1));
-    tlCurrentFrame = target;
-    const signal = tlAbortController?.signal;
-    if (!tlBlobCache.has(target)) {
-      tlSeekTimeout = setTimeout(() => { tlSeekLoading = true; }, 500);
-      ensureFrameCached(target, signal).finally(() => {
-        if (tlSeekTimeout) { clearTimeout(tlSeekTimeout); tlSeekTimeout = null; }
-        tlSeekLoading = false;
-      });
-    }
-    prefetchAhead(target + 1, signal);
+    tlCurrentFrame = Math.max(0, Math.min(index, timelapseFrames.length - 1));
   }
   function tlToggleLoop() { tlLoop = !tlLoop; }
   function toggleFullscreen() {
@@ -1184,14 +1045,11 @@
     return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   }
 
-  // Cleanup on destroy: abort in-flight requests, revoke blob URLs, clear timers.
+  // Cleanup on destroy: abort in-flight requests, clear timers.
   onDestroy(() => {
     teardownContinuous();
     tlAbortController?.abort();
     tlAbortController = null;
-    tlBlobCache.forEach(url => URL.revokeObjectURL(url));
-    tlBlobCache = new Map();
-    stopTimelapsePlayback();
     if (formatBadgeTimeout) { clearTimeout(formatBadgeTimeout); formatBadgeTimeout = null; }
     if (videoStallTimeout) { clearTimeout(videoStallTimeout); videoStallTimeout = null; }
     stopTranscodePoll();
@@ -1201,29 +1059,26 @@
   export function handleKeyAction(key: string) {
     if (!recording) return;
     const f = recording.format;
+    // mjpeg and timelapse formats both play through the sequence player
+    // (playbackMode === 'timelapse') — shared control path.
+    const seq = f === 'mjpeg' || f === 'timelapse';
     if (key === 'space') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('togglePlay');
-      else if (f === 'timelapse') tlTogglePlay();
+      if (seq) tlTogglePlay();
       else { const v = videoEl; if (v) { if (v.paused) void v.play(); else v.pause(); } }
     } else if (key === 'arrowleft') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('prevFrame');
-      else if (f === 'timelapse') tlSeek(tlCurrentFrame - 1);
+      if (seq) tlSeek(tlCurrentFrame - 1);
       else { const v = videoEl; if (v) v.currentTime = Math.max(0, v.currentTime - 5); }
     } else if (key === 'arrowright') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('nextFrame');
-      else if (f === 'timelapse') tlSeek(tlCurrentFrame + 1);
+      if (seq) tlSeek(tlCurrentFrame + 1);
       else { const v = videoEl; if (v) v.currentTime = Math.min(v.duration, v.currentTime + 5); }
     } else if (key === 'f') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('toggleFullscreen');
-      else if (f === 'timelapse') toggleFullscreen();
+      if (seq) toggleFullscreen();
       else toggleVideoFullscreen();
     } else if (key === 'l') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('toggleLoop');
-      else if (f === 'timelapse') tlToggleLoop();
+      if (seq) tlToggleLoop();
       else if (f === 'h264' || f === 'h265') toggleVideoLoop();
     } else if (key === 'home') {
-      if (f === 'mjpeg') mjpegPlayer?.handleKeyAction('home');
-      else if (f === 'timelapse') tlSeek(0);
+      if (seq) tlSeek(0);
       else if (f === 'h264' || f === 'h265') setVideoSpeed(1);
     }
   }
@@ -1391,25 +1246,23 @@
       </div>
     </div>
   {:else}
-    <!-- Frame display -->
-    <div class="timelapse-container relative max-h-[75vh] overflow-hidden flex items-center justify-center bg-black min-h-[200px]">
-      {#if timelapseFrames[tlCurrentFrame]}
-        {@const frame = timelapseFrames[tlCurrentFrame]}
-        {#if tlBlobCache.has(tlCurrentFrame)}
-          <img src={tlBlobCache.get(tlCurrentFrame)} alt={frame.filename} class="max-w-full max-h-[75vh]" style="transition: opacity 0.2s ease-in-out" />
-        {:else if tlCurrentFrame > 0 && tlBlobCache.has(tlCurrentFrame - 1)}
-          <img src={tlBlobCache.get(tlCurrentFrame - 1)} alt={frame.filename} class="max-w-full max-h-[75vh] opacity-50" style="transition: opacity 0.3s ease-in-out" />
-          {#if tlSeekLoading}
-            <div class="absolute inset-0 flex items-center justify-center bg-black/30">
-              <div class="spinner spinner-lg"></div>
-            </div>
-          {/if}
-        {:else}
-          <div class="flex items-center justify-center h-64 bg-black">
-            <div class="spinner spinner-lg"></div>
-          </div>
-        {/if}
-      {/if}
+    <!-- Frame display: multipart batch fetch + canvas rendering (no per-frame
+         GETs, no <img src> swaps → no stutter, no flicker). Keyed by recording
+         so caches reset on segment change. -->
+    <div class="timelapse-container relative overflow-hidden flex items-center justify-center bg-black min-h-[200px]">
+      {#key currentId}
+        <MjpegSequencePlayer
+          frameCount={timelapseFrames.length}
+          fps={10}
+          fetchBatch={(offset, limit, signal) => fetchRecordingFrameBatch(currentId, offset, limit, signal)}
+          bind:currentIndex={tlCurrentFrame}
+          bind:playing={tlIsPlaying}
+          bind:speed={tlSpeed}
+          loop={tlLoop}
+          showControls={false}
+          onEnded={handleSequenceEnded}
+        />
+      {/key}
     </div>
 
     <!-- Inline merge controls -->


### PR DESCRIPTION
## Summary

MJPEG/HTTP-JPEG 相机（ESP32 MiBeeCam 类）开录像后现在能自动产出每日延时录像，且 MJPEG 内容的播放从“每帧一个 HTTP 请求 + img src 切换”换成一个 multipart 批量请求 + canvas 渲染——不再卡顿、不再闪屏。

### 后端（纯 Go，无新依赖）

- **修复 MJPEG 双模延时完全失效**：`RecordingFrameExtractor` 此前把 `FormatMJPEG`（时间戳命名的 JPEG 目录）当 AVI 文件去解，必然失败 → MJPEG 相机开录像后周期合并产出为 0。新增真正的 MJPEG 目录分支（帧时间取自文件名）。
- **修复帧编号覆盖 bug**：一个合并窗口内多段录像共用一个临时目录且每段从 `frame_000001` 重新编号，后段覆盖前段——碎片化相机只剩最后一段的帧。改为 `FrameSampler` 绝对时间窗采样 + `startIndex` 跨段续号（AVI/H264/H265 同样受益）。
- **采样间隔统一为 `timelapse.interval`**（默认 30s）：真延时压缩语义（24h ≈ 96s @30fps），替代原先 `1/输出fps`（≈全天复制）。MJPEG/AVI/timelapse 源合并进同一无后缀 `jpeg` 组。
- **新增 opt-in `delete_recordings_after_merge`**：周期合并成功后删除窗口内源录像段（复用 cleanup 管理器：MiBeeVision 处理中的跳过、合并失败绝不删）。UI 配置开关 + 定时/手动合并两条路径都接线。
- **两个 multipart 批量帧端点**：
  - `GET /api/timelapse/merges/{id}/frames`（`merge.ParseSegment` 样本表切片 mjpa）
  - `GET /api/recordings/{id}/timelapse-frames/batch`（目录缓存 / AVI 帧索引）
  - 一次请求最多 240 帧；compress 中间件跳过 `multipart/*`。

### 前端

- 新组件 `MjpegSequencePlayer`：multipart 流式解析（`web/src/lib/multipart.ts`）+ `createImageBitmap` 解码 + canvas `drawImage` + 漂移修正 rAF 节奏。无 per-frame GET、无 `<img>` swap、无 opacity 过渡——卡顿与闪屏的根源修复。
- `PlaybackPanel` 的 JPEG cycler 内部实现整体替换为该组件（控制条/时间线 seek/键盘保持不变）；`TimelapseMergeDetail` 对 `codec=mjpeg` 的合并改用 canvas 播放器（原先直接塞 `<video>` 必报错）。

### 顺带修掉的 3 个被掩盖的既有 bug

`#/timelapse` 旧路由重定向吞掉 `#/timelapse-merge/:id`（合并详情页从来进不去）；该页 `ConfirmDialog` 传了不存在的 props 导致遮罩常驻拦截点击；键盘分发器对 mjpeg 格式还路由到死代码 `MjpegPlayer`。

## Test plan

- [x] TDD：`frame_extractor`（MJPEG 目录/窗口采样/续号）、`periodic_merge_extract`（分组/间隔/删除开关/失败不删）、`handlers_frame_batch`（multipart 端点/limit 上限/AVI）、`timelapse_wiring`（装配回归）、config、`multipart.test.ts` 全部 RED→GREEN
- [x] `go test ./...` 5587 passed · `golangci-lint` 0 issues · vitest 613 passed
- [x] 本地实机 e2e（python MJPEG stub + 新二进制）：录像→手动合并→`timelapse_merges` 行（mjpeg/30帧）→批量端点 200；浏览器（Chromium）验证合并详情页 canvas 播放推进（12→24→30 @30fps）、录像回放页播放推进（@10fps）、删除开关端到端（18→11 段）；零 JS 错误
- [ ] M5 部署 + `cam-121f81b1`（.148）启用 timelapse + 补历史合并（merge 后跟进）

🤖 Generated with [Claude Code](https://claude.com/claude-code)