### PR TITLE
fix(timelapse): skip latest-frame poller on rebuild path when recording enabled

### DIFF
--- a/internal/camera/recorder_factory.go
+++ b/internal/camera/recorder_factory.go
@@ -194,10 +194,23 @@ func (cm *CameraManager) startRecorderLocked(ctx context.Context, cam config.Cam
 				"camera_id", cam.ID)
 		}
 	} else if effectiveDualModeFrameSource(cam) == "latest_frame" {
-		if poller, perr := cm.startTimelapseFramePoller(cam.ID, cam, rec); perr != nil {
-			logger.Error("failed to start timelapse frame poller", "camera_id", cam.ID, "error", perr)
-		} else if poller != nil {
-			cm.setFramePoller(cam.ID, poller)
+		// Same dual-mode guard as the rtsp_keyframe branch above (and
+		// startCamera in lifecycle.go): with recording_enabled=true (nil =
+		// default), timelapse frames come from recorded segments via
+		// PeriodicMergeManager. Starting the live poller here made every
+		// reconnect of a disconnect-heavy JPEG camera spawn a poller that
+		// spammed ~150s/6-frame timelapse fragments into the recordings list
+		// (206 segments in 9h observed on production).
+		recordingEnabled := cam.RecordingEnabled == nil || *cam.RecordingEnabled
+		if !recordingEnabled {
+			if poller, perr := cm.startTimelapseFramePoller(cam.ID, cam, rec); perr != nil {
+				logger.Error("failed to start timelapse frame poller", "camera_id", cam.ID, "error", perr)
+			} else if poller != nil {
+				cm.setFramePoller(cam.ID, poller)
+			}
+		} else {
+			logger.Debug("timelapse latest-frame poller skipped: recording enabled (frames from PeriodicMergeManager)",
+				"camera_id", cam.ID)
 		}
 	}
 

--- a/internal/camera/recorder_factory_capturer_test.go
+++ b/internal/camera/recorder_factory_capturer_test.go
@@ -1,0 +1,164 @@
+// Regression tests for the dual-mode live-capturer guard on the
+// recorder-rebuild path: with recording_enabled=true, the latest_frame
+// timelapse poller must NOT start (frames come from PeriodicMergeManager).
+// Before the fix, every reconnect of a disconnect-heavy MJPEG camera started
+// a poller that spammed ~150s/6-frame timelapse fragments — 206 segments in
+// 9h observed on production M5.
+package camera
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMJPEGServer serves a multipart/x-mixed-replace MJPEG stream so an
+// http/jpeg camera can actually connect and start recording.
+func newTestMJPEGServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	closed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if closed {
+			mu.Unlock()
+			return
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "multipart/x-mixed-replace;boundary=frame")
+		flusher := w.(http.Flusher)
+		frame := []byte{0xFF, 0xD8, 0xFF, 0xD9} // minimal JPEG
+		for range 200 {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			fmt.Fprintf(w, "--frame\r\nContent-Type: image/jpeg\r\nContent-Length: %d\r\n\r\n", len(frame))
+			w.Write(frame)
+			w.Write([]byte("\r\n"))
+			flusher.Flush()
+			time.Sleep(50 * time.Millisecond)
+		}
+	}))
+	t.Cleanup(func() {
+		mu.Lock()
+		closed = true
+		mu.Unlock()
+		srv.Close()
+	})
+	return srv
+}
+
+func (cm *CameraManager) hasFramePollerForTest(cameraID string) bool {
+	cm.auxMu.Lock()
+	defer cm.auxMu.Unlock()
+	_, ok := cm.framePollers[cameraID]
+	return ok
+}
+
+// TestStartRecorder_LatestFramePollerSkippedWhenRecordingEnabled: the
+// reconnect/rebuild path must honor the dual-mode skip — recording_enabled
+// (nil or true) + timelapse enabled → NO live latest-frame poller.
+func TestStartRecorder_LatestFramePollerSkippedWhenRecordingEnabled(t *testing.T) {
+	t.Helper()
+	for _, recEnabled := range []*bool{nil, boolPtrForTest(true)} {
+		label := "true"
+		if recEnabled == nil {
+			label = "nil(default)"
+		}
+		t.Run(label, func(t *testing.T) {
+			srv := newTestMJPEGServer(t)
+			tmpDir := t.TempDir()
+			cfg := &config.Config{
+				Storage: config.StorageConfig{
+					RootDir:         filepath.Join(tmpDir, "storage"),
+					SegmentDuration: "10m",
+				},
+				Cameras: []config.CameraConfig{{
+					ID:               "cam-capturer-guard",
+					Name:             "Capturer Guard",
+					Protocol:         "http",
+					Encoding:         "jpeg",
+					URL:              srv.URL + "/stream",
+					RecordingEnabled: recEnabled,
+					Timelapse: &config.CameraTimelapseConfig{
+						Enabled:     true,
+						Interval:    "30s",
+						FrameSource: "auto",
+					},
+				}},
+			}
+			require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
+			store, err := storage.NewManager(cfg.Storage.RootDir)
+			require.NoError(t, err)
+			t.Cleanup(func() { store.CleanupTempFiles() })
+
+			mgr := NewCameraManager(cfg, store, nil, "")
+			t.Cleanup(func() { _ = mgr.Stop() })
+
+			segDur, _ := time.ParseDuration(cfg.Storage.SegmentDuration)
+			err = mgr.startRecorder(context.Background(), cfg.Cameras[0], segDur)
+			require.NoError(t, err, "http/jpeg camera against local stub must start")
+
+			assert.False(t, mgr.hasFramePollerForTest("cam-capturer-guard"),
+				"latest_frame poller must NOT run when recording_enabled=%s (frames come from PeriodicMergeManager)", label)
+		})
+	}
+}
+
+// TestStartRecorder_LatestFramePollerRunsWhenRecordingDisabled: the skip must
+// not break the legitimate case — recording off + timelapse on → poller runs.
+func TestStartRecorder_LatestFramePollerRunsWhenRecordingDisabled(t *testing.T) {
+	t.Helper()
+	srv := newTestMJPEGServer(t)
+	tmpDir := t.TempDir()
+	falseVal := false
+	cfg := &config.Config{
+		Storage: config.StorageConfig{
+			RootDir:         filepath.Join(tmpDir, "storage"),
+			SegmentDuration: "10m",
+		},
+		Cameras: []config.CameraConfig{{
+			ID:               "cam-capturer-guard-off",
+			Name:             "Capturer Guard Off",
+			Protocol:         "http",
+			Encoding:         "jpeg",
+			URL:              srv.URL + "/stream",
+			RecordingEnabled: &falseVal,
+			Timelapse: &config.CameraTimelapseConfig{
+				Enabled:     true,
+				Interval:    "30s",
+				FrameSource: "auto",
+			},
+		}},
+	}
+	require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
+	store, err := storage.NewManager(cfg.Storage.RootDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { store.CleanupTempFiles() })
+
+	mgr := NewCameraManager(cfg, store, nil, "")
+	t.Cleanup(func() { _ = mgr.Stop() })
+
+	segDur, _ := time.ParseDuration(cfg.Storage.SegmentDuration)
+	err = mgr.startRecorder(context.Background(), cfg.Cameras[0], segDur)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return mgr.hasFramePollerForTest("cam-capturer-guard-off")
+	}, 10*time.Second, 100*time.Millisecond, "poller should run when recording is disabled")
+}
+
+func boolPtrForTest(v bool) *bool { return &v }


### PR DESCRIPTION
## Summary

`startRecorderLocked`（相机重连/重建装配路径）的 dual-mode 守卫只护住了 `rtsp_keyframe` 分支——`latest_frame` 分支（JPEG/MJPEG 相机）无条件启动了实时 SnapshotCapturer。recording_enabled=true 的相机每次断连重连都会孵化一个轮询器，把 ~150s/6 帧的 timelapse 碎片段直接灌进录像列表（生产 M5 启用双模延时后 9 小时实测 206 条）。与 lifecycle.go（startCamera）和 schedule monitor 中已有的守卫对齐。

## Test plan

- [x] RED→GREEN：`TestStartRecorder_LatestFramePollerSkippedWhenRecordingEnabled`（recording_enabled=true 和 nil 两种）修复前失败；`...RunsWhenRecordingDisabled` 锁定 recording 关闭时轮询器仍启动
- [x] `go test -race ./internal/camera/` 236 passed · golangci-lint 0 issues
- [ ] M5 部署后确认不再新增 timelapse 碎片段

🤖 Generated with [Claude Code](https://claude.com/claude-code)