### PR TITLE
fix(timelapse): suppress source deletion while merge window is still open

### DIFF
--- a/internal/camera/recorder_factory_capturer_test.go
+++ b/internal/camera/recorder_factory_capturer_test.go
@@ -101,11 +101,14 @@ func TestStartRecorder_LatestFramePollerSkippedWhenRecordingEnabled(t *testing.T
 				}},
 			}
 			require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
+			db, err := storage.New(filepath.Join(tmpDir, "test.db"))
+			require.NoError(t, err)
+			t.Cleanup(func() { db.Close() })
 			store, err := storage.NewManager(cfg.Storage.RootDir)
 			require.NoError(t, err)
 			t.Cleanup(func() { store.CleanupTempFiles() })
 
-			mgr := NewCameraManager(cfg, store, nil, "")
+			mgr := NewCameraManager(cfg, store, db, "")
 			t.Cleanup(func() { _ = mgr.Stop() })
 
 			segDur, _ := time.ParseDuration(cfg.Storage.SegmentDuration)
@@ -145,11 +148,14 @@ func TestStartRecorder_LatestFramePollerRunsWhenRecordingDisabled(t *testing.T) 
 		}},
 	}
 	require.NoError(t, os.MkdirAll(cfg.Storage.RootDir, 0o755))
+	db, err := storage.New(filepath.Join(tmpDir, "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
 	store, err := storage.NewManager(cfg.Storage.RootDir)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.CleanupTempFiles() })
 
-	mgr := NewCameraManager(cfg, store, nil, "")
+	mgr := NewCameraManager(cfg, store, db, "")
 	t.Cleanup(func() { _ = mgr.Stop() })
 
 	segDur, _ := time.ParseDuration(cfg.Storage.SegmentDuration)

--- a/internal/timelapse/periodic_merge.go
+++ b/internal/timelapse/periodic_merge.go
@@ -201,6 +201,15 @@ func (m *PeriodicMergeManager) HasSourceDeleter() bool {
 	return m.sourceDeleter != nil
 }
 
+// mergeWindowStillOpen reports whether the current Run's window end is in the
+// future (e.g. a mid-day manual preview of a natural-day window). Source
+// deletion must be suppressed in that case — see runPerCodecMerge.
+func (m *PeriodicMergeManager) mergeWindowStillOpen() bool {
+	m.runCtxMu.Lock()
+	defer m.runCtxMu.Unlock()
+	return !m.runCtx.endTime.IsZero() && m.runCtx.endTime.After(time.Now())
+}
+
 // WithRecordingEnabledProvider sets a function that reports if a camera has
 // recording_enabled=true. When true, Run will extract frames from video
 // recordings in the merge window and include them in the timelapse output.

--- a/internal/timelapse/periodic_merge_extract_test.go
+++ b/internal/timelapse/periodic_merge_extract_test.go
@@ -254,3 +254,49 @@ func TestPeriodicMerge_DeleteSkippedOnMergeFailure(t *testing.T) {
 		t.Errorf("DeleteRecordings must not be called when the merge failed, got %d calls", deleter.callCount())
 	}
 }
+
+// TestPeriodicMerge_DeleteSkippedForOpenWindow: a manual merge of TODAY's
+// still-open window must NOT delete source recordings even with the flag on —
+// the scheduled re-run at window close would otherwise regenerate the output
+// from only the surviving (post-preview) segments and lose the morning.
+func TestPeriodicMerge_DeleteSkippedForOpenWindow(t *testing.T) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	// Reference time INSIDE the window being merged (natural-day: today).
+	windowStart := time.Now().Truncate(time.Hour)
+
+	dirA := filepath.Join(dataDir, "segA")
+	writeMJPEGDirFixture(t, dirA, windowStart, 60, time.Second, 0)
+
+	lister := &mockRecordingListerMultiFormat{
+		videoSegments: []model.Recording{
+			{ID: "vid-open-1", CameraID: cameraID, FilePath: dirA, Format: model.FormatMJPEG, StartedAt: windowStart},
+		},
+	}
+
+	deleter := &fakeSourceDeleter{}
+	mgr := NewPeriodicMergeManager(
+		lister, newTrackDB(), NewGoMerger(), 30, dataDir, 24*time.Hour, nil,
+		WithRecordingEnabledProvider(func(string) bool { return true }),
+		WithExtractionInterval(10*time.Second),
+		WithDeleteRecordingsAfterMerge(true),
+	)
+	mgr.SetSourceRecordingDeleter(deleter)
+
+	// Merge a window whose end is in the FUTURE (today, still recording).
+	if err := mgr.Run(context.Background(), cameraID, windowStart.Add(time.Minute)); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if deleter.callCount() != 0 {
+		t.Errorf("DeleteRecordings must not run for an open (not-yet-elapsed) window, got %d calls", deleter.callCount())
+	}
+
+	// The output itself must still be produced (preview use case). The
+	// natural-day window label is the (local) midnight of the reference day.
+	label := time.Now().Format("2006-01-02") + "_000000"
+	if _, err := os.Stat(filepath.Join(dataDir, cameraID, "periodic_"+label+".mp4")); err != nil {
+		t.Errorf("expected preview output for open window (label %s): %v", label, err)
+	}
+}

--- a/internal/timelapse/periodic_merge_strategies.go
+++ b/internal/timelapse/periodic_merge_strategies.go
@@ -394,8 +394,11 @@ func (m *PeriodicMergeManager) runPerCodecMerge(ctx context.Context, segments []
 
 		// Opt-in source cleanup: delete the group's source video recordings
 		// only after its output was produced. Never on failure — that would
-		// lose data with no timelapse to show for it.
-		if m.deleteRecordingsAfterMerge && m.sourceDeleter != nil {
+		// lose data with no timelapse to show for it — and never while the
+		// window is still open (a mid-day manual preview merge must not delete
+		// the morning's sources: the scheduled re-run at window close would
+		// then rebuild the output from only the surviving evening segments).
+		if m.deleteRecordingsAfterMerge && m.sourceDeleter != nil && !m.mergeWindowStillOpen() {
 			if srcs := extractedSources[codec]; len(srcs) > 0 {
 				deleted, err := m.sourceDeleter.DeleteRecordings(ctx, srcs, "timelapse_source_merged")
 				if err != nil {


### PR DESCRIPTION
## Summary

对仍未结束的合并窗口（如当天中途手动预览 natural-day）执行合并时，不再触发 `delete_recordings_after_merge` 源段删除——否则午夜调度重跑时只能用幸存的晚间段重建输出，上午素材被静默丢弃。删除现在要求窗口已完全过去。

## Test plan

- [x] RED→GREEN：`TestPeriodicMerge_DeleteSkippedForOpenWindow`（开放窗口不删 + 预览输出仍生成）
- [x] `go test -race ./internal/timelapse/` 404 passed · lint 0 · camera/app/api 回归 1163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)