### PR TITLE
feat(ops): 配置防呆 — validate-config CLI + 悬空 vision_targets 降级 Warn + 崩溃循环熔断 (#737)

### DIFF
--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -318,6 +318,8 @@ func dispatchSubcommand(args []string) {
 		cmdUpdate()
 	case "cleanup":
 		cmdCleanup()
+	case "validate-config":
+		cmdValidateConfig()
 	}
 }
 

--- a/cmd/mibee-nvr/main.go
+++ b/cmd/mibee-nvr/main.go
@@ -141,6 +141,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Snapshot the boot-validated config as the recovery point for
+	// shutdown-persist overwrites (running NVR re-serializes the YAML at
+	// shutdown, clobbering hand edits; older binaries zero unknown sections).
+	if err := config.WriteLastGoodBackup(*configPath); err != nil {
+		slog.Warn("failed to write last-good config snapshot", "error", err)
+	}
+
 	// Reconfigure logger with user settings after config load
 	logger = authmw.SetupLogger(cfg.Observability.LogLevel, cfg.Observability.LogFormat)
 	slog.SetDefault(logger)

--- a/cmd/mibee-nvr/validate_config.go
+++ b/cmd/mibee-nvr/validate_config.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// cmdValidateConfig implements `mibee-nvr validate-config [--config <path>]`.
+//
+// Pre-deploy smoke check for hand-edited YAML: loads the config through the
+// exact same Load → Validate pipeline the server uses at boot and reports
+// pass/fail without starting anything. Exit code 0 = the NVR would boot on
+// this file; 1 = it would crash-loop. Born from the 2026-09-11 M5 incident
+// (removing a vision instance while a camera still referenced it bricked the
+// service into a systemd restart loop for ~2 minutes).
+func cmdValidateConfig() {
+	os.Exit(runValidateConfig(os.Args))
+}
+
+// runValidateConfig is the testable core of cmdValidateConfig: returns the
+// process exit code instead of calling os.Exit itself. defaultPath mirrors
+// the serve path's flag default so a bare `mibee-nvr validate-config` checks
+// the file the server would load from the working directory.
+func runValidateConfig(args []string) int {
+	fs := flag.NewFlagSet("validate-config", flag.ContinueOnError)
+	configPath := fs.String("config", "mibee-nvr.yaml", "path to the config file to validate")
+	if err := fs.Parse(args[2:]); err != nil {
+		return 1
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %s: %v\n", *configPath, err)
+		return 1
+	}
+	if err := config.Validate(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL %s: config validation: %v\n", *configPath, err)
+		return 1
+	}
+	fmt.Printf("OK %s — the NVR would boot on this config\n", *configPath)
+	return 0
+}

--- a/cmd/mibee-nvr/validate_config_test.go
+++ b/cmd/mibee-nvr/validate_config_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+)
+
+// TestRunValidateConfigExitCodes pins the CLI contract of the pre-deploy
+// validation subcommand: 0 for a config that would boot, 1 for anything that
+// would brick the NVR at startup. This is the prevention tool for the
+// 2026-09-11 crash-loop class — hand-edited YAML can now be checked BEFORE
+// systemctl restart.
+func TestRunValidateConfigExitCodes(t *testing.T) {
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "good.yaml")
+	cfg := &config.Config{}
+	cfg.ApplyDefaults()
+	if err := config.Save(good, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// retention_days outside the 1..3650 range fails Validate() fatally.
+	bad := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(bad, []byte("cleanup:\n  retention_days: 99999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"valid config exits 0", []string{"mibee-nvr", "validate-config", "--config", good}, 0},
+		{"invalid config exits 1", []string{"mibee-nvr", "validate-config", "--config", bad}, 1},
+		{"missing config exits 1", []string{"mibee-nvr", "validate-config", "--config", filepath.Join(dir, "nope.yaml")}, 1},
+		{"default path falls back to ./mibee-nvr.yaml", []string{"mibee-nvr", "validate-config"}, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runValidateConfig(tt.args); got != tt.want {
+				t.Errorf("runValidateConfig(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/deploy/mibee-nvr.service
+++ b/deploy/mibee-nvr.service
@@ -2,6 +2,11 @@
 Description=MiBee NVR - Network Video Recorder
 After=network.target
 Requires=network.target
+# Crash-loop fuse: a fatal config error (e.g. a hand-edited YAML) must not
+# hammer the box forever — 5 restarts within 2 minutes stop the unit until an
+# operator intervenes (`journalctl -u mibee-nvr` shows the validation error).
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=simple

--- a/internal/config/config_vision_test.go
+++ b/internal/config/config_vision_test.go
@@ -153,7 +153,9 @@ func TestValidateVisionInstances(t *testing.T) {
 		}}
 	})), "name is required")
 
-	// 相机路由引用未知实例 → 拒绝;引用 default/显式实例 → 通过。
+	// 相机路由引用未知实例 → 加载层降级 WARN + 剔除(2026-09-11 起;此前
+	// fatal 会把手改 yaml 的悬空引用 brick 成 systemd 崩溃循环);引用
+	// default/显式实例 → 通过且不动。API 写边界仍严格拒绝。
 	withCam := func(targets []string, instances []VisionInstance) *Config {
 		return base(func(c *Config) {
 			c.Vision = VisionConfig{Instances: instances}
@@ -163,9 +165,10 @@ func TestValidateVisionInstances(t *testing.T) {
 			}}
 		})
 	}
-	require.ErrorContains(t, Validate(withCam([]string{"ghost"},
-		[]VisionInstance{{Name: "a", URL: "http://a:9091"}})),
-		"unknown vision instance")
+	cfg := withCam([]string{"a", "ghost"},
+		[]VisionInstance{{Name: "a", URL: "http://a:9091"}})
+	require.NoError(t, Validate(cfg))
+	require.Equal(t, []string{"a"}, cfg.Cameras[0].VisionTargets)
 	require.NoError(t, Validate(withCam([]string{"a", "default"},
 		[]VisionInstance{{Name: "a", URL: "http://a:9091"}})))
 	require.NoError(t, Validate(withCam(nil, nil))) // legacy 全兼容

--- a/internal/config/last_good_backup.go
+++ b/internal/config/last_good_backup.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// WriteLastGoodBackup atomically snapshots a config file next to itself as
+// "<path>.last-good". main.go calls this after a successful boot-side
+// validation so there is always a recovery point for the two config-loss
+// gotchas this project has hit repeatedly:
+//
+//  1. shutdown-persist overwrite — the running NVR re-serializes the YAML on
+//     shutdown, clobbering hand edits made while it was up;
+//  2. older-binary zeroing — deploying a branch binary that lacks a newer
+//     config section's schema rewrites that section to zero values at its
+//     shutdown (2026-09-08: trigger.webhook got enabled:false this way).
+//
+// Best-effort by design: failures return an error for the caller to WARN,
+// never block the boot that already validated successfully.
+func WriteLastGoodBackup(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read config for last-good snapshot: %w", err)
+	}
+	tmp := path + ".last-good.tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write last-good snapshot: %w", err)
+	}
+	if err := os.Rename(tmp, path+".last-good"); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename last-good snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/config/last_good_backup_test.go
+++ b/internal/config/last_good_backup_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteLastGoodBackupAtomicSnapshot verifies the boot-time recovery
+// snapshot: after a successful boot-side validation, main.go snapshots the
+// config next to itself as <path>.last-good. This is the recovery point for
+// the shutdown-persist overwrite gotcha (a running NVR re-serializes the YAML
+// on shutdown — a hand-edited change can be clobbered, and an older binary
+// can zero out newly added sections).
+func TestWriteLastGoodBackupAtomicSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mibee-nvr.yaml")
+	original := []byte("server:\n  listen: :9090\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteLastGoodBackup(path); err != nil {
+		t.Fatalf("WriteLastGoodBackup() errored: %v", err)
+	}
+	got, err := os.ReadFile(path + ".last-good")
+	if err != nil {
+		t.Fatalf("last-good snapshot missing: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("snapshot content mismatch: got %q, want %q", got, original)
+	}
+	// No temp file left behind by the atomic write.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 { // original + last-good
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("atomic write must not leave temp files behind: %v", names)
+	}
+}
+
+// TestWriteLastGoodBackupOverwriteStale ensures a reboot refreshes the
+// snapshot instead of failing on an existing one.
+func TestWriteLastGoodBackupOverwriteStale(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mibee-nvr.yaml")
+	if err := os.WriteFile(path, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "mibee-nvr.yaml.last-good"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteLastGoodBackup(path); err != nil {
+		t.Fatalf("WriteLastGoodBackup() must overwrite a stale snapshot: %v", err)
+	}
+	got, err := os.ReadFile(path + ".last-good")
+	if err != nil || string(got) != "new" {
+		t.Fatalf("snapshot must refresh, got %q err=%v", got, err)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -189,12 +189,28 @@ func validateConfigDetails(cfg *Config) error {
 		}
 
 		// Validate IP self-healing fields (stable_id + subnet_hints).
-		// 相机的 vision_targets 必须引用已定义实例——typo 会让该相机静默
-		// 失去推送路由。
-		for j, name := range c.VisionTargets {
-			if !visionNames[name] {
-				return fmt.Errorf("camera[%d].vision_targets[%d] references unknown vision instance %q", i, j, name)
+		// 相机的 vision_targets 引用已删除/改名的实例(手改 yaml 清理实例后
+		// 留下的悬空引用)降级为 WARN + 就地剔除,不再 fatal——硬拒绝会让一次
+		// 实例清理把整个 NVR brick 进 systemd 崩溃循环(2026-09-11 M5 实录,
+		// ~2min 录像中断)。与 #216 stable_id 同一原则:API 写边界保持严格
+		// (camera create/update 400、settings PUT 的搁浅相机检查),加载层
+		// 容错存量数据。全部引用悬空时列表清空 = RouteFor 的"广播全部启用
+		// 实例"语义——沿用运行时对空列表的既有定义,但显式告警路由面变宽。
+		keptVisionTargets := make([]string, 0, len(c.VisionTargets))
+		for _, name := range c.VisionTargets {
+			if visionNames[name] {
+				keptVisionTargets = append(keptVisionTargets, name)
+				continue
 			}
+			slog.Warn("camera vision_targets references unknown vision instance; dropping it",
+				"camera_idx", i, "camera_id", c.ID, "instance", name)
+		}
+		if len(keptVisionTargets) != len(c.VisionTargets) {
+			if len(keptVisionTargets) == 0 {
+				slog.Warn("camera lost every vision target to dangling references; routing falls back to broadcast (all enabled instances)",
+					"camera_idx", i, "camera_id", c.ID)
+			}
+			cfg.Cameras[i].VisionTargets = keptVisionTargets
 		}
 		// A non-empty stable_id that fails IsValidStableID (IP, URL, all-zero
 		// MAC — frozen in YAML by a prior firmware glitch, see #216) is logged

--- a/internal/config/validate_vision_targets_test.go
+++ b/internal/config/validate_vision_targets_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestValidateDanglingVisionTargetWarnsAndDrops is the regression guard for
+// the 2026-09-11 M5 outage: removing a vision instance from the YAML while a
+// camera still routes to it made Validate() fail fatally, bricking the NVR
+// into a systemd restart loop (~2 min of recording downtime until the
+// reference was fixed by hand). Load-time validation MUST tolerate dangling
+// camera.vision_targets references — warn and drop them in place — mirroring
+// the #216 stable_id precedent. Strict rejection stays at the API write
+// boundary (camera create/update) and at the settings PUT (stranded-camera
+// check); a hand-edited YAML is exactly the path those cannot cover.
+func TestValidateDanglingVisionTargetWarnsAndDrops(t *testing.T) {
+	cfg := &Config{
+		Vision: VisionConfig{
+			Enabled: true,
+			Instances: []VisionInstance{
+				{Name: "default", URL: "http://192.0.2.1:9091"},
+				{Name: "gpu", URL: "http://192.0.2.2:9092"},
+			},
+		},
+		Cameras: []CameraConfig{{
+			ID:            "cam-test",
+			URL:           "rtsp://x",
+			Protocol:      "rtsp",
+			VisionTargets: []string{"default", "ghost", "gpu"},
+		}},
+	}
+	cfg.ApplyDefaults()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() must not brick startup on a dangling vision_targets reference: %v", err)
+	}
+	got := cfg.Cameras[0].VisionTargets
+	if len(got) != 2 || got[0] != "default" || got[1] != "gpu" {
+		t.Fatalf("dangling reference must be dropped in place, known ones kept: got %v, want [default gpu]", got)
+	}
+	if !strings.Contains(buf.String(), "ghost") {
+		t.Fatalf("dropping must leave a warning trail naming the instance, got log: %q", buf.String())
+	}
+}
+
+// TestValidateAllVisionTargetsDanglingFallsBackToBroadcast covers the edge of
+// the drop rule: when every reference dangles, the camera's target list
+// becomes empty, which RouteFor treats as broadcast-to-all-enabled-instances.
+// That is the pre-existing runtime semantic for an empty list — the load-time
+// drop must not invent a third "routes nowhere" state, but it must warn
+// loudly because the routing scope silently widens.
+func TestValidateAllVisionTargetsDanglingFallsBackToBroadcast(t *testing.T) {
+	cfg := &Config{
+		Vision: VisionConfig{
+			Enabled: true,
+			Instances: []VisionInstance{
+				{Name: "gpu", URL: "http://192.0.2.2:9092"},
+			},
+		},
+		Cameras: []CameraConfig{{
+			ID:            "cam-test",
+			URL:           "rtsp://x",
+			Protocol:      "rtsp",
+			VisionTargets: []string{"ghost"},
+		}},
+	}
+	cfg.ApplyDefaults()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() must not brick startup when all vision_targets dangle: %v", err)
+	}
+	if n := len(cfg.Cameras[0].VisionTargets); n != 0 {
+		t.Fatalf("fully dangling targets must drop to empty (= broadcast), got %d left", n)
+	}
+	if !strings.Contains(buf.String(), "broadcast") {
+		t.Fatalf("broadcast fallback must be called out in the warning, got log: %q", buf.String())
+	}
+}
+
+// TestValidateKnownVisionTargetsUntouched ensures the drop path is not
+// trigger-happy: fully valid references survive Validate() untouched and
+// without a warning.
+func TestValidateKnownVisionTargetsUntouched(t *testing.T) {
+	targets := []string{"gpu"}
+	cfg := &Config{
+		Vision: VisionConfig{
+			Enabled: true,
+			Instances: []VisionInstance{
+				{Name: "gpu", URL: "http://192.0.2.2:9092"},
+			},
+		},
+		Cameras: []CameraConfig{{
+			ID:            "cam-test",
+			URL:           "rtsp://x",
+			Protocol:      "rtsp",
+			VisionTargets: targets,
+		}},
+	}
+	cfg.ApplyDefaults()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("Validate() errored on a fully valid config: %v", err)
+	}
+	if got := cfg.Cameras[0].VisionTargets; len(got) != 1 || got[0] != "gpu" {
+		t.Fatalf("valid targets must survive untouched: got %v", got)
+	}
+	if s := buf.String(); strings.Contains(s, "vision") {
+		t.Fatalf("no vision warning expected for valid targets, got log: %q", s)
+	}
+}


### PR DESCRIPTION
## 背景 #737（2026-09-11 M5 实录）

手改 yaml 删除 vision 实例 `vm-v8` 时一台相机的 `vision_targets` 仍引用它 → 启动校验 fatal → **systemd 5 秒崩溃循环约 2 分钟**（录像中断 2–3 分钟）。

## 变更

1. **悬空 `camera.vision_targets` 降级**：加载层 `Validate()` WARN + 就地剔除，不再 fatal（#216 stable_id 同原则）；API 写边界（camera create/update 400、settings PUT 搁浅检查）保持严格。全悬空 → 空 = `RouteFor` 既有广播语义 + 显式告警。
2. **`mibee-nvr validate-config [--config]`**：部署前烟雾检查，与启动同一 Load→Validate 管线，exit 0/1。
3. **systemd 熔断**：`deploy/mibee-nvr.service` 加 `StartLimitIntervalSec=120`/`StartLimitBurst=5`——致命配置错误 5 次重试后停机等人工，不再无限锤。
4. **`<config>.last-good` 快照**：启动校验成功后原子写入，作为 shutdown-persist 覆盖/旧二进制清零新节的恢复点。

## 测试（TDD 先红后绿）

- 新增 6 个用例（3 校验语义 + 2 快照 + 1 CLI 退出码）；更新 `TestValidateVisionInstances` 钉新语义（原用例断言旧 fatal 行为）
- WSL 全量：config / cmd / srt / api 四包 ok（api 仅剩 WSL 环境性 `TestTestConnection_RTSPConnectionRefused`，CI 正常——台账已知）

## M5 实测（v0.12.0-54-g6c5275ff-cfgsafe-1，备份 bak-0911-pre-cfgsafe）

- 部署启动正常，health ok 15/15 在录，`mibee-nvr.yaml.last-good` 已生成，SPA 200
- **事故重放**：live config 副本注入 `- vm-v8-ghost` 悬空引用 → `validate-config` 输出 WARN（点名相机+实例）+ **OK/exit 0**——今日的崩溃循环形态不再触发
- 坏 retention 副本 → FAIL/exit 1