### PR TITLE
feat(vision): 推送熔断 — 心跳健康但 URL 不可达的实例自动退避 + #726 目录形段拦截 (#739)

### DIFF
--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -86,6 +86,8 @@ type Coordinator struct {
 	order  []string // 配置顺序的实例名
 	// paused 是各实例的推送暂停窗口起点(mu 保护;缺键=未暂停)。
 	paused map[string]time.Time
+	// dirWarned 记录已对目录形/MJPEG 段告警过的相机(#726 每相机一次)。
+	dirWarned sync.Map
 	// subLayer 是子码流分析层 (#514)。nil(未接 provider)时整个层停用。
 	subLayer *SubLayerManager
 }
@@ -265,6 +267,9 @@ type InstanceStatus struct {
 	SkipCameras []string       `json:"skip_cameras,omitempty"`
 	Metrics     *VisionMetrics `json:"metrics,omitempty"`
 	MarkedDrops int64          `json:"drops_marked_total,omitempty"`
+	// 推送熔断观测(#737-A):closed/open/half-open + 连续失败数。
+	PushState string `json:"push_state,omitempty"`
+	PushFails int    `json:"push_fails,omitempty"`
 }
 
 // InstancesStatus 返回全部生效实例的状态(配置顺序)。
@@ -291,6 +296,7 @@ func (c *Coordinator) InstancesStatus() []InstanceStatus {
 		st.SkipCameras = hs.SkipCameras
 		st.Metrics = hs.Metrics
 		st.MarkedDrops = ins.health.MarkedDropTotal()
+		st.PushState, st.PushFails, _ = ins.health.PushBreakerSnapshot()
 		out = append(out, st)
 	}
 	return out
@@ -402,6 +408,14 @@ func (c *Coordinator) handleSegment(ctx context.Context, seg event.SegmentComple
 	if seg.Format == "timelapse" {
 		return
 	}
+	// #726: MJPEG/目录形段(帧序列目录)无法作为单文件字节流上传——推送
+	// 必然失败并进补偿队列无限重试(每段一次失败请求 + 一次磁盘读)。
+	// 按格式与实际路径形态双重拦截,每相机只 WARN 一次(建议配 skip_cameras
+	// 或由消费者心跳跳单声明)。
+	if seg.Format == "mjpeg" || isDirPath(c.storageRoot(), seg.FilePath) {
+		c.warnDirFormOnce(seg.CameraID, seg.Format)
+		return
+	}
 	// 配置显式排除的相机(MJPEG/JPEG 等外部消费者无法解码的编码):推送纯浪费
 	// 带宽与 CPU,直接跳过(离线补偿重推走同一路径,一并跳过)。
 	if vcfg.ShouldSkipCamera(seg.CameraID) {
@@ -478,8 +492,10 @@ func (c *Coordinator) fanout(ctx context.Context, routed []routeTarget, absPath 
 }
 
 // pushToInstance 单实例推送:无地址(default 合成、URL 未配)→ 静默跳过;
-// 不健康 → 记暂停窗(补偿重推的窗口锚点)并跳过;该实例心跳声明的跳单
-// (#515)→ 跳过;否则上传。
+// 不健康 → 记暂停窗(补偿重推的窗口锚点)并跳过;推送熔断打开 → 同样记
+// 暂停窗并跳过(退避过后的半开探测放行一次);该实例心跳声明的跳单
+// (#515)→ 跳过;否则上传并回填熔断结果——闭合瞬间触发有界补偿补齐
+// 熔断期间错过的段(与心跳恢复同路径)。
 func (c *Coordinator) pushToInstance(ctx context.Context, rt routeTarget, absPath string, fileSize int64, hdr map[string]string) bool {
 	if rt.url == "" {
 		return false
@@ -491,6 +507,13 @@ func (c *Coordinator) pushToInstance(ctx context.Context, rt routeTarget, absPat
 			"recording_id", hdr["X-Recording-Id"])
 		return false
 	}
+	if !rt.health.PushGate() {
+		c.markPausedFor(rt.name)
+		slog.Debug("vision push breaker open, skip push",
+			"instance", rt.name,
+			"recording_id", hdr["X-Recording-Id"])
+		return false
+	}
 	if rt.health.SkipCamera(hdr["X-Camera-Id"]) {
 		slog.Debug("vision push skipped by consumer-reported skip list",
 			"instance", rt.name,
@@ -498,7 +521,23 @@ func (c *Coordinator) pushToInstance(ctx context.Context, rt routeTarget, absPat
 			"recording_id", hdr["X-Recording-Id"])
 		return false
 	}
-	return c.uploadSegment(ctx, rt.url, absPath, fileSize, hdr)
+	ok := c.uploadSegment(ctx, rt.url, absPath, fileSize, hdr)
+	justOpened, justClosed := rt.health.RecordPushOutcome(ok)
+	if justOpened {
+		slog.Warn("vision push breaker opened — consecutive push failures, backing off",
+			"instance", rt.name,
+			"consecutive_failures", func() int { _, f, _ := rt.health.PushBreakerSnapshot(); return f }())
+	}
+	if !ok {
+		// 首个失败就锚定补偿窗——熔断打开前的失败段也不能丢。
+		c.markPausedFor(rt.name)
+	}
+	if justClosed {
+		slog.Info("vision push breaker closed — push path reachable again, compensating missed segments",
+			"instance", rt.name)
+		go c.compensateOffline(rt.name)
+	}
+	return ok
 }
 
 // uploadSegment POSTs a segment file's bytes to a Vision instance. Headers
@@ -609,6 +648,27 @@ func (c *Coordinator) pushSubSegment(ctx context.Context, seg SubSegment) bool {
 		return true
 	}
 	return false
+}
+
+// isDirPath 解析段的绝对路径并报告它是否是目录(相对路径按录像根拼接)。
+// stat 失败按非目录处理——文件缺失由上传路径按需报错。
+func isDirPath(storageRoot, p string) bool {
+	abs := p
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(storageRoot, abs)
+	}
+	fi, err := os.Stat(abs)
+	return err == nil && fi.IsDir()
+}
+
+// warnDirFormOnce 对目录形/MJPEG 段的相机打一次 WARN(#726):每段一条会
+// 刷屏且无行动价值,一次性墓碑提示配置 skip_cameras 或消费者跳单。
+func (c *Coordinator) warnDirFormOnce(cameraID, format string) {
+	if _, loaded := c.dirWarned.LoadOrStore(cameraID, true); loaded {
+		return
+	}
+	slog.Warn("vision push skipped — directory-form/MJPEG segment cannot be uploaded as a byte stream; add the camera to skip_cameras or have the consumer report it in its heartbeat skip list",
+		"camera_id", cameraID, "format", format)
 }
 
 // markPausedFor records the start of an instance's push-pause window (first

--- a/internal/vision/coordinator.go
+++ b/internal/vision/coordinator.go
@@ -524,9 +524,10 @@ func (c *Coordinator) pushToInstance(ctx context.Context, rt routeTarget, absPat
 	ok := c.uploadSegment(ctx, rt.url, absPath, fileSize, hdr)
 	justOpened, justClosed := rt.health.RecordPushOutcome(ok)
 	if justOpened {
+		_, fails, _ := rt.health.PushBreakerSnapshot()
 		slog.Warn("vision push breaker opened — consecutive push failures, backing off",
 			"instance", rt.name,
-			"consecutive_failures", func() int { _, f, _ := rt.health.PushBreakerSnapshot(); return f }())
+			"consecutive_failures", fails)
 	}
 	if !ok {
 		// 首个失败就锚定补偿窗——熔断打开前的失败段也不能丢。

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -115,10 +115,10 @@ func NewHealthTracker(timeoutSecs int) *HealthTracker {
 		timeoutSecs = 60
 	}
 	return &HealthTracker{
-		timeout:          time.Duration(timeoutSecs) * time.Second,
-		pushBreakerN:     pushBreakerThreshold,
-		pushBackoffBase:  pushBackoffBaseDef,
-		pushBackoffMax:   pushBackoffMaxDef,
+		timeout:         time.Duration(timeoutSecs) * time.Second,
+		pushBreakerN:    pushBreakerThreshold,
+		pushBackoffBase: pushBackoffBaseDef,
+		pushBackoffMax:  pushBackoffMaxDef,
 	}
 }
 

--- a/internal/vision/health.go
+++ b/internal/vision/health.go
@@ -88,7 +88,26 @@ type HealthTracker struct {
 	onRecovery  func()
 	samples     []VisionSample // 心跳历史环(≤maxHistorySamples)
 	markedDrops int64          // 累计按丢弃报告标记为 skipped 的录像数
+
+	// 推送熔断(2026-09-11 vm-v8 实录):心跳健康只证明消费者进程活着,
+	// 不证明 NVR 配置的推送 URL 可达(隧道断/端口没监听/实例挪了网络位置
+	// 时心跳照常入站、推送照常出站失败)。连续上传失败达到阈值后熔断,
+	// 指数退避后半开探测恢复;心跳不重置熔断。
+	pushFails        int           // 连续推送失败数(成功即清零)
+	pushOpenUntil    time.Time     // 非零 = 熔断打开,在此之前拒绝推送
+	pushBreakerN     int           // 阈值(测试可调;默认 pushBreakerThreshold)
+	pushBackoffBase  time.Duration // 首次打开的退避(测试可调)
+	pushBackoffMax   time.Duration // 退避上限(测试可调)
+	pushTotalOpens   int64         // 累计打开次数(观测)
+	pushLastOpenedAt time.Time
 }
+
+// 推送熔断默认参数:5 连败打开,30s 起指数退避,封顶 10 分钟。
+const (
+	pushBreakerThreshold = 5
+	pushBackoffBaseDef   = 30 * time.Second
+	pushBackoffMaxDef    = 10 * time.Minute
+)
 
 // NewHealthTracker 创建健康追踪器。timeoutSecs ≤ 0 时默认 60 秒。
 func NewHealthTracker(timeoutSecs int) *HealthTracker {
@@ -96,7 +115,10 @@ func NewHealthTracker(timeoutSecs int) *HealthTracker {
 		timeoutSecs = 60
 	}
 	return &HealthTracker{
-		timeout: time.Duration(timeoutSecs) * time.Second,
+		timeout:          time.Duration(timeoutSecs) * time.Second,
+		pushBreakerN:     pushBreakerThreshold,
+		pushBackoffBase:  pushBackoffBaseDef,
+		pushBackoffMax:   pushBackoffMaxDef,
 	}
 }
 
@@ -203,6 +225,58 @@ func (h *HealthTracker) SkipCamera(cameraID string) bool {
 		}
 	}
 	return false
+}
+
+// RecordPushOutcome 记录一次推送结果,驱动熔断状态机。返回 (justOpened,
+// justClosed):本次调用刚打开 / 刚闭合熔断为 true(供调用方记日志与触发
+// 补偿)。心跳路径不经过这里——熔断与心跳健康正交(vm-v8 实录的核心)。
+func (h *HealthTracker) RecordPushOutcome(success bool) (justOpened, justClosed bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if success {
+		wasOpen := !h.pushOpenUntil.IsZero()
+		h.pushFails = 0
+		h.pushOpenUntil = time.Time{}
+		return false, wasOpen
+	}
+	h.pushFails++
+	if h.pushFails < h.pushBreakerN || h.pushOpenUntil.After(time.Now()) {
+		// 未达阈值,或半开探测失败(熔断本就开着):只累计,退避在下次
+		// 真正跨越阈值时按累计失败数计算。
+		return false, false
+	}
+	backoff := h.pushBackoffBase << min(h.pushFails-h.pushBreakerN, 20)
+	if backoff > h.pushBackoffMax || backoff <= 0 {
+		backoff = h.pushBackoffMax
+	}
+	h.pushOpenUntil = time.Now().Add(backoff)
+	h.pushTotalOpens++
+	h.pushLastOpenedAt = time.Now()
+	return true, false
+}
+
+// PushGate 报告当前是否允许发起推送:熔断关闭恒 true;打开且退避已过
+// true(半开,放行一次探测,结果由 RecordPushOutcome 决定去留)。
+func (h *HealthTracker) PushGate() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.pushOpenUntil.IsZero() || !time.Now().Before(h.pushOpenUntil)
+}
+
+// PushBreakerSnapshot 返回熔断观测状态:state closed/open/half-open、
+// 连续失败数、累计打开次数。
+func (h *HealthTracker) PushBreakerSnapshot() (state string, fails int, opens int64) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	switch {
+	case h.pushOpenUntil.IsZero():
+		state = "closed"
+	case time.Now().Before(h.pushOpenUntil):
+		state = "open"
+	default:
+		state = "half-open"
+	}
+	return state, h.pushFails, h.pushTotalOpens
 }
 
 // Snapshot 返回当前健康状态、最后心跳时间和状态详情。

--- a/internal/vision/push_breaker_test.go
+++ b/internal/vision/push_breaker_test.go
@@ -77,7 +77,7 @@ func TestPushBreakerBackoffCapsAtMax(t *testing.T) {
 	h.pushBackoffMax = 40 * time.Millisecond
 	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
 
-	for i := 0; i < 8; i++ { // far past the cap's reach
+	for range 8 { // far past the cap's reach
 		h.RecordPushOutcome(false)
 	}
 	require.False(t, h.PushGate())
@@ -146,7 +146,7 @@ func TestCoordinatorPushBreakerEndToEnd(t *testing.T) {
 	}
 
 	fail.Store(true)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		c.handleSegment(context.Background(), seg)
 	}
 	require.Equal(t, int32(5), hits.Load(), "five failed pushes hit the server")

--- a/internal/vision/push_breaker_test.go
+++ b/internal/vision/push_breaker_test.go
@@ -1,0 +1,240 @@
+package vision
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPushBreakerStateMachine is the regression core of the 2026-09-11 vm-v8
+// incident class: a Vision instance whose heartbeats arrive fine but whose
+// push URL is dead (tunnel down, listener gone, moved network) got hammered
+// with a failed push per segment for HOURS. The push breaker opens after
+// consecutive upload failures, ignores heartbeats (a heartbeat proves the
+// process is alive, NOT that our push URL is reachable), and re-closes via a
+// half-open probe after a backoff.
+func TestPushBreakerStateMachine(t *testing.T) {
+	h := NewHealthTracker(60)
+	h.pushBackoffBase = 30 * time.Millisecond // test speed
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.True(t, h.IsHealthy())
+
+	// Below threshold: failures accumulate but the gate stays open.
+	for i := 1; i <= 4; i++ {
+		justOpened, justClosed := h.RecordPushOutcome(false)
+		require.False(t, justOpened, "failure %d must not open the breaker", i)
+		require.False(t, justClosed)
+		require.True(t, h.PushGate(), "gate still closed below threshold")
+	}
+
+	// Threshold failure opens the breaker.
+	justOpened, _ := h.RecordPushOutcome(false)
+	require.True(t, justOpened, "5th consecutive failure must open the breaker")
+	require.False(t, h.PushGate(), "open breaker must block pushes")
+
+	// THE vm-v8 regression essence: heartbeats must NOT close the breaker.
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.True(t, h.IsHealthy(), "heartbeat health unaffected")
+	require.False(t, h.PushGate(), "healthy heartbeat must NOT reset the push breaker")
+
+	// Backoff elapses → half-open: exactly one probe is allowed.
+	require.Eventually(t, func() bool { return h.PushGate() },
+		2*time.Second, 5*time.Millisecond, "gate must half-open after the backoff")
+
+	// Probe fails → re-opens (escalated backoff), still no heartbeat reset.
+	justOpened, _ = h.RecordPushOutcome(false)
+	require.True(t, justOpened, "failed probe must re-open the breaker")
+	require.False(t, h.PushGate())
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+	require.False(t, h.PushGate())
+
+	// Escalated backoff also elapses → probe succeeds → breaker closes and
+	// reports justClosed exactly once.
+	require.Eventually(t, func() bool { return h.PushGate() },
+		2*time.Second, 5*time.Millisecond)
+	_, justClosed := h.RecordPushOutcome(true)
+	require.True(t, justClosed, "successful probe must report justClosed")
+	require.True(t, h.PushGate())
+	_, justClosed = h.RecordPushOutcome(true)
+	require.False(t, justClosed, "steady-state success reports no transition")
+}
+
+// TestPushBreakerBackoffCapsAtMax ensures the exponential backoff is bounded.
+func TestPushBreakerBackoffCapsAtMax(t *testing.T) {
+	h := NewHealthTracker(60)
+	h.pushBackoffBase = 20 * time.Millisecond
+	h.pushBackoffMax = 40 * time.Millisecond
+	h.RecordHeartbeat(HeartbeatStatus{Status: "healthy"})
+
+	for i := 0; i < 8; i++ { // far past the cap's reach
+		h.RecordPushOutcome(false)
+	}
+	require.False(t, h.PushGate())
+	// Cap is 40ms — after 200ms the gate MUST be half-open regardless of how
+	// many failures accumulated.
+	require.Eventually(t, func() bool { return h.PushGate() },
+		2*time.Second, 5*time.Millisecond, "backoff must cap at pushBackoffMax")
+}
+
+// TestCoordinatorPushBreakerEndToEnd drives the full wiring: a dead push URL
+// under healthy heartbeats gets breaker-opened after the threshold, further
+// segments are not even attempted (no disk read, no request), the pause
+// window is anchored for compensation, and a later successful probe closes
+// the breaker and fires the bounded offline compensation.
+func TestCoordinatorPushBreakerEndToEnd(t *testing.T) {
+	var hits atomic.Int32
+	var mu sync.Mutex
+	pushedIDs := map[string]int{}
+	fail := atomic.Bool{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		mu.Lock()
+		pushedIDs[r.Header.Get("X-Recording-Id")]++
+		mu.Unlock()
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	segFile := filepath.Join(t.TempDir(), "seg.mp4")
+	require.NoError(t, os.WriteFile(segFile, []byte("payload"), 0o600))
+
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{
+		Enabled:   true,
+		PushMode:  "upload",
+		Instances: []config.VisionInstance{{Name: "default", URL: srv.URL}},
+	}
+	rep := &fakeRepusher{recs: []model.Recording{{
+		ID: "rec-lost", CameraID: "cam-a", FilePath: segFile, Format: "h264",
+		EndedAt: time.Now().Add(-time.Minute),
+	}}}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus, rep, nil,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+	c.RecordHeartbeat("", HeartbeatStatus{Status: "healthy"})
+
+	// Shrink the breaker timing for the test (unexported, same package).
+	c.instMu.Lock()
+	dflt := c.insts["default"]
+	c.instMu.Unlock()
+	require.NotNil(t, dflt)
+	dflt.health.pushBackoffBase = 30 * time.Millisecond
+
+	seg := event.SegmentCompleted{
+		CameraID: "cam-a", RecordingID: "rec-1", FilePath: segFile,
+		FileSize: 7, Format: "h264", Encoding: "h264", Layer: model.LayerMain,
+	}
+
+	fail.Store(true)
+	for i := 0; i < 5; i++ {
+		c.handleSegment(context.Background(), seg)
+	}
+	require.Equal(t, int32(5), hits.Load(), "five failed pushes hit the server")
+
+	// Breaker open: the 6th segment must not even attempt a request.
+	c.handleSegment(context.Background(), seg)
+	require.Equal(t, int32(5), hits.Load(), "open breaker must skip the upload entirely")
+	require.False(t, c.takePausedSinceFor("default").IsZero(),
+		"a failed push must anchor the compensation window")
+	c.rearmPausedFor("default", time.Now().Add(-2*time.Minute))
+
+	// Heartbeat still healthy — breaker must stay open regardless.
+	c.RecordHeartbeat("", HeartbeatStatus{Status: "healthy"})
+	c.handleSegment(context.Background(), seg)
+	require.Equal(t, int32(5), hits.Load())
+
+	// Half-open probe succeeds → breaker closes → compensation re-pushes the
+	// lost recording (repush routes through handleSegment again).
+	fail.Store(false)
+	require.Eventually(t, func() bool {
+		c.handleSegment(context.Background(), seg)
+		return hits.Load() > 5
+	}, 3*time.Second, 10*time.Millisecond, "half-open probe must eventually go through")
+	require.Eventually(t, func() bool {
+		c.instMu.Lock()
+		defer c.instMu.Unlock()
+		return c.insts["default"].health.PushGate()
+	}, 2*time.Second, 5*time.Millisecond, "successful probe must close the breaker")
+	// 熔断闭合触发有界补偿:错过的 rec-lost 被补推上去。
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return pushedIDs["rec-lost"] > 0
+	}, 3*time.Second, 10*time.Millisecond, "breaker close must compensate missed segments")
+}
+
+// TestCoordinatorMjpegDirSegmentSkipped is the #726 guard: MJPEG (directory-
+// form) segments can never be uploaded as a single byte stream — pushing them
+// just burns a failed request + compensation retry per segment, forever.
+func TestCoordinatorMjpegDirSegmentSkipped(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	bus := event.NewEventBus(64)
+	cfg := config.VisionConfig{
+		Enabled:   true,
+		PushMode:  "upload",
+		Instances: []config.VisionInstance{{Name: "default", URL: srv.URL}},
+	}
+	c := NewCoordinator(
+		func() config.VisionConfig { return cfg },
+		func() string { return t.TempDir() },
+		bus, nil, nil,
+	)
+	require.NoError(t, c.Start(context.Background()))
+	defer c.Stop()
+	c.RecordHeartbeat("", HeartbeatStatus{Status: "healthy"})
+
+	// Directory-form segment (what MJPEG cameras actually produce).
+	dirSeg := filepath.Join(t.TempDir(), "frames-dir")
+	require.NoError(t, os.Mkdir(dirSeg, 0o755))
+
+	c.handleSegment(context.Background(), event.SegmentCompleted{
+		CameraID: "cam-mjpeg", RecordingID: "rec-dir", FilePath: dirSeg,
+		Format: "mjpeg", Layer: model.LayerMain,
+	})
+	// Labeled-mjpeg segment whose path happens to be a file — still skipped
+	// (the consumer cannot decode an MJPEG byte stream anyway).
+	fileSeg := filepath.Join(t.TempDir(), "seg.mp4")
+	require.NoError(t, os.WriteFile(fileSeg, []byte("x"), 0o600))
+	c.handleSegment(context.Background(), event.SegmentCompleted{
+		CameraID: "cam-mjpeg", RecordingID: "rec-mjpeg", FilePath: fileSeg,
+		Format: "mjpeg", Layer: model.LayerMain,
+	})
+	// Directory-form segment with a non-mjpeg label — skipped mechanically.
+	c.handleSegment(context.Background(), event.SegmentCompleted{
+		CameraID: "cam-b", RecordingID: "rec-dir2", FilePath: dirSeg,
+		Format: "h264", Layer: model.LayerMain,
+	})
+	// Sanity: a normal h264 file segment DOES get pushed.
+	c.handleSegment(context.Background(), event.SegmentCompleted{
+		CameraID: "cam-b", RecordingID: "rec-ok", FilePath: fileSeg,
+		Format: "h264", Layer: model.LayerMain,
+	})
+	require.Equal(t, int32(1), hits.Load(),
+		"only the regular h264 segment may be uploaded")
+}


### PR DESCRIPTION
## 背景 #739（2026-09-11 M5 实录）

`vm-v8` 实例**心跳始终健康**但推送 URL 不可达（127.0.0.1:9092 connection refused）——现有心跳健康机制永不触发暂停，3 小时 423 次白费推送（每次都读一次盘）。心跳证明消费者进程活着，不证明 NVR 配置的推送 URL 可达。fixes #726（MJPEG 目录形段 `is a directory` 无限重试同类）。

## 变更

1. **推送熔断器**（`HealthTracker`）：连续 5 次上传失败打开（指数退避 30s→10m 封顶）；退避后半开放行一次探测；成功闭合并触发有界补偿（复用 #329 离线补偿，2h/500 段上限）。**心跳不重置熔断**。
2. **补偿窗锚定提前到首个失败**——熔断打开前丢的段也在补偿范围。
3. **#726 拦截**：`format=mjpeg` 与目录形路径双重拦截，每相机一次 WARN 墓碑。
4. **观测**：`/api/vision/status` 实例新增 `push_state`（closed/open/half-open）+ `push_fails`。

## 测试（TDD 先红后绿）

- `TestPushBreakerStateMachine`：状态机全路径 + 心跳不重置（vm-v8 核心）
- `TestPushBreakerBackoffCapsAtMax`：退避封顶
- `TestCoordinatorPushBreakerEndToEnd`：5 连败开路→后续段零尝试→补偿窗锚定→半开探测→闭合→补偿命中
- `TestCoordinatorMjpegDirSegmentSkipped`（#726）：mjpeg/目录形零上传、h264 照推
- 已知环境项：`TestHealthTracker_MetricsHistoryRing` 在 Windows 本机因时钟粒度挂（pristine main 同挂，WSL/CI 正常）

## M5 实测（v0.12.0-55-ga9aa5c35-pb-1，D+A 集成，备份 bak-0911-pre-pb）

- 启动稳定 health ok、14/16 在录（2 台 live-only）、H80 子层推送每 60s 成功流向前
- `/api/vision/status` 实例暴露 `push_state: closed`
- 零推送失败、零熔断日志（健康路径不可见 = 设计如此）