### PR TITLE
feat(observability): 仪表盘补齐饱和观测 — iowait + loadavg + 磁盘水位 (#741)

### DIFF
--- a/internal/api/diskusage_linux.go
+++ b/internal/api/diskusage_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package api
+
+import "syscall"
+
+// diskUsageFor 返回路径所在文件系统的总容量与剩余字节(statfs)。
+// Linux-only: syscall.Statfs 在非 Linux 平台不存在,见 diskusage_other.go。
+func diskUsageFor(path string) (total, free uint64, ok bool) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, 0, false
+	}
+	bs := uint64(st.Bsize)
+	total = st.Blocks * bs
+	free = st.Bavail * bs // 可用按非 root 视角(Bavail),与 df 一致
+	return total, free, true
+}

--- a/internal/api/diskusage_other.go
+++ b/internal/api/diskusage_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package api
+
+// diskUsageFor 非 Linux 开发机上的桩:报告不可用(handler 输出 status=unknown)。
+func diskUsageFor(path string) (total, free uint64, ok bool) {
+	return 0, 0, false
+}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -92,11 +92,34 @@ type SystemStats struct {
 	Network   NetworkStats `json:"network"`
 	Uptime    string       `json:"uptime"`
 	Timestamp int64        `json:"timestamp"`
+	// Load / Disk 补齐饱和观测(2026-09-11 M5 IO 饱和事故:73% iowait + 负载
+	// 15 在既有 CPU 瓦片上完全不可见——CPU 忙闲是低的)。nil = 不可用平台。
+	Load *LoadStats `json:"load,omitempty"`
+	Disk *DiskStats `json:"disk,omitempty"`
 }
 
 type CPUStats struct {
-	Total uint64 `json:"total"` // cumulative total jiffies
-	Idle  uint64 `json:"idle"`  // cumulative idle jiffies
+	Total  uint64 `json:"total"`  // cumulative total jiffies
+	Idle   uint64 `json:"idle"`   // cumulative idle jiffies
+	Iowait uint64 `json:"iowait"` // cumulative iowait jiffies (delta between polls = iowait%)
+}
+
+// LoadStats 是 /proc/loadavg 快照(1/5/15 分钟)。
+type LoadStats struct {
+	One     float64 `json:"one"`
+	Five    float64 `json:"five"`
+	Fifteen float64 `json:"fifteen"`
+}
+
+// DiskStats 是录像根的容量水位。WatermarkPct 取 cleanup.disk_threshold_percent
+// (清理已在执行的阈值),used_pct 越线即 status=high——录满盘前的可见预警。
+type DiskStats struct {
+	Path         string  `json:"path"`
+	TotalBytes   uint64  `json:"total_bytes"`
+	FreeBytes    uint64  `json:"free_bytes"`
+	UsedPct      float64 `json:"used_pct"`
+	WatermarkPct float64 `json:"watermark_pct"`
+	Status       string  `json:"status"` // ok | high | unknown
 }
 
 type MemoryStats struct {

--- a/internal/api/handlers_sysinfo.go
+++ b/internal/api/handlers_sysinfo.go
@@ -69,24 +69,61 @@ func formatUptime(d time.Duration) string {
 
 // --- System stats helpers (Linux /proc) ---
 
-func readCPURaw() (total, idle uint64, err error) {
+// readCPURaw 读取 /proc/stat 聚合 cpu 行的累计 jiffies:total=全部计数器之和,
+// idle=第 4 计数器,iowait=第 5 计数器(客户端两次轮询差分得出 iowait%)。
+func readCPURaw() (total, idle, iowait uint64, err error) {
 	data, err := os.ReadFile("/proc/stat")
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
+	return parseProcStat(data)
+}
+
+// parseProcStat 是 readCPURaw 的纯函数内核(可测)。
+func parseProcStat(data []byte) (total, idle, iowait uint64, err error) {
 	lines := strings.Split(string(data), "\n")
 	if len(lines) == 0 {
-		return 0, 0, fmt.Errorf("empty /proc/stat")
+		return 0, 0, 0, fmt.Errorf("empty /proc/stat")
 	}
 	fields := strings.Fields(lines[0])
 	if len(fields) < 5 {
-		return 0, 0, fmt.Errorf("unexpected /proc/stat format")
+		return 0, 0, 0, fmt.Errorf("unexpected /proc/stat format")
 	}
 	for i := 1; i < len(fields); i++ {
 		v, _ := strconv.ParseUint(fields[i], 10, 64)
 		total += v
 	}
 	idle, _ = strconv.ParseUint(fields[4], 10, 64)
+	if len(fields) > 5 {
+		iowait, _ = strconv.ParseUint(fields[5], 10, 64)
+	}
+	return
+}
+
+// readLoadAvg 读取 /proc/loadavg 的 1/5/15 分钟负载。
+func readLoadAvg() (one, five, fifteen float64, err error) {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return parseLoadAvg(data)
+}
+
+// parseLoadAvg 是 readLoadAvg 的纯函数内核(可测)。
+func parseLoadAvg(data []byte) (one, five, fifteen float64, err error) {
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return 0, 0, 0, fmt.Errorf("unexpected /proc/loadavg format")
+	}
+	if one, err = strconv.ParseFloat(fields[0], 64); err != nil {
+		return 0, 0, 0, err
+	}
+	if five, err = strconv.ParseFloat(fields[1], 64); err != nil {
+		return 0, 0, 0, err
+	}
+	if fifteen, err = strconv.ParseFloat(fields[2], 64); err != nil {
+		return 0, 0, 0, err
+	}
 	return
 }
 
@@ -170,18 +207,48 @@ func readProcessRSS() uint64 {
 }
 
 func (h *Handler) handleSystemStats(w http.ResponseWriter, r *http.Request) {
-	cpuTotal, cpuIdle, _ := readCPURaw()
+	cpuTotal, cpuIdle, cpuIowait, _ := readCPURaw()
 	memTotal, memAvailable, _ := readMemoryInfo()
 	netSent, netRecv, _ := readNetworkInfo()
 	processRSS := readProcessRSS()
 
-	writeJSON(w, http.StatusOK, SystemStats{
-		CPU:       CPUStats{Total: cpuTotal, Idle: cpuIdle},
+	resp := SystemStats{
+		CPU:       CPUStats{Total: cpuTotal, Idle: cpuIdle, Iowait: cpuIowait},
 		Memory:    MemoryStats{Total: memTotal, Available: memAvailable, ProcessRSS: processRSS},
 		Network:   NetworkStats{BytesSent: netSent, BytesRecv: netRecv},
 		Uptime:    formatUptime(time.Since(appStartTime)),
 		Timestamp: time.Now().Unix(),
-	})
+	}
+
+	if one, five, fifteen, err := readLoadAvg(); err == nil {
+		resp.Load = &LoadStats{One: one, Five: five, Fifteen: fifteen}
+	}
+
+	root := "/"
+	watermark := 90.0
+	if h.config != nil {
+		if h.config.Storage.RootDir != "" {
+			root = h.config.Storage.RootDir
+		}
+		if p := h.config.Cleanup.DiskThresholdPercent; p > 0 {
+			watermark = float64(p)
+		}
+	}
+	if total, free, ok := diskUsageFor(root); ok && total > 0 {
+		usedPct := (1 - float64(free)/float64(total)) * 100
+		status := "ok"
+		if usedPct >= watermark {
+			status = "high"
+		}
+		resp.Disk = &DiskStats{
+			Path: root, TotalBytes: total, FreeBytes: free,
+			UsedPct: usedPct, WatermarkPct: watermark, Status: status,
+		}
+	} else {
+		resp.Disk = &DiskStats{Path: root, WatermarkPct: watermark, Status: "unknown"}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleGetAutoDiscoverSettings returns the current auto_discover config. The

--- a/internal/api/handlers_sysinfo_extra_test.go
+++ b/internal/api/handlers_sysinfo_extra_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseProcStatIowait pins the extended /proc/stat parser: iowait is the
+// 5th counter (index 5 in Fields after the "cpu" label). The 2026-09-11 M5
+// saturation was 73% iowait with LOW cpu busy — invisible in the dashboard
+// because /api/stats/system never reported iowait at all.
+func TestParseProcStatIowait(t *testing.T) {
+	total, idle, iowait, err := parseProcStat([]byte(
+		"cpu  100 20 30 400 50 5 10 0 0 0\n" +
+			"cpu0 50 10 15 200 25 2 5 0 0 0\n" +
+			"intr 12345\n"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(615), total, "sum of all cpu counters")
+	require.Equal(t, uint64(400), idle)
+	require.Equal(t, uint64(50), iowait)
+}
+
+func TestParseProcStatMalformed(t *testing.T) {
+	_, _, _, err := parseProcStat([]byte("cpu  1 2 3\n"))
+	require.Error(t, err)
+	_, _, _, err = parseProcStat(nil)
+	require.Error(t, err)
+}
+
+// TestParseLoadAvg pins the /proc/loadavg parser ("0.74 2.39 4.92 3/421 12345").
+func TestParseLoadAvg(t *testing.T) {
+	one, five, fifteen, err := parseLoadAvg([]byte("0.74 2.39 4.92 3/421 12345\n"))
+	require.NoError(t, err)
+	require.InDelta(t, 0.74, one, 0.0001)
+	require.InDelta(t, 2.39, five, 0.0001)
+	require.InDelta(t, 4.92, fifteen, 0.0001)
+
+	_, _, _, err = parseLoadAvg([]byte("garbage"))
+	require.Error(t, err)
+}
+
+// TestHandleSystemStatsExtendedFields asserts the endpoint now carries the
+// saturation signals: cpu.iowait (cumulative jiffies for client-side deltas),
+// load{one,five,fifteen}, and a disk block with the recording-root watermark.
+// On non-Linux dev machines the /proc reads return zeros — the fields must
+// still be present and well-formed.
+func TestHandleSystemStatsExtendedFields(t *testing.T) {
+	h := &Handler{config: &config.Config{}}
+	h.config.ApplyDefaults()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/stats/system", nil)
+	rr := httptest.NewRecorder()
+	h.handleSystemStats(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		CPU struct {
+			Total  uint64 `json:"total"`
+			Idle   uint64 `json:"idle"`
+			Iowait uint64 `json:"iowait"`
+		} `json:"cpu"`
+		Load *struct {
+			One      float64 `json:"one"`
+			Five     float64 `json:"five"`
+			Fifteen  float64 `json:"fifteen"`
+		} `json:"load"`
+		Disk *struct {
+			Path         string  `json:"path"`
+			TotalBytes   uint64  `json:"total_bytes"`
+			FreeBytes    uint64  `json:"free_bytes"`
+			UsedPct      float64 `json:"used_pct"`
+			WatermarkPct float64 `json:"watermark_pct"`
+			Status       string  `json:"status"`
+		} `json:"disk"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Disk.Path, "disk block must report the recording root")
+	require.Greater(t, body.Disk.WatermarkPct, 0.0)
+	require.Contains(t, []string{"ok", "high", "unknown"}, body.Disk.Status)
+}

--- a/internal/api/handlers_sysinfo_extra_test.go
+++ b/internal/api/handlers_sysinfo_extra_test.go
@@ -65,9 +65,9 @@ func TestHandleSystemStatsExtendedFields(t *testing.T) {
 			Iowait uint64 `json:"iowait"`
 		} `json:"cpu"`
 		Load *struct {
-			One      float64 `json:"one"`
-			Five     float64 `json:"five"`
-			Fifteen  float64 `json:"fifteen"`
+			One     float64 `json:"one"`
+			Five    float64 `json:"five"`
+			Fifteen float64 `json:"fifteen"`
 		} `json:"load"`
 		Disk *struct {
 			Path         string  `json:"path"`

--- a/internal/api/handlers_system_extra_test.go
+++ b/internal/api/handlers_system_extra_test.go
@@ -125,10 +125,11 @@ func TestProcReaders(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("/proc readers are Linux-only")
 	}
-	total, idle, err := readCPURaw()
+	total, idle, iowait, err := readCPURaw()
 	require.NoError(t, err)
 	require.Positive(t, total)
 	require.GreaterOrEqual(t, total, idle)
+	require.LessOrEqual(t, iowait, total)
 
 	memTotal, memAvail, err := readMemoryInfo()
 	require.NoError(t, err)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -77,6 +77,7 @@ export interface SystemStats {
   cpu: {
     total: number;
     idle: number;
+    iowait: number;
   };
   memory: {
     total: number;
@@ -86,6 +87,19 @@ export interface SystemStats {
   network: {
     bytes_sent: number;
     bytes_recv: number;
+  };
+  load?: {
+    one: number;
+    five: number;
+    fifteen: number;
+  };
+  disk?: {
+    path: string;
+    total_bytes: number;
+    free_bytes: number;
+    used_pct: number;
+    watermark_pct: number;
+    status: 'ok' | 'high' | 'unknown';
   };
   uptime: string;
   timestamp: number;

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -57,6 +57,8 @@
   let prevSystemStats = $state<SystemStats | null>(null);
   let currentSystemStats = $state<SystemStats | null>(null);
   let cpuPercent = $state<string | null>(null);
+  let iowaitPercent = $state<string | null>(null);
+  let loadOne = $state<number | null>(null);
   let memoryPercent = $state<string | null>(null);
   let netRateUp = $state<string | null>(null);
   let netRateDown = $state<string | null>(null);
@@ -259,10 +261,17 @@
           const idleDelta = s.cpu.idle - prevSystemStats.cpu.idle;
           if (totalDelta > 0) {
             cpuPercent = ((totalDelta - idleDelta) / totalDelta * 100).toFixed(1) + '%';
+            const iowaitDelta = (s.cpu.iowait ?? 0) - (prevSystemStats.cpu.iowait ?? 0);
+            if (iowaitDelta >= 0) {
+              iowaitPercent = (iowaitDelta / totalDelta * 100).toFixed(1) + '%';
+            }
           }
           netRateUp = formatFileSize((s.network.bytes_sent - prevSystemStats.network.bytes_sent) / dt) + '/s';
           netRateDown = formatFileSize((s.network.bytes_recv - prevSystemStats.network.bytes_recv) / dt) + '/s';
         }
+      }
+      if (s.load) {
+        loadOne = s.load.one;
       }
       if (s.memory.total > 0) {
         memoryPercent = ((s.memory.total - s.memory.available) / s.memory.total * 100).toFixed(1) + '%';
@@ -426,6 +435,14 @@
                 <div class="h-full rounded-full transition-all duration-500" style="width: {cpuPercent}; background-color: {getUsageColor(parseFloat(cpuPercent))}"></div>
               {/if}
             </div>
+            {#if iowaitPercent && parseFloat(iowaitPercent) >= 20}
+              <span class="text-[10px] th-text-secondary" style="color: var(--color-warning)">
+                IO {iowaitPercent}
+              </span>
+            {/if}
+            {#if loadOne !== null}
+              <span class="text-[10px] th-text-secondary">load {loadOne.toFixed(2)}</span>
+            {/if}
           </div>
 
           <!-- Memory -->


### PR DESCRIPTION
## 背景 #741（2026-09-11 M5 实录）

IO 饱和事故（iowait 73%、负载 6→15）在仪表盘上不可见——CPU 瓦片只算 busy%，事故时 CPU 是低的、盘在等；负载与磁盘水位无处可看。

## 变更

- `/api/stats/system` 扩展（零依赖 /proc + statfs）：
  - `cpu.iowait` 累计 jiffies（SPA 与 busy% 同一差分模式）
  - `load{one,five,fifteen}`（/proc/loadavg）
  - `disk{path,total_bytes,free_bytes,used_pct,watermark_pct,status}`——录像根 statfs，水位阈值复用 `cleanup.disk_threshold_percent`，越线 `status=high`
- SPA：CPU 瓦片加 IO 徽章（iowait ≥20% 显示）+ load1 小字（client.ts 类型同步）
- `readCPURaw` 提纯出可测的 `parseProcStat/parseLoadAvg`；statfs 分平台桩

## 测试（TDD 先红后绿）

4 个新用例（解析纯函数 ×2 + 端点形态 + 真实 /proc），`TestProcReaders` 适配新签名。

## M5 实测（v0.12.0-55-g76993f4d-sysobs-1，备份 bak-0911-pre-sysobs）

- API load **3.09/2.52/3.88 与 uptime 逐位一致**；disk 与 statfs 一致（65.6% used / 90% 水位 ok）
- 服务稳定，SPA 构建含新瓦片逻辑（iowait 差分路径与 cpu 同构）