### PR TITLE
feat(cli): timelapse-merge subcommand — batch convert recordings to timelapse (#736)

### DIFF
--- a/cmd/mibee-nvr/cli.go
+++ b/cmd/mibee-nvr/cli.go
@@ -312,6 +312,8 @@ func dispatchSubcommand(args []string) {
 		cmdDownloadModelFn()
 	case "merge-cameras":
 		cmdMergeCameras()
+	case "timelapse-merge":
+		cmdTimelapseMerge()
 	case "eval-replay":
 		cmdEvalReplay()
 	case "update":

--- a/cmd/mibee-nvr/timelapse_merge.go
+++ b/cmd/mibee-nvr/timelapse_merge.go
@@ -1,0 +1,546 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/cleanup"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+)
+
+// timelapse-merge converts existing video recordings (H264/H265/AVI/MJPEG)
+// into periodic timelapse merges over a date range — the CLI counterpart of
+// POST /api/timelapse/{id}/merge, executed in-process against the storage DB
+// instead of over HTTP. Frame sampling (--interval), output fps and source
+// deletion are per-run overrides that never mutate the camera config.
+//
+// The DB is opened with the same WAL + busy_timeout pragmas as the server, so
+// the command MAY run while the NVR is live (same multi-process model as the
+// cleanup/repair CLIs). One guard applies: while the server is running,
+// cameras with timelapse.enabled=true are refused unless --force — their
+// windows belong to the server's own merge scheduler, and the per-process
+// activeMerges dedup cannot see cross-process concurrent merges of the same
+// window.
+
+func cmdTimelapseMerge() {
+	f, exitCode := parseTimelapseMergeFlags(os.Args)
+	if exitCode >= 0 {
+		os.Exit(exitCode)
+	}
+	// Probe the configured listen address (same resolution as merge-cameras)
+	// so the CLI knows whether the NVR is live.
+	cfg, err := config.Load(f.cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading config %q: %v\n", f.cfgPath, err)
+		os.Exit(1)
+	}
+	probeAddr := net.JoinHostPort(listenHostOf(cfg.Server.Listen), listenPortOf(cfg.Server.Listen))
+	os.Exit(runTimelapseMerge(f, os.Stdout, isPortOpen(probeAddr)))
+}
+
+// tlmBoolPtr is the local *bool helper (test file reuses it).
+func tlmBoolPtr(b bool) *bool { return &b }
+
+// timelapseMergeFlags carries the parsed `timelapse-merge` subcommand flags.
+type timelapseMergeFlags struct {
+	cfgPath    string
+	camerasArg string // "all" or comma-separated camera IDs
+	encoding   string // optional encoding filter, only used with --camera all
+	start      string // YYYY-MM-DD (required)
+	end        string // YYYY-MM-DD (default: yesterday in config tz)
+	duration   string // window size label (default natural-day)
+	interval   string // frame sampling interval override (Go duration)
+	fps        int    // output fps override (0 = camera config / 10)
+	deleteSrc  *bool  // tri-state: nil = camera config default
+	execute    bool
+	force      bool
+}
+
+const timelapseMergeUsage = `Usage: mibee-nvr timelapse-merge [options]
+
+Convert existing video recordings (H264/H265/AVI/MJPEG) into periodic
+timelapse merges over a date range, in-process against the storage DB
+(the CLI counterpart of POST /api/timelapse/{id}/merge). Open windows
+are skipped; windows with an existing completed merge row are skipped;
+source recordings can be deleted after a successful merge.
+
+Options:
+  --camera <ids|all>       Comma-separated camera IDs, or "all"
+  --encoding <enc>         With --camera all: only cameras matching (e.g. jpeg)
+  --start <YYYY-MM-DD>     First window date (required, config timezone)
+  --end <YYYY-MM-DD>       Last window date (default: yesterday)
+  --duration <label>       Window size: natural-day (default), 8h, 12h, 24h, 7d, 30d
+  --interval <dur>         Frame sampling interval (default: camera timelapse.interval, else 30s)
+  --fps <n>                Output fps (default: camera merge_output_fps, else 10)
+  --delete-sources         Delete source recordings after a successful merge
+  --no-delete-sources      Never delete sources for this run
+  --execute                Execute (default: dry-run)
+  --force                  Process timelapse-enabled cameras while the NVR is running
+  --config <path>          Config file path (default: mibee-nvr.yaml)
+
+Examples:
+  mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 --dry-run
+  mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 --interval 1s --delete-sources --execute
+`
+
+// parseTimelapseMergeFlags reads the flags from a full argv (flags start at
+// [2]). The int result is an exit code sentinel: 0 = help printed, -1 =
+// proceed, 1 = parse error printed.
+func parseTimelapseMergeFlags(args []string) (timelapseMergeFlags, int) {
+	var f timelapseMergeFlags
+	for i := 2; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--execute":
+			f.execute = true
+		case arg == "--dry-run":
+			f.execute = false
+		case arg == "--force":
+			f.force = true
+		case arg == "--delete-sources":
+			f.deleteSrc = tlmBoolPtr(true)
+		case arg == "--no-delete-sources":
+			f.deleteSrc = tlmBoolPtr(false)
+		case arg == "--help" || arg == "-h":
+			fmt.Print(timelapseMergeUsage)
+			return f, 0
+		default:
+			v, ok := parseFlag(args, &i, "camera")
+			if !ok {
+				v, ok = parseFlag(args, &i, "encoding")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "start")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "end")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "duration")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "interval")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "fps")
+			}
+			if !ok {
+				v, ok = parseFlag(args, &i, "config")
+			}
+			if !ok {
+				fmt.Fprintf(os.Stderr, "Error: unknown flag %q\n\n%s", arg, timelapseMergeUsage)
+				return f, 1
+			}
+			switch {
+			case strings.HasPrefix(arg, "--camera"):
+				f.camerasArg = v
+			case strings.HasPrefix(arg, "--encoding"):
+				f.encoding = v
+			case strings.HasPrefix(arg, "--start"):
+				f.start = v
+			case strings.HasPrefix(arg, "--end"):
+				f.end = v
+			case strings.HasPrefix(arg, "--duration"):
+				f.duration = v
+			case strings.HasPrefix(arg, "--interval"):
+				f.interval = v
+			case strings.HasPrefix(arg, "--fps"):
+				n, err := strconv.Atoi(v)
+				if err != nil || n <= 0 {
+					fmt.Fprintf(os.Stderr, "Error: invalid --fps %q\n", v)
+					return f, 1
+				}
+				f.fps = n
+			case strings.HasPrefix(arg, "--config"):
+				f.cfgPath = v
+			}
+		}
+	}
+	if f.duration == "" {
+		f.duration = "natural-day"
+	}
+	if f.cfgPath == "" {
+		f.cfgPath = "mibee-nvr.yaml"
+	}
+	if f.interval != "" {
+		d, err := time.ParseDuration(f.interval)
+		if err != nil || d <= 0 {
+			fmt.Fprintf(os.Stderr, "Error: invalid --interval %q (must be a positive Go duration)\n", f.interval)
+			return f, 1
+		}
+	}
+	return f, -1
+}
+
+// resolveTimelapseMergeCameras picks the target cameras: explicit comma-
+// separated IDs (all must exist), or "all" (optionally filtered by encoding).
+func resolveTimelapseMergeCameras(cfg *config.Config, camerasArg, encoding string) ([]config.CameraConfig, error) {
+	if camerasArg == "" {
+		return nil, fmt.Errorf("--camera is required (comma-separated IDs or \"all\")")
+	}
+	var picked []config.CameraConfig
+	if camerasArg == "all" {
+		for _, c := range cfg.Cameras {
+			if encoding != "" && c.Encoding != encoding {
+				continue
+			}
+			picked = append(picked, c)
+		}
+		if len(picked) == 0 {
+			return nil, fmt.Errorf("no cameras match --camera all%s", encodingSuffix(encoding))
+		}
+		return picked, nil
+	}
+	index := make(map[string]bool, len(cfg.Cameras))
+	for _, c := range cfg.Cameras {
+		index[c.ID] = true
+	}
+	for _, id := range strings.Split(camerasArg, ",") {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if !index[id] {
+			return nil, fmt.Errorf("camera %q not found in config", id)
+		}
+		for _, c := range cfg.Cameras {
+			if c.ID == id {
+				picked = append(picked, c)
+			}
+		}
+	}
+	if len(picked) == 0 {
+		return nil, fmt.Errorf("no valid camera IDs in %q", camerasArg)
+	}
+	return picked, nil
+}
+
+func encodingSuffix(encoding string) string {
+	if encoding == "" {
+		return ""
+	}
+	return " --encoding " + encoding
+}
+
+// timelapseMergeWindow is one enumerated merge window [Start, End).
+type timelapseMergeWindow struct {
+	Start, End time.Time
+}
+
+// enumerateMergeWindows tiles merge windows from the local-midnight window
+// containing startDay up to (but not including) the day AFTER endDay — i.e.
+// both boundary dates are inclusive.
+func enumerateMergeWindows(startDay, endDay time.Time, dur time.Duration, loc *time.Location) []timelapseMergeWindow {
+	first, _ := timelapse.MergeWindowFor(startDay, dur, loc)
+	endBound := time.Date(endDay.Year(), endDay.Month(), endDay.Day(), 0, 0, 0, 0, loc).Add(24 * time.Hour)
+	var ws []timelapseMergeWindow
+	for cur := first; cur.Before(endBound); cur = cur.Add(dur) {
+		ws = append(ws, timelapseMergeWindow{Start: cur, End: cur.Add(dur)})
+	}
+	return ws
+}
+
+// effectiveTimelapseMergeInterval resolves the frame sampling interval:
+// override flag > camera timelapse.interval > 30s default. A malformed camera
+// config value falls back to the default (config is validated at server
+// startup; the CLI degrades instead of hard-failing).
+func effectiveTimelapseMergeInterval(cam config.CameraConfig, override string) (time.Duration, error) {
+	if override != "" {
+		return time.ParseDuration(override)
+	}
+	if cam.Timelapse != nil && cam.Timelapse.Interval != "" {
+		if d, err := time.ParseDuration(cam.Timelapse.Interval); err == nil && d > 0 {
+			return d, nil
+		}
+	}
+	return 30 * time.Second, nil
+}
+
+// effectiveTimelapseMergeFPS resolves the output fps: override flag >
+// camera merge_output_fps > 10 default (mirrors the API handler).
+func effectiveTimelapseMergeFPS(cam config.CameraConfig, override int) int {
+	if override > 0 {
+		return override
+	}
+	if cam.Timelapse != nil && cam.Timelapse.MergeOutputFPS > 0 {
+		return cam.Timelapse.MergeOutputFPS
+	}
+	return 10
+}
+
+// effectiveTimelapseMergeDeleteSources resolves the source-deletion flag:
+// CLI tri-state override > camera delete_recordings_after_merge.
+func effectiveTimelapseMergeDeleteSources(cam config.CameraConfig, override *bool) bool {
+	if override != nil {
+		return *override
+	}
+	return cam.Timelapse != nil && cam.Timelapse.DeleteRecordingsAfterMerge
+}
+
+// cameraRecordingEnabled mirrors the API's recording-enabled resolution:
+// nil pointer = enabled.
+func cameraRecordingEnabled(cam config.CameraConfig) bool {
+	return cam.RecordingEnabled == nil || *cam.RecordingEnabled
+}
+
+// cliSourceDeleter adapts cleanup.CleanupManager to timelapse.SourceRecordingDeleter
+// (the CLI twin of pkg/app's timelapseSourceDeleter).
+type cliSourceDeleter struct{ cm *cleanup.CleanupManager }
+
+func (d cliSourceDeleter) DeleteRecordings(ctx context.Context, recordings []model.Recording, reason string) ([]string, error) {
+	return d.cm.BatchDeleteRecordingsWithFiles(ctx, recordings, reason)
+}
+
+// runTimelapseMerge is the CLI core. serverRunning gates timelapse-enabled
+// cameras (their windows belong to the server's scheduler). Returns the
+// process exit code.
+func runTimelapseMerge(f timelapseMergeFlags, stdout io.Writer, serverRunning bool) int {
+	if f.duration == "" {
+		f.duration = "natural-day"
+	}
+	dur, err := config.ParseMergeDuration(f.duration)
+	if err != nil {
+		fmt.Fprintf(stdout, "Error: %v\n", err)
+		return 1
+	}
+	cfg, err := config.Load(f.cfgPath)
+	if err != nil {
+		fmt.Fprintf(stdout, "Error loading config %q: %v\n", f.cfgPath, err)
+		return 1
+	}
+	loc := resolveTimelapseMergeLocation(cfg)
+
+	cameras, err := resolveTimelapseMergeCameras(cfg, f.camerasArg, f.encoding)
+	if err != nil {
+		fmt.Fprintf(stdout, "Error: %v\n", err)
+		return 1
+	}
+
+	if f.start == "" {
+		_, _ = fmt.Fprintln(stdout, "Error: --start is required (YYYY-MM-DD)")
+		return 1
+	}
+	startDay, err := time.ParseInLocation("2006-01-02", f.start, loc)
+	if err != nil {
+		fmt.Fprintf(stdout, "Error: invalid --start %q: %v\n", f.start, err)
+		return 1
+	}
+	endDay := time.Now().In(loc).AddDate(0, 0, -1)
+	if f.end != "" {
+		endDay, err = time.ParseInLocation("2006-01-02", f.end, loc)
+		if err != nil {
+			fmt.Fprintf(stdout, "Error: invalid --end %q: %v\n", f.end, err)
+			return 1
+		}
+	}
+	if endDay.Before(startDay) {
+		fmt.Fprintf(stdout, "Error: --end (%s) is before --start (%s)\n", f.end, f.start)
+		return 1
+	}
+
+	windows := enumerateMergeWindows(startDay, endDay, dur, loc)
+
+	db, err := storage.New(filepath.Join(cfg.Storage.RootDir, "mibee-nvr.db"))
+	if err != nil {
+		fmt.Fprintf(stdout, "Error opening database: %v\n", err)
+		return 1
+	}
+	defer db.Close()
+	if err := db.Init(context.Background()); err != nil {
+		fmt.Fprintf(stdout, "Error initialising database: %v\n", err)
+		return 1
+	}
+
+	// While the NVR is live, refuse timelapse-enabled cameras: the server's
+	// merge scheduler owns their windows and the per-process dedup can't see
+	// a cross-process concurrent merge of the same window. Dry-run bypasses
+	// the gate — planning makes no changes.
+	if f.execute && serverRunning && !f.force {
+		var kept []config.CameraConfig
+		for _, cam := range cameras {
+			if cam.Timelapse != nil && cam.Timelapse.Enabled {
+				fmt.Fprintf(stdout, "Refusing camera %s: timelapse-enabled camera while the NVR is running (its merge scheduler owns these windows; use --force to override or stop the NVR)\n", cam.ID)
+				continue
+			}
+			kept = append(kept, cam)
+		}
+		if len(kept) == 0 {
+			_, _ = fmt.Fprintln(stdout, "No cameras left to process.")
+			return 1
+		}
+		cameras = kept
+	} else if f.execute && serverRunning {
+		_, _ = fmt.Fprintln(stdout, "Notice: NVR is running; proceeding with WAL-concurrent DB access (--force).")
+	}
+
+	mode := "DRY RUN — no changes made (run with --execute)"
+	if f.execute {
+		mode = "EXECUTE"
+	}
+	fmt.Fprintf(stdout, "TIME LAPSE MERGE — %s\n", mode)
+	fmt.Fprintf(stdout, "  config=%s db=%s\n", f.cfgPath, filepath.Join(cfg.Storage.RootDir, "mibee-nvr.db"))
+	fmt.Fprintf(stdout, "  windows=%d duration=%s range=%s..%s tz=%s\n\n",
+		len(windows), f.duration, startDay.Format("2006-01-02"), endDay.Format("2006-01-02"), loc.String())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if f.execute {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigCh
+			cancel()
+		}()
+	}
+
+	var deleter timelapse.SourceRecordingDeleter
+	if f.execute {
+		store, err := storage.NewManager(cfg.Storage.RootDir)
+		if err != nil {
+			fmt.Fprintf(stdout, "Error creating storage manager: %v\n", err)
+			return 1
+		}
+		cleanupMgr, err := cleanup.NewCleanupManager(db, store, cfg.Cleanup)
+		if err != nil {
+			fmt.Fprintf(stdout, "Error creating cleanup manager: %v\n", err)
+			return 1
+		}
+		deleter = cliSourceDeleter{cm: cleanupMgr}
+	}
+
+	var totalMerged, totalFailed int
+	for _, cam := range cameras {
+		interval, err := effectiveTimelapseMergeInterval(cam, f.interval)
+		if err != nil {
+			fmt.Fprintf(stdout, "Error: invalid --interval %q: %v\n", f.interval, err)
+			return 1
+		}
+		fps := effectiveTimelapseMergeFPS(cam, f.fps)
+		delSources := effectiveTimelapseMergeDeleteSources(cam, f.deleteSrc)
+
+		fmt.Fprintf(stdout, "camera %s (%s, %s)\n", cam.ID, cam.Name, cam.Encoding)
+		fmt.Fprintf(stdout, "  interval=%s fps=%d delete-sources=%v\n", interval, fps, delSources)
+
+		var mgr *timelapse.PeriodicMergeManager
+		if f.execute {
+			dataDir := filepath.Join(cfg.Storage.RootDir, "periodic-merge")
+			mgr = timelapse.NewPeriodicMergeManager(
+				db, db, timelapse.NewGoMerger(), fps, dataDir, dur, loc,
+				timelapse.WithMergeStore(db),
+				timelapse.WithDurationLabel(f.duration),
+				timelapse.WithRecordingEnabledProvider(func(string) bool { return cameraRecordingEnabled(cam) }),
+				timelapse.WithRetainIntermediateMP4(cam.Timelapse.RetainIntermediateMP4Value()),
+				timelapse.WithIntermediateMP4Pruner(db),
+				timelapse.WithExtractionInterval(interval),
+				timelapse.WithDeleteRecordingsAfterMerge(delSources),
+			)
+			if delSources {
+				mgr.SetSourceRecordingDeleter(deleter)
+			}
+		}
+
+		for _, w := range windows {
+			if ctx.Err() != nil {
+				_, _ = fmt.Fprintln(stdout, "\nInterrupted — stopping. Already-merged windows are safe; re-run to resume.")
+				return 1
+			}
+			label := fmt.Sprintf("%s → %s", w.Start.Format("2006-01-02 15:04"), w.End.Format("2006-01-02 15:04"))
+			if w.End.After(time.Now()) {
+				fmt.Fprintf(stdout, "  window %s: skipped (open — sources not final, deletion suppressed per #734)\n", label)
+				continue
+			}
+			row, err := db.FindTimelapseMergeByWindow(ctx, cam.ID, w.Start, f.duration)
+			if err != nil {
+				fmt.Fprintf(stdout, "  window %s: lookup failed: %v\n", label, err)
+				totalFailed++
+				continue
+			}
+			if row != nil && row.Status == model.TimelapseMergeStatusCompleted {
+				fmt.Fprintf(stdout, "  window %s: skipped (already merged, %d frames)\n", label, row.FrameCount)
+				continue
+			}
+			if !f.execute {
+				count, size := countWindowRecordings(ctx, db, cam.ID, w)
+				fmt.Fprintf(stdout, "  window %s: would merge (%d recordings, %.1f MB)\n", label, count, float64(size)/1e6)
+				continue
+			}
+			fmt.Fprintf(stdout, "  window %s: merging...\n", label)
+			if err := mgr.Run(ctx, cam.ID, w.Start.Add(dur/2)); err != nil {
+				fmt.Fprintf(stdout, "  window %s: FAILED: %v\n", label, err)
+				totalFailed++
+				continue
+			}
+			// Run() writes no row when the window has no segments.
+			row, err = db.FindTimelapseMergeByWindow(ctx, cam.ID, w.Start, f.duration)
+			switch {
+			case err != nil || row == nil:
+				fmt.Fprintf(stdout, "  window %s: no segments (empty window)\n", label)
+			case row.Status == model.TimelapseMergeStatusCompleted:
+				fmt.Fprintf(stdout, "  window %s: completed (%d frames, %.1f MB → %s)\n",
+					label, row.FrameCount, float64(row.FileSize)/1e6, row.OutputPath)
+				totalMerged++
+			default:
+				fmt.Fprintf(stdout, "  window %s: finished with status %q (%s)\n", label, row.Status, row.Error)
+				totalFailed++
+			}
+		}
+		_, _ = fmt.Fprintln(stdout)
+	}
+
+	if f.execute {
+		fmt.Fprintf(stdout, "SUMMARY: merged=%d failed=%d (skipped windows not counted)\n", totalMerged, totalFailed)
+		if totalFailed > 0 {
+			return 1
+		}
+	} else {
+		_, _ = fmt.Fprintln(stdout, "DRY RUN — no changes made. Re-run with --execute to apply.")
+	}
+	return 0
+}
+
+// resolveTimelapseMergeLocation mirrors the API handler's display-timezone
+// resolution (Local needs special-casing — time.LoadLocation("Local") fails).
+func resolveTimelapseMergeLocation(cfg *config.Config) *time.Location {
+	switch {
+	case cfg.Timezone == "" || cfg.Timezone == "UTC":
+		return time.UTC
+	case cfg.Timezone == "Local":
+		return time.Local
+	default:
+		if l, err := time.LoadLocation(cfg.Timezone); err == nil {
+			return l
+		}
+		return time.UTC
+	}
+}
+
+// countWindowRecordings returns the video-format recording count and bytes
+// inside the window (the extraction input — what would be converted).
+func countWindowRecordings(ctx context.Context, db *storage.DB, cameraID string, w timelapseMergeWindow) (int, int64) {
+	recs, err := db.ListRecordings(ctx, model.RecordingFilter{
+		CameraID:  cameraID,
+		Formats:   []model.Format{model.FormatH264, model.FormatH265, model.FormatAVI, model.FormatMJPEG},
+		StartTime: w.Start,
+		EndTime:   w.End,
+	})
+	if err != nil {
+		return 0, 0
+	}
+	var size int64
+	for _, r := range recs {
+		size += r.FileSize
+	}
+	return len(recs), size
+}

--- a/cmd/mibee-nvr/timelapse_merge_test.go
+++ b/cmd/mibee-nvr/timelapse_merge_test.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/timelapse"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Flag parsing
+// ---------------------------------------------------------------------------
+
+func TestParseTimelapseMergeFlags_Defaults(t *testing.T) {
+	t.Helper()
+	f, code := parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "cam-1", "--start", "2026-09-04"})
+	require.Equal(t, -1, code, "expected proceed code -1")
+	require.False(t, f.execute, "dry-run must be the default")
+	require.Equal(t, "natural-day", f.duration)
+	require.Equal(t, "mibee-nvr.yaml", f.cfgPath)
+	require.Empty(t, f.interval, "no interval override by default")
+	require.Equal(t, 0, f.fps, "no fps override by default")
+	require.Nil(t, f.deleteSrc, "delete-sources tri-state default = follow camera config")
+	require.False(t, f.force)
+}
+
+func TestParseTimelapseMergeFlags_FullSet(t *testing.T) {
+	t.Helper()
+	argv := []string{
+		"mibee-nvr", "timelapse-merge",
+		"--camera", "cam-1,cam-2",
+		"--start", "2026-08-26",
+		"--end", "2026-09-10",
+		"--duration", "8h",
+		"--interval", "1s",
+		"--fps", "15",
+		"--delete-sources",
+		"--execute",
+		"--force",
+		"--config", "/tmp/x.yaml",
+	}
+	f, code := parseTimelapseMergeFlags(argv)
+	require.Equal(t, -1, code)
+	require.Equal(t, "cam-1,cam-2", f.camerasArg)
+	require.Equal(t, "2026-08-26", f.start)
+	require.Equal(t, "2026-09-10", f.end)
+	require.Equal(t, "8h", f.duration)
+	require.Equal(t, "1s", f.interval)
+	require.Equal(t, 15, f.fps)
+	require.True(t, *f.deleteSrc)
+	require.True(t, f.execute)
+	require.True(t, f.force)
+	require.Equal(t, "/tmp/x.yaml", f.cfgPath)
+}
+
+func TestParseTimelapseMergeFlags_EqualsFormAndOverrides(t *testing.T) {
+	t.Helper()
+	// --flag=value form, and --no-delete-sources overriding an earlier --delete-sources.
+	f, code := parseTimelapseMergeFlags([]string{
+		"mibee-nvr", "timelapse-merge",
+		"--camera=all", "--encoding=jpeg", "--start=2026-09-01",
+		"--interval=500ms", "--delete-sources", "--no-delete-sources",
+	})
+	require.Equal(t, -1, code)
+	require.Equal(t, "all", f.camerasArg)
+	require.Equal(t, "jpeg", f.encoding)
+	require.Equal(t, "500ms", f.interval)
+	require.NotNil(t, f.deleteSrc)
+	require.False(t, *f.deleteSrc)
+}
+
+func TestParseTimelapseMergeFlags_Errors(t *testing.T) {
+	t.Helper()
+	// Unknown flag → error exit code 1.
+	_, code := parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "a", "--start", "2026-09-01", "--bogus"})
+	require.Equal(t, 1, code)
+	// Bad fps → error.
+	_, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "a", "--start", "2026-09-01", "--fps", "abc"})
+	require.Equal(t, 1, code)
+	// Bad interval → error.
+	_, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "a", "--start", "2026-09-01", "--interval", "fast"})
+	require.Equal(t, 1, code)
+	// Non-positive interval → error.
+	_, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "a", "--start", "2026-09-01", "--interval", "0s"})
+	require.Equal(t, 1, code)
+	// Help → exit code 0.
+	_, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--help"})
+	require.Equal(t, 0, code)
+}
+
+// ---------------------------------------------------------------------------
+// Camera resolution
+// ---------------------------------------------------------------------------
+
+func TestResolveTimelapseMergeCameras(t *testing.T) {
+	t.Helper()
+	cfg := &config.Config{Cameras: []config.CameraConfig{
+		{ID: "cam-jpeg-a", Name: "a", Encoding: "jpeg"},
+		{ID: "cam-jpeg-b", Name: "b", Encoding: "jpeg"},
+		{ID: "cam-h265", Name: "c", Encoding: "h265"},
+	}}
+
+	cams, err := resolveTimelapseMergeCameras(cfg, "cam-jpeg-a,cam-h265", "")
+	require.NoError(t, err)
+	require.Len(t, cams, 2)
+	require.Equal(t, "cam-jpeg-a", cams[0].ID)
+	require.Equal(t, "cam-h265", cams[1].ID)
+
+	// "all" without filter → every camera.
+	cams, err = resolveTimelapseMergeCameras(cfg, "all", "")
+	require.NoError(t, err)
+	require.Len(t, cams, 3)
+
+	// "all" + encoding filter.
+	cams, err = resolveTimelapseMergeCameras(cfg, "all", "jpeg")
+	require.NoError(t, err)
+	require.Len(t, cams, 2)
+	for _, c := range cams {
+		require.Equal(t, "jpeg", c.Encoding)
+	}
+
+	// Unknown explicit ID → error.
+	_, err = resolveTimelapseMergeCameras(cfg, "cam-nope", "")
+	require.Error(t, err)
+
+	// Empty arg → error.
+	_, err = resolveTimelapseMergeCameras(cfg, "", "")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Window enumeration
+// ---------------------------------------------------------------------------
+
+func TestEnumerateMergeWindows(t *testing.T) {
+	t.Helper()
+	loc := time.UTC
+	start := time.Date(2026, 9, 4, 0, 0, 0, 0, loc)
+	end := time.Date(2026, 9, 6, 0, 0, 0, 0, loc)
+
+	// natural-day: 09-04..09-06 inclusive → 3 windows of 24h.
+	ws := enumerateMergeWindows(start, end, 24*time.Hour, loc)
+	require.Len(t, ws, 3)
+	require.Equal(t, start, ws[0].Start)
+	require.Equal(t, start.Add(24*time.Hour), ws[0].End)
+	require.Equal(t, end, ws[2].Start)
+
+	// 8h: one day → 3 windows (00:00, 08:00, 16:00).
+	day := time.Date(2026, 9, 4, 0, 0, 0, 0, loc)
+	ws = enumerateMergeWindows(day, day, 8*time.Hour, loc)
+	require.Len(t, ws, 3)
+	require.Equal(t, day, ws[0].Start)
+	require.Equal(t, day.Add(8*time.Hour), ws[1].Start)
+	require.Equal(t, day.Add(16*time.Hour), ws[2].Start)
+	require.Equal(t, day.Add(24*time.Hour), ws[2].End)
+
+	// 8h across two days → 6 windows.
+	ws = enumerateMergeWindows(day, day.AddDate(0, 0, 1), 8*time.Hour, loc)
+	require.Len(t, ws, 6)
+}
+
+// ---------------------------------------------------------------------------
+// Effective per-camera parameters
+// ---------------------------------------------------------------------------
+
+func TestEffectiveTimelapseMergeParams(t *testing.T) {
+	t.Helper()
+	interval1s := "1s"
+	cam := config.CameraConfig{
+		ID:       "cam-x",
+		Encoding: "jpeg",
+		Timelapse: &config.CameraTimelapseConfig{
+			Interval:                   "5s",
+			MergeOutputFPS:             12,
+			DeleteRecordingsAfterMerge: true,
+		},
+	}
+
+	// Overrides win.
+	d, err := effectiveTimelapseMergeInterval(cam, interval1s)
+	require.NoError(t, err)
+	require.Equal(t, time.Second, d)
+	require.Equal(t, 15, effectiveTimelapseMergeFPS(cam, 15))
+	require.False(t, effectiveTimelapseMergeDeleteSources(cam, tlmBoolPtr(false)))
+
+	// Without overrides: camera config values.
+	d, err = effectiveTimelapseMergeInterval(cam, "")
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Second, d)
+	require.Equal(t, 12, effectiveTimelapseMergeFPS(cam, 0))
+	require.True(t, effectiveTimelapseMergeDeleteSources(cam, nil))
+
+	// Camera without timelapse config: 30s default, fps 10 default, no delete.
+	bare := config.CameraConfig{ID: "cam-bare"}
+	d, err = effectiveTimelapseMergeInterval(bare, "")
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, d)
+	require.Equal(t, 10, effectiveTimelapseMergeFPS(bare, 0))
+	require.False(t, effectiveTimelapseMergeDeleteSources(bare, nil))
+
+	// Invalid camera-config interval falls back to the default (config is
+	// validated at server startup; the CLI must not hard-fail on it).
+	bad := config.CameraConfig{ID: "cam-bad", Timelapse: &config.CameraTimelapseConfig{Interval: "oops"}}
+	d, err = effectiveTimelapseMergeInterval(bad, "")
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Second, d)
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: MJPEG recordings → timelapse merge with 1s sampling + delete
+// ---------------------------------------------------------------------------
+
+// writeTLMTestConfig writes a minimal CLI config pointing at rootDir.
+func writeTLMTestConfig(t *testing.T, path, rootDir string, cams ...config.CameraConfig) {
+	t.Helper()
+	cfg := config.Config{
+		Server:   config.ServerConfig{Listen: ":9090"},
+		Storage:  config.StorageConfig{RootDir: rootDir},
+		Cleanup:  config.CleanupConfig{RetentionDays: 30, CheckInterval: "1h"},
+		Timezone: "Local", // matches parseMJPEGFrameTime (frame filenames are local wall clock)
+		Cameras:  cams,
+	}
+	require.NoError(t, config.Save(path, &cfg))
+}
+
+// makeTLMJPEGFrames writes n timestamped JPEG frames into dir, every step
+// starting from start (local wall clock — the storage layer's naming).
+func makeTLMJPEGFrames(t *testing.T, dir string, start time.Time, n int, step time.Duration) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for i := range n {
+		name := start.Add(time.Duration(i)*step).Format("20060102_150405.000") + ".jpg"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("jpeg-dummy-frame-content"), 0o644))
+	}
+}
+
+func insertTLMRecording(t *testing.T, db *storage.DB, id, camID, path string, start, end time.Time) {
+	t.Helper()
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID:        id,
+		CameraID:  camID,
+		FilePath:  path,
+		Format:    model.FormatMJPEG,
+		StartedAt: start,
+		EndedAt:   end,
+		Duration:  end.Sub(start).Seconds(),
+		FileSize:  4096,
+	}))
+}
+
+// closedLocalDay returns the local-calendar midnight of N days ago — a window
+// guaranteed to be closed regardless of when the test runs.
+func closedLocalDay(t *testing.T, daysAgo int) time.Time {
+	t.Helper()
+	d := time.Now().In(time.Local).AddDate(0, 0, -daysAgo)
+	return time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.Local)
+}
+
+func TestRunTimelapseMerge_MJPEGExecuteWithDelete(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "mibee-nvr.yaml")
+	writeTLMTestConfig(t, cfgPath, root, config.CameraConfig{
+		ID: "cam-jpeg", Name: "jpeg cam", Protocol: "onvif", Encoding: "jpeg",
+		RecordingEnabled: tlmBoolPtr(true),
+	})
+
+	db, err := storage.New(filepath.Join(root, "mibee-nvr.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { db.Close() })
+
+	dayStart := closedLocalDay(t, 2)
+	dayStr := dayStart.Format("2006-01-02")
+
+	// Two MJPEG recordings inside the window: at 00:00 and 01:00 local,
+	// each 60s of frames at 2fps (every 500ms) → 120 frames per recording.
+	dir1 := filepath.Join(root, "cam-jpeg", "rec-1")
+	dir2 := filepath.Join(root, "cam-jpeg", "rec-2")
+	rec2Start := dayStart.Add(time.Hour)
+	makeTLMJPEGFrames(t, dir1, dayStart, 120, 500*time.Millisecond)
+	makeTLMJPEGFrames(t, dir2, rec2Start, 120, 500*time.Millisecond)
+	insertTLMRecording(t, db, "rec-1", "cam-jpeg", dir1, dayStart, dayStart.Add(60*time.Second))
+	insertTLMRecording(t, db, "rec-2", "cam-jpeg", dir2, rec2Start, rec2Start.Add(60*time.Second))
+
+	var out bytes.Buffer
+	code := runTimelapseMerge(timelapseMergeFlags{
+		cfgPath:    cfgPath,
+		camerasArg: "cam-jpeg",
+		start:      dayStr,
+		end:        dayStr,
+		interval:   "1s",
+		deleteSrc:  tlmBoolPtr(true),
+		execute:    true,
+	}, &out, false /* serverRunning */)
+	require.Equal(t, 0, code, "output:\n%s", out.String())
+
+	// The merge row exists, completed, with ~1 frame per sampled second:
+	// 2 recordings × 60 samples each = 120 frames.
+	row, err := db.FindTimelapseMergeByWindow(context.Background(), "cam-jpeg", dayStart, "natural-day")
+	require.NoError(t, err)
+	require.NotNil(t, row, "expected a timelapse_merges row; CLI output:\n%s", out.String())
+	require.Equal(t, model.TimelapseMergeStatusCompleted, row.Status)
+	require.Equal(t, 120, row.FrameCount)
+	require.Equal(t, model.TimelapseMergeCodecMJPEG, row.Codec)
+	require.Greater(t, row.FileSize, int64(0))
+
+	// Output MP4 exists and is non-empty.
+	outPath := filepath.Join(root, "periodic-merge", "cam-jpeg",
+		"periodic_"+dayStart.Format("2006-01-02_150405")+".mp4")
+	st, err := os.Stat(outPath)
+	require.NoError(t, err, "output mp4 must exist")
+	require.Greater(t, st.Size(), int64(0))
+
+	// Source recordings were deleted (DB rows + dirs on disk).
+	recs, err := db.ListRecordings(context.Background(), model.RecordingFilter{CameraID: "cam-jpeg"})
+	require.NoError(t, err)
+	require.Empty(t, recs, "source recordings must be deleted after merge")
+	_, err = os.Stat(dir1)
+	require.True(t, os.IsNotExist(err), "source dir 1 must be removed")
+	_, err = os.Stat(dir2)
+	require.True(t, os.IsNotExist(err), "source dir 2 must be removed")
+
+	// Re-run is idempotent: the window is skipped as already merged.
+	var out2 bytes.Buffer
+	code = runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-jpeg", start: dayStr, end: dayStr,
+		interval: "1s", deleteSrc: tlmBoolPtr(true), execute: true,
+	}, &out2, false)
+	require.Equal(t, 0, code, "output:\n%s", out2.String())
+	require.Contains(t, out2.String(), "already", "re-run should report the window as already merged")
+
+	row2, err := db.FindTimelapseMergeByWindow(context.Background(), "cam-jpeg", dayStart, "natural-day")
+	require.NoError(t, err)
+	require.NotNil(t, row2)
+	require.Equal(t, 120, row2.FrameCount, "re-run must not re-merge the window")
+}
+
+func TestRunTimelapseMerge_DryRunMakesNoChanges(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "mibee-nvr.yaml")
+	writeTLMTestConfig(t, cfgPath, root, config.CameraConfig{
+		ID: "cam-jpeg", Name: "jpeg cam", Protocol: "onvif", Encoding: "jpeg",
+		RecordingEnabled: tlmBoolPtr(true),
+	})
+
+	db, err := storage.New(filepath.Join(root, "mibee-nvr.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { db.Close() })
+
+	dayStart := closedLocalDay(t, 3)
+	dayStr := dayStart.Format("2006-01-02")
+	dir := filepath.Join(root, "cam-jpeg", "rec-1")
+	makeTLMJPEGFrames(t, dir, dayStart, 10, time.Second)
+	insertTLMRecording(t, db, "rec-1", "cam-jpeg", dir, dayStart, dayStart.Add(10*time.Second))
+
+	var out bytes.Buffer
+	code := runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-jpeg", start: dayStr, end: dayStr,
+	}, &out, false)
+	require.Equal(t, 0, code, "output:\n%s", out.String())
+	require.Contains(t, out.String(), "DRY RUN")
+
+	// No merge row, recordings untouched, dir still there.
+	row, err := db.FindTimelapseMergeByWindow(context.Background(), "cam-jpeg", dayStart, "natural-day")
+	require.NoError(t, err)
+	require.Nil(t, row)
+	recs, err := db.ListRecordings(context.Background(), model.RecordingFilter{CameraID: "cam-jpeg"})
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	_, err = os.Stat(dir)
+	require.NoError(t, err)
+}
+
+func TestRunTimelapseMerge_SkipsOpenWindows(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "mibee-nvr.yaml")
+	writeTLMTestConfig(t, cfgPath, root, config.CameraConfig{
+		ID: "cam-jpeg", Name: "jpeg cam", Protocol: "onvif", Encoding: "jpeg",
+		RecordingEnabled: tlmBoolPtr(true),
+	})
+
+	// A future date: every window is open → all skipped.
+	tomorrow := time.Now().In(time.Local).AddDate(0, 0, 1)
+	dayStr := tomorrow.Format("2006-01-02")
+
+	var out bytes.Buffer
+	code := runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-jpeg", start: dayStr, end: dayStr, execute: true,
+	}, &out, false)
+	require.Equal(t, 0, code, "output:\n%s", out.String())
+	require.Contains(t, strings.ToLower(out.String()), "open")
+}
+
+func TestRunTimelapseMerge_RefusesEnabledCameraWhileServerRunning(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "mibee-nvr.yaml")
+	writeTLMTestConfig(t, cfgPath, root, config.CameraConfig{
+		ID: "cam-en", Name: "enabled cam", Protocol: "onvif", Encoding: "jpeg",
+		RecordingEnabled: tlmBoolPtr(true),
+		Timelapse:        &config.CameraTimelapseConfig{Enabled: true, Interval: "1s"},
+	})
+
+	db, err := storage.New(filepath.Join(root, "mibee-nvr.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { db.Close() })
+
+	dayStart := closedLocalDay(t, 2)
+	dayStr := dayStart.Format("2006-01-02")
+	dir := filepath.Join(root, "cam-en", "rec-1")
+	makeTLMJPEGFrames(t, dir, dayStart, 10, time.Second)
+	insertTLMRecording(t, db, "rec-1", "cam-en", dir, dayStart, dayStart.Add(10*time.Second))
+
+	// Server running + timelapse-enabled camera + no --force → refuse and
+	// exit non-zero (nothing processed).
+	var out bytes.Buffer
+	code := runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-en", start: dayStr, end: dayStr, execute: true,
+	}, &out, true /* serverRunning */)
+	require.Equal(t, 1, code, "output:\n%s", out.String())
+	require.Contains(t, strings.ToLower(out.String()), "timelapse-enabled")
+
+	// Nothing merged.
+	row, err := db.FindTimelapseMergeByWindow(context.Background(), "cam-en", dayStart, "natural-day")
+	require.NoError(t, err)
+	require.Nil(t, row)
+
+	// Dry-run bypasses the refusal gate (planning makes no changes).
+	var outDry bytes.Buffer
+	code = runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-en", start: dayStr, end: dayStr,
+	}, &outDry, true /* serverRunning */)
+	require.Equal(t, 0, code, "output:\n%s", outDry.String())
+	require.Contains(t, outDry.String(), "DRY RUN")
+	require.Contains(t, outDry.String(), "would merge")
+
+	// With --force it proceeds and merges (offline-style access).
+	var out2 bytes.Buffer
+	code = runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "cam-en", start: dayStr, end: dayStr,
+		execute: true, force: true,
+	}, &out2, true /* serverRunning */)
+	require.Equal(t, 0, code, "output:\n%s", out2.String())
+	row, err = db.FindTimelapseMergeByWindow(context.Background(), "cam-en", dayStart, "natural-day")
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.Equal(t, model.TimelapseMergeStatusCompleted, row.Status)
+}
+
+func TestRunTimelapseMerge_EncodingFilterDryRun(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	cfgPath := filepath.Join(root, "mibee-nvr.yaml")
+	writeTLMTestConfig(t, cfgPath, root,
+		config.CameraConfig{ID: "cam-jpeg", Name: "j", Protocol: "onvif", Encoding: "jpeg"},
+		config.CameraConfig{ID: "cam-h265", Name: "h", Protocol: "onvif", Encoding: "h265"},
+	)
+
+	dayStart := closedLocalDay(t, 5)
+	dayStr := dayStart.Format("2006-01-02")
+	var out bytes.Buffer
+	code := runTimelapseMerge(timelapseMergeFlags{
+		cfgPath: cfgPath, camerasArg: "all", encoding: "jpeg", start: dayStr, end: dayStr,
+	}, &out, false)
+	require.Equal(t, 0, code, "output:\n%s", out.String())
+	require.Contains(t, out.String(), "cam-jpeg")
+	require.NotContains(t, out.String(), "cam-h265")
+}
+
+// Sanity-check the exported window helper used for enumeration.
+func TestTimelapseMergeWindowFor(t *testing.T) {
+	t.Helper()
+	loc := time.UTC
+	ref := time.Date(2026, 9, 5, 15, 42, 0, 0, loc)
+	start, end := timelapse.MergeWindowFor(ref, 24*time.Hour, loc)
+	require.Equal(t, time.Date(2026, 9, 5, 0, 0, 0, 0, loc), start)
+	require.Equal(t, time.Date(2026, 9, 6, 0, 0, 0, 0, loc), end)
+
+	s, e := timelapse.MergeWindowFor(ref, 8*time.Hour, loc)
+	require.Equal(t, time.Date(2026, 9, 5, 8, 0, 0, 0, loc), s)
+	require.Equal(t, time.Date(2026, 9, 5, 16, 0, 0, 0, loc), e)
+}

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -33,6 +33,7 @@ mibee-nvr -config mibee-nvr.yaml
 | [`encrypt-config`](#encrypt-config-encrypt-sensitive-fields) | Encrypt plaintext secrets in the config |
 | [`download-model`](#download-model-download-the-ai-model) | Download the browser-side AI model |
 | [`merge-cameras`](#merge-cameras-merge-cameras) | Merge two duplicate camera entries |
+| [`timelapse-merge`](#timelapse-merge-convert-recordings-to-timelapse) | Batch-convert recordings of any period/camera into timelapse merges |
 | [`repair`](#repair-data-repair) | Data repair toolkit (7 subcommands) |
 | [`cleanup`](#cleanup-recording-cleanup) | Delete recordings by date / orphan files |
 
@@ -121,6 +122,39 @@ Steps performed: back up the database → re-tag recordings/events and rewrite f
 | `--execute` | Actually perform the merge (default is dry-run preview) |
 | `--force` | Proceed even if orphan records exist |
 | `--config <path>` | Config file path (default `mibee-nvr.yaml`) |
+
+## timelapse-merge — Convert Recordings to Timelapse
+
+Batch-converts existing video recordings (H264/H265/AVI/MJPEG) of **any camera over any date range** into periodic timelapse merges — the CLI counterpart of `POST /api/timelapse/{id}/merge`, executed in-process against the storage DB. Sampling interval, output fps and source deletion are **per-run overrides that never mutate the camera config**:
+
+```bash
+# Preview: all JPEG cameras, everything since 2026-08-26
+mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26
+
+# Execute: 1-second sampling + delete sources after a successful merge
+mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 \
+  --interval 1s --delete-sources --execute
+```
+
+Behavior notes:
+
+- Windows (default `natural-day`) are enumerated across the date range and merged one by one; windows with an existing completed merge are skipped (safe to re-run and resume), open windows are skipped.
+- `--delete-sources` deletes source recordings (DB rows + files) only after the window's merge **succeeded**; recordings being processed by MiBeeVision are always skipped.
+- The command may run while the NVR is live (WAL concurrency, same as cleanup/repair); cameras with timelapse enabled are refused though — their windows belong to the server's merge scheduler (use `--force` or stop the server).
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--camera <ids\|all>` | (required) | Comma-separated camera IDs or `all` |
+| `--encoding <enc>` | — | With `--camera all`: filter by encoding (e.g. `jpeg`) |
+| `--start <YYYY-MM-DD>` | (required) | First window date (config timezone) |
+| `--end <YYYY-MM-DD>` | yesterday | Last window date (inclusive) |
+| `--duration <label>` | `natural-day` | Window size: `8h` / `12h` / `24h` / `7d` / `30d` … |
+| `--interval <dur>` | camera `timelapse.interval`, else 30s | Frame sampling interval (e.g. `1s`) |
+| `--fps <n>` | camera `merge_output_fps`, else 10 | Output playback fps |
+| `--delete-sources` / `--no-delete-sources` | camera `delete_recordings_after_merge` | Override source deletion for this run |
+| `--execute` | dry-run | Actually execute |
+| `--force` | — | Process timelapse-enabled cameras while the NVR is running |
+| `--config <path>` | `mibee-nvr.yaml` | Config file path |
 
 ## repair — Data Repair
 

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -33,6 +33,7 @@ mibee-nvr -config mibee-nvr.yaml
 | [`encrypt-config`](#encrypt-config-加密敏感字段) | 加密配置中的明文密码 |
 | [`download-model`](#download-model-下载-ai-模型) | 下载浏览器端 AI 检测模型 |
 | [`merge-cameras`](#merge-cameras-合并摄像头) | 合并两个重复的摄像头条目 |
+| [`timelapse-merge`](#timelapse-merge-录像转延时合并) | 把任意时段的录像批量转成延时合并产物 |
 | [`repair`](#repair-数据修复) | 数据修复工具集（7 个子命令） |
 | [`cleanup`](#cleanup-录像清理) | 按日期 / 孤儿文件清理录像 |
 
@@ -121,6 +122,39 @@ mibee-nvr merge-cameras --source cam-old --target cam-new --execute
 | `--execute` | 真正执行（默认 dry-run 仅预览） |
 | `--force` | 存在孤儿记录时仍然继续 |
 | `--config <path>` | 配置文件路径（默认 `mibee-nvr.yaml`） |
+
+## timelapse-merge — 录像转延时合并
+
+把**任意时段、任意摄像头**的既有录像（H264 / H265 / AVI / MJPEG）批量转成周期延时合并产物 —— `POST /api/timelapse/{id}/merge` 的 CLI 版，进程内直连数据库执行。采样间隔、输出帧率、源录像删除都是**本次运行覆盖值，不改摄像头配置**：
+
+```bash
+# 预览：所有 JPEG 摄像头、2026-08-26 起的全部录像
+mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26
+
+# 执行：1 秒采样 + 合并成功后删除源录像
+mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 \
+  --interval 1s --delete-sources --execute
+```
+
+行为要点：
+
+- 按窗口（默认 `natural-day`，即自然日）枚举日期范围，逐窗口执行；已完成的窗口自动跳过（可安全重跑续传），尚未闭合的窗口跳过。
+- `--delete-sources` 仅在对应窗口合并**成功后**删除源录像（DB 行 + 文件），MiBeeVision 处理中的录像始终跳过。
+- 命令可在 NVR 运行中执行（WAL 并发模型，与 cleanup/repair 一致）；但 timelapse 已启用的摄像头会被拒绝 —— 其窗口归服务器合并调度器所有，需 `--force` 或停服后运行。
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--camera <ids\|all>` | （必填） | 逗号分隔摄像头 ID 或 `all` |
+| `--encoding <enc>` | — | 配合 `--camera all` 按编码过滤（如 `jpeg`） |
+| `--start <YYYY-MM-DD>` | （必填） | 起始窗口日期（配置时区） |
+| `--end <YYYY-MM-DD>` | 昨天 | 结束窗口日期（含） |
+| `--duration <label>` | `natural-day` | 窗口大小：`8h` / `12h` / `24h` / `7d` / `30d` 等 |
+| `--interval <dur>` | 摄像头 `timelapse.interval`，缺省 30s | 帧采样间隔（如 `1s`） |
+| `--fps <n>` | 摄像头 `merge_output_fps`，缺省 10 | 输出播放帧率 |
+| `--delete-sources` / `--no-delete-sources` | 摄像头 `delete_recordings_after_merge` | 覆盖本次运行的源录像删除开关 |
+| `--execute` | dry-run | 真正执行 |
+| `--force` | — | NVR 运行中仍处理 timelapse 已启用的摄像头 |
+| `--config <path>` | `mibee-nvr.yaml` | 配置文件路径 |
 
 ## repair — 数据修复
 

--- a/internal/timelapse/periodic_merge.go
+++ b/internal/timelapse/periodic_merge.go
@@ -536,6 +536,16 @@ func (m *PeriodicMergeManager) runMergePipeline(ctx context.Context, segments []
 //   - 24h: aligned to 00:00 local time
 //   - 7d:  aligned to Monday 00:00 local time
 //   - 30d: aligned to 1st of month 00:00 local time
+//
+// MergeWindowFor returns the [start, end) periodic-merge window containing t
+// for the given duration, aligned per parseMergeRange's rules (natural-day →
+// local midnight, 8h → 00/08/16 local, 7d → Monday 00:00, 30d → 1st of month,
+// …). Exported so the timelapse-merge CLI can enumerate windows across a date
+// range without re-implementing the alignment table.
+func MergeWindowFor(t time.Time, dur time.Duration, loc *time.Location) (time.Time, time.Time) {
+	return parseMergeRange(t, dur, loc)
+}
+
 func parseMergeRange(t time.Time, dur time.Duration, loc *time.Location) (time.Time, time.Time) {
 	if loc == nil {
 		loc = time.UTC

--- a/internal/timelapse/snapshot_capturer_test.go
+++ b/internal/timelapse/snapshot_capturer_test.go
@@ -105,15 +105,14 @@ func TestSnapshotCapturer_CaptureJPEGFrame(t *testing.T) {
 	err := capturer.Start(ctx)
 	require.NoError(t, err)
 
-	// Let it capture a few frames
-	time.Sleep(200 * time.Millisecond)
+	// Wait (bounded) for at least 2 snapshots — poll the observable request
+	// count instead of a fixed sleep so a loaded runner doesn't flake.
+	require.Eventually(t, func() bool {
+		return requestCount.Load() >= 2
+	}, 5*time.Second, 50*time.Millisecond, "expected at least 2 HTTP requests (50ms interval)")
 
 	err = capturer.Stop()
 	require.NoError(t, err)
-
-	// Should have made at least 2 requests
-	assert.GreaterOrEqual(t, requestCount.Load(), int32(2),
-		"expected at least 2 HTTP requests (50ms interval over 200ms)")
 
 	// Should have created at least one segment
 	assert.GreaterOrEqual(t, store.segmentCount(), 1,
@@ -543,16 +542,16 @@ func TestSnapshotCapturer_SegmentRotation(t *testing.T) {
 	err := capturer.Start(ctx)
 	require.NoError(t, err)
 
-	// Wait enough time for at least one rotation
-	time.Sleep(300 * time.Millisecond)
+	// Wait (bounded) for at least one rotation — poll the observable segment
+	// count instead of a fixed sleep so a loaded runner doesn't flake.
+	require.Eventually(t, func() bool {
+		return store.segmentCount() >= 2
+	}, 5*time.Second, 30*time.Millisecond, "expected at least 2 segments with 100ms SegmentDur")
 
 	err = capturer.Stop()
 	require.NoError(t, err)
 
-	// Should have created multiple segments
 	t.Logf("segments created: %d, closed: %d", store.segmentCount(), store.closedCount())
-	assert.GreaterOrEqual(t, store.segmentCount(), 2,
-		"expected at least 2 segments with 100ms SegmentDur over 300ms")
 
 	// Check frames were written to each segment
 	for i, seg := range store.segments {


### PR DESCRIPTION
Closes #736.

## What

`mibee-nvr timelapse-merge` — batch-converts existing video recordings (H264/H265/AVI/MJPEG) of **any camera over any date range** into periodic timelapse merges, executed in-process against the storage DB. This is the CLI counterpart of `POST /api/timelapse/{id}/merge`, replacing the shell-script workflow used for the ov5640 bulk conversion (29 windows / ~316 GB reclaimed).

```bash
# Preview: all JPEG cameras, everything since 2026-08-26
mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26

# Execute: 1-second sampling + delete sources after successful merges
mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 \
  --interval 1s --delete-sources --execute
```

## Design

- **In-process, WAL-concurrent** (same multi-process model as `cleanup`/`repair` CLIs) — no NVR downtime, unlike `merge-cameras`. While the NVR runs, cameras with `timelapse.enabled=true` are refused (`--force` overrides): their windows belong to the server's merge scheduler and the per-process `activeMerges` dedup can't see cross-process merges of the same window. Dry-run bypasses the gate.
- Windows enumerated per `--duration` (default `natural-day`) across `--start..--end` (end defaults to yesterday, so only closed windows). Completed windows are skipped via `FindTimelapseMergeByWindow` → **idempotent re-runs / resumability**. Open windows skipped (#734 semantics — deletion suppressed anyway).
- `--interval` / `--fps` / `--delete-sources` are **per-run overrides** that never mutate camera config (flag > camera timelapse config > defaults, mirroring the API handler's resolution). Source deletion reuses the production deleter chain (`cleanup.BatchDeleteRecordingsWithFiles` — MiBeeVision `processing` rows always skipped).
- Manager construction mirrors `handleTimelapseMergeWithDuration` option-for-option (merge store, duration label, recording-enabled provider, intermediate-mp4 pruner/retention).
- New export `timelapse.MergeWindowFor` (thin wrapper over `parseMergeRange`) so the CLI enumerates windows without duplicating the alignment table.

## Tests

TDD red→green; `go test -race ./cmd/mibee-nvr/ ./internal/timelapse/` green:

- flag parsing (defaults / full set / `--flag=value` / error paths)
- camera resolution (`all` + `--encoding jpeg` filter, unknown IDs)
- window enumeration (natural-day, 8h tiling)
- effective interval/fps/delete resolution matrix
- **E2E**: real MJPEG timestamped-JPEG dirs + DB rows → execute with `--interval 1s --delete-sources` → completed `timelapse_merges` row (exact frame count), non-empty mjpa MP4 on disk, sources deleted (rows + dirs); re-run skips as already merged
- refusal gate: enabled camera + running server → exit 1; dry-run bypasses; `--force` proceeds
- Also hardens two pre-existing `snapshot_capturer_test.go` flakes (fixed sleep + count assert → `require.Eventually` polling) that surfaced under the added parallel load — per the #571 anti-flaky rules these were already non-compliant.

## Docs

`docs/{zh,en}/cli.md`: new section + subcommand overview row.