### PR TITLE
fix(timelapse): merge IO hardening — storage-root tmpdir + CLI self-throttle + paced directory deletion

### DIFF
--- a/cmd/mibee-nvr/throttle_linux.go
+++ b/cmd/mibee-nvr/throttle_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// selfThrottle lowers this process's CPU and IO scheduling priority (#748).
+// Batch timelapse merges at the NVR's default priority starve online
+// recording on saturated ARM + SMR-HDD devices (2026-09-12 incident: load
+// 8-13 for 4.5h, recordings dropped 17→10). nice 19 = lowest CPU priority;
+// IOPRIO_CLASS_BE level 7 = lowest best-effort IO urgency.
+func selfThrottle() error {
+	if err := unix.Setpriority(unix.PRIO_PROCESS, 0, 19); err != nil {
+		return fmt.Errorf("setpriority nice 19: %w", err)
+	}
+	// x/sys does not export the IOPRIO_* user constants; they are stable
+	// kernel ABI (include/linux/ioprio.h).
+	const (
+		ioprioWhoProcess = 1
+		ioprioClassBE    = 2
+		ioprioClassShift = 13
+		ioprioLevelLow   = 7
+	)
+	prio := ioprioClassBE<<ioprioClassShift | ioprioLevelLow
+	if _, _, errno := unix.Syscall(unix.SYS_IOPRIO_SET, ioprioWhoProcess, 0, uintptr(prio)); errno != 0 {
+		return fmt.Errorf("ioprio_set best-effort 7: %w", errno)
+	}
+	return nil
+}

--- a/cmd/mibee-nvr/throttle_other.go
+++ b/cmd/mibee-nvr/throttle_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package main
+
+import "errors"
+
+// selfThrottle is a no-op on platforms without nice/ioprio (dev builds).
+func selfThrottle() error {
+	return errors.New("self-throttle not supported on this platform")
+}

--- a/cmd/mibee-nvr/timelapse_merge.go
+++ b/cmd/mibee-nvr/timelapse_merge.go
@@ -55,17 +55,19 @@ func tlmBoolPtr(b bool) *bool { return &b }
 
 // timelapseMergeFlags carries the parsed `timelapse-merge` subcommand flags.
 type timelapseMergeFlags struct {
-	cfgPath    string
-	camerasArg string // "all" or comma-separated camera IDs
-	encoding   string // optional encoding filter, only used with --camera all
-	start      string // YYYY-MM-DD (required)
-	end        string // YYYY-MM-DD (default: yesterday in config tz)
-	duration   string // window size label (default natural-day)
-	interval   string // frame sampling interval override (Go duration)
-	fps        int    // output fps override (0 = camera config / 10)
-	deleteSrc  *bool  // tri-state: nil = camera config default
-	execute    bool
-	force      bool
+	cfgPath     string
+	camerasArg  string // "all" or comma-separated camera IDs
+	encoding    string // optional encoding filter, only used with --camera all
+	start       string // YYYY-MM-DD (required)
+	end         string // YYYY-MM-DD (default: yesterday in config tz)
+	duration    string // window size label (default natural-day)
+	interval    string // frame sampling interval override (Go duration)
+	fps         int    // output fps override (0 = camera config / 10)
+	deleteSrc   *bool  // tri-state: nil = camera config default
+	execute     bool
+	force       bool
+	noThrottle  bool   // --no-throttle: skip the automatic nice/ionice self-downgrade
+	delThrottle string // --delete-throttle <dur>: per-chunk pause for directory-form source deletion ("0" = off)
 }
 
 const timelapseMergeUsage = `Usage: mibee-nvr timelapse-merge [options]
@@ -86,8 +88,10 @@ Options:
   --fps <n>                Output fps (default: camera merge_output_fps, else 10)
   --delete-sources         Delete source recordings after a successful merge
   --no-delete-sources      Never delete sources for this run
+  --delete-throttle <dur>  Pause between chunks when deleting directory-form sources (default 200ms, "0"=off)
   --execute                Execute (default: dry-run)
   --force                  Process timelapse-enabled cameras while the NVR is running
+  --no-throttle            Skip the automatic self-downgrade (nice 19 + io best-effort)
   --config <path>          Config file path (default: mibee-nvr.yaml)
 
 Examples:
@@ -109,6 +113,8 @@ func parseTimelapseMergeFlags(args []string) (timelapseMergeFlags, int) {
 			f.execute = false
 		case arg == "--force":
 			f.force = true
+		case arg == "--no-throttle":
+			f.noThrottle = true
 		case arg == "--delete-sources":
 			f.deleteSrc = tlmBoolPtr(true)
 		case arg == "--no-delete-sources":
@@ -140,6 +146,9 @@ func parseTimelapseMergeFlags(args []string) (timelapseMergeFlags, int) {
 				v, ok = parseFlag(args, &i, "config")
 			}
 			if !ok {
+				v, ok = parseFlag(args, &i, "delete-throttle")
+			}
+			if !ok {
 				fmt.Fprintf(os.Stderr, "Error: unknown flag %q\n\n%s", arg, timelapseMergeUsage)
 				return f, 1
 			}
@@ -165,6 +174,8 @@ func parseTimelapseMergeFlags(args []string) (timelapseMergeFlags, int) {
 				f.fps = n
 			case strings.HasPrefix(arg, "--config"):
 				f.cfgPath = v
+			case strings.HasPrefix(arg, "--delete-throttle"):
+				f.delThrottle = v
 			}
 		}
 	}
@@ -178,6 +189,13 @@ func parseTimelapseMergeFlags(args []string) (timelapseMergeFlags, int) {
 		d, err := time.ParseDuration(f.interval)
 		if err != nil || d <= 0 {
 			fmt.Fprintf(os.Stderr, "Error: invalid --interval %q (must be a positive Go duration)\n", f.interval)
+			return f, 1
+		}
+	}
+	if f.delThrottle != "" {
+		d, err := time.ParseDuration(f.delThrottle)
+		if err != nil || d < 0 {
+			fmt.Fprintf(os.Stderr, "Error: invalid --delete-throttle %q (must be a non-negative Go duration, e.g. 200ms or 0)\n", f.delThrottle)
 			return f, 1
 		}
 	}
@@ -405,6 +423,27 @@ func runTimelapseMerge(f timelapseMergeFlags, stdout io.Writer, serverRunning bo
 		}()
 	}
 
+	// Self-downgrade before any heavy IO (#748): the 2026-09-12 incident had
+	// the CLI at the NVR's priority starving online recording (load 8-13,
+	// cameras 17→10) — renice after the fact could not undo the storm.
+	if f.execute && !f.noThrottle {
+		if err := selfThrottle(); err != nil {
+			fmt.Fprintf(stdout, "Notice: self-throttle unavailable (%v) — running at default priority\n", err)
+		} else {
+			_, _ = fmt.Fprintln(stdout, "Self-throttled: nice 19, io best-effort level 7 (--no-throttle to disable).")
+		}
+	}
+
+	// Directory-form source deletion pacing (#748): --delete-throttle pauses
+	// between chunks of frame-file unlinks so the ext4 journal keeps up.
+	delThrottle := 200 * time.Millisecond
+	if f.delThrottle != "" {
+		d, err := time.ParseDuration(f.delThrottle)
+		if err == nil {
+			delThrottle = d
+		}
+	}
+
 	var deleter timelapse.SourceRecordingDeleter
 	if f.execute {
 		store, err := storage.NewManager(cfg.Storage.RootDir)
@@ -416,6 +455,9 @@ func runTimelapseMerge(f timelapseMergeFlags, stdout io.Writer, serverRunning bo
 		if err != nil {
 			fmt.Fprintf(stdout, "Error creating cleanup manager: %v\n", err)
 			return 1
+		}
+		if delThrottle > 0 {
+			cleanupMgr.SetDirectoryDeleteThrottle(200, delThrottle)
 		}
 		deleter = cliSourceDeleter{cm: cleanupMgr}
 	}

--- a/cmd/mibee-nvr/timelapse_merge_test.go
+++ b/cmd/mibee-nvr/timelapse_merge_test.go
@@ -494,3 +494,27 @@ func TestTimelapseMergeWindowFor(t *testing.T) {
 	require.Equal(t, time.Date(2026, 9, 5, 8, 0, 0, 0, loc), s)
 	require.Equal(t, time.Date(2026, 9, 5, 16, 0, 0, 0, loc), e)
 }
+
+func TestParseTimelapseMergeFlags_ThrottleFlags(t *testing.T) {
+	t.Helper()
+	// Defaults: self-throttle on, delete pacing at the built-in 200ms.
+	f, code := parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "cam-1", "--start", "2026-09-04"})
+	require.Equal(t, -1, code)
+	require.False(t, f.noThrottle, "self-throttle is on by default")
+	require.Empty(t, f.delThrottle, "delete-throttle default = built-in 200ms")
+
+	// Explicit overrides.
+	f, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "cam-1", "--start", "2026-09-04", "--no-throttle", "--delete-throttle", "500ms"})
+	require.Equal(t, -1, code)
+	require.True(t, f.noThrottle)
+	require.Equal(t, "500ms", f.delThrottle)
+
+	// "0" disables pacing.
+	f, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "cam-1", "--start", "2026-09-04", "--delete-throttle", "0"})
+	require.Equal(t, -1, code)
+	require.Equal(t, "0", f.delThrottle)
+
+	// Invalid durations are rejected.
+	_, code = parseTimelapseMergeFlags([]string{"mibee-nvr", "timelapse-merge", "--camera", "cam-1", "--start", "2026-09-04", "--delete-throttle", "fast"})
+	require.Equal(t, 1, code, "invalid --delete-throttle must exit 1")
+}

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -141,6 +141,9 @@ Behavior notes:
 - Windows (default `natural-day`) are enumerated across the date range and merged one by one; windows with an existing completed merge are skipped (safe to re-run and resume), open windows are skipped.
 - `--delete-sources` deletes source recordings (DB rows + files) only after the window's merge **succeeded**; recordings being processed by MiBeeVision are always skipped.
 - The command may run while the NVR is live (WAL concurrency, same as cleanup/repair); cameras with timelapse enabled are refused though — their windows belong to the server's merge scheduler (use `--force` or stop the server).
+- **Self-downgrades on execute** (nice 19 + lowest best-effort IO class; `--no-throttle` disables): merges at the NVR's default priority starve online recording (2026-09-12 incident: load 8-13 for 4.5h, recordings dropped 17→10; renicing after the fact could not undo the storm).
+- **Directory-form source deletion is rate-limited** (pause every 200 files, `--delete-throttle`): unlinking the millions of small files in MJPEG/timelapse frame directories saturates the ext4 journal (jbd2) for tens of minutes and slows all disk IO.
+- Merge intermediates (frame extract/copy dirs) are written under the **storage root** at `<root>/periodic-merge/tmp/`, never the system `/tmp` (a 1s-sampled natural-day window needs ~3.5-7GB and small root partitions hit ENOSPC); merge output is generated streaming (#747), so memory use is independent of window size.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -152,8 +155,10 @@ Behavior notes:
 | `--interval <dur>` | camera `timelapse.interval`, else 30s | Frame sampling interval (e.g. `1s`) |
 | `--fps <n>` | camera `merge_output_fps`, else 10 | Output playback fps |
 | `--delete-sources` / `--no-delete-sources` | camera `delete_recordings_after_merge` | Override source deletion for this run |
+| `--delete-throttle <dur>` | `200ms` | Pause between chunks when deleting directory-form sources; `0` disables |
 | `--execute` | dry-run | Actually execute |
 | `--force` | — | Process timelapse-enabled cameras while the NVR is running |
+| `--no-throttle` | — | Skip the automatic self-downgrade (nice 19 + IO best-effort) |
 | `--config <path>` | `mibee-nvr.yaml` | Config file path |
 
 ## repair — Data Repair

--- a/docs/zh/cli.md
+++ b/docs/zh/cli.md
@@ -141,6 +141,9 @@ mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 \
 - 按窗口（默认 `natural-day`，即自然日）枚举日期范围，逐窗口执行；已完成的窗口自动跳过（可安全重跑续传），尚未闭合的窗口跳过。
 - `--delete-sources` 仅在对应窗口合并**成功后**删除源录像（DB 行 + 文件），MiBeeVision 处理中的录像始终跳过。
 - 命令可在 NVR 运行中执行（WAL 并发模型，与 cleanup/repair 一致）；但 timelapse 已启用的摄像头会被拒绝 —— 其窗口归服务器合并调度器所有，需 `--force` 或停服后运行。
+- **执行时自动自降级**（nice 19 + IO best-effort 最低档，`--no-throttle` 关闭）：大窗口合并与在线录像平权竞争会拖垮录像（2026-09-12 事故：load 8-13 持续 4.5h，录像 17→10 台），事后 renice 无法挽回。
+- **目录形源删除自动限速**（每 200 个文件暂停 `--delete-throttle`）：MJPEG/延时帧目录的百万级小文件 unlink 会让 ext4 日志（jbd2）饱和数十分钟，拖慢所有磁盘 IO。
+- 合并中间产物（帧提取/复制目录）写在**存储根** `<root>/periodic-merge/tmp/` 下，不再用系统 `/tmp`（1s 采样全天窗口约需 3.5-7GB，小根分区会 ENOSPC）；合并输出采用流式生成（#747），内存占用与窗口大小无关。
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
@@ -152,8 +155,10 @@ mibee-nvr timelapse-merge --camera all --encoding jpeg --start 2026-08-26 \
 | `--interval <dur>` | 摄像头 `timelapse.interval`，缺省 30s | 帧采样间隔（如 `1s`） |
 | `--fps <n>` | 摄像头 `merge_output_fps`，缺省 10 | 输出播放帧率 |
 | `--delete-sources` / `--no-delete-sources` | 摄像头 `delete_recordings_after_merge` | 覆盖本次运行的源录像删除开关 |
+| `--delete-throttle <dur>` | `200ms` | 删除目录形源（MJPEG/延时帧目录）时的分块暂停，`0` 关闭 |
 | `--execute` | dry-run | 真正执行 |
 | `--force` | — | NVR 运行中仍处理 timelapse 已启用的摄像头 |
+| `--no-throttle` | — | 跳过启动时自动自降级（nice 19 + IO best-effort） |
 | `--config <path>` | `mibee-nvr.yaml` | 配置文件路径 |
 
 ## repair — 数据修复

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -11,7 +11,9 @@ package cleanup
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -57,6 +59,15 @@ type CleanupManager struct {
 	eventBus                   *event.EventBus
 	consecutivePassiveFailures int  // tracks consecutive PASSIVE checkpoint failures for escalation to TRUNCATE
 	motionAwareDisk            bool // disk-threshold path deletes boring-first (issue #435); default true
+
+	// Directory-form deletion pacing (#748): MJPEG/timelapse sources are frame
+	// directories holding up to hundreds of thousands of small files (a 1s
+	// natural-day window ≈ 600K). Unthrottled recursive removal saturates the
+	// ext4 journal (jbd2 D-state) and starves online recording IO for minutes
+	// even after the deleting process exits. When paced, every dirDeleteChunk
+	// unlinked files are followed by a ctx-aware dirDeleteSleep pause.
+	dirDeleteChunk int
+	dirDeleteSleep time.Duration
 }
 
 // NewCleanupManager creates a new CleanupManager with the given config.
@@ -235,6 +246,58 @@ func (cm *CleanupManager) SetEventBus(bus *event.EventBus) {
 	cm.eventBus = bus
 }
 
+// SetDirectoryDeleteThrottle paces directory-form recording deletion (#748):
+// after every chunk files removed inside a frame directory (MJPEG/timelapse
+// trees with up to hundreds of thousands of small files), the deletion loop
+// sleeps for d so the ext4 journal (jbd2) can drain and online recording IO
+// is not starved. chunk <= 0 or d <= 0 disables pacing (legacy behavior).
+func (cm *CleanupManager) SetDirectoryDeleteThrottle(chunk int, d time.Duration) {
+	if cm == nil {
+		return
+	}
+	cm.dirDeleteChunk, cm.dirDeleteSleep = chunk, d
+}
+
+// deleteRecordingFile deletes one recording path, pacing directory-form
+// (frame-tree) deletions when throttling is configured. Plain files keep the
+// storage-manager semantics (including the .vodidx sidecar); paced directories
+// are unlinked file-by-file in chunks and the remaining empty tree is swept by
+// a final RemoveAll. A ctx cancellation mid-walk leaves a partially-deleted
+// tree — the orphan scanner reclaims it later.
+func (cm *CleanupManager) deleteRecordingFile(ctx context.Context, path string) error {
+	if cm.dirDeleteChunk <= 0 || cm.dirDeleteSleep <= 0 {
+		return cm.store.DeleteFile(path)
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return cm.store.DeleteFile(path)
+	}
+	n := 0
+	if err := filepath.WalkDir(path, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if err := os.Remove(p); err != nil {
+			return err
+		}
+		n++
+		if n%cm.dirDeleteChunk == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(cm.dirDeleteSleep):
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("paced delete %q: %w", path, err)
+	}
+	return os.RemoveAll(path)
+}
+
 // adaptiveBatchSleep sleeps between batch delete operations, adapting the sleep
 // duration based on the current WAL file size. Larger WAL = longer sleep to give
 // the checkpoint process time to catch up.
@@ -366,7 +429,7 @@ func (cm *CleanupManager) BatchDeleteRecordingsWithFiles(ctx context.Context, re
 				logger.Warn("failed to delete merged file", "merge_path", rec.MergePath, "error", err)
 			}
 		}
-		if err := cm.store.DeleteFile(rec.FilePath); err != nil {
+		if err := cm.deleteRecordingFile(ctx, rec.FilePath); err != nil {
 			logger.Warn("failed to delete file", "file_path", rec.FilePath, "error", err)
 		}
 		// Ambient archive sidecar shares the recording's lifetime (#496).

--- a/internal/cleanup/cleanup_throttle_test.go
+++ b/internal/cleanup/cleanup_throttle_test.go
@@ -1,0 +1,147 @@
+// Directory-form deletion pacing tests (#748): MJPEG/timelapse frame-tree
+// recordings must be unlinked in paced chunks so the ext4 journal (jbd2)
+// keeps up, while plain-file recordings keep the legacy unpaced path.
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// TestBatchDeleteRecordingsWithFiles_DirThrottlePacing deletes an MJPEG
+// frame directory with pacing enabled and verifies the recording is fully
+// removed and the chunk sleeps actually happened.
+func TestBatchDeleteRecordingsWithFiles_DirThrottlePacing(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cm, err := NewCleanupManager(env.db, env.store, defaultCleanupConfig())
+	if err != nil {
+		t.Fatalf("NewCleanupManager: %v", err)
+	}
+	cm.SetDirectoryDeleteThrottle(3, 25*time.Millisecond)
+
+	dir := filepath.Join(env.store.RootDir(), "cam1", "frames")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 10 {
+		p := filepath.Join(dir, fmt.Sprintf("frame_%06d.jpg", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	rec := &model.Recording{
+		ID: "mjpeg-1", CameraID: "cam1", FilePath: dir, Format: model.FormatMJPEG,
+		StartedAt: now.Add(-2 * time.Hour), EndedAt: now.Add(-time.Hour),
+		MergeStatus: model.MergeStatusPending,
+	}
+	if err := env.db.InsertRecording(context.Background(), rec); err != nil {
+		t.Fatalf("InsertRecording: %v", err)
+	}
+
+	start := time.Now()
+	deleted, err := cm.BatchDeleteRecordingsWithFiles(context.Background(), []model.Recording{*rec}, "timelapse_source_merged")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("BatchDeleteRecordingsWithFiles: %v", err)
+	}
+	if len(deleted) != 1 || deleted[0] != "mjpeg-1" {
+		t.Fatalf("deleted = %v, want [mjpeg-1]", deleted)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("frame dir still exists after paced deletion")
+	}
+	// 10 files with chunk 3 → sleeps after files 3, 6 and 9 → ≥ 3 × 25ms.
+	if elapsed < 60*time.Millisecond {
+		t.Errorf("paced deletion finished in %v — chunk sleeps did not happen", elapsed)
+	}
+}
+
+// TestDeleteRecordingFile_ThrottleDisabledKeepsLegacyPath verifies the
+// unpaced fallback: with no throttle configured a directory goes through the
+// storage manager's RemoveAll (fast, no pacing).
+func TestDeleteRecordingFile_ThrottleDisabledKeepsLegacyPath(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cm, err := NewCleanupManager(env.db, env.store, defaultCleanupConfig())
+	if err != nil {
+		t.Fatalf("NewCleanupManager: %v", err)
+	}
+
+	dir := filepath.Join(env.store.RootDir(), "cam1", "frames")
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "frame.jpg"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.deleteRecordingFile(context.Background(), dir); err != nil {
+		t.Fatalf("deleteRecordingFile: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("dir still exists after unpaced deletion")
+	}
+}
+
+// TestDeleteRecordingFile_PlainFileWithThrottleEnabled verifies plain files
+// bypass the paced walk (storage-manager semantics, incl. sidecars).
+func TestDeleteRecordingFile_PlainFileWithThrottleEnabled(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cm, err := NewCleanupManager(env.db, env.store, defaultCleanupConfig())
+	if err != nil {
+		t.Fatalf("NewCleanupManager: %v", err)
+	}
+	cm.SetDirectoryDeleteThrottle(3, 25*time.Millisecond)
+
+	file := filepath.Join(env.store.RootDir(), "plain.mp4")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.deleteRecordingFile(context.Background(), file); err != nil {
+		t.Fatalf("deleteRecordingFile: %v", err)
+	}
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Errorf("plain file still exists")
+	}
+}
+
+// TestDeleteRecordingFile_PacedCtxCancel verifies a cancelled context stops
+// the paced walk (partial tree left for the orphan scanner) instead of
+// spinning forever.
+func TestDeleteRecordingFile_PacedCtxCancel(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.close(t)
+
+	cm, err := NewCleanupManager(env.db, env.store, defaultCleanupConfig())
+	if err != nil {
+		t.Fatalf("NewCleanupManager: %v", err)
+	}
+	cm.SetDirectoryDeleteThrottle(2, 50*time.Millisecond)
+
+	dir := filepath.Join(env.store.RootDir(), "cam1", "frames")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 6 {
+		p := filepath.Join(dir, fmt.Sprintf("frame_%06d.jpg", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := cm.deleteRecordingFile(ctx, dir); err == nil {
+		t.Fatal("expected error from cancelled paced walk")
+	}
+}

--- a/internal/timelapse/periodic_merge.go
+++ b/internal/timelapse/periodic_merge.go
@@ -201,6 +201,38 @@ func (m *PeriodicMergeManager) HasSourceDeleter() bool {
 	return m.sourceDeleter != nil
 }
 
+// tempDirBase returns the parent directory for merge intermediate frame
+// directories (#746). Dense-sampling windows (e.g. 1s over a natural day ≈
+// 86,400 frames × 40–80KB, ×2 during extract+copy phases) need several GB —
+// the system /tmp usually sits on the small root partition and fills up
+// (ENOSPC on Banana Pi-class devices), so intermediates live under the merge
+// data dir on the storage root instead. Empty dataDir (never in production)
+// falls back to the os.MkdirTemp default.
+func (m *PeriodicMergeManager) tempDirBase() string {
+	if m.dataDir == "" {
+		return ""
+	}
+	return filepath.Join(m.dataDir, "tmp")
+}
+
+// TempDirBase exposes the effective intermediate-frame directory base.
+// Exposed for wiring regression tests.
+func (m *PeriodicMergeManager) TempDirBase() string {
+	return m.tempDirBase()
+}
+
+// mkdirTemp creates a unique directory for merge intermediates under
+// tempDirBase (created on demand). Pattern semantics match os.MkdirTemp.
+func (m *PeriodicMergeManager) mkdirTemp(pattern string) (string, error) {
+	base := m.tempDirBase()
+	if base != "" {
+		if err := os.MkdirAll(base, 0o755); err != nil {
+			return "", fmt.Errorf("create temp base %s: %w", base, err)
+		}
+	}
+	return os.MkdirTemp(base, pattern)
+}
+
 // mergeWindowStillOpen reports whether the current Run's window end is in the
 // future (e.g. a mid-day manual preview of a natural-day window). Source
 // deletion must be suppressed in that case — see runPerCodecMerge.

--- a/internal/timelapse/periodic_merge_probe.go
+++ b/internal/timelapse/periodic_merge_probe.go
@@ -227,7 +227,7 @@ func (m *PeriodicMergeManager) extractRecordingFrames(ctx context.Context, camer
 	sourcesByGroup := make(map[string][]model.Recording)
 
 	for codec, codecRecs := range codecRecordings {
-		tmpDir, err := os.MkdirTemp("", fmt.Sprintf("periodic_extract_%s_*", codec))
+		tmpDir, err := m.mkdirTemp(fmt.Sprintf("periodic_extract_%s_*", codec))
 		if err != nil {
 			// Clean up previously created dirs on error.
 			for _, d := range tmpDirs {

--- a/internal/timelapse/periodic_merge_strategies.go
+++ b/internal/timelapse/periodic_merge_strategies.go
@@ -221,7 +221,7 @@ func (m *PeriodicMergeManager) goMergeSegments(ctx context.Context, segments []m
 		return fmt.Errorf("periodic merge: create output dir: %w", err)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "periodic_go_merge_*")
+	tmpDir, err := m.mkdirTemp("periodic_go_merge_*")
 	if err != nil {
 		return fmt.Errorf("periodic merge: create temp dir: %w", err)
 	}

--- a/internal/timelapse/periodic_merge_tmp_test.go
+++ b/internal/timelapse/periodic_merge_tmp_test.go
@@ -1,0 +1,90 @@
+// Periodic-merge intermediate-directory placement tests (#746): extraction
+// and copy temp dirs must live under the merge data dir (storage-root volume)
+// instead of the system /tmp — dense-sampling windows need several GB and the
+// root partition on Banana Pi-class devices holds only ~9GB free.
+package timelapse
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+)
+
+// TestPeriodicMergeManager_TempDirBase verifies the derived base: empty
+// dataDir keeps the os.MkdirTemp default; a data dir yields <dataDir>/tmp.
+func TestPeriodicMergeManager_TempDirBase(t *testing.T) {
+	t.Parallel()
+	if got := (&PeriodicMergeManager{}).TempDirBase(); got != "" {
+		t.Errorf("empty dataDir: TempDirBase() = %q, want \"\" (os default)", got)
+	}
+	dataDir := t.TempDir()
+	mgr := NewPeriodicMergeManager(&mockRecordingLister{}, &mockMergeStatusUpdater{}, nil, 30, dataDir, time.Hour, nil)
+	want := filepath.Join(dataDir, "tmp")
+	if got := mgr.TempDirBase(); got != want {
+		t.Errorf("TempDirBase() = %q, want %q", got, want)
+	}
+	dir, err := mgr.mkdirTemp("periodic_probe_*")
+	if err != nil {
+		t.Fatalf("mkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	if filepath.Dir(dir) != want {
+		t.Errorf("mkdirTemp created %q, want parent %q", dir, want)
+	}
+}
+
+// TestExtractRecordingFrames_TempDirsUnderStorageRoot runs the real
+// extraction path and asserts every intermediate dir lands under
+// <dataDir>/tmp with nothing leaking into the system temp directory.
+func TestExtractRecordingFrames_TempDirsUnderStorageRoot(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	cameraID := "test-cam"
+	windowStart := time.Date(2026, 9, 9, 10, 0, 0, 0, time.Local)
+
+	srcDir := filepath.Join(dataDir, "segA")
+	writeMJPEGDirFixture(t, srcDir, windowStart, 30, time.Second, 0)
+
+	lister := &mockRecordingListerMultiFormat{
+		videoSegments: []model.Recording{
+			{ID: "vid-mjpeg-1", CameraID: cameraID, FilePath: srcDir, Format: model.FormatMJPEG, StartedAt: windowStart},
+		},
+	}
+	mgr := NewPeriodicMergeManager(
+		lister, &mockMergeStatusUpdater{}, nil, 30, dataDir, 8*time.Hour, nil,
+		WithRecordingEnabledProvider(func(string) bool { return true }),
+		WithExtractionInterval(5*time.Second),
+	)
+
+	_, tmpDirs, _, err := mgr.extractRecordingFrames(context.Background(), cameraID, windowStart, windowStart.Add(8*time.Hour))
+	if err != nil {
+		t.Fatalf("extractRecordingFrames: %v", err)
+	}
+	defer func() {
+		for _, d := range tmpDirs {
+			os.RemoveAll(d)
+		}
+	}()
+	if len(tmpDirs) == 0 {
+		t.Fatal("expected at least one extraction temp dir")
+	}
+	wantBase := filepath.Join(dataDir, "tmp")
+	for _, d := range tmpDirs {
+		if filepath.Dir(d) != wantBase {
+			t.Errorf("extraction dir %q not under %q", d, wantBase)
+		}
+	}
+	entries, err := os.ReadDir(os.TempDir())
+	if err == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), "periodic_extract_") {
+				t.Errorf("system temp leak: %s", e.Name())
+			}
+		}
+	}
+}

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -832,6 +832,10 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 			cleanupMgr.SetTranscodeHistoryRetention(hr)
 		}
 	}
+	// Pace directory-form (MJPEG/timelapse frame-tree) recording deletion so
+	// the opt-in delete_recordings_after_merge cleanup cannot saturate the
+	// ext4 journal (jbd2) and starve online recording IO (#748).
+	cleanupMgr.SetDirectoryDeleteThrottle(200, 200*time.Millisecond)
 	deps.cleanupMgr = cleanupMgr
 	deps.archiveDeleter = cleanup.NewArchiveDeleter(db, store)
 


### PR DESCRIPTION
Fixes #746
Fixes #748

## #746 — 合并中间产物改放存储根

`PeriodicMergeManager` 的两个 `os.MkdirTemp("")`（`periodic_extract_*` 帧提取 / `periodic_go_merge_*` 帧复制）改为 `m.mkdirTemp()`，落在 `<dataDir>/tmp`（即 `<root>/periodic-merge/tmp`）——与合并输出同卷。1s 采样的 natural-day 窗口需要 ~3.5-7GB（两阶段叠加 2×），M5 根分区只剩 9.3GB 时系统 /tmp 直接 ENOSPC。dataDir 为空（仅测试）回退系统默认。保留 defer 清理语义不变。

## #748 — CLI 自降级 + 目录删除限速（09-12 事故复盘）

- **`timelapse-merge --execute` 启动即自降级**：`nice 19` + `IOPRIO_CLASS_BE level 7`（x/sys 原生 syscall；linux 构建，非 linux 平台 no-op），`--no-throttle` 逃生口。事故中 CLI 与在线录像平权竞争 4.5h（load 8-13，录像 17→10），事后 renice 无法挽回风暴。
- **目录形源删除限速**：`CleanupManager.SetDirectoryDeleteThrottle(chunk, d)` —— MJPEG/timelapse 帧目录（单窗口可达 ~600K 小文件）的删除改为分块 unlink + ctx 感知暂停（每 200 文件），最后 RemoveAll 清空目录骨架；普通文件路径不变（含 .vodidx sidecar 语义）；ctx 取消留下部分树由孤儿扫描回收。服务端 `delete_recordings_after_merge` 路径（builders.go 装配）与 CLI（`--delete-throttle`，默认 200ms，`0` 关闭）都已接线。
- **文档**：zh/en `cli.md` timelapse-merge 章节补齐 1s 大窗口三件套——tmpdir 位置（自动）、流式输出（#747 已修）、IO 节流。

## 验证

- 新增测试：`TestPeriodicMergeManager_TempDirBase`、`TestExtractRecordingFrames_TempDirsUnderStorageRoot`（真实提取路径断言落在 dataDir/tmp 且系统 /tmp 零泄漏）、`TestBatchDeleteRecordingsWithFiles_DirThrottlePacing`（分块睡眠实证 ≥3×25ms + 全量删除）、`ThrottleDisabledKeepsLegacyPath`/`PlainFileWithThrottleEnabled`/`PacedCtxCancel`、CLI 旗标解析。
- 包级回归全绿：`internal/timelapse`、`internal/cleanup`、`cmd/mibee-nvr`、`pkg/app`；golangci-lint 0 issues。
- **M5 实机**（v0.12.0-60-g2dea64c4-tlmerge-11）：`timelapse-merge --execute` 输出 `Self-throttled: nice 19, io best-effort level 7`（arm64 双 syscall 实证成功）；服务健康 18 相机 13 recording（= 事故前慢性基线）；journal 零 ERROR。