### PR TITLE
fix(update): git-describe dev builds no longer report a phantom available update

### DIFF
--- a/internal/update/checker.go
+++ b/internal/update/checker.go
@@ -262,6 +262,10 @@ func (c *Checker) fetchAndCache(ctx context.Context) (Status, error) {
 //     avoids false positives on local/dev builds)
 //   - "v" prefix is optional (semver.Compare normalizes it)
 //   - prereleases: per semver, v1.0.0-beta < v1.0.0
+//   - git-describe dev builds (v1.2.0-61-g<sha>[-local]) sit AHEAD of their
+//     base tag even though semver orders prereleases below the release —
+//     the release tag itself must not look "newer" (otherwise every
+//     main-built deployment between releases shows a phantom update dot)
 //   - equal versions → false (no downgrades either)
 func isNewer(current, candidate string) bool {
 	cur := ensureV(strings.TrimSpace(current))
@@ -269,7 +273,48 @@ func isNewer(current, candidate string) bool {
 	if !semver.IsValid(cur) || !semver.IsValid(cand) {
 		return false
 	}
+	if isDescribeBuild(cur) {
+		// Compare against the BASE tag ("v1.2.0"): a describe build contains
+		// the tag plus N commits, so the tag and anything older are not newer.
+		base := cur[:len(cur)-len(semver.Prerelease(cur))-len(semver.Build(cur))]
+		return semver.Compare(cand, base) > 0
+	}
 	return semver.Compare(cand, cur) > 0
+}
+
+// isDescribeBuild reports whether v is a git-describe style dev build, i.e.
+// its prerelease starts with "<N>-g<sha>" (optionally with local suffix
+// segments after — e.g. "v0.12.0-61-g1f07d1ac-tlmerge-15" from `git
+// describe` + deploy naming). Distinguishes them from real prereleases
+// (-rc/-beta), which keep strict semver ordering.
+func isDescribeBuild(v string) bool {
+	pre := strings.TrimPrefix(semver.Prerelease(v), "-")
+	if pre == "" {
+		return false
+	}
+	// Prerelease identifiers are dot-separated; a describe suffix arrives as
+	// hyphenated identifiers "61-g1f07d1ac-tlmerge-15" (one identifier set
+	// when no dots, which is how git describe emits it).
+	first := strings.SplitN(pre, ".", 2)[0]
+	parts := strings.Split(first, "-")
+	if len(parts) < 2 || parts[0] == "" {
+		return false
+	}
+	for _, r := range parts[0] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	sha := strings.TrimPrefix(parts[1], "g")
+	if sha == parts[1] || len(sha) < 7 || len(sha) > 40 {
+		return false
+	}
+	for _, r := range sha {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
 }
 
 // ensureV adds the "v" prefix that golang.org/x/mod/semver requires for

--- a/internal/update/checker_test.go
+++ b/internal/update/checker_test.go
@@ -30,6 +30,15 @@ func TestIsNewer(t *testing.T) {
 		{"empty local build never reports update", "", "v0.10.0", false},
 		{"non-semver local build", "dirty-build", "v0.10.0", false},
 		{"non-semver remote", "v0.10.0", "latest", false},
+		// git-describe dev builds sit AHEAD of their base tag: the tag itself
+		// must not look "newer" (phantom update dot on main-built deploys).
+		{"describe build vs its base tag", "v0.12.0-61-g1f07d1ac", "v0.12.0", false},
+		{"describe build + local suffix vs base tag", "v0.12.0-61-g1f07d1ac-tlmerge-15", "v0.12.0", false},
+		{"describe build vs older tag", "v0.12.0-61-g1f07d1ac", "v0.11.9", false},
+		{"describe build vs genuinely newer release", "v0.12.0-61-g1f07d1ac", "v0.13.0", true},
+		{"describe build vs newer rc of a later minor", "v0.12.0-61-g1f07d1ac", "v0.13.0-rc1", true},
+		{"six-hex sha is not a describe build (strict semver)", "v0.12.0-61-g1f07d1", "v0.12.0", true},
+		{"not-a-describe suffix keeps semver order", "v0.10.0-beta.1", "v0.10.0", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## 问题

部署版本为 git-describe 形态（如 `v0.12.0-61-g1f07d1ac-tlmerge-15`，即 `make deploy` 从 main 构建的常态）时，导航「设置」旁会亮起「有可用更新」琥珀点——但该版本实际比 tag 领先 61 个提交。

## 根因

`isNewer` 用 x/mod/semver 严格比较：`-61-g…` 后缀按 semver 是 v0.12.0 的**预发布**（< 正式版），于是已发布的 v0.12.0 被判"更新"。**任何两次 release 之间从 main 构建的部署都会误报**，不只测试版。

## 修复

- `isDescribeBuild`：识别 prerelease 首标识符为 `<N>-g<sha≥7hex>` 的 describe 形态（`-rc`/`-beta`/6 位 hex 不算）。
- describe 版与 **BASE tag** 比较：tag 本身及更旧版本不再是"更新"；真正的新正式版照常提示。
- 真预发布语义不变。

## 验证

- `TestIsNewer` +7 用例全绿（describe vs tag/更旧 tag/真新版/新版 rc/6-hex 文档化用例等）。
- M5 实机：修复前 `update_available: true`（幻影灯亮），修复后 `false`、页面 `.update-dot` 0 个。