### PR TITLE
feat(storage): per-segment writer state — FD retention, write coalescing, lock sharding (#750)

### DIFF
--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -28,7 +28,13 @@ type Manager struct {
 	rootDir     string
 	cameraRoots map[string]string
 	metrics     *metrics.Metrics
-	mu          sync.Mutex
+
+	// Per-segment writer states (#750), keyed by temp path: classification,
+	// camera attribution, retained FD + coalescing buffer for the append path.
+	// Replaces the former global write mutex — each state carries its own lock
+	// so cameras no longer serialize through one another.
+	statesMu      sync.RWMutex
+	segmentStates map[string]*segmentWriter
 
 	// Health tracking (per-camera)
 	healthMu      sync.Mutex
@@ -59,6 +65,7 @@ func NewManager(rootDir string, opts ...*metrics.Metrics) (*Manager, error) {
 		metrics:          m,
 		cameraHealths:    make(map[string]*cameraHealth),
 		segmentCameraMap: make(map[string]string),
+		segmentStates:    make(map[string]*segmentWriter),
 	}, nil
 }
 
@@ -210,6 +217,7 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 		// already protected (2026-09-08 incident: the scan deleted an active
 		// segment temp mid-write).
 		m.registerTempPath(tempPath, cameraID)
+		m.registerWriterState(tempPath, cameraID, false)
 		f, err := os.Create(tempPath)
 		if err != nil {
 			m.recordWriteFailure(cameraID)
@@ -223,6 +231,7 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 		finalPath = filepath.Join(hourDir, fmt.Sprintf("%s_%s_%s", cameraID, ts, uuid))
 
 		m.registerTempPath(tempPath, cameraID)
+		m.registerWriterState(tempPath, cameraID, true)
 		if err := os.MkdirAll(tempPath, 0o755); err != nil {
 			m.recordWriteFailure(cameraID)
 			m.unregisterTempPath(tempPath)
@@ -233,6 +242,7 @@ func (m *Manager) CreateSegment(cameraID string, format string) (tempPath string
 		tempPath = filepath.Join(hourDir, uuid+".tmp")
 		finalPath = filepath.Join(hourDir, fmt.Sprintf("%s_%s_%s.avi", cameraID, ts, uuid))
 		m.registerTempPath(tempPath, cameraID)
+		m.registerWriterState(tempPath, cameraID, false)
 		f, err := os.Create(tempPath)
 		if err != nil {
 			m.recordWriteFailure(cameraID)
@@ -295,16 +305,24 @@ func (m *Manager) recordFinalizeFailure(tempPath string, err error) {
 }
 
 // CloseSegment atomically finalizes a segment by syncing and renaming .tmp to final path.
+// Segments with writer state (#750) finalize through the retained FD — any
+// coalesced bytes are flushed first; segments written through external
+// handles (the MP4 muxer, merge outputs) fall back to the reopen-and-sync
+// path, preserving the original behavior.
 func (m *Manager) CloseSegment(tempPath, finalPath string) error {
-	// Check if temp is a directory (MJPEG) or file (H.264)
-	info, err := os.Stat(tempPath)
-	if err != nil {
-		m.recordFinalizeFailure(tempPath, err)
+	st, serr := m.stateFor(tempPath)
+	if serr != nil {
+		// No state and classification failed (external temp that is already
+		// gone, or stat trouble) — identical to the pre-#750 behavior.
+		m.recordFinalizeFailure(tempPath, serr)
 		m.unregisterTempPath(tempPath)
-		return fmt.Errorf("storage: temp path not found: %w", err)
+		return fmt.Errorf("storage: temp path not found: %w", serr)
 	}
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	isDir := st.isDir
 
-	if info.IsDir() {
+	if isDir {
 		// Sync the directory for MJPEG
 		dirFd, err := os.Open(tempPath)
 		if err != nil {
@@ -326,19 +344,27 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 			return fmt.Errorf("storage: failed to rename temp dir to final: %w", err)
 		}
 	} else {
-		// Sync and close the file for H.264
-		f, err := os.OpenFile(tempPath, os.O_WRONLY, 0)
-		if err != nil {
-			m.recordFinalizeFailure(tempPath, err)
-			m.unregisterTempPath(tempPath)
-			return fmt.Errorf("storage: cannot open temp file for sync: %w", err)
-		}
-		if err := f.Sync(); err != nil {
+		// File form: finalize the retained FD when this segment wrote through
+		// WriteFrame (flushes the coalescing buffer); otherwise reopen-and-sync
+		// for externally written temps (muxer/merge outputs already closed
+		// their own handles before calling CloseSegment).
+		if st == nil || st.file == nil {
+			f, err := openFileFn(tempPath, os.O_WRONLY, 0)
+			if err != nil {
+				m.recordFinalizeFailure(tempPath, err)
+				m.unregisterTempPath(tempPath)
+				return fmt.Errorf("storage: cannot open temp file for sync: %w", err)
+			}
+			if err := f.Sync(); err != nil {
+				f.Close()
+				m.RecordWriteFailureForPath(tempPath)
+				return fmt.Errorf("storage: failed to sync temp file: %w", err)
+			}
 			f.Close()
+		} else if err := st.finalize(); err != nil {
 			m.RecordWriteFailureForPath(tempPath)
-			return fmt.Errorf("storage: failed to sync temp file: %w", err)
+			return fmt.Errorf("storage: failed to finalize temp file: %w", err)
 		}
-		f.Close()
 
 		// Atomic rename
 		if err := os.Rename(tempPath, finalPath); err != nil {
@@ -348,69 +374,77 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 		}
 	}
 
-	// Success — unregister mapping.
+	// Success — unregister mapping (also drops the writer state).
 	m.unregisterTempPath(tempPath)
 	return nil
 }
 
 // WriteFrame writes data to a segment's temp path.
-// For H.264: appends data to the temp file.
+// For H.264/AVI: appends data through the segment's coalescing buffer (#750).
 // For MJPEG: creates a timestamped .jpg file in the temp directory.
+//
+// Classification and camera attribution come from the per-segment writer
+// state (registered at CreateSegment, or classified once lazily) — no
+// per-frame stat or path→camera map lookup. Locking is per segment, so
+// cameras do not serialize through a global mutex.
 func (m *Manager) WriteFrame(tempPath string, data []byte) (int, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	st, serr := m.stateFor(tempPath)
+	if serr != nil {
+		// Classification stat failed. A vanished temp is a rotation/cleanup
+		// artifact, not an I/O error — counting it escalates a healthy camera
+		// to Failed and the skip-before-write recorders then never record the
+		// successful write that would reset the state (#413). Anything else
+		// (permissions, EIO) is a real failure.
+		if errors.Is(serr, fs.ErrNotExist) {
+			slog.Warn("storage: temp segment vanished before write — frame dropped, storage healthy",
+				"path", tempPath)
+			return 0, fmt.Errorf("storage: temp path not accessible: %w", serr)
+		}
+		m.recordWriteFailure(m.lookupCameraByPath(tempPath))
+		return 0, fmt.Errorf("storage: temp path not accessible: %w", serr)
+	}
 
-	info, err := os.Stat(tempPath)
+	n, err := st.writeFrame(data)
 	if err != nil {
-		// A vanished temp is a rotation/cleanup artifact, not an I/O error —
-		// same rationale as the CloseSegment gate: counting it escalates a
-		// healthy camera to Failed and the skip-before-write recorders then
-		// never record the successful write that would reset the state.
+		// A vanished temp (or a write racing segment finalize) is a
+		// rotation/cleanup artifact, not an I/O error — same rationale
+		// as the classification gate above (#413).
 		if errors.Is(err, fs.ErrNotExist) {
 			slog.Warn("storage: temp segment vanished before write — frame dropped, storage healthy",
 				"path", tempPath)
-			return 0, fmt.Errorf("storage: temp path not accessible: %w", err)
+			m.dropWriterState(tempPath)
+			return n, err
 		}
-		m.RecordWriteFailureForPath(tempPath)
-		return 0, fmt.Errorf("storage: temp path not accessible: %w", err)
+		m.recordWriteFailure(st.cameraID)
+		return n, err
 	}
 
-	if info.IsDir() {
-		// MJPEG: write individual JPEG file with timestamp name
-		ts := time.Now().Format("20060102_150405.000")
-		jpgPath := filepath.Join(tempPath, ts+".jpg")
-		if err := os.WriteFile(jpgPath, data, 0o644); err != nil {
-			m.RecordWriteFailureForPath(tempPath)
-			return 0, fmt.Errorf("storage: failed to write JPEG frame: %w", err)
-		}
-		m.RecordWriteSuccessForPath(tempPath)
-		return 0, nil
-	}
-
-	// H.264: append to temp file
-	f, err := os.OpenFile(tempPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		m.RecordWriteFailureForPath(tempPath)
-		return 0, fmt.Errorf("storage: failed to open temp file for writing: %w", err)
-	}
-	defer f.Close()
-
-	n, err := f.Write(data)
-	if err != nil {
-		m.RecordWriteFailureForPath(tempPath)
-		return n, fmt.Errorf("storage: write failed: %w", err)
-	}
-
-	m.RecordWriteSuccessForPath(tempPath)
+	m.recordWriteSuccess(st.cameraID)
 	return n, nil
 }
 
-// unregisterTempPath removes the tempPath → cameraID mapping.
+// unregisterTempPath removes the tempPath → cameraID mapping and drops the
+// per-segment writer state. The retained-FD close is a backstop: CloseSegment
+// (which holds the state lock while finalizing) normally closed it already,
+// hence the try-lock — a contended state is being finalized by its holder.
 // Safe for concurrent use.
 func (m *Manager) unregisterTempPath(tempPath string) {
 	m.segMapMu.Lock()
 	delete(m.segmentCameraMap, tempPath)
 	m.segMapMu.Unlock()
+
+	if st := m.peekWriterState(tempPath); st != nil && st.mu.TryLock() {
+		st.releaseLocked()
+		st.mu.Unlock()
+	}
+	m.dropWriterState(tempPath)
+}
+
+// peekWriterState returns the state without creating one (nil if absent).
+func (m *Manager) peekWriterState(tempPath string) *segmentWriter {
+	m.statesMu.RLock()
+	defer m.statesMu.RUnlock()
+	return m.segmentStates[tempPath]
 }
 
 // ListFiles lists all recording files (non-.tmp) for a camera.

--- a/internal/storage/segment_writer.go
+++ b/internal/storage/segment_writer.go
@@ -1,0 +1,276 @@
+package storage
+
+// segment_writer.go — per-segment writer state (#750).
+//
+// The frame write path used to pay, on EVERY frame: the global Manager mutex
+// (all cameras serialized through one lock), a full os.Stat(tempPath) to
+// classify dir-vs-file, and — on the append path — an open/write/close cycle.
+// With N cameras × ~25fps that is hundreds of path resolutions and
+// open/close pairs per second, which the block layer cannot coalesce.
+//
+// This file replaces that with a per-segment writer state, registered at
+// CreateSegment (the segment's form is known there, so no classification
+// stat is ever needed) or lazily classified once on first write:
+//
+//   - segment-lifetime FD retention on the append path (one open per segment)
+//   - userspace write coalescing: frames accumulate in a bufio and flush at a
+//     size threshold; CloseSegment flushes the remainder before fsync+rename,
+//     so the temp→rename atomic-finalize contract is unchanged
+//   - per-segment locking (cross-camera writes no longer serialize)
+//   - cached camera attribution for health accounting (no per-frame map lookup)
+//
+// Crash semantics are unchanged: a crashed segment's .tmp (including any
+// bytes still in the userspace buffer) is discarded by CleanupTempFiles —
+// buffering inside an unfinalized temp was never durable to begin with.
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// segmentWriteBufSize is the userspace coalescing buffer for the append
+	// path — same order as the MP4 muxer's (#521), tuned for the RPi-class
+	// memory budget: a few hundred KB per in-flight file-form segment.
+	segmentWriteBufSize = 256 * 1024
+	// segmentFlushThreshold: once this many bytes are buffered, flush to the
+	// kernel. Bounds both the crash loss window and per-segment memory.
+	segmentFlushThreshold = 256 * 1024
+	// segmentRevalidateWrites: with the FD retained, a vanished temp (unlinked
+	// under us) is no longer surfaced by the write itself — unix happily
+	// writes into an unlinked inode. Re-stat the path every N writes to keep
+	// the #413 vanish detection alive at 1/Nth of the old cost.
+	segmentRevalidateWrites = 1024
+)
+
+// Test seams (#750 TDD): syscall-count assertions swap these; production code
+// must route classification stats and appends through them.
+var (
+	statFn     = os.Stat
+	openFileFn = os.OpenFile
+)
+
+// errSegmentReleased is returned when the writer state was already finalized
+// (segment closed) but a late write raced in. It chains fs.ErrNotExist so
+// callers treat it exactly like a vanished temp: benign frame drop.
+var errSegmentReleased = fmt.Errorf("storage: segment already finalized: %w", fs.ErrNotExist)
+
+// segmentWriter holds the per-segment write state: classification (dir vs
+// file), camera attribution, and — for file-form segments — the retained FD
+// and coalescing buffer. Registered at CreateSegment or classified lazily;
+// released at segment finalize (or when the temp vanishes). Its mutex
+// serializes writes within ONE segment, replacing the former global lock.
+type segmentWriter struct {
+	mu       sync.Mutex
+	tempPath string
+	cameraID string // cached attribution — kills the per-frame map lookup
+	isDir    bool
+
+	// Append-path state (file-form segments); file is opened lazily on the
+	// first write and held until finalize. nil for dir-form segments.
+	file     *os.File
+	bw       *bufio.Writer
+	pending  int64 // bytes buffered since the last flush
+	writes   int64 // total write calls (drives vanish revalidation)
+	released bool  // set when the segment finalized; late writes fail benign
+
+	// Dir-form frame naming: frames written within the same millisecond get a
+	// monotonically increasing suffix so they cannot overwrite each other
+	// (name order still equals frame order — '.' < '_', suffix is numeric).
+	lastBase string
+	seq      int
+}
+
+// newSegmentWriter builds a classified writer state.
+func newSegmentWriter(tempPath, cameraID string, isDir bool) *segmentWriter {
+	return &segmentWriter{tempPath: tempPath, cameraID: cameraID, isDir: isDir}
+}
+
+// writeFrame appends one frame to the segment. Dir-form segments write the
+// JPEG as its own timestamped file (per-frame files are #761's container work,
+// out of scope here); file-form segments append through the coalescing buffer.
+func (s *segmentWriter) writeFrame(data []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.released {
+		return 0, errSegmentReleased
+	}
+
+	if s.isDir {
+		base := time.Now().Format("20060102_150405.000")
+		if base == s.lastBase {
+			// Sub-millisecond burst: same-ms frames would collide into one
+			// file (silent frame loss). Append a per-segment sequence suffix;
+			// lexical order still matches frame order.
+			s.seq++
+			base = fmt.Sprintf("%s_%d", base, s.seq)
+		} else {
+			s.lastBase = base
+			s.seq = 0
+		}
+		jpgPath := filepath.Join(s.tempPath, base+".jpg")
+		if err := os.WriteFile(jpgPath, data, 0o644); err != nil {
+			return 0, fmt.Errorf("storage: failed to write JPEG frame: %w", err)
+		}
+		return 0, nil
+	}
+
+	// Retained-FD caveat: a temp unlinked after the FD was opened would keep
+	// accepting writes into the orphaned inode. Re-stat periodically so the
+	// vanish still surfaces (benign, #413) at bounded staleness.
+	s.writes++
+	if s.file != nil && s.writes%segmentRevalidateWrites == 0 {
+		if _, err := statFn(s.tempPath); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				s.releaseLocked()
+				return 0, fmt.Errorf("storage: temp path not accessible: %w", err)
+			}
+			// Non-ENOENT stat trouble: report it — the write itself may still
+			// succeed, so don't tear the segment down here.
+			slog.Warn("storage: segment temp revalidation failed", "path", s.tempPath, "error", err)
+		}
+	}
+
+	if s.file == nil {
+		// No O_CREATE: the temp must exist (CreateSegment made it, or the lazy
+		// classification just stat'ed it). Recreating a vanished temp here
+		// would silently fork the segment into a fresh file and lose every
+		// earlier frame — the ENOENT must surface so the recorder restarts
+		// the segment (#413).
+		f, err := openFileFn(s.tempPath, os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			return 0, fmt.Errorf("storage: failed to open temp file for writing: %w", err)
+		}
+		s.file = f
+		s.bw = bufio.NewWriterSize(f, segmentWriteBufSize)
+	}
+
+	n, err := s.bw.Write(data)
+	if err != nil {
+		return n, fmt.Errorf("storage: write failed: %w", err)
+	}
+	s.pending += int64(n)
+	if s.pending >= segmentFlushThreshold {
+		if err := s.bw.Flush(); err != nil {
+			return n, fmt.Errorf("storage: flush failed: %w", err)
+		}
+		s.pending = 0
+	}
+	return n, nil
+}
+
+// finalize flushes any buffered bytes, fsyncs the retained FD, and closes it.
+// Called from CloseSegment with s.mu held. A nil FD (segment written through
+// an external handle — the MP4 muxer, merge outputs) is a no-op so the caller
+// falls back to its reopen-and-sync path.
+func (s *segmentWriter) finalize() error {
+	if s.bw != nil {
+		if err := s.bw.Flush(); err != nil {
+			return fmt.Errorf("storage: flush media: %w", err)
+		}
+		s.pending = 0
+	}
+	if s.file != nil {
+		if err := s.file.Sync(); err != nil {
+			s.file.Close()
+			s.file = nil
+			s.bw = nil
+			s.released = true
+			return fmt.Errorf("storage: failed to sync temp file: %w", err)
+		}
+		if err := s.file.Close(); err != nil {
+			s.file = nil
+			s.bw = nil
+			s.released = true
+			return fmt.Errorf("storage: failed to close temp file: %w", err)
+		}
+		s.file = nil
+		s.bw = nil
+	}
+	s.released = true
+	return nil
+}
+
+// releaseLocked drops the retained FD without flushing (temp vanished —
+// nothing to preserve). Callers hold s.mu.
+func (s *segmentWriter) releaseLocked() {
+	if s.file != nil {
+		_ = s.file.Close()
+		s.file = nil
+		s.bw = nil
+	}
+	s.pending = 0
+	s.released = true
+}
+
+// ---------------------------------------------------------------------------
+// Manager integration
+// ---------------------------------------------------------------------------
+
+// registerWriterState records the classified state for a segment. Segments
+// created via CreateSegment call this with the form's classification; the
+// path→camera map registration stays in registerTempPath.
+func (m *Manager) registerWriterState(tempPath, cameraID string, isDir bool) {
+	m.statesMu.Lock()
+	if m.segmentStates == nil {
+		m.segmentStates = make(map[string]*segmentWriter)
+	}
+	m.segmentStates[tempPath] = newSegmentWriter(tempPath, cameraID, isDir)
+	m.statesMu.Unlock()
+}
+
+// stateFor returns the writer state for tempPath, lazily classifying and
+// registering it for temps we did not create (external writers). The error
+// is non-nil only when classification was attempted and the stat failed —
+// callers distinguish a vanished temp (fs.ErrNotExist, benign) from real
+// trouble; a registered segment never stats, so the hot path sees no error.
+func (m *Manager) stateFor(tempPath string) (*segmentWriter, error) {
+	m.statesMu.RLock()
+	st := m.segmentStates[tempPath]
+	m.statesMu.RUnlock()
+	if st != nil {
+		return st, nil
+	}
+
+	info, err := statFn(tempPath)
+	if err != nil {
+		return nil, err
+	}
+	cameraID := m.lookupCameraByPath(tempPath)
+	st = newSegmentWriter(tempPath, cameraID, info.IsDir())
+
+	m.statesMu.Lock()
+	if m.segmentStates == nil {
+		m.segmentStates = make(map[string]*segmentWriter)
+	}
+	if existing := m.segmentStates[tempPath]; existing != nil {
+		st = existing // concurrent first-writers: keep the winner
+	} else {
+		m.segmentStates[tempPath] = st
+	}
+	m.statesMu.Unlock()
+	return st, nil
+}
+
+// dropWriterState removes the state for tempPath (best-effort, idempotent).
+func (m *Manager) dropWriterState(tempPath string) {
+	m.statesMu.Lock()
+	delete(m.segmentStates, tempPath)
+	m.statesMu.Unlock()
+}
+
+// segmentStateCount reports the number of live writer states (test hook for
+// FD/state lifecycle assertions).
+func (m *Manager) segmentStateCount() int {
+	m.statesMu.RLock()
+	defer m.statesMu.RUnlock()
+	return len(m.segmentStates)
+}

--- a/internal/storage/segment_writer_test.go
+++ b/internal/storage/segment_writer_test.go
@@ -1,0 +1,338 @@
+package storage
+
+// Tests for #750 — per-segment writer state:
+//   - segment-lifetime FD retention on the append path (one open per segment,
+//     not one per frame)
+//   - write coalescing with size-threshold flush + mandatory flush at
+//     CloseSegment (byte-equivalent output)
+//   - registration-time classification (no per-frame os.Stat)
+//   - per-segment locking (cross-camera writes no longer serialize on one
+//     global mutex)
+//   - state lifecycle: released at CloseSegment, vanished temps stay benign
+//     (#413 semantics), writes after close fail
+//
+// Syscall-count assertions use injectable func-field seams (statFn /
+// openFileFn), per the project's test-seam convention.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// swapStatFn replaces the package stat seam for the duration of the test.
+func swapStatFn(t *testing.T, fn func(string) (fs.FileInfo, error)) {
+	t.Helper()
+	old := statFn
+	statFn = fn
+	t.Cleanup(func() { statFn = old })
+}
+
+// swapOpenFileFn replaces the package open-file seam for the duration of the test.
+func swapOpenFileFn(t *testing.T, fn func(name string, flag int, perm os.FileMode) (*os.File, error)) {
+	t.Helper()
+	old := openFileFn
+	openFileFn = fn
+	t.Cleanup(func() { openFileFn = old })
+}
+
+// countingStat wraps os.Stat with a counter (nil fn → plain os.Stat).
+func countingStat(counter *atomic.Int64) func(string) (fs.FileInfo, error) {
+	return func(name string) (fs.FileInfo, error) {
+		counter.Add(1)
+		return os.Stat(name)
+	}
+}
+
+// countingOpenFile wraps os.OpenFile with a counter.
+func countingOpenFile(counter *atomic.Int64) func(string, int, os.FileMode) (*os.File, error) {
+	return func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		counter.Add(1)
+		return os.OpenFile(name, flag, perm)
+	}
+}
+
+// TestWriteFrame_AppendRetainsSegmentFD is the core #750 red test: N frames
+// through the append path must ride exactly ONE lazy open (held for the
+// segment's lifetime), and CloseSegment must fsync through that retained FD
+// instead of reopening the temp by path.
+func TestWriteFrame_AppendRetainsSegmentFD(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	var opens atomic.Int64
+	swapOpenFileFn(t, countingOpenFile(&opens))
+
+	temp, final, err := m.CreateSegment("cam-fd", "h264")
+	require.NoError(t, err)
+	base := opens.Load() // CreateSegment's own create is not on the seam
+
+	var want bytes.Buffer
+	for i := range 10 {
+		frame := fmt.Sprintf("frame-%02d;", i)
+		want.WriteString(frame)
+		n, werr := m.WriteFrame(temp, []byte(frame))
+		require.NoError(t, werr)
+		require.Positive(t, n)
+	}
+	require.Equal(t, int64(1), opens.Load()-base,
+		"10 frames must ride one retained FD — not open/close per frame")
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Equal(t, int64(1), opens.Load()-base,
+		"CloseSegment must fsync via the retained FD, not reopen the temp by path")
+
+	got, rerr := os.ReadFile(final)
+	require.NoError(t, rerr)
+	require.Equal(t, want.String(), string(got))
+}
+
+// TestWriteFrame_RegisteredDirSegmentSkipsStat: segments created via
+// CreateSegment have their form (dir vs file) registered at creation, so the
+// per-frame write path must not stat the temp at all — the old path resolved
+// the full directory chain once per frame.
+func TestWriteFrame_RegisteredDirSegmentSkipsStat(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	var stats atomic.Int64
+	swapStatFn(t, countingStat(&stats))
+
+	temp, final, err := m.CreateSegment("cam-stat", "mjpeg")
+	require.NoError(t, err)
+	base := stats.Load()
+
+	for range 8 {
+		_, werr := m.WriteFrame(temp, []byte("jpeg-bytes"))
+		require.NoError(t, werr)
+	}
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Equal(t, int64(0), stats.Load()-base,
+		"registered segments must not stat the temp per frame nor at close")
+
+	entries, lerr := os.ReadDir(final)
+	require.NoError(t, lerr)
+	require.Len(t, entries, 8)
+}
+
+// TestSegmentStateReleasedAfterClose: the writer state (and its FD) must be
+// dropped when the segment finalizes — across rotation, camera removal, and
+// recording toggles, states are bounded by in-flight segments.
+func TestSegmentStateReleasedAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	temp, final, err := m.CreateSegment("cam-rel", "h264")
+	require.NoError(t, err)
+	_, werr := m.WriteFrame(temp, []byte("payload"))
+	require.NoError(t, werr)
+	require.Equal(t, 1, m.segmentStateCount())
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Zero(t, m.segmentStateCount(), "state must be released at CloseSegment")
+
+	// Write-after-close must fail (state resurrected lazily → path is gone).
+	_, werr = m.WriteFrame(temp, []byte("more"))
+	require.Error(t, werr)
+}
+
+// TestCloseSegment_FlushesBufferedAppendData: sub-threshold frames sit in the
+// userspace buffer until CloseSegment flushes them — the finalized file must
+// be byte-identical to the unbuffered output.
+func TestCloseSegment_FlushesBufferedAppendData(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	temp, final, err := m.CreateSegment("cam-flush", "h264")
+	require.NoError(t, err)
+
+	var want bytes.Buffer
+	for i, sz := range []int{1000, 2000, 500} {
+		chunk := bytes.Repeat([]byte{byte('a' + i)}, sz)
+		want.Write(chunk)
+		_, werr := m.WriteFrame(temp, chunk)
+		require.NoError(t, werr)
+	}
+	require.NoError(t, m.CloseSegment(temp, final))
+
+	got, rerr := os.ReadFile(final)
+	require.NoError(t, rerr)
+	require.Equal(t, want.Bytes(), got)
+}
+
+// TestWriteFrame_FlushesAtThreshold: buffered bytes must hit the kernel once
+// the coalescing threshold is crossed, not only at CloseSegment — bounded
+// loss window on crash, bounded memory per segment.
+func TestWriteFrame_FlushesAtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	temp, final, err := m.CreateSegment("cam-thr", "h264")
+	require.NoError(t, err)
+
+	_, werr := m.WriteFrame(temp, bytes.Repeat([]byte{1}, 100_000))
+	require.NoError(t, werr)
+	info1, serr := os.Stat(temp)
+	require.NoError(t, serr)
+
+	// 300KB buffered total ≥ threshold → the third write must have flushed.
+	_, werr = m.WriteFrame(temp, bytes.Repeat([]byte{2}, 100_000))
+	require.NoError(t, werr)
+	_, werr = m.WriteFrame(temp, bytes.Repeat([]byte{3}, 100_000))
+	require.NoError(t, werr)
+	info2, serr := os.Stat(temp)
+	require.NoError(t, serr)
+
+	require.Greater(t, info2.Size(), info1.Size(),
+		"bytes must reach the file once the flush threshold is crossed")
+	require.GreaterOrEqual(t, info2.Size(), int64(300_000))
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	got, rerr := os.ReadFile(final)
+	require.NoError(t, rerr)
+	require.Len(t, got, 300_000)
+}
+
+// TestWriteFrame_VanishedTempStaysBenign: a temp removed under us (stale
+// cleanup, rotation race) must stay a benign frame-drop — NOT a storage
+// health failure (#413) — for both dir-form and file-form segments.
+func TestWriteFrame_VanishedTempStaysBenign(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	dirTemp, _, err := m.CreateSegment("cam-van-dir", "mjpeg")
+	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(dirTemp))
+	_, werr := m.WriteFrame(dirTemp, []byte("j"))
+	require.ErrorIs(t, werr, fs.ErrNotExist)
+	require.False(t, m.StorageFailed("cam-van-dir"), "vanished temp must not count as an I/O failure")
+
+	fileTemp, _, err := m.CreateSegment("cam-van-file", "h264")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(fileTemp))
+	_, werr = m.WriteFrame(fileTemp, []byte("j"))
+	require.ErrorIs(t, werr, fs.ErrNotExist)
+	require.False(t, m.StorageFailed("cam-van-file"), "vanished temp must not count as an I/O failure")
+}
+
+// TestWriteFrame_ConcurrentAcrossSegments: frames from different segments
+// (different cameras) written concurrently must all land intact — the sharded
+// per-segment locks must be race-clean (run under -race).
+func TestWriteFrame_ConcurrentAcrossSegments(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	const cams = 4
+	const frames = 200
+
+	temps := make([]string, cams)
+	finals := make([]string, cams)
+	for i := range cams {
+		temps[i], finals[i], err = m.CreateSegment(fmt.Sprintf("cam-cc-%d", i), "mjpeg")
+		require.NoError(t, err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range cams {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for f := range frames {
+				payload := fmt.Sprintf("cam%d-frame%04d;", idx, f)
+				_, werr := m.WriteFrame(temps[idx], []byte(payload))
+				if werr != nil {
+					t.Errorf("camera %d frame %d: %v", idx, f, werr)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range cams {
+		require.NoError(t, m.CloseSegment(temps[i], finals[i]))
+	}
+	for i := range cams {
+		entries, lerr := os.ReadDir(finals[i])
+		require.NoError(t, lerr)
+		require.Len(t, entries, frames, "camera %d lost frames", i)
+		for _, e := range entries {
+			content, rerr := os.ReadFile(fmt.Sprintf("%s/%s", finals[i], e.Name()))
+			require.NoError(t, rerr)
+			require.True(t, bytes.HasPrefix(content, []byte(fmt.Sprintf("cam%d-frame", i))),
+				"camera %d got another camera's frame: %q", i, content[:min(16, len(content))])
+		}
+	}
+}
+
+// TestWriteFrame_HealthAccountingPerCamera: successes route through the
+// segment's cached camera attribution, and real I/O failures (non-ENOENT)
+// still escalate storage health for the owning camera.
+func TestWriteFrame_HealthAccountingPerCamera(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	okTemp, okFinal, err := m.CreateSegment("cam-health", "mjpeg")
+	require.NoError(t, err)
+	_, werr := m.WriteFrame(okTemp, []byte("j"))
+	require.NoError(t, werr)
+	require.Equal(t, HealthHealthy, m.StorageHealth("cam-health"))
+	require.NoError(t, m.CloseSegment(okTemp, okFinal))
+
+	// Real I/O failure on the append path: the lazy open returns a non-ENOENT
+	// error → storage health for the OWNING camera must degrade.
+	failTemp, _, err := m.CreateSegment("cam-health-fail", "h264")
+	require.NoError(t, err)
+	swapOpenFileFn(t, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		return nil, &os.PathError{Op: "open", Path: name, Err: errors.New("io: host is down")}
+	})
+	_, werr = m.WriteFrame(failTemp, []byte("x"))
+	require.Error(t, werr)
+	require.False(t, errors.Is(werr, fs.ErrNotExist))
+	require.NotEqual(t, HealthHealthy, m.StorageHealth("cam-health-fail"),
+		"a real open failure must degrade the owning camera's storage health")
+
+	// An unrelated camera stays healthy — failures are attributed per segment.
+	require.Equal(t, HealthHealthy, m.StorageHealth("cam-health"))
+}
+
+// TestSegmentStateLazyClassification: temps registered externally (no form
+// known — tierrec-style writers) get classified once on first WriteFrame.
+func TestSegmentStateLazyClassification(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	external := filepath.Join(dir, "cam-lazy", "202601", "01", "02", "999.tmp")
+	require.NoError(t, os.MkdirAll(external, 0o755))
+	m.RegisterActiveTemp(external, "cam-lazy")
+
+	var stats atomic.Int64
+	swapStatFn(t, countingStat(&stats))
+	base := stats.Load()
+
+	for range 4 {
+		_, werr := m.WriteFrame(external, []byte("j"))
+		require.NoError(t, werr)
+	}
+	require.Equal(t, int64(1), stats.Load()-base,
+		"unregistered temps classify ONCE on first write, not per frame")
+	m.UnregisterActiveTemp(external)
+	require.Zero(t, m.segmentStateCount())
+}


### PR DESCRIPTION
Closes #750

## What

Replaces the WriteFrame hot path's per-frame costs with a per-segment writer state:

- **Segment-lifetime FD retention** on the append path — one lazy open per segment instead of open/write/close per frame
- **Userspace write coalescing** — 256KB bufio with threshold flush; `CloseSegment` flushes + fsyncs the retained FD before the temp→rename finalize (atomicity contract unchanged)
- **Zero per-frame Stat / map lookups** — dir-vs-file classification and camera attribution are registered at `CreateSegment`; external temps classify once lazily
- **Lock sharding** — the global `Manager.mu` is gone; each segment carries its own mutex, so cameras no longer serialize through one another
- **Two latent bugs fixed along the way** (both exposed by the new tests):
  - same-millisecond JPEG frames silently overwrote each other (burst frame loss) → monotonic name suffix, order preserved
  - the append path's `O_CREATE` would silently **recreate a vanished temp** and fork the segment — dropped `O_CREATE`; ENOENT surfaces so recorders restart the segment (#413 semantics); periodic revalidation catches unlink-while-open

H.264/H.265/AVI recorders were already covered by the #521 streaming muxer (FD + 512KB bufio); this brings the MJPEG/HTTP-JPEG/upload `WriteFrame` paths to the same shape.

## Compatibility preserved

- Muxer/merge/tierrec outputs keep the reopen-and-sync finalize fallback (state exists, no retained FD)
- Vanished-temp stays a benign frame drop (no health escalation)
- Writer states bounded by in-flight segments, released at finalize (try-lock backstop avoids the CloseSegment deadlock)

## Testing (TDD red→green)

- 9 new tests incl. syscall-count seams (`statFn`/`openFileFn`): 10 frames → exactly 1 open; registered segments → 0 stats; threshold flush; byte-equivalence after close-flush; concurrent cross-segment writes; FD/state release; lazy classification
- `go test -race ./internal/storage/` 313 pass; downstream recorder/merge/upload/timelapse/tierrec/api 1786 pass; full repo 5713 pass; golangci-lint 0 issues

## M5 production validation (2026-09-12, combined batch build)

Deployed `v0.12.0-68-g4a9ad5a0`: all 12 cameras recording with layer-identical rotation cadence; MJPEG camera live on the new path (temp frames + finalized segments verified); FD count stable (no leak); goroutines stable; zero storage errors overnight-window.