### PR TITLE
perf(cli): repair delete-by-format chunked batch delete (#753)

### DIFF
--- a/cmd/mibee-nvr/repair_delete_batch.go
+++ b/cmd/mibee-nvr/repair_delete_batch.go
@@ -1,0 +1,96 @@
+package main
+
+// repair_delete_batch.go — chunked batch deletion for `repair delete-by-format`
+// (#753). The historical execute loop issued one transaction per row
+// (measured 1-3 rows/s against a live server — each DELETE pays its own WAL
+// commit and writer-lock round trip). WAL+NORMAL makes multi-row deletes in
+// one transaction nearly free, so candidates now ride
+// storage.DeleteRecordingsBatch in bounded chunks with a per-row fallback
+// that pinpoints bad rows when a batch statement fails.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+)
+
+// repairDeleteChunkSize bounds the batch DELETE: large enough to amortize
+// the transaction overhead, small enough that the writer lock is held well
+// under the 15s busy_timeout while the server records concurrently.
+const repairDeleteChunkSize = 300
+
+// Seams for call-pattern and failure-injection tests (#753 TDD).
+var (
+	repairDeleteBatchFn = func(ctx context.Context, db *storage.DB, ids []string) ([]string, error) {
+		return db.DeleteRecordingsBatch(ctx, ids)
+	}
+	repairDeleteOneFn = func(ctx context.Context, db *storage.DB, id string) error {
+		return db.DeleteRecording(ctx, id)
+	}
+)
+
+// deleteCandidatesInChunks deletes candidates DB-first in chunks of
+// repairDeleteChunkSize (single transaction per chunk), then reclaims the
+// files of every DB-deleted row (best-effort RemoveAll on file_path and a
+// distinct merge_path sibling). A failing batch statement falls back to
+// per-row deletes for that chunk so one bad row cannot poison the rest.
+// progress(deleted, total) fires once per chunk. Returns rows deleted, rows
+// that failed their DB delete, and the freed byte total.
+func deleteCandidatesInChunks(ctx context.Context, db *storage.DB, candidates []model.Recording,
+	progress func(deleted, total int),
+) (deleted, failed int, freedBytes int64) {
+	total := len(candidates)
+	for start := 0; start < total; start += repairDeleteChunkSize {
+		if ctx.Err() != nil {
+			break
+		}
+		end := min(start+repairDeleteChunkSize, total)
+		chunk := candidates[start:end]
+
+		ids := make([]string, len(chunk))
+		for i, r := range chunk {
+			ids[i] = r.ID
+		}
+		ok := chunk
+		if _, err := repairDeleteBatchFn(ctx, db, ids); err != nil {
+			fmt.Fprintf(os.Stderr, "  batch delete failed (%v) — retrying chunk row by row\n", err)
+			ok = ok[:0]
+			for _, r := range chunk {
+				if ctx.Err() != nil {
+					break
+				}
+				if err := repairDeleteOneFn(ctx, db, r.ID); err != nil {
+					fmt.Fprintf(os.Stderr, "  DB DELETE FAILED %s: %v\n", r.ID, err)
+					failed++
+					continue
+				}
+				ok = append(ok, r)
+			}
+		}
+
+		for _, r := range ok {
+			freedBytes += r.FileSize
+			deleted++
+			// Best-effort file removal, after the DB row is gone (source of
+			// truth first; an orphan file is recoverable, a dangling row is not).
+			if r.FilePath != "" {
+				_ = os.RemoveAll(r.FilePath)
+			}
+			if r.MergePath != "" && r.MergePath != r.FilePath {
+				_ = os.RemoveAll(r.MergePath)
+			}
+		}
+		progress(deleted, total)
+
+		// Throttle between chunks — bounded I/O burst while the server runs.
+		select {
+		case <-time.After(20 * time.Millisecond):
+		case <-ctx.Done():
+		}
+	}
+	return deleted, failed, freedBytes
+}

--- a/cmd/mibee-nvr/repair_delete_batch_test.go
+++ b/cmd/mibee-nvr/repair_delete_batch_test.go
@@ -1,0 +1,214 @@
+package main
+
+// Tests for #753 — chunked batch deletion in `repair delete-by-format`:
+// the execute loop must ride DeleteRecordingsBatch (one transaction per
+// chunk) with a per-row fallback when the batch statement fails, instead of
+// one transaction per row (measured 1-3 rows/s against a live server).
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// swapRepairDeleteSeams replaces the batch/single delete seams, returning a
+// restore func. Counters observe call patterns; failBatch makes the batch
+// statement fail so the fallback path runs.
+func swapRepairDeleteSeams(t *testing.T, failBatch bool) (batchCalls, singleCalls *atomic.Int64) {
+	t.Helper()
+	batchCalls = &atomic.Int64{}
+	singleCalls = &atomic.Int64{}
+	oldBatch, oldSingle := repairDeleteBatchFn, repairDeleteOneFn
+	repairDeleteBatchFn = func(ctx context.Context, db *storage.DB, ids []string) ([]string, error) {
+		batchCalls.Add(1)
+		if failBatch {
+			return nil, errors.New("injected batch failure")
+		}
+		return db.DeleteRecordingsBatch(ctx, ids)
+	}
+	repairDeleteOneFn = func(ctx context.Context, db *storage.DB, id string) error {
+		singleCalls.Add(1)
+		return db.DeleteRecording(ctx, id)
+	}
+	t.Cleanup(func() {
+		repairDeleteBatchFn = oldBatch
+		repairDeleteOneFn = oldSingle
+	})
+	return batchCalls, singleCalls
+}
+
+// seedChunkTestDB seeds count h264 recordings with on-disk files and returns
+// the opened storage DB, a raw SQL handle for assertions, and the records.
+func seedChunkTestDB(t *testing.T, count int) (*storage.DB, *sql.DB, []model.Recording) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	recs := make([]model.Recording, count)
+	ctx := context.Background()
+	for i := range count {
+		f := filepath.Join(dir, fmt.Sprintf("seg_%04d.mp4", i))
+		require.NoError(t, os.WriteFile(f, []byte("payload"), 0o644))
+		r := repairRec(fmt.Sprintf("chunk-%04d", i), "cam1", "h264", model.MergeStatusPending, old)
+		r.FilePath = f
+		require.NoError(t, db.InsertRecording(ctx, r))
+		recs[i] = *r
+	}
+	return db, raw, recs
+}
+
+// countRowsLeft returns the number of remaining recordings for the camera.
+func countRowsLeft(t *testing.T, raw *sql.DB) int {
+	t.Helper()
+	var n int
+	require.NoError(t, raw.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM recordings WHERE camera_id='cam1'").Scan(&n))
+	return n
+}
+
+// TestDeleteCandidatesInChunks_BatchPathIsUsed: with the batch statement
+// healthy, ALL deletes ride chunked batch calls (one transaction per chunk)
+// and the end state matches the per-row implementation exactly — rows gone,
+// files gone (incl. merge_path siblings), freed bytes accounted.
+func TestDeleteCandidatesInChunks_BatchPathIsUsed(t *testing.T) {
+	db, raw, recs := seedChunkTestDB(t, 5)
+	defer db.Close()
+	defer raw.Close()
+	// Give two rows a distinct merge_path sibling to reclaim alongside. The
+	// DB row and the in-memory candidate must agree — production candidates
+	// arrive from ListRecordings with merge_path populated.
+	for i := range 2 {
+		mp := recs[i].FilePath + ".merged.mp4"
+		require.NoError(t, os.WriteFile(mp, []byte("m"), 0o644))
+		_, err := raw.ExecContext(context.Background(),
+			"UPDATE recordings SET merge_path=? WHERE id=?", mp, recs[i].ID)
+		require.NoError(t, err)
+		recs[i].MergePath = mp
+	}
+
+	batchCalls, singleCalls := swapRepairDeleteSeams(t, false)
+	deleted, failed, freed := deleteCandidatesInChunks(context.Background(), db, recs,
+		func(d, total int) {})
+	require.Equal(t, 5, deleted)
+	require.Zero(t, failed)
+	require.Equal(t, int64(5*1024), freed)
+	require.Equal(t, int64(1), batchCalls.Load(), "5 candidates ≤ chunk size → exactly ONE batch statement")
+	require.Zero(t, singleCalls.Load(), "healthy batch path must not fall back to per-row deletes")
+
+	require.Zero(t, countRowsLeft(t, raw))
+	for _, r := range recs {
+		require.NoFileExists(t, r.FilePath)
+		require.NoFileExists(t, r.FilePath+".merged.mp4")
+	}
+}
+
+// TestDeleteCandidatesInChunks_ChunksLargeSets: more than one chunk's worth
+// of candidates splits into ceil(n/chunk) batch calls with correct end state.
+func TestDeleteCandidatesInChunks_ChunksLargeSets(t *testing.T) {
+	const n = repairDeleteChunkSize*2 + 50
+	db, raw, recs := seedChunkTestDB(t, n)
+	defer db.Close()
+	defer raw.Close()
+
+	batchCalls, singleCalls := swapRepairDeleteSeams(t, false)
+	deleted, failed, _ := deleteCandidatesInChunks(context.Background(), db, recs,
+		func(d, total int) {})
+	require.Equal(t, n, deleted)
+	require.Zero(t, failed)
+	require.Equal(t, int64(3), batchCalls.Load(), "%d candidates / chunk %d → 3 batch calls", n, repairDeleteChunkSize)
+	require.Zero(t, singleCalls.Load())
+	require.Zero(t, countRowsLeft(t, raw))
+}
+
+// TestDeleteCandidatesInChunks_FallbackOnBatchFailure: a failing batch
+// statement degrades to per-row deletes so a single bad row cannot poison
+// the chunk — everything still gets deleted.
+func TestDeleteCandidatesInChunks_FallbackOnBatchFailure(t *testing.T) {
+	db, raw, recs := seedChunkTestDB(t, 5)
+	defer db.Close()
+	defer raw.Close()
+
+	batchCalls, singleCalls := swapRepairDeleteSeams(t, true)
+	deleted, failed, _ := deleteCandidatesInChunks(context.Background(), db, recs,
+		func(d, total int) {})
+	require.Equal(t, 5, deleted)
+	require.Zero(t, failed)
+	require.Equal(t, int64(1), batchCalls.Load())
+	require.Equal(t, int64(5), singleCalls.Load(), "failed batch must retry the chunk row by row")
+	require.Zero(t, countRowsLeft(t, raw))
+}
+
+// TestRunRepairDeleteByFormat_ExecuteLargeSetEndState: end-to-end — the CLI
+// execute path over a multi-chunk candidate set leaves the same end state as
+// the historical per-row implementation (kept formats untouched, files gone).
+func TestRunRepairDeleteByFormat_ExecuteLargeSetEndState(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeRepairConfig(t, dir)
+	dbPath := filepath.Join(dir, "mibee-nvr.db")
+
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	raw, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	db, err := storage.New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	ctx := context.Background()
+
+	keepFile := filepath.Join(dir, "keep.mp4")
+	require.NoError(t, os.WriteFile(keepFile, []byte("tl"), 0o644))
+	keep := repairRec("big-keep", "cam1", "timelapse", model.MergeStatusPending, old)
+	keep.FilePath = keepFile
+	require.NoError(t, db.InsertRecording(ctx, keep))
+
+	var wantFreed int64
+	for i := range repairDeleteChunkSize + 10 {
+		f := filepath.Join(dir, fmt.Sprintf("del_%04d.mp4", i))
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+		r := repairRec(fmt.Sprintf("big-%04d", i), "cam1", "h264", model.MergeStatusPending, old)
+		r.FilePath = f
+		require.NoError(t, db.InsertRecording(ctx, r))
+		wantFreed += r.FileSize
+	}
+	require.NoError(t, db.Close())
+	require.NoError(t, raw.Close())
+
+	var rc int
+	withArgs([]string{
+		"bin", "repair", "delete-by-format", "--camera", "cam1",
+		"--keep-format", "timelapse", "--execute", "--config", cfgPath,
+	},
+		func() { rc = runRepairDeleteByFormat() })
+	require.Zero(t, rc)
+
+	// Everything h264 gone (rows + files); timelapse untouched.
+	raw2, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	var h264Left, tlLeft int
+	require.NoError(t, raw2.QueryRow("SELECT COUNT(*) FROM recordings WHERE camera_id='cam1' AND format='h264'").Scan(&h264Left))
+	require.NoError(t, raw2.QueryRow("SELECT COUNT(*) FROM recordings WHERE camera_id='cam1' AND format='timelapse'").Scan(&tlLeft))
+	require.NoError(t, raw2.Close())
+	require.Zero(t, h264Left)
+	require.Equal(t, 1, tlLeft)
+	require.FileExists(t, keepFile)
+	for i := range repairDeleteChunkSize + 10 {
+		require.NoFileExists(t, filepath.Join(dir, fmt.Sprintf("del_%04d.mp4", i)))
+	}
+}

--- a/cmd/mibee-nvr/repair_delete_by_format.go
+++ b/cmd/mibee-nvr/repair_delete_by_format.go
@@ -38,7 +38,8 @@ import (
 //   - For rows with a separate merge_path (rolling/periodic merge output), the
 //     merge_path file is also removed so it doesn't linger as an orphan that
 //     orphan-cleanup can't sweep (it doesn't match the <cameraID>_* pattern).
-//   - --dry-run default; --execute to apply. 20ms throttle between deletes.
+//   - --dry-run default; --execute to apply. Chunked batch DELETE (300 rows/txn,
+//     #753) with per-row fallback; 20ms throttle between chunks.
 func runRepairDeleteByFormat() int {
 	opts := parseRepairFlags(3)
 	if opts.configPath == "__help__" {
@@ -216,48 +217,15 @@ func runRepairDeleteByFormat() int {
 		return 0
 	}
 
-	// --- Execute: per-row delete (DB first, then file + merge_path sibling) ---
+	// --- Execute: chunked batch delete (DB first, then files) — #753 ---
 	fmt.Println()
-	fmt.Println("Executing deletions...")
-	deleted := 0
-	deleteFailed := 0
-	var freedBytes int64
-	for i, r := range candidates {
-		if ctx.Err() != nil {
-			fmt.Fprintf(os.Stderr, "\nInterrupted by signal. Deleted %d of %d before stop.\n", deleted, len(candidates))
-			break
-		}
-		// DB row first (source of truth). On failure, do NOT touch the file —
-		// leaving an orphan file is recoverable; a dangling DB row is not.
-		if err := db.DeleteRecording(ctx, r.ID); err != nil {
-			fmt.Fprintf(os.Stderr, "  [%d/%d] DB DELETE FAILED %s: %v\n", i+1, len(candidates), r.ID, err)
-			deleteFailed++
-			continue
-		}
-		freedBytes += r.FileSize
-		deleted++
-		// Best-effort file removal. FilePath is a regular .mp4/.avi file for
-		// non-timelapse formats (we kept timelapse, so no frame-dir case here,
-		// but os.RemoveAll handles both safely).
-		if r.FilePath != "" {
-			_ = os.RemoveAll(r.FilePath)
-		}
-		// Also remove the merged-output sibling if it's a distinct file.
-		// Rolling/periodic merge produces <file_path>.mp4 (or a periodic_*.mp4)
-		// stored in merge_path — orphan-cleanup won't sweep these because they
-		// don't match the <cameraID>_* filename pattern.
-		if r.MergePath != "" && r.MergePath != r.FilePath {
-			_ = os.RemoveAll(r.MergePath)
-		}
-		if deleted%50 == 0 || deleted == len(candidates) {
-			fmt.Printf("  [%d/%d] deleted\n", deleted, len(candidates))
-		}
-		// Throttle: avoid IO spikes on RPi/SD-card during large deletes
-		// (matches repair fragments --force-delete cadence).
-		select {
-		case <-time.After(20 * time.Millisecond):
-		case <-ctx.Done():
-		}
+	fmt.Println("Executing deletions (batched)...")
+	deleted, deleteFailed, freedBytes := deleteCandidatesInChunks(ctx, db, candidates,
+		func(done, total int) {
+			fmt.Printf("  [%d/%d] deleted\n", done, total)
+		})
+	if ctx.Err() != nil {
+		fmt.Fprintf(os.Stderr, "\nInterrupted by signal. Deleted %d of %d before stop.\n", deleted, len(candidates))
 	}
 	fmt.Println()
 	fmt.Printf("Summary: %d deleted (%.2f GB freed), %d failed (of %d candidates)\n",
@@ -287,7 +255,8 @@ func runRepairDeleteByFormat() int {
 //     (recommended — never prune the most-recent window the periodic merger
 //     may still be working on).
 //   - --limit caps the count for bounded runs.
-//   - --dry-run default; --execute to apply. 20ms throttle between deletes.
+//   - --dry-run default; --execute to apply. Chunked batch DELETE (300 rows/txn,
+//     #753) with per-row fallback; 20ms throttle between chunks.
 
 func printRepairDeleteByFormatUsage() {
 	fmt.Print(`Usage: mibee-nvr repair delete-by-format [options]
@@ -307,7 +276,8 @@ Safety guards:
   - MiBeeVision-protected segments (ai_status='processing') are skipped.
   - DB row deleted first, then file (best-effort); merge_path siblings are
     also removed so rolling/periodic merge outputs don't linger as orphans.
-  - --dry-run default; --execute to apply. 20ms throttle between deletes.
+  - --dry-run default; --execute to apply. Chunked batch DELETE (300 rows per
+    transaction) with per-row fallback; 20ms throttle between chunks.
 
 Examples:
   # See what would be deleted for one camera (count, size, samples)


### PR DESCRIPTION
Closes #753

## What

`repair delete-by-format` execute loop: one transaction per row (measured **1-3 rows/s** against a live server — each DELETE paid its own WAL commit + writer-lock round trip) → `storage.DeleteRecordingsBatch` in **300-row chunks** (single transaction per chunk):

- batch statement failure falls back to per-row deletes for that chunk, so one bad row cannot poison the rest
- all safety guards unchanged: in-flight skip, `ai_status='processing'` skip, DB-first-then-files, merge_path sibling reclaim, signal handling, dry-run default
- 20ms throttle now paces chunks instead of rows
- chunk size bounded so the writer lock stays well under the 15s busy_timeout while the server records concurrently

## Testing (TDD red→green)

- 4 new tests via injected seams (`repairDeleteBatchFn`/`repairDeleteOneFn`): 5 candidates → exactly 1 batch statement (0 single calls); 650 candidates → 3 chunks; injected batch failure → 5 per-row fallback deletes with full end state; end-to-end multi-chunk CLI run leaves identical end state to the historical per-row path (kept formats untouched)
- `go test -race ./cmd/mibee-nvr/` 90 pass; lint 0 issues