### PR TITLE
feat(db): planned WAL checkpointing — gated idle PASSIVE ticker + journal_size_limit cap (#752)

### DIFF
--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -537,6 +537,12 @@ func (d *DB) Init(ctx context.Context) error {
 	// Enable auto_vacuum = INCREMENTAL for fresh databases (no-op for existing).
 	_, _ = d.db.ExecContext(ctx, "PRAGMA auto_vacuum = INCREMENTAL")
 
+	// Cap the WAL high-water mark (#752): after a checkpoint the -wal file
+	// shrinks to at most this size, and crash-recovery replay is bounded by
+	// it. Set on the writer only (the checkpointing connection) — the DSN
+	// baseline stays frozen.
+	_, _ = d.db.ExecContext(ctx, fmt.Sprintf("PRAGMA journal_size_limit = %d", walJournalSizeLimit))
+
 	// Refresh query planner stats (incremental ANALYZE where needed). Cheap on startup.
 	_, _ = d.db.ExecContext(ctx, `PRAGMA optimize`)
 

--- a/internal/storage/wal_maintenance.go
+++ b/internal/storage/wal_maintenance.go
@@ -1,0 +1,115 @@
+package storage
+
+// wal_maintenance.go — planned WAL checkpointing (#752).
+//
+// Baseline already in place elsewhere: the cleanup cycle's tail does a
+// PASSIVE checkpoint (TRUNCATE escalation after 3 busy cycles) and the 60s
+// metrics ticker exports sqlite_wal_size_bytes. What was missing:
+//
+//   - checkpointing was coupled to the (default hourly) cleanup cycle, so a
+//     WAL bloated by reader pressure sat large until the next cycle;
+//   - nothing bounded the WAL high-water mark for crash exits.
+//
+// This file adds a time-gated idle-window PASSIVE ticker (fires only when
+// the WAL exceeds the threshold AND the minimum gap since the last trigger
+// has passed — quiet read-mostly periods burn nothing) and caps the WAL via
+// journal_size_limit in Init() (NOT in the DSN — the DSN baseline stays
+// frozen; the limit only matters on the writer, the checkpointing conn).
+//
+// Graceful shutdown needs no explicit TRUNCATE: closing the last connection
+// checkpoints and removes the -wal file (SQLite semantics, verified by
+// TestClose_CheckpointsWALViaLastConnClose). Crash exits are bounded by
+// journal_size_limit instead.
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// walJournalSizeLimit bounds the WAL file's high-water mark: after a
+	// checkpoint the file shrinks to at most this size, and an un-checkpointed
+	// crash replay is capped by it.
+	walJournalSizeLimit = 64 << 20 // 64MB
+	// walCheckpointThreshold: trigger a PASSIVE checkpoint once the WAL holds
+	// more than this (~2× the 1000-page autocheckpoint, i.e. autocheckpointing
+	// is already losing ground — usually sustained reader pressure).
+	walCheckpointThreshold = 8 << 20 // 8MB
+	// walCheckpointMinGap is the minimum spacing between triggered
+	// checkpoints — read-heavy phases must not turn the ticker into a busy
+	// checkpoint loop.
+	walCheckpointMinGap = 5 * time.Minute
+	// walMaintenanceTick is how often the gates are evaluated.
+	walMaintenanceTick = time.Minute
+)
+
+// walCheckpointFn is the loop's checkpoint seam (call-pattern tests).
+var walCheckpointFn = func(d *DB, mode string) (busy int, logFrames int, checkpointedFrames int, err error) {
+	return d.CheckpointWAL(context.Background(), mode)
+}
+
+// shouldTriggerWALCheckpoint is the pure gate: WAL must exceed the threshold
+// and the last trigger must be older than the minimum gap. Zero last means
+// "never triggered" (startup) and passes the gap immediately.
+func shouldTriggerWALCheckpoint(now, last time.Time, walBytes, threshold int64) bool {
+	if walBytes < threshold {
+		return false
+	}
+	if last.IsZero() {
+		return true
+	}
+	return now.Sub(last) >= walCheckpointMinGap
+}
+
+// StartWALMaintenance launches the idle-window PASSIVE checkpoint loop. It
+// exits when ctx is cancelled (the App start context), never blocks callers,
+// and deliberately never escalates to TRUNCATE — the aggressive action keeps
+// its single owner in the cleanup tail.
+func (d *DB) StartWALMaintenance(ctx context.Context) {
+	d.startWALMaintenance(ctx, walMaintenanceTick, walCheckpointThreshold)
+}
+
+// StartWALMaintenanceWithInterval is StartWALMaintenance with an injectable
+// tick (tests).
+func (d *DB) StartWALMaintenanceWithInterval(ctx context.Context, tick time.Duration) {
+	d.startWALMaintenance(ctx, tick, walCheckpointThreshold)
+}
+
+// startWALMaintenance is the core loop with injectable tick and size
+// threshold (tests lower the threshold instead of manufacturing an 8MB WAL).
+func (d *DB) startWALMaintenance(ctx context.Context, tick time.Duration, threshold int64) {
+	go func() {
+		ticker := time.NewTicker(tick)
+		defer ticker.Stop()
+		var last time.Time
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				size, err := d.GetWALSize()
+				if err != nil {
+					logger.Warn("wal maintenance: stat WAL failed", "error", err)
+					continue
+				}
+				now := time.Now()
+				if !shouldTriggerWALCheckpoint(now, last, size, threshold) {
+					continue
+				}
+				last = now
+				busy, logFrames, ckptFrames, err := walCheckpointFn(d, "PASSIVE")
+				if err != nil {
+					logger.Warn("wal maintenance: PASSIVE checkpoint failed", "error", err)
+					continue
+				}
+				if busy == 1 {
+					logger.Warn("wal maintenance: PASSIVE checkpoint busy — readers hold the WAL; cleanup tail owns TRUNCATE escalation",
+						"wal_bytes", size, "log_frames", logFrames)
+				} else if ckptFrames > 0 {
+					logger.Info("wal maintenance: PASSIVE checkpoint drained frames",
+						"wal_bytes", size, "checkpointed_frames", ckptFrames)
+				}
+			}
+		}
+	}()
+}

--- a/internal/storage/wal_maintenance_test.go
+++ b/internal/storage/wal_maintenance_test.go
@@ -1,0 +1,175 @@
+package storage
+
+// Tests for #752 — planned WAL checkpointing:
+//   - journal_size_limit caps the WAL high-water mark (bounds crash-recovery
+//     replay; the DSN baseline is intentionally unchanged — the limit rides
+//     Init() on the writer, the only connection that checkpoints)
+//   - an idle-window PASSIVE ticker decoupled from the hourly cleanup tail,
+//     gated by WAL size AND a minimum interval between triggers
+//
+// Note (verified empirically, TestClose_CheckpointsWALViaLastConnClose):
+// DB.Close() already checkpoints and removes the -wal file through SQLite's
+// last-connection-close semantics, so no explicit shutdown TRUNCATE is
+// needed — crash exits are bounded by journal_size_limit instead.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClose_CheckpointsWALViaLastConnClose(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "close-probe.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for i := range 50 {
+		r := &model.Recording{
+			ID:          walTestID(i),
+			CameraID:    "cam-probe",
+			FilePath:    "/tmp/x.mp4",
+			Format:      model.FormatH264,
+			StartedAt:   now.Add(-time.Duration(i) * time.Minute),
+			EndedAt:     now,
+			Duration:    30,
+			FileSize:    1024,
+			MergeStatus: model.MergeStatusPending,
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+	}
+	walBefore, err := db.GetWALSize()
+	require.NoError(t, err)
+	require.Positive(t, walBefore, "50 committed inserts must leave WAL frames")
+
+	require.NoError(t, db.Close())
+	_, statErr := os.Stat(dbPath + "-wal")
+	require.Error(t, statErr, "last-conn close must checkpoint and remove the -wal file")
+}
+
+func TestInit_SetsJournalSizeLimit(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "jsl.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	defer db.Close()
+
+	var limit int64
+	require.NoError(t, db.DB().QueryRowContext(context.Background(),
+		"PRAGMA journal_size_limit").Scan(&limit))
+	require.Equal(t, int64(walJournalSizeLimit), limit,
+		"Init must cap the WAL high-water mark at %d bytes", walJournalSizeLimit)
+}
+
+func TestShouldTriggerWALCheckpoint_Gating(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name      string
+		walBytes  int64
+		sinceLast time.Duration
+		want      bool
+	}{
+		{"small wal no trigger", 1 << 20, 10 * time.Minute, false},
+		{"large wal fresh checkpoint", 16 << 20, time.Minute, false},
+		{"large wal past gap", 16 << 20, 6 * time.Minute, true},
+		{"just over both gates", walCheckpointThreshold + 1, walCheckpointMinGap + time.Second, true},
+		{"just under size gate", walCheckpointThreshold - 1, walCheckpointMinGap + time.Second, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want,
+				shouldTriggerWALCheckpoint(now, now.Add(-tc.sinceLast), tc.walBytes, walCheckpointThreshold))
+		})
+	}
+	// Zero last-checkpoint time (startup) triggers immediately when large.
+	require.True(t, shouldTriggerWALCheckpoint(now, time.Time{}, 16<<20, walCheckpointThreshold))
+}
+
+func TestWALMaintenanceLoop_TriggersAndStops(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "loop.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	defer db.Close()
+
+	var passiveCalls atomic.Int64
+	restore := swapWALCheckpoint(func(_ *DB, mode string) (int, int, int, error) {
+		if mode == "PASSIVE" {
+			passiveCalls.Add(1)
+		}
+		return 0, 100, 100, nil
+	})
+	defer restore()
+
+	base := runtime.NumGoroutine()
+	ctx, cancel := context.WithCancel(context.Background())
+	db.startWALMaintenance(ctx, 20*time.Millisecond, 1) // 1-byte threshold: any WAL triggers
+
+	// Real inserts keep the size gate honest (the seam only fake-reports the
+	// checkpoint call, not the WAL size the gating reads).
+	now := time.Now().UTC()
+	for i := range 60 {
+		r := &model.Recording{
+			ID: walTestID(i), CameraID: "cam-loop", FilePath: "/tmp/y.mp4",
+			Format: model.FormatH264, StartedAt: now, EndedAt: now,
+			Duration: 30, FileSize: 1024, MergeStatus: model.MergeStatusPending,
+		}
+		require.NoError(t, db.InsertRecording(ctx, r))
+	}
+
+	require.Eventually(t, func() bool { return passiveCalls.Load() >= 1 },
+		5*time.Second, 50*time.Millisecond, "loop must fire PASSIVE once the gates open")
+
+	cancel()
+	// Bounded manual poll instead of require.Eventually: testify runs the
+	// condition in its own goroutine, which would count itself in
+	// NumGoroutine and never satisfy the baseline.
+	deadline := time.Now().Add(5 * time.Second)
+	for runtime.NumGoroutine() > base && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.LessOrEqual(t, runtime.NumGoroutine(), base,
+		"cancelled loop must drain its goroutine")
+}
+
+func TestWALMaintenanceLoop_SkipsSmallWAL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quiet.db")
+	db, err := New(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	defer db.Close()
+
+	var passiveCalls atomic.Int64
+	restore := swapWALCheckpoint(func(_ *DB, mode string) (int, int, int, error) {
+		passiveCalls.Add(1)
+		return 0, 0, 0, nil
+	})
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db.StartWALMaintenanceWithInterval(ctx, 20*time.Millisecond)
+	time.Sleep(150 * time.Millisecond) // no writes → WAL under threshold
+	require.Zero(t, passiveCalls.Load(), "quiet DB must not burn checkpoints")
+}
+
+// --- helpers ---
+
+func walTestID(i int) string {
+	return "wal-" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26))
+}
+
+func swapWALCheckpoint(fn func(d *DB, mode string) (int, int, int, error)) (restore func()) {
+	old := walCheckpointFn
+	walCheckpointFn = fn
+	return func() { walCheckpointFn = old }
+}

--- a/pkg/app/deps.go
+++ b/pkg/app/deps.go
@@ -55,6 +55,7 @@ type appDeps struct {
 
 	// Storage + observability
 	db           *storage.DB
+	dbStopWAL    context.CancelFunc // cancels the db service's WAL maintenance loop (#752)
 	store        *storage.Manager
 	migrationMgr *migration.Migrator
 	metrics      *metrics.Metrics

--- a/pkg/app/register.go
+++ b/pkg/app/register.go
@@ -48,13 +48,23 @@ func registerServices(a *App, deps *appDeps) error {
 		return err
 	}
 
-	// 1. db — registered first so it stops last
+	// 1. db — registered first so it stops last. Start also launches the
+	// idle-window WAL checkpoint loop (#752); it owns a cancel derived from
+	// the start ctx because App.Stop does not cancel it — the service's Stop
+	// cancels first, then closes the DB (checkpoint+remove -wal happens on
+	// last-connection close).
 	if err := a.Register(&serviceFunc{
 		name: "db",
-		startFunc: func(_ context.Context) error {
+		startFunc: func(ctx context.Context) error {
+			walCtx, walCancel := context.WithCancel(ctx)
+			deps.dbStopWAL = walCancel
+			deps.db.StartWALMaintenance(walCtx)
 			return nil
 		},
 		stopFunc: func() error {
+			if deps.dbStopWAL != nil {
+				deps.dbStopWAL()
+			}
 			deps.db.Close()
 			return nil
 		},


### PR DESCRIPTION
Closes #752

## What

- **`journal_size_limit=64MB`** set in `Init()` on the writer (DSN baseline untouched) — bounds the WAL high-water mark and crash-recovery replay
- **Idle-window PASSIVE ticker**: 60s gate evaluation, ≥5min spacing, ≥8MB size gate — decouples checkpointing from the (default hourly) cleanup tail so a reader-bloated WAL drains in minutes, not hours. Quiet read-mostly periods burn nothing. TRUNCATE escalation deliberately keeps its single owner in the cleanup tail
- **No shutdown TRUNCATE needed** — verified empirically (`TestClose_CheckpointsWALViaLastConnClose`): `DB.Close()` already checkpoints and removes `-wal` via SQLite last-connection-close semantics; crash exits are bounded by the size limit instead
- db app service owns a cancel for the loop (App.Stop doesn't cancel the start ctx — goroutine-leak guard); `sqlite_wal_size_bytes` metric was already exported by the cleanup 60s ticker

## Testing (TDD red→green)

- close-probe (WAL frames positive → post-close `-wal` absent), journal_size_limit pragma assertion, pure gating function table test, loop fires PASSIVE with injectable threshold + drains its goroutine on cancel (manual bounded poll — testify `Eventually` runs the condition in its own goroutine and would count itself in `NumGoroutine`), quiet-DB burn-nothing test
- `go test -race -count=3` storage WAL tests 30 pass; storage + pkg/app 368 pass; lint 0 issues

## M5 production validation

WAL flat at 4.2MB across the observation window (autocheckpoint coping); loop silent-by-design below the 8MB gate; goroutines stable.