### PR TITLE
feat(recorder): segment fallocate preallocation + finalize ftruncate (#757)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -224,6 +224,29 @@ version: "1.0"
 - **Always strict regardless of tier**: merged recordings, timelapse products, the database (WAL+NORMAL) and config writes — long-term assets keep their fsync.
 - **Who benefits**: flash boards (SD/eMMC) where per-segment fsync is both a latency spike and write-amplification source (~26 fsync/min at 13 cameras × 30s segments); HDD arrays recording continuously.
 - **Example**: `durability: "relaxed"` under the `storage:` section.
+### `storage.prealloc_enabled`
+- **Type**: boolean
+- **Default**: `true` (leaving it unset counts as enabled)
+- **Description**: whole-segment preallocation (fallocate) — the previous segment's final size estimates this one, reserved up front as one contiguous extent. This removes per-append inode metadata transactions, cuts write amplification on SD/eMMC, and improves merge/playback read locality. The reservation is a hint, not a bound — writes past it grow the file normally; filesystems without fallocate degrade to plain append writes. `false` restores pure append-write growth (takes effect after restart)
+- **Example**: `true`, `false`
+
+### `storage.prealloc_headroom_percent`
+- **Type**: int
+- **Default**: `10`
+- **Description**: growth margin over the previous segment's size (absorbs bitrate drift without re-growing mid-segment); range 0–400
+- **Example**: `10`, `25`
+
+### `storage.prealloc_min_bytes`
+- **Type**: int
+- **Default**: `4194304` (4MiB)
+- **Description**: preallocation floor — segments whose predecessor was smaller than this skip preallocation (tiny segments don't churn extents enough to matter); must not exceed `prealloc_max_bytes`
+- **Example**: `4194304`
+
+### `storage.prealloc_max_bytes`
+- **Type**: int
+- **Default**: `536870912` (512MiB)
+- **Description**: per-segment reservation cap so a pathological segment cannot reserve absurd space for its successors
+- **Example**: `536870912`
 
 ### `storage.db_path`
 - **Type**: string

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -185,6 +185,29 @@ version: "1.0"
 - **两档恒为 strict**: 合并产物、timelapse 产物、数据库（WAL+NORMAL）、配置写入——长期资产保留 fsync。
 - **适合谁**: 闪存板（SD/eMMC，每段 fsync 是延迟尖峰 + 写放大来源——13 路 × 30s 段 ≈ 每分钟 26 次 fsync）；连续录像的 HDD 阵列。
 - **示例**: 在 `storage:` 节下写 `durability: "relaxed"`。
+### `storage.prealloc_enabled`
+- **类型**: boolean
+- **默认**: `true`（不设置即视为开启）
+- **描述**: 录像段整段预分配（fallocate）——用上一段的实际大小估算本段大小并一次性预留连续磁盘区域，免去逐次追加的 inode 元数据事务，减少 SD/eMMC 写放大、提升合并/回放读取局部性。预分配只是提示不是上限，实际写入超出会照常增长；不支持 fallocate 的文件系统自动降级为普通追加写。设为 `false` 恢复纯追加写（重启生效）
+- **示例**: `true`, `false`
+
+### `storage.prealloc_headroom_percent`
+- **类型**: int
+- **默认**: `10`
+- **描述**: 预分配相对上一段大小的余量百分比（吸收码率漂移，避免段内再次增长）；范围 0–400
+- **示例**: `10`, `25`
+
+### `storage.prealloc_min_bytes`
+- **类型**: int
+- **默认**: `4194304`（4MiB）
+- **描述**: 预分配下限——上一段小于该值时跳过预分配（小段的 extent 抖动不值得折腾）；不得大于 `prealloc_max_bytes`
+- **示例**: `4194304`
+
+### `storage.prealloc_max_bytes`
+- **类型**: int
+- **默认**: `536870912`（512MiB）
+- **描述**: 单段预分配上限，防止病态大段把后续段的预留空间也撑爆
+- **示例**: `536870912`
 
 ### `storage.db_path`
 - **类型**: string

--- a/internal/camera/recorder_builders.go
+++ b/internal/camera/recorder_builders.go
@@ -84,6 +84,7 @@ func (cm *CameraManager) buildRTSPRecorder(cam config.CameraConfig, segDur time.
 			Username:          cam.Username,
 			Password:          cam.Password,
 			SegmentDur:        segDur,
+			Prealloc:          preallocParamsFromConfig(cm.cfg),
 			DB:                cm.db,
 			AudioEnabled:      cam.AudioEnabled,
 			AudioInRecordings: cam.AudioInRecordings,
@@ -106,6 +107,7 @@ func (cm *CameraManager) buildRTSPRecorder(cam config.CameraConfig, segDur time.
 			Username:          cam.Username,
 			Password:          cam.Password,
 			SegmentDur:        segDur,
+			Prealloc:          preallocParamsFromConfig(cm.cfg),
 			DB:                cm.db,
 			AudioEnabled:      cam.AudioEnabled,
 			AudioInRecordings: cam.AudioInRecordings,
@@ -293,4 +295,19 @@ func (cm *CameraManager) buildIngestRecorder(cam config.CameraConfig, segDur tim
 		EventBus:      cm.eventBus,
 		RecordEnabled: cam.RecordingEnabled,
 	})
+}
+
+// preallocParamsFromConfig maps the storage.prealloc_* knobs onto the
+// recorder-side params (#757). Values are materialized by config defaults;
+// zero-value fields keep the recorder's documented defaults.
+func preallocParamsFromConfig(cfg *config.Config) recorder.PreallocParams {
+	if cfg == nil {
+		return recorder.PreallocParams{}
+	}
+	return recorder.PreallocParams{
+		Disabled:        !cfg.Storage.PreallocEnabled,
+		HeadroomPercent: cfg.Storage.PreallocHeadroomPercent,
+		MinBytes:        cfg.Storage.PreallocMinBytes,
+		MaxBytes:        cfg.Storage.PreallocMaxBytes,
+	}
 }

--- a/internal/camera/recorder_builders.go
+++ b/internal/camera/recorder_builders.go
@@ -297,6 +297,12 @@ func (cm *CameraManager) buildIngestRecorder(cam config.CameraConfig, segDur tim
 	})
 }
 
+// preallocEnabled resolves the tri-state prealloc switch (#757): nil
+// (config defaults materialize it to true) or true = enabled.
+func preallocEnabled(v *bool) bool {
+	return v == nil || *v
+}
+
 // preallocParamsFromConfig maps the storage.prealloc_* knobs onto the
 // recorder-side params (#757). Values are materialized by config defaults;
 // zero-value fields keep the recorder's documented defaults.
@@ -305,7 +311,7 @@ func preallocParamsFromConfig(cfg *config.Config) recorder.PreallocParams {
 		return recorder.PreallocParams{}
 	}
 	return recorder.PreallocParams{
-		Disabled:        !cfg.Storage.PreallocEnabled,
+		Disabled:        !preallocEnabled(cfg.Storage.PreallocEnabled),
 		HeadroomPercent: cfg.Storage.PreallocHeadroomPercent,
 		MinBytes:        cfg.Storage.PreallocMinBytes,
 		MaxBytes:        cfg.Storage.PreallocMaxBytes,

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -276,6 +276,21 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.Memory.AutoCgroupPercent == 0 {
 		cfg.Memory.AutoCgroupPercent = 80
 	}
+	// Segment preallocation defaults (#757).
+	if !cfg.Storage.PreallocEnabled && cfg.Storage.PreallocHeadroomPercent == 0 && cfg.Storage.PreallocMinBytes == 0 && cfg.Storage.PreallocMaxBytes == 0 {
+		// All-zero (unset section) = defaults on. An explicit false only
+		// reaches here together with other non-zero knobs, so it stays off.
+		cfg.Storage.PreallocEnabled = true
+	}
+	if cfg.Storage.PreallocHeadroomPercent == 0 {
+		cfg.Storage.PreallocHeadroomPercent = 10
+	}
+	if cfg.Storage.PreallocMinBytes == 0 {
+		cfg.Storage.PreallocMinBytes = 4 << 20
+	}
+	if cfg.Storage.PreallocMaxBytes == 0 {
+		cfg.Storage.PreallocMaxBytes = 512 << 20
+	}
 	// Merge defaults
 	if cfg.Merge.BatchLimit <= 0 {
 		cfg.Merge.BatchLimit = 200

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -276,11 +276,13 @@ func applyConfigDefaults(cfg *Config) {
 	if cfg.Memory.AutoCgroupPercent == 0 {
 		cfg.Memory.AutoCgroupPercent = 80
 	}
-	// Segment preallocation defaults (#757).
-	if !cfg.Storage.PreallocEnabled && cfg.Storage.PreallocHeadroomPercent == 0 && cfg.Storage.PreallocMinBytes == 0 && cfg.Storage.PreallocMaxBytes == 0 {
-		// All-zero (unset section) = defaults on. An explicit false only
-		// reaches here together with other non-zero knobs, so it stays off.
-		cfg.Storage.PreallocEnabled = true
+	// Segment preallocation defaults (#757). nil (unset) = ON — the
+	// deployed behavior since the feature landed; an explicit false is
+	// preserved by the pointer (a bare `prealloc_enabled: false` must NOT
+	// be flipped back on).
+	if cfg.Storage.PreallocEnabled == nil {
+		cfg.Storage.PreallocEnabled = new(bool)
+		*cfg.Storage.PreallocEnabled = true
 	}
 	if cfg.Storage.PreallocHeadroomPercent == 0 {
 		cfg.Storage.PreallocHeadroomPercent = 10

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -133,6 +133,12 @@ type StorageConfig struct {
 	// can tolerate losing the last seconds of raw recording on power loss
 	// benefit most.
 	Durability string `yaml:"durability"`
+	// Segment preallocation knobs (#757) — defaults materialized by config
+	// defaults; every value operator-tunable, nothing hardcoded in recorders.
+	PreallocEnabled         bool  `yaml:"prealloc_enabled"`          // default true; false restores pure append-write growth
+	PreallocHeadroomPercent int   `yaml:"prealloc_headroom_percent"` // default 10
+	PreallocMinBytes        int64 `yaml:"prealloc_min_bytes"`        // default 4MiB (below = skip)
+	PreallocMaxBytes        int64 `yaml:"prealloc_max_bytes"`        // default 512MiB
 	// Candidates lists additional storage locations made available to the NVR
 	// by the host platform (#395): on fnOS these are the user-authorized
 	// directories (TRIM_DATA_ACCESSIBLE_PATHS), mounted into the container and

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -135,7 +135,10 @@ type StorageConfig struct {
 	Durability string `yaml:"durability"`
 	// Segment preallocation knobs (#757) — defaults materialized by config
 	// defaults; every value operator-tunable, nothing hardcoded in recorders.
-	PreallocEnabled         bool  `yaml:"prealloc_enabled"`          // default true; false restores pure append-write growth
+	// PreallocEnabled is a pointer so "unset" (default ON) is distinguishable
+	// from an explicit `prealloc_enabled: false` — same tri-state pattern as
+	// hls.low_latency (#772).
+	PreallocEnabled         *bool `yaml:"prealloc_enabled"`          // default true; explicit false restores pure append-write growth
 	PreallocHeadroomPercent int   `yaml:"prealloc_headroom_percent"` // default 10
 	PreallocMinBytes        int64 `yaml:"prealloc_min_bytes"`        // default 4MiB (below = skip)
 	PreallocMaxBytes        int64 `yaml:"prealloc_max_bytes"`        // default 512MiB

--- a/internal/config/prealloc_config_test.go
+++ b/internal/config/prealloc_config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreallocDefaults(t *testing.T) {
+	cfg := &Config{}
+	applyConfigDefaults(cfg)
+	if !cfg.Storage.PreallocEnabled || cfg.Storage.PreallocHeadroomPercent != 10 ||
+		cfg.Storage.PreallocMinBytes != 4<<20 || cfg.Storage.PreallocMaxBytes != 512<<20 {
+		t.Errorf("prealloc defaults = %v/%d/%d/%d, want true/10/4MiB/512MiB",
+			cfg.Storage.PreallocEnabled, cfg.Storage.PreallocHeadroomPercent,
+			cfg.Storage.PreallocMinBytes, cfg.Storage.PreallocMaxBytes)
+	}
+
+	// Explicit disable stays disabled.
+	cfg = &Config{}
+	cfg.Storage.PreallocEnabled = false
+	cfg.Storage.PreallocHeadroomPercent = 10 // explicit any knob marks the section as set
+	applyConfigDefaults(cfg)
+	if cfg.Storage.PreallocEnabled {
+		t.Error("explicit prealloc_enabled=false must stay false")
+	}
+}
+
+func TestPreallocValidate(t *testing.T) {
+	cfg := &Config{}
+	applyConfigDefaults(cfg)
+	cfg.Storage.PreallocHeadroomPercent = 500
+	err := Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "prealloc_headroom_percent") {
+		t.Errorf("Validate(headroom=500) = %v, want range error", err)
+	}
+
+	cfg = &Config{}
+	applyConfigDefaults(cfg)
+	cfg.Storage.PreallocMinBytes = 600 << 20 // > max
+	err = Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "prealloc_min_bytes") {
+		t.Errorf("Validate(min>max) = %v, want ordering error", err)
+	}
+}

--- a/internal/config/prealloc_config_test.go
+++ b/internal/config/prealloc_config_test.go
@@ -8,20 +8,27 @@ import (
 func TestPreallocDefaults(t *testing.T) {
 	cfg := &Config{}
 	applyConfigDefaults(cfg)
-	if !cfg.Storage.PreallocEnabled || cfg.Storage.PreallocHeadroomPercent != 10 ||
+	if cfg.Storage.PreallocEnabled == nil || !*cfg.Storage.PreallocEnabled ||
+		cfg.Storage.PreallocHeadroomPercent != 10 ||
 		cfg.Storage.PreallocMinBytes != 4<<20 || cfg.Storage.PreallocMaxBytes != 512<<20 {
 		t.Errorf("prealloc defaults = %v/%d/%d/%d, want true/10/4MiB/512MiB",
 			cfg.Storage.PreallocEnabled, cfg.Storage.PreallocHeadroomPercent,
 			cfg.Storage.PreallocMinBytes, cfg.Storage.PreallocMaxBytes)
 	}
 
-	// Explicit disable stays disabled.
+	// An explicit `prealloc_enabled: false` set ALONE must stay false — the
+	// pre-pointer version flipped it back on (bool zero-value ambiguity).
+	f := false
 	cfg = &Config{}
-	cfg.Storage.PreallocEnabled = false
-	cfg.Storage.PreallocHeadroomPercent = 10 // explicit any knob marks the section as set
+	cfg.Storage.PreallocEnabled = &f
 	applyConfigDefaults(cfg)
-	if cfg.Storage.PreallocEnabled {
-		t.Error("explicit prealloc_enabled=false must stay false")
+	if cfg.Storage.PreallocEnabled == nil || *cfg.Storage.PreallocEnabled {
+		t.Error("explicit prealloc_enabled=false must stay false even when set alone")
+	}
+
+	// Headroom still defaults while an explicit false is honored.
+	if cfg.Storage.PreallocHeadroomPercent != 10 {
+		t.Errorf("headroom default = %d, want 10", cfg.Storage.PreallocHeadroomPercent)
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -354,6 +354,16 @@ func validateConfigDetails(cfg *Config) error {
 	default:
 		return fmt.Errorf("storage.durability must be \"strict\" or \"relaxed\" (empty = strict default), got %q", cfg.Storage.Durability)
 	}
+	// Preallocation knobs (#757).
+	if cfg.Storage.PreallocHeadroomPercent < 0 || cfg.Storage.PreallocHeadroomPercent > 400 {
+		return fmt.Errorf("storage.prealloc_headroom_percent must be between 0 and 400, got %d", cfg.Storage.PreallocHeadroomPercent)
+	}
+	if cfg.Storage.PreallocMinBytes < 0 {
+		return fmt.Errorf("storage.prealloc_min_bytes must be >= 0, got %d", cfg.Storage.PreallocMinBytes)
+	}
+	if cfg.Storage.PreallocMaxBytes > 0 && cfg.Storage.PreallocMinBytes > cfg.Storage.PreallocMaxBytes {
+		return fmt.Errorf("storage.prealloc_min_bytes %d exceeds prealloc_max_bytes %d", cfg.Storage.PreallocMinBytes, cfg.Storage.PreallocMaxBytes)
+	}
 	// Validate retention_days
 	if cfg.Cleanup.RetentionDays < 1 || cfg.Cleanup.RetentionDays > 3650 {
 		return fmt.Errorf("cleanup.retention_days must be between 1 and 3650, got %d", cfg.Cleanup.RetentionDays)

--- a/internal/muxer/mp4mux.go
+++ b/internal/muxer/mp4mux.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/mp4util"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/prealloc"
 	"github.com/abema/go-mp4"
 )
 
@@ -75,6 +77,11 @@ type MP4Muxer struct {
 	// totalDuration accumulates every sample's duration (both Write methods).
 	totalDuration time.Duration
 	closed        bool
+	// preallocBytes is the whole-segment size estimate fallocate'd at open
+	// (#757): one contiguous extent instead of per-append growth metadata
+	// transactions. Close truncates the file back to the real content end.
+	// 0 = no preallocation. Hint, not a bound.
+	preallocBytes int64
 }
 
 // NewMP4Muxer creates a new MP4 muxer that will write to filePath.
@@ -82,6 +89,19 @@ func NewMP4Muxer(filePath string) *MP4Muxer {
 	return &MP4Muxer{
 		filePath:    filePath,
 		nextTrackID: 1,
+	}
+}
+
+// SetPreallocateBytes advises the muxer of the expected final segment size.
+// The file is fallocate'd to that size when opened (before the first sample
+// arrives); Close() truncates to the actual content length. Must be called
+// before the first WriteSample to take effect. Failures to preallocate are
+// logged-and-ignored (append-write status quo).
+func (m *MP4Muxer) SetPreallocateBytes(n int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !m.closed && m.file == nil && n > 0 {
+		m.preallocBytes = n
 	}
 }
 
@@ -331,6 +351,17 @@ func (m *MP4Muxer) ensureOpen() error {
 	m.file = f
 	m.bw = bufio.NewWriterSize(f, 512*1024)
 	m.mdatSizeOff = ftypSize // offset of mdat's SIZE field (box starts here)
+
+	// Whole-segment preallocation (#757): reserve the estimated extent up
+	// front so the append path stops paying per-growth inode metadata
+	// transactions and the segment lands contiguous. Degrades silently on
+	// filesystems without fallocate.
+	if m.preallocBytes > 0 {
+		if err := prealloc.Preallocate(f, m.preallocBytes); err != nil {
+			slog.Debug("segment preallocation unavailable, continuing append-only",
+				"path", m.filePath, "estimate", m.preallocBytes, "error", err)
+		}
+	}
 	return nil
 }
 
@@ -381,10 +412,12 @@ func (m *MP4Muxer) Close() error {
 		return fmt.Errorf("patch mdat size: %w", err)
 	}
 
-	// Append moov at EOF. It sits after the mdat, so per-sample offsets are
-	// already final — no placeholder/sizing pass needed (the old layout had
-	// to size moov first because stco offsets pointed INTO the file ahead).
-	if _, err := m.file.Seek(0, io.SeekEnd); err != nil {
+	// Append moov after the mdat payload. Position is COMPUTED, not
+	// SeekEnd — with preallocation (#757) the file size already includes
+	// the reserved extent, so EOF is not the content end. Per-sample
+	// offsets are already final (moov trails mdat).
+	moovStart := m.mdatSizeOff + 8 + m.payloadN
+	if _, err := m.file.Seek(moovStart, io.SeekStart); err != nil {
 		m.file.Close()
 		return fmt.Errorf("seek to moov: %w", err)
 	}
@@ -392,7 +425,26 @@ func (m *MP4Muxer) Close() error {
 		m.file.Close()
 		return fmt.Errorf("write moov: %w", err)
 	}
+
+	// THE zero-tail nail (#757): preallocation extended the file to the
+	// estimate — truncate back to the actual content end, or every
+	// crash-recovered segment carries a zero tail that inflates the probed
+	// duration. No-op without preallocation (offset == size).
+	if end, err := m.file.Seek(0, io.SeekCurrent); err == nil && end < m.preallocExpected() {
+		if err := m.file.Truncate(end); err != nil {
+			m.file.Close()
+			return fmt.Errorf("truncate preallocated tail: %w", err)
+		}
+	}
 	return m.file.Close()
+}
+
+// preallocExpected reports the file size the preallocation reserved (0 when
+// none). Close only needs to truncate when the content end is BELOW the
+// reserved size; seeking past it (overshoot) means the file already ends at
+// the content.
+func (m *MP4Muxer) preallocExpected() int64 {
+	return m.preallocBytes
 }
 
 // --- Box writing functions ---

--- a/internal/muxer/mp4mux_prealloc_test.go
+++ b/internal/muxer/mp4mux_prealloc_test.go
@@ -1,0 +1,143 @@
+package muxer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/prealloc"
+	"github.com/stretchr/testify/require"
+)
+
+// writePreallocTestSamples drives one muxer through a fixed sample set so
+// outputs are comparable across prealloc on/off.
+func writePreallocTestSamples(t *testing.T, path string, preallocBytes int64) {
+	t.Helper()
+	m := NewMP4Muxer(path)
+	if preallocBytes > 0 {
+		m.SetPreallocateBytes(preallocBytes)
+	}
+	trackID, err := m.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	for i := range 60 {
+		var nalu []byte
+		if i%15 == 0 {
+			nalu = make([]byte, 32<<10) // periodic "keyframe"-sized sample
+		} else {
+			nalu = make([]byte, 4<<10)
+		}
+		require.NoError(t, m.WriteSample(trackID, nalu, time.Duration(i)*33*time.Millisecond, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close())
+}
+
+// TestMP4Muxer_PreallocOutputByteIdentical: preallocation must not change
+// the output content — same samples, byte-identical files.
+func TestMP4Muxer_PreallocOutputByteIdentical(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain.mp4")
+	pre := filepath.Join(dir, "pre.mp4")
+
+	writePreallocTestSamples(t, plain, 0)
+	writePreallocTestSamples(t, pre, 4<<20)
+
+	plainB, err := os.ReadFile(plain)
+	require.NoError(t, err)
+	preB, err := os.ReadFile(pre)
+	require.NoError(t, err)
+	require.Equal(t, plainB, preB, "preallocated output must be byte-identical")
+}
+
+// TestMP4Muxer_PreallocTruncatesZeroTail is THE nail test (#757): fallocate
+// extends the file to the estimated size, so Close MUST ftruncate to the
+// actual content end — otherwise crash-recovered segments carry zero tails
+// that inflate probed durations.
+func TestMP4Muxer_PreallocTruncatesZeroTail(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "plain.mp4")
+	pre := filepath.Join(dir, "pre.mp4")
+
+	writePreallocTestSamples(t, plain, 0)
+	writePreallocTestSamples(t, pre, 8<<20) // estimate far above actual (~300KB)
+
+	plainInfo, err := os.Stat(plain)
+	require.NoError(t, err)
+	preInfo, err := os.Stat(pre)
+	require.NoError(t, err)
+	require.Equal(t, plainInfo.Size(), preInfo.Size(),
+		"preallocated file must be truncated to the exact content length (no zero tail)")
+
+	// Sanity: only zeros at the tail would make sizes differ — also verify
+	// the last bytes are real moov content, not zero padding.
+	preB, err := os.ReadFile(pre)
+	require.NoError(t, err)
+	tail := preB[len(preB)-16:]
+	allZero := true
+	for _, b := range tail {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	require.False(t, allZero, "file tail must be moov content, not zero padding")
+}
+
+// TestMP4Muxer_PreallocOvershootStillGrows: the estimate is a hint, not a
+// bound — writing past it must grow the file normally.
+func TestMP4Muxer_PreallocOvershootStillGrows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "over.mp4")
+
+	m := NewMP4Muxer(path)
+	m.SetPreallocateBytes(16 << 10) // deliberately tiny
+	trackID, err := m.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	for i := range 40 {
+		require.NoError(t, m.WriteSample(trackID, make([]byte, 32<<10), time.Duration(i)*33*time.Millisecond, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(40*32<<10), "file must grow past the preallocation hint")
+}
+
+// TestMP4Muxer_PreallocFailureDegrades: an unsupported filesystem (ENOSYS /
+// EOPNOTSUPP) must degrade silently to the append-write status quo.
+func TestMP4Muxer_PreallocFailureDegrades(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "degrade.mp4")
+
+	restore := prealloc.SwapForTest(func(_ *os.File, _ int64) error { return errors.New("injected EOPNOTSUPP") })
+	t.Cleanup(restore)
+
+	m := NewMP4Muxer(path)
+	m.SetPreallocateBytes(4 << 20)
+	trackID, err := m.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	for i := range 10 {
+		require.NoError(t, m.WriteSample(trackID, make([]byte, 8<<10), time.Duration(i)*33*time.Millisecond, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close(), "preallocation failure must not fail the segment")
+
+	// Output still parses as the plain variant.
+	plain := filepath.Join(dir, "plain.mp4")
+	writePreallocTestSamples2(t, plain)
+	preB, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, preB)
+}
+
+// writePreallocTestSamples2 is the 10×8KB variant matching the degrade test.
+func writePreallocTestSamples2(t *testing.T, path string) {
+	t.Helper()
+	m := NewMP4Muxer(path)
+	trackID, err := m.AddH264Track(testSPS, testPPS)
+	require.NoError(t, err)
+	for i := range 10 {
+		require.NoError(t, m.WriteSample(trackID, make([]byte, 8<<10), time.Duration(i)*33*time.Millisecond, 33*time.Millisecond))
+	}
+	require.NoError(t, m.Close())
+}

--- a/internal/prealloc/prealloc.go
+++ b/internal/prealloc/prealloc.go
@@ -1,0 +1,28 @@
+// Package prealloc pre-allocates disk space for segment files (#757).
+//
+// ext4 grows an appending file one extent at a time — each growth pays an
+// inode-size metadata transaction. A whole-segment fallocate up front gives
+// the allocator one contiguous region (better merge/playback read locality,
+// fewer journal commits, less write amplification on SD/eMMC).
+//
+// Preallocation is a HINT, never a bound: writes past the allocated size
+// simply grow the file as before. Filesystems without fallocate (ENOSYS /
+// EOPNOTSUPP) degrade to the append-write status quo.
+package prealloc
+
+import "os"
+
+// Preallocate extends f's size to size bytes (offset 0, length size) without
+// writing data. Failures are the caller's to ignore-and-log — this is an
+// optimization, not a correctness step.
+func Preallocate(f *os.File, size int64) error {
+	return preallocFn(f, size)
+}
+
+// SwapForTest replaces the platform implementation for failure-injection
+// tests; the returned func restores it.
+func SwapForTest(fn func(*os.File, int64) error) (restore func()) {
+	prev := preallocFn
+	preallocFn = fn
+	return func() { preallocFn = prev }
+}

--- a/internal/prealloc/prealloc_linux.go
+++ b/internal/prealloc/prealloc_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package prealloc
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// preallocFn is the seam for failure-injection tests.
+var preallocFn = func(f *os.File, size int64) error {
+	if size <= 0 {
+		return nil
+	}
+	return unix.Fallocate(int(f.Fd()), 0, 0, size)
+}

--- a/internal/prealloc/prealloc_other.go
+++ b/internal/prealloc/prealloc_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package prealloc
+
+import (
+	"errors"
+	"os"
+)
+
+// preallocFn is a no-op on non-Linux platforms (seam for tests).
+var preallocFn = func(_ *os.File, _ int64) error {
+	return errors.New("prealloc: unsupported platform")
+}

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -66,6 +66,9 @@ type BaseConfig struct {
 	RingBufCap   int
 	DB           RecordingDB
 	AudioEnabled bool
+	// Prealloc carries the storage.prealloc_* knobs (#757). Zero value =
+	// documented defaults (enabled, 10%% headroom, 4MiB floor, 512MiB cap).
+	Prealloc PreallocParams
 	// AudioInRecordings keeps the camera's real audio track in recorded
 	// segments (event spans in merged products). Default false — recordings
 	// are video-only unless enabled per camera; live preview and the audio
@@ -897,10 +900,10 @@ func (b *baseRecorder) createNewSegment(at time.Time) bool {
 		return false
 	}
 	m := muxer.NewMP4Muxer(tempPath)
-	// Segment preallocation (#757): last segment's actual size × 1.1
-	// headroom, clamped, is the estimate for this one — contiguous extents,
-	// no per-append inode metadata transactions. No history yet → skip.
-	if est := segmentPreallocEstimate(b.lastSegBytes); est > 0 {
+	// Segment preallocation (#757): last segment's actual size × headroom,
+	// clamped, is the estimate for this one — contiguous extents, no
+	// per-append inode metadata transactions. No history yet → skip.
+	if est := segmentPreallocEstimate(b.lastSegBytes, b.cfg.Prealloc); est > 0 {
 		m.SetPreallocateBytes(est)
 	}
 	trackID, err := b.driver.addTrack(m, b)

--- a/internal/recorder/base.go
+++ b/internal/recorder/base.go
@@ -298,6 +298,14 @@ type baseRecorder struct {
 	frameCount    int
 	lastFrameTime time.Time
 
+	// lastSegBytes feeds segment preallocation (#757): the previous
+	// segment's final size is the best estimate of the next one (same
+	// camera, same bitrate, same duration policy). Written only in
+	// closeCurrentSegment and read only in createNewSegment — both on the
+	// single writer goroutine. 0 = no estimate yet (first segment after
+	// start: no preallocation).
+	lastSegBytes int64
+
 	// Codec parameter sets (Tier 2, #219): immutable snapshot behind
 	// atomic.Pointer so the live-preview (HLS/WebRTC/WS) goroutines can read
 	// SPS/PPS/VPS concurrently with the writeFrames writer without a data race
@@ -889,6 +897,12 @@ func (b *baseRecorder) createNewSegment(at time.Time) bool {
 		return false
 	}
 	m := muxer.NewMP4Muxer(tempPath)
+	// Segment preallocation (#757): last segment's actual size × 1.1
+	// headroom, clamped, is the estimate for this one — contiguous extents,
+	// no per-append inode metadata transactions. No history yet → skip.
+	if est := segmentPreallocEstimate(b.lastSegBytes); est > 0 {
+		m.SetPreallocateBytes(est)
+	}
 	trackID, err := b.driver.addTrack(m, b)
 	if err != nil {
 		b.log.Error("failed to add video track",
@@ -1033,6 +1047,8 @@ func (b *baseRecorder) closeCurrentSegment() {
 		if info, err := os.Stat(b.curFinalPath); err == nil {
 			finalExists = true
 			fileSize = info.Size()
+			// Feed the next segment's preallocation estimate (#757).
+			b.lastSegBytes = fileSize
 		} else {
 			b.log.Warn("segment file missing after finalize — recording row skipped",
 				"camera_id", b.cfg.CameraID, "path", b.curFinalPath)

--- a/internal/recorder/prealloc.go
+++ b/internal/recorder/prealloc.go
@@ -1,23 +1,52 @@
 package recorder
 
+// PreallocParams carries the operator-tunable segment-preallocation knobs
+// (#757). The zero value means "documented defaults, enabled" so hand-built
+// configs and tests need no initialization; config defaults materialize the
+// same values on Load.
+type PreallocParams struct {
+	// Disabled turns preallocation off entirely (config:
+	// storage.prealloc_enabled: false).
+	Disabled bool
+	// HeadroomPercent is the growth margin over the previous segment's
+	// size (default 10) — absorbs bitrate drift without re-growing.
+	HeadroomPercent int
+	// MinBytes is the floor below which preallocation is skipped (default
+	// 4MiB): tiny segments don't churn extents enough to matter.
+	MinBytes int64
+	// MaxBytes caps one segment's reservation (default 512MiB) so a
+	// pathological segment doesn't reserve absurd space for successors.
+	MaxBytes int64
+}
+
+func (p PreallocParams) withDefaults() PreallocParams {
+	if p.HeadroomPercent <= 0 {
+		p.HeadroomPercent = 10
+	}
+	if p.MinBytes <= 0 {
+		p.MinBytes = 4 << 20
+	}
+	if p.MaxBytes <= 0 {
+		p.MaxBytes = 512 << 20
+	}
+	return p
+}
+
 // segmentPreallocEstimate converts the previous segment's final size into
 // the fallocate hint for the next one (#757). Recorders know no encoder
 // bitrate; the last segment is the best proxy (same camera, same duration
-// policy, same scene complexity).
-//
-//   - 10% headroom absorbs bitrate drift without re-growing the file;
-//   - the floor skips pointless preallocation for tiny/failed segments;
-//   - the cap stops one pathological segment (e.g. a 4GiB stco-limit run)
-//     from reserving absurd space for its successors.
-func segmentPreallocEstimate(lastSegBytes int64) int64 {
-	const floor = 4 << 20      // 4MiB — below this, extent churn is negligible
-	const capBytes = 512 << 20 // 512MiB — stco-limit headroom is 4GiB
-	if lastSegBytes < floor {
+// policy, same scene complexity). Returns 0 = don't preallocate.
+func segmentPreallocEstimate(lastSegBytes int64, p PreallocParams) int64 {
+	if p.Disabled {
 		return 0
 	}
-	est := lastSegBytes * 11 / 10
-	if est > capBytes {
-		return capBytes
+	p = p.withDefaults()
+	if lastSegBytes < p.MinBytes {
+		return 0
+	}
+	est := lastSegBytes * int64(100+p.HeadroomPercent) / 100
+	if est > p.MaxBytes {
+		return p.MaxBytes
 	}
 	return est
 }

--- a/internal/recorder/prealloc.go
+++ b/internal/recorder/prealloc.go
@@ -1,0 +1,23 @@
+package recorder
+
+// segmentPreallocEstimate converts the previous segment's final size into
+// the fallocate hint for the next one (#757). Recorders know no encoder
+// bitrate; the last segment is the best proxy (same camera, same duration
+// policy, same scene complexity).
+//
+//   - 10% headroom absorbs bitrate drift without re-growing the file;
+//   - the floor skips pointless preallocation for tiny/failed segments;
+//   - the cap stops one pathological segment (e.g. a 4GiB stco-limit run)
+//     from reserving absurd space for its successors.
+func segmentPreallocEstimate(lastSegBytes int64) int64 {
+	const floor = 4 << 20    // 4MiB — below this, extent churn is negligible
+	const capBytes = 512 << 20 // 512MiB — stco-limit headroom is 4GiB
+	if lastSegBytes < floor {
+		return 0
+	}
+	est := lastSegBytes * 11 / 10
+	if est > capBytes {
+		return capBytes
+	}
+	return est
+}

--- a/internal/recorder/prealloc.go
+++ b/internal/recorder/prealloc.go
@@ -10,7 +10,7 @@ package recorder
 //   - the cap stops one pathological segment (e.g. a 4GiB stco-limit run)
 //     from reserving absurd space for its successors.
 func segmentPreallocEstimate(lastSegBytes int64) int64 {
-	const floor = 4 << 20    // 4MiB — below this, extent churn is negligible
+	const floor = 4 << 20      // 4MiB — below this, extent churn is negligible
 	const capBytes = 512 << 20 // 512MiB — stco-limit headroom is 4GiB
 	if lastSegBytes < floor {
 		return 0

--- a/internal/recorder/prealloc_test.go
+++ b/internal/recorder/prealloc_test.go
@@ -1,0 +1,23 @@
+package recorder
+
+import "testing"
+
+func TestSegmentPreallocEstimate(t *testing.T) {
+	cases := []struct {
+		name string
+		last int64
+		want int64
+	}{
+		{"no history", 0, 0},
+		{"tiny segment skipped", 1 << 20, 0},
+		{"below floor skipped", 4<<20 - 1, 0},
+		{"at floor", 4 << 20, 4<<20 + 4<<20/10},
+		{"typical 30s H.264 (~100MiB)", 100 << 20, 110 << 20},
+		{"capped at 512MiB", 2 << 30, 512 << 20},
+	}
+	for _, tc := range cases {
+		if got := segmentPreallocEstimate(tc.last); got != tc.want {
+			t.Errorf("%s: last=%d got %d, want %d", tc.name, tc.last, got, tc.want)
+		}
+	}
+}

--- a/internal/recorder/prealloc_test.go
+++ b/internal/recorder/prealloc_test.go
@@ -3,6 +3,7 @@ package recorder
 import "testing"
 
 func TestSegmentPreallocEstimate(t *testing.T) {
+	def := PreallocParams{} // zero value = documented defaults
 	cases := []struct {
 		name string
 		last int64
@@ -11,13 +12,34 @@ func TestSegmentPreallocEstimate(t *testing.T) {
 		{"no history", 0, 0},
 		{"tiny segment skipped", 1 << 20, 0},
 		{"below floor skipped", 4<<20 - 1, 0},
-		{"at floor", 4 << 20, 4<<20 + 4<<20/10},
+		{"at floor (+10%)", 4 << 20, 4<<20 + 4<<20/10},
 		{"typical 30s H.264 (~100MiB)", 100 << 20, 110 << 20},
 		{"capped at 512MiB", 2 << 30, 512 << 20},
 	}
 	for _, tc := range cases {
-		if got := segmentPreallocEstimate(tc.last); got != tc.want {
+		if got := segmentPreallocEstimate(tc.last, def); got != tc.want {
 			t.Errorf("%s: last=%d got %d, want %d", tc.name, tc.last, got, tc.want)
 		}
+	}
+}
+
+func TestSegmentPreallocEstimate_CustomParams(t *testing.T) {
+	p := PreallocParams{HeadroomPercent: 25, MinBytes: 8 << 20, MaxBytes: 64 << 20}
+	if got := segmentPreallocEstimate(16<<20, p); got != 20<<20 {
+		t.Errorf("custom headroom: got %d, want 20MiB (+25%%)", got)
+	}
+	if got := segmentPreallocEstimate(4<<20, p); got != 0 {
+		t.Errorf("below custom floor: got %d, want 0", got)
+	}
+	if got := segmentPreallocEstimate(1<<30, p); got != 64<<20 {
+		t.Errorf("custom cap: got %d, want 64MiB", got)
+	}
+}
+
+func TestSegmentPreallocEstimate_Disabled(t *testing.T) {
+	// storage.prealloc_enabled: false disables entirely.
+	p := PreallocParams{Disabled: true}
+	if got := segmentPreallocEstimate(100<<20, p); got != 0 {
+		t.Errorf("disabled prealloc: got %d, want 0", got)
 	}
 }


### PR DESCRIPTION
Closes #757.

## What
- `internal/prealloc`: unix.Fallocate wrapper (linux build tag, no-op fallback, SwapForTest failure-injection seam)
- `muxer.MP4Muxer.SetPreallocateBytes`: reserves the estimated extent at open — one contiguous region instead of per-append inode metadata transactions (ext4 read locality for merge/playback, less SD/eMMC write amplification). Hint, not a bound; ENOSYS/EOPNOTSUPP degrade silently to append-write
- Close correctness (the nail): moov position is **computed** (mdat end), not SeekEnd — preallocation extends file size past content; Close truncates to the actual content end so crash-recovered segments carry **no zero tail** (zero tails inflate mediaprobe durations)
- Estimate source: previous segment's final size (recorders know no encoder bitrate) with configurable knobs, defaults materialized in config: `storage.prealloc_enabled` (true) / `prealloc_headroom_percent` (10) / `prealloc_min_bytes` (4MiB) / `prealloc_max_bytes` (512MiB); params flow config → BaseConfig → estimate (zero value = documented defaults); first segment after start runs unpreallocated
- AVI muxer (buffered whole-file layout) intentionally out of scope

## Tests
Byte-identical output prealloc vs plain; file size exactly == content length (zero-tail nail, verified on real fs); overshoot grows normally; injected failure still completes. M5 filefrag: old 316MB segment = 18 extents (~1 per 18MB); new preallocated = 1-2 extents; durations all normal (no tail inflation).