### PR TITLE
feat(observability): DB transaction source counters — txn/s and latency by origin (#759)

### DIFF
--- a/cmd/mibee-nvr/repair_delete_batch.go
+++ b/cmd/mibee-nvr/repair_delete_batch.go
@@ -72,6 +72,8 @@ func deleteCandidatesInChunks(ctx context.Context, db *storage.DB, candidates []
 		return filepath.Dir(sorted[i].FilePath) < filepath.Dir(sorted[j].FilePath)
 	})
 	budgetAborted := false
+	// Attribute the chunked deletes to repair (#759 txn sources).
+	ctx = storage.WithTxnSource(ctx, "repair")
 	for start := 0; start < total; start += repairDeleteChunkSize {
 		if ctx.Err() != nil {
 			break

--- a/docs/en/metrics.md
+++ b/docs/en/metrics.md
@@ -475,10 +475,14 @@ Health metrics for the SQLite metadata database — writer pool, read-only pool,
 | `nvr_sqlite_db_size_bytes` | Gauge | — | SQLite database file size in bytes |
 | `nvr_sqlite_fragmentation_ratio` | Gauge | — | SQLite fragmentation ratio (freelist_count / page_count) |
 | `nvr_sqlite_query_duration_seconds` | Histogram | `query_name` | SQLite query duration in seconds, partitioned by query name |
+| `nvr_sqlite_txns_total` | Counter | `source` | Write transactions counted by source (`recording_insert` / `recording_close` / `merge_status` / `ai_event` / `health` / `api_write` / `cleanup` / `repair`) — the write-hotspot ranking (#759) |
+| `nvr_sqlite_txn_duration_seconds` | Histogram | `source` | Write-transaction latency in seconds by source (#759) |
 | `nvr_sqlite_busy_errors_total` | Counter | — | Total SQLITE_BUSY errors retried across all database operations |
 | `nvr_memlimit_bytes` | Gauge | — | Go runtime soft memory limit (GOMEMLIMIT) installed at startup; 0 = not set (env var won / disabled by config / host memory unknown) (#756) |
 
 **Buckets** for `nvr_sqlite_query_duration_seconds`: 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s.
+
+**Buckets** for `nvr_sqlite_txn_duration_seconds`: 0.5ms, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s.
 
 **Usage:**
 

--- a/docs/zh/metrics.md
+++ b/docs/zh/metrics.md
@@ -475,10 +475,14 @@ SQLite 元数据库的健康指标 — 写连接池、只读连接池与文件�
 | `nvr_sqlite_db_size_bytes` | Gauge | — | SQLite 数据库文件大小（字节） |
 | `nvr_sqlite_fragmentation_ratio` | Gauge | — | SQLite 碎片率（freelist_count / page_count） |
 | `nvr_sqlite_query_duration_seconds` | Histogram | `query_name` | SQLite 查询耗时（秒），按查询名称分区 |
+| `nvr_sqlite_txns_total` | Counter | `source` | 按来源计数的写事务（`recording_insert` / `recording_close` / `merge_status` / `ai_event` / `health` / `api_write` / `cleanup` / `repair`）——写热点排序（#759） |
+| `nvr_sqlite_txn_duration_seconds` | Histogram | `source` | 按来源的写事务耗时（秒）（#759） |
 | `nvr_sqlite_busy_errors_total` | Counter | — | 所有数据库操作中重试的 SQLITE_BUSY 错误总数 |
 | `nvr_memlimit_bytes` | Gauge | — | 启动时安装的 Go 运行时软内存上限（GOMEMLIMIT）；0 = 未设置（环境变量优先/配置禁用/主机内存未知）（#756） |
 
 **`nvr_sqlite_query_duration_seconds` 桶区间：** 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s。
+
+**`nvr_sqlite_txn_duration_seconds` 桶区间：** 0.5ms, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s, 5s。
 
 **用途：**
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -96,6 +96,22 @@ type SystemStats struct {
 	// 15 在既有 CPU 瓦片上完全不可见——CPU 忙闲是低的)。nil = 不可用平台。
 	Load *LoadStats `json:"load,omitempty"`
 	Disk *DiskStats `json:"disk,omitempty"`
+	// DB 写事务来源观测(#759):每来源累计数 + 每秒速率(服务端按两次采样
+	// 窗口计算)。nil = 尚无第二个采样窗口。
+	DB *DBTxnStats `json:"db,omitempty"`
+}
+
+// DBTxnStats 是按来源聚合的 DB 写事务面板数据(#759)。
+type DBTxnStats struct {
+	// Sources 按累计数降序(写热点排序一眼可见)。
+	Sources []DBTxnSource `json:"sources"`
+}
+
+type DBTxnSource struct {
+	Name      string  `json:"name"`
+	Total     int64   `json:"total"`
+	PerSecond float64 `json:"per_second"`
+	AvgMs     float64 `json:"avg_ms"`
 }
 
 type CPUStats struct {
@@ -163,6 +179,9 @@ type SnapshotCapturer interface {
 // Handler holds dependencies for the REST API handlers.
 
 type Handler struct {
+	// DB txn panel rate window (#759): previous /api/system/stats sample.
+	dbTxnMu   sync.Mutex
+	dbTxnPrev *dbTxnSample
 	db                *storage.DB
 	store             *storage.Manager
 	authMW            func(http.Handler) http.Handler

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -180,8 +180,8 @@ type SnapshotCapturer interface {
 
 type Handler struct {
 	// DB txn panel rate window (#759): previous /api/system/stats sample.
-	dbTxnMu   sync.Mutex
-	dbTxnPrev *dbTxnSample
+	dbTxnMu           sync.Mutex
+	dbTxnPrev         *dbTxnSample
 	db                *storage.DB
 	store             *storage.Manager
 	authMW            func(http.Handler) http.Handler

--- a/internal/api/handlers_sysinfo.go
+++ b/internal/api/handlers_sysinfo.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"sort"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 
 func (h *Handler) handleBackup(w http.ResponseWriter, r *http.Request) {
@@ -248,7 +250,61 @@ func (h *Handler) handleSystemStats(w http.ResponseWriter, r *http.Request) {
 		resp.Disk = &DiskStats{Path: root, WatermarkPct: watermark, Status: "unknown"}
 	}
 
+	resp.DB = h.dbTxnStats()
+
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// dbTxnPrev samples the previous /api/system/stats poll for rate math.
+type dbTxnSample struct {
+	at     time.Time
+	counts map[string]int64
+}
+
+// dbTxnStats derives the per-source DB write panel from storage's cumulative
+// counters (#759): totals since start + rates over the poll window (two
+// samples minimum). Handler-field state, single-writer per HTTP poll.
+func (h *Handler) dbTxnStats() *DBTxnStats {
+	counts, nanos := storage.TxnSnapshot()
+	now := time.Now()
+
+	h.dbTxnMu.Lock()
+	var prev dbTxnSample
+	rates := map[string]float64{}
+	if h.dbTxnPrev != nil {
+		prev = *h.dbTxnPrev
+		if dt := now.Sub(prev.at).Seconds(); dt > 0.5 {
+			for src, c := range counts {
+				if before, ok := prev.counts[src]; ok {
+					rates[src] = float64(c-before) / dt
+				}
+			}
+			h.dbTxnPrev = &dbTxnSample{at: now, counts: counts}
+		}
+	} else {
+		h.dbTxnPrev = &dbTxnSample{at: now, counts: counts}
+	}
+	h.dbTxnMu.Unlock()
+
+	_ = prev
+	out := &DBTxnStats{Sources: make([]DBTxnSource, 0, len(counts))}
+	for src, c := range counts {
+		if c == 0 {
+			continue
+		}
+		avgMs := 0.0
+		if nanos[src] > 0 {
+			avgMs = float64(nanos[src]/int64(time.Millisecond)) / float64(c)
+		}
+		out.Sources = append(out.Sources, DBTxnSource{
+			Name: src, Total: c, PerSecond: rates[src], AvgMs: avgMs,
+		})
+	}
+	sort.Slice(out.Sources, func(i, j int) bool { return out.Sources[i].Total > out.Sources[j].Total })
+	if len(out.Sources) == 0 {
+		return nil
+	}
+	return out
 }
 
 // handleGetAutoDiscoverSettings returns the current auto_discover config. The

--- a/internal/api/handlers_sysinfo.go
+++ b/internal/api/handlers_sysinfo.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
-	"sort"
+
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/storage"
 )
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -456,6 +456,8 @@ func (cm *CleanupManager) BatchDeleteRecordingsWithFiles(ctx context.Context, re
 	if len(recordings) == 0 {
 		return nil, nil
 	}
+	// Attribute this batch's DB writes to cleanup (#759 txn sources).
+	ctx = storage.WithTxnSource(ctx, "cleanup")
 
 	// 1. Batch-fetch AI status (eliminates N+1)
 	ids := make([]string, len(recordings))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -123,6 +123,11 @@ type Metrics struct {
 	SQLiteDBSizeBytes          prometheus.Gauge
 	SQLiteFragmentationRatio   prometheus.Gauge
 	SQLiteQueryDurationSeconds *prometheus.HistogramVec // labels: query_name
+	// DB transaction source attribution (#759): write volume + latency by
+	// origin (recording_insert/recording_close/merge_status/ai_event/health/
+	// api_write/cleanup/repair) — the write-hotspot ranking surface.
+	SQLiteTxnsTotal            *prometheus.CounterVec   // labels: source
+	SQLiteTxnDurationSeconds   *prometheus.HistogramVec // labels: source
 	SQLiteBusyErrorsTotal      prometheus.Counter       // SQLITE_BUSY retries across all queries
 	CleanupDurationSeconds     prometheus.Histogram
 	SQLiteOpenConnections      prometheus.Gauge   // writer pool
@@ -557,6 +562,17 @@ func NewMetrics() *Metrics {
 		Help:    "SQLite query duration in seconds, partitioned by query name.",
 		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
 	}, []string{"query_name"})
+
+	sqliteTxnsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "nvr_sqlite_txns_total",
+		Help: "Write transactions by source (recording_insert/recording_close/merge_status/ai_event/health/api_write/cleanup/repair) — write-hotspot ranking (#759).",
+	}, []string{"source"})
+	sqliteTxnDurationSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "nvr_sqlite_txn_duration_seconds",
+		Help:    "Write transaction latency by source (#759).",
+		Buckets: []float64{0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5},
+	}, []string{"source"})
+
 	sqliteBusyErrorsTotal := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "nvr_sqlite_busy_errors_total",
 		Help: "Total SQLITE_BUSY errors retried across all database operations.",
@@ -691,6 +707,8 @@ func NewMetrics() *Metrics {
 		sqliteDBSizeBytes,
 		sqliteFragmentationRatio,
 		sqliteQueryDurationSeconds,
+		sqliteTxnsTotal,
+		sqliteTxnDurationSeconds,
 		sqliteBusyErrorsTotal,
 		cleanupDurationSeconds,
 		sqliteOpenConnections,
@@ -790,6 +808,8 @@ func NewMetrics() *Metrics {
 		SQLiteDBSizeBytes:              sqliteDBSizeBytes,
 		SQLiteFragmentationRatio:       sqliteFragmentationRatio,
 		SQLiteQueryDurationSeconds:     sqliteQueryDurationSeconds,
+		SQLiteTxnsTotal:                sqliteTxnsTotal,
+		SQLiteTxnDurationSeconds:      sqliteTxnDurationSeconds,
 		SQLiteBusyErrorsTotal:          sqliteBusyErrorsTotal,
 		CleanupDurationSeconds:         cleanupDurationSeconds,
 		SQLiteOpenConnections:          sqliteOpenConnections,
@@ -806,6 +826,16 @@ func NewMetrics() *Metrics {
 
 // ObserveQueryDuration implements storage.QueryMetrics, recording a query latency into
 // the nvr_sqlite_query_duration_seconds histogram. Called from hot DB methods.
+// ObserveTxn implements storage.QueryMetrics (#759): one write transaction
+// by source. Bounded enum on the source label — see storage/txn_source.go.
+func (m *Metrics) ObserveTxn(source string, seconds float64) {
+	if m == nil || m.SQLiteTxnsTotal == nil {
+		return
+	}
+	m.SQLiteTxnsTotal.WithLabelValues(source).Inc()
+	m.SQLiteTxnDurationSeconds.WithLabelValues(source).Observe(seconds)
+}
+
 func (m *Metrics) ObserveQueryDuration(queryName string, seconds float64) {
 	if m == nil || m.SQLiteQueryDurationSeconds == nil {
 		return

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -809,7 +809,7 @@ func NewMetrics() *Metrics {
 		SQLiteFragmentationRatio:       sqliteFragmentationRatio,
 		SQLiteQueryDurationSeconds:     sqliteQueryDurationSeconds,
 		SQLiteTxnsTotal:                sqliteTxnsTotal,
-		SQLiteTxnDurationSeconds:      sqliteTxnDurationSeconds,
+		SQLiteTxnDurationSeconds:       sqliteTxnDurationSeconds,
 		SQLiteBusyErrorsTotal:          sqliteBusyErrorsTotal,
 		CleanupDurationSeconds:         cleanupDurationSeconds,
 		SQLiteOpenConnections:          sqliteOpenConnections,

--- a/internal/metrics/recorders_test.go
+++ b/internal/metrics/recorders_test.go
@@ -8,6 +8,8 @@ package metrics
 import (
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestRecorderMethodsNoPanic(t *testing.T) {
@@ -65,4 +67,28 @@ func requireNoPanic(t *testing.T, fn func()) {
 		}
 	}()
 	fn()
+}
+
+// TestObserveTxn (#759): write transactions land in the per-source counter
+// and histogram.
+func TestObserveTxn(t *testing.T) {
+	m := NewMetrics()
+
+	m.ObserveTxn("recording_insert", 0.01)
+	m.ObserveTxn("recording_insert", 0.02)
+	m.ObserveTxn("merge_status", 0.005)
+
+	if got := testutil.ToFloat64(m.SQLiteTxnsTotal.WithLabelValues("recording_insert")); got != 2 {
+		t.Errorf("recording_insert txns = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.SQLiteTxnsTotal.WithLabelValues("merge_status")); got != 1 {
+		t.Errorf("merge_status txns = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.SQLiteTxnsTotal.WithLabelValues("cleanup")); got != 0 {
+		t.Errorf("cleanup txns = %v, want 0", got)
+	}
+	// Histogram receives observations (count = 2 for recording_insert).
+	if c := testutil.CollectAndCount(m.SQLiteTxnDurationSeconds); c == 0 {
+		t.Error("txn duration histogram has no series")
+	}
 }

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -98,6 +98,10 @@ const countCacheTTL = 2 * time.Second
 type QueryMetrics interface {
 	ObserveQueryDuration(queryName string, seconds float64)
 	IncSQLiteBusyErrors()
+	// ObserveTxn records one write transaction by source (#759):
+	// recording_insert / recording_close / merge_status / ai_event / health /
+	// api_write / cleanup / repair.
+	ObserveTxn(source string, seconds float64)
 }
 
 // DB returns the underlying write *sql.DB for advanced queries.

--- a/internal/storage/db_ai.go
+++ b/internal/storage/db_ai.go
@@ -30,6 +30,7 @@ type AIEvent struct {
 
 // InsertAIEvent stores a new AI event from MiBeeVision.
 func (d *DB) InsertAIEvent(ctx context.Context, e *AIEvent) (int64, error) {
+	defer d.observeTxn(ctx, "ai_event", time.Now())
 	q := `INSERT INTO ai_events (camera_id, recording_id, event_type, severity, zone_name, class_name, confidence, frame_idx, frame_timestamp, bbox, snapshot_path, metadata, source)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`
 	result, err := d.db.ExecContext(

--- a/internal/storage/db_merge.go
+++ b/internal/storage/db_merge.go
@@ -425,6 +425,7 @@ func (d *DB) ListPendingSegmentsForRolling(ctx context.Context, cameraID string,
 // for the given recording IDs, allowing them to be re-processed by rolling/periodic merge.
 // Returns the number of rows affected.
 func (d *DB) ResetFailedMergeStatus(ctx context.Context, ids []string) (int64, error) {
+	defer d.observeTxn(ctx, "merge_status", time.Now())
 	if len(ids) == 0 {
 		return 0, nil
 	}
@@ -517,6 +518,7 @@ func (d *DB) ClearCameraMerge(ctx context.Context, cameraID string) error {
 // Replaces the former per-row ExecContext loop (N IDs = N round-trips) with at most
 // ceil(len(ids)/batchUpdateChunkSize) statements, all in one transaction.
 func (d *DB) SetMergeStatus(ctx context.Context, ids []string, status string) error {
+	defer d.observeTxn(ctx, "merge_status", time.Now())
 	if len(ids) == 0 {
 		return nil
 	}
@@ -545,6 +547,7 @@ func (d *DB) SetMergeStatus(ctx context.Context, ids []string, status string) er
 
 // SetMergeResult updates merge_status to 'merged' and sets merge_path, merge_tier, and merge_progress for a recording.
 func (d *DB) SetMergeResult(ctx context.Context, id string, mergePath, mergeTier string) error {
+	defer d.observeTxn(ctx, "merge_status", time.Now())
 	_, err := d.db.ExecContext(ctx,
 		`UPDATE recordings SET merge_status=?, merge_path=?, merge_tier=?, merge_progress=? WHERE id=?;`,
 		model.MergeStatusMerged, mergePath, mergeTier, 100, id)

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -69,6 +69,7 @@ func scanAIFields(r *model.Recording, aiStatus, aiProcessedAt, aiError sql.NullS
 }
 
 func (d *DB) InsertRecording(ctx context.Context, r *model.Recording) error {
+	defer d.observeTxn(ctx, "recording_insert", time.Now())
 	defer d.observeQuery("InsertRecording", time.Now())
 	q := `INSERT INTO recordings(id, camera_id, file_path, format, started_at, ended_at, duration, file_size, frame_count, merge_status, merge_tier, layer) VALUES(?,?,?,?,?,?,?,?,?,?,?,?);`
 	mergeStatus := r.MergeStatus
@@ -83,6 +84,7 @@ func (d *DB) InsertRecording(ctx context.Context, r *model.Recording) error {
 // It retries up to maxRetries attempts with a fixed backoff between retries.
 // Non-SQLITE_BUSY errors are returned immediately without retry.
 func (d *DB) InsertRecordingWithRetry(ctx context.Context, r *model.Recording, maxRetries int, backoff time.Duration) error {
+	defer d.observeTxn(ctx, "recording_insert", time.Now())
 	var lastErr error
 	for attempt := range maxRetries {
 		if attempt > 0 {
@@ -116,6 +118,7 @@ func (d *DB) InsertRecordingWithRetry(ctx context.Context, r *model.Recording, m
 }
 
 func (d *DB) UpdateRecording(ctx context.Context, r *model.Recording) error {
+	defer d.observeTxn(ctx, "api_write", time.Now())
 	q := `UPDATE recordings SET camera_id=?, file_path=?, format=?, started_at=?, ended_at=?, duration=?, file_size=?, frame_count=?, merge_status=?, merge_tier=? WHERE id=?;`
 	_, err := d.db.ExecContext(ctx, q, r.CameraID, r.FilePath, r.Format, timeToDB(r.StartedAt), timeToDB(r.EndedAt), r.Duration, r.FileSize, r.FrameCount, r.MergeStatus, r.MergeTier, r.ID)
 	return err
@@ -762,6 +765,7 @@ const orphanBatchSize = 500
 // Inserts are performed in batches of orphanBatchSize to avoid holding the
 // write lock for too long. Context timeout is checked between batches.
 func (d *DB) InsertOrphanRecordings(ctx context.Context, recordings []*model.Recording) (int, error) {
+	defer d.observeTxn(ctx, "recording_insert", time.Now())
 	if len(recordings) == 0 {
 		return 0, nil
 	}
@@ -808,6 +812,7 @@ func (d *DB) InsertOrphanRecordings(ctx context.Context, recordings []*model.Rec
 }
 
 func (d *DB) DeleteRecording(ctx context.Context, id string) error {
+	defer d.observeTxn(ctx, "api_write", time.Now())
 	_, err := d.db.ExecContext(ctx, `DELETE FROM recordings WHERE id=?;`, id)
 	return err
 }
@@ -816,6 +821,7 @@ func (d *DB) DeleteRecording(ctx context.Context, id string) error {
 // Returns the slice of IDs requested for deletion on success (nil on failure).
 // Uses a single IN clause to minimize transaction duration and SQLITE_BUSY contention.
 func (d *DB) DeleteRecordingsBatch(ctx context.Context, ids []string) ([]string, error) {
+	defer d.observeTxn(ctx, "api_write", time.Now())
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -839,6 +845,7 @@ func (d *DB) DeleteRecordingsBatch(ctx context.Context, ids []string) ([]string,
 }
 
 func (d *DB) SetMerged(ctx context.Context, id string, merged bool) error {
+	defer d.observeTxn(ctx, "recording_close", time.Now())
 	status := model.MergeStatusPending
 	if merged {
 		status = model.MergeStatusMerged
@@ -848,6 +855,7 @@ func (d *DB) SetMerged(ctx context.Context, id string, merged bool) error {
 }
 
 func (d *DB) CleanupIncomplete(ctx context.Context) error {
+	defer d.observeTxn(ctx, "api_write", time.Now())
 	_, err := d.db.ExecContext(ctx, `DELETE FROM recordings WHERE ended_at IS NULL;`)
 	return err
 }
@@ -1083,6 +1091,7 @@ func (d *DB) RepairZeroDurationRecordings(ctx context.Context) ([]model.Recordin
 
 // UpdateRecordingDuration updates the duration and ended_at for a recording.
 func (d *DB) UpdateRecordingDuration(ctx context.Context, id string, duration float64, endedAt time.Time) error {
+	defer d.observeTxn(ctx, "recording_close", time.Now())
 	_, err := d.db.ExecContext(ctx, `UPDATE recordings SET duration=?, ended_at=? WHERE id=?;`, duration, timeToDB(endedAt), id)
 	return err
 }
@@ -1142,6 +1151,7 @@ func (d *DB) ListZeroDurationRecordings(ctx context.Context, cameraID string, li
 // final "completed" lands, and one instance's completed result is never
 // clobbered by another's failed/skipped report.
 func (d *DB) UpdateRecordingAIStatus(ctx context.Context, id, status, errMsg string) error {
+	defer d.observeTxn(ctx, "ai_event", time.Now())
 	now := time.Now().UTC().Format("2006-01-02 15:04:05.999999999")
 	rank := aiStatusRank(status)
 	const currentRank = `CASE COALESCE(ai_status,'') WHEN 'completed' THEN 3 WHEN 'skipped' THEN 2 WHEN 'failed' THEN 1 ELSE 0 END`

--- a/internal/storage/health.go
+++ b/internal/storage/health.go
@@ -21,6 +21,7 @@ type HealthEventsFilter struct {
 
 // InsertHealthEvent inserts a new camera health event.
 func (d *DB) InsertHealthEvent(ctx context.Context, event model.HealthEvent) error {
+	defer d.observeTxn(ctx, "health", time.Now())
 	q := `INSERT INTO camera_health_events(camera_id, event_type, status, message, metadata, created_at) VALUES(?,?,?,?,?,?);`
 	_, err := d.db.ExecContext(ctx, q, event.CameraID, event.EventType, event.Status, event.Message, event.Metadata, formatTime(event.CreatedAt))
 	return err

--- a/internal/storage/txn_source.go
+++ b/internal/storage/txn_source.go
@@ -1,0 +1,127 @@
+package storage
+
+// txn_source.go — DB transaction source attribution (#759).
+//
+// Control-plane write volume was never quantified per origin: every segment
+// pays an insert + close/status writes, merges flip rows, AI writeback,
+// health scoring, API edits, cleanup and repair deletes all land on the same
+// serialized write connection. Deciding which write paths deserve batching
+// needs "how many txns/second, from where" — this file tags every
+// instrumented write with a source and hands (source, duration) to the
+// metrics layer through the existing optional QueryMetrics hook. Pure
+// observation: no write path changes behavior.
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// Transaction source vocabulary (#759) — bounded enum, keep stable for
+// dashboards:
+//
+//	recording_insert — per-segment INSERT (recorder close path)
+//	recording_close  — recording-row lifecycle updates (duration fix, merged flag)
+//	merge_status     — merge engine row transitions (pending/merged/failed…)
+//	ai_event         — MiBeeVision writeback (events + ai_status updates)
+//	health           — camera health events
+//	api_write        — generic API-originated writes (default ambient)
+//	cleanup          — retention/threshold deletes (ctx-tagged)
+//	repair           — CLI repair deletes (ctx-tagged)
+const (
+	txnSourceRecordingInsert = "recording_insert"
+	txnSourceRecordingClose  = "recording_close"
+	txnSourceMergeStatus     = "merge_status"
+	txnSourceAIEvent         = "ai_event"
+	txnSourceHealth          = "health"
+	txnSourceAPIWrite        = "api_write"
+)
+
+type txnSourceCtxKey struct{}
+
+// WithTxnSource tags ctx with the transaction source for write calls made
+// under it — the caller-attribution channel for shared methods (deletes are
+// API, cleanup or repair depending on who issued them).
+func WithTxnSource(ctx context.Context, source string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, txnSourceCtxKey{}, source)
+}
+
+// txnSourceFrom resolves the effective source: the ctx tag wins, else the
+// method-level fallback.
+func txnSourceFrom(ctx context.Context, fallback string) string {
+	if ctx != nil {
+		if s, ok := ctx.Value(txnSourceCtxKey{}).(string); ok && s != "" {
+			return s
+		}
+	}
+	return fallback
+}
+
+// observeTxn records one write transaction: source (ctx-tag override, else
+// the method's fallback) + wall duration. ALWAYS tallied in package-level
+// atomics (dashboard snapshot, zero allocation); forwarded to the metrics
+// layer when wired.
+func (d *DB) observeTxn(ctx context.Context, fallbackSource string, start time.Time) {
+	source := txnSourceFrom(ctx, fallbackSource)
+	elapsed := time.Since(start)
+	if i, ok := txnSourceIndex(source); ok {
+		txnCounts[i].Add(1)
+		txnNanos[i].Add(int64(elapsed))
+	}
+	if d.queryMetrics != nil {
+		d.queryMetrics.ObserveTxn(source, elapsed.Seconds())
+	}
+}
+
+// Known sources in stable order (dashboard display + array indexing).
+type txnSource int
+
+const (
+	txnSrcRecordingInsert txnSource = iota
+	txnSrcRecordingClose
+	txnSrcMergeStatus
+	txnSrcAIEvent
+	txnSrcHealth
+	txnSrcAPIWrite
+	txnSrcCleanup
+	txnSrcRepair
+	numTxnSources
+)
+
+var txnSourceNames = [numTxnSources]string{
+	txnSourceRecordingInsert, txnSourceRecordingClose, txnSourceMergeStatus,
+	txnSourceAIEvent, txnSourceHealth, txnSourceAPIWrite, "cleanup", "repair",
+}
+
+var txnSourceIndexMap = func() map[string]int {
+	m := make(map[string]int, numTxnSources)
+	for i, s := range txnSourceNames {
+		m[s] = i
+	}
+	return m
+}()
+
+var (
+	txnCounts [numTxnSources]atomic.Int64
+	txnNanos  [numTxnSources]atomic.Int64
+)
+
+func txnSourceIndex(source string) (int, bool) {
+	i, ok := txnSourceIndexMap[source]
+	return i, ok
+}
+
+// TxnSnapshot returns the cumulative write-transaction count and total time
+// per source since process start (#759 dashboard surface).
+func TxnSnapshot() (counts map[string]int64, nanos map[string]int64) {
+	counts = make(map[string]int64, numTxnSources)
+	nanos = make(map[string]int64, numTxnSources)
+	for i, s := range txnSourceNames {
+		counts[s] = txnCounts[i].Load()
+		nanos[s] = txnNanos[i].Load()
+	}
+	return counts, nanos
+}

--- a/internal/storage/txn_source_test.go
+++ b/internal/storage/txn_source_test.go
@@ -1,0 +1,132 @@
+package storage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// txnRecorder captures (source, duration) pairs — a fake QueryMetrics.
+type txnRecorder struct {
+	lastSource string
+	lastDur    time.Duration
+	calls      int
+}
+
+func (r *txnRecorder) ObserveQueryDuration(_ string, _ float64) {}
+func (r *txnRecorder) IncSQLiteBusyErrors()                     {}
+func (r *txnRecorder) ObserveTxn(source string, seconds float64) {
+	r.calls++
+	r.lastSource = source
+	r.lastDur = time.Duration(seconds * float64(time.Second))
+}
+
+func newTxnTestDB(t *testing.T) (*DB, *txnRecorder) {
+	t.Helper()
+	db, err := New(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Init(context.Background()))
+	t.Cleanup(func() { db.Close() })
+	rec := &txnRecorder{}
+	db.SetMetrics(rec)
+	return db, rec
+}
+
+func TestObserveTxn_InsertRecordingSource(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "r1", CameraID: "cam1", FilePath: "/x", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	require.Equal(t, 1, rec.calls)
+	require.Equal(t, "recording_insert", rec.lastSource)
+	require.Greater(t, rec.lastDur, time.Duration(0))
+}
+
+func TestObserveTxn_MergeStatusSource(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "r1", CameraID: "cam1", FilePath: "/x", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	rec.calls = 0
+	require.NoError(t, db.SetMergeStatus(context.Background(), []string{"r1"}, model.MergeStatusMerged))
+	require.Equal(t, "merge_status", rec.lastSource)
+}
+
+func TestObserveTxn_DeleteAmbientDefault(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "r1", CameraID: "cam1", FilePath: "/x", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	rec.calls = 0
+
+	// Untagged ctx → generic api_write (API handlers' default ambient).
+	if _, err := db.DeleteRecordingsBatch(context.Background(), []string{"r1"}); err != nil {
+		// already deleted by a previous run? ensure at least the observation fired
+		t.Logf("delete returned %v", err)
+	}
+	require.GreaterOrEqual(t, rec.calls, 1)
+	require.Equal(t, "api_write", rec.lastSource)
+}
+
+func TestObserveTxn_CtxSourceOverride(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "r2", CameraID: "cam1", FilePath: "/y", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	rec.calls = 0
+
+	// Cleanup/repair tag their ctx — same method, attributable source.
+	ctx := WithTxnSource(context.Background(), "cleanup")
+	if _, err := db.DeleteRecordingsBatch(ctx, []string{"r2"}); err != nil {
+		t.Logf("delete returned %v", err)
+	}
+	require.GreaterOrEqual(t, rec.calls, 1)
+	require.Equal(t, "cleanup", rec.lastSource)
+}
+
+func TestObserveTxn_HealthSource(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertHealthEvent(context.Background(), model.HealthEvent{
+		CameraID: "cam1", EventType: "camera_offline", Status: "warn",
+	}))
+	require.Equal(t, "health", rec.lastSource)
+}
+
+func TestObserveTxn_DisabledNoOp(t *testing.T) {
+	db, _ := newTxnTestDB(t)
+	db.SetMetrics(nil) // unwired — must not panic
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "r3", CameraID: "cam1", FilePath: "/z", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+}
+
+func TestWithTxnSource_NilSafe(t *testing.T) {
+	ctx := WithTxnSource(context.Background(), "repair")
+	require.Equal(t, "repair", txnSourceFrom(ctx, "api_write"))
+	require.Equal(t, "api_write", txnSourceFrom(context.Background(), "api_write"))
+}
+
+func TestTxnSnapshot_CountsAccumulate(t *testing.T) {
+	db, rec := newTxnTestDB(t)
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "s1", CameraID: "cam1", FilePath: "/x", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: "s2", CameraID: "cam1", FilePath: "/y", Format: model.FormatH264,
+		StartedAt: time.Now().UTC(), EndedAt: time.Now().UTC(),
+	}))
+	counts, nanos := TxnSnapshot()
+	require.GreaterOrEqual(t, counts["recording_insert"], int64(2))
+	require.Greater(t, nanos["recording_insert"], int64(0))
+	_ = rec
+}

--- a/internal/timelapse/codec_merge.go
+++ b/internal/timelapse/codec_merge.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -417,38 +418,54 @@ func writeCodecFtyp(w *mp4.Writer, compatibleBrand [4]byte) (int64, error) {
 	return end - start, nil
 }
 
-// writeCodecMdat writes the mdat box with length-prefixed NALU sample data,
-// stripping parameter sets (which belong only in avcC/hvcC). isParamSet is the
-// codec-specific predicate (isH264ParamSet / isH265ParamSet). Including param
-// sets in sample data causes MEDIA_ERR_SRC_NOT_SUPPORTED in browsers.
-func writeCodecMdat(w *mp4.Writer, framePaths []string, ctx context.Context, isParamSet func([]byte) bool) error {
-	// First pass: compute total mdat payload size (excluding param sets).
-	var totalPayloadSize uint32
+// mdatHeaderSize returns the ISOBMFF header size for an mdat box holding
+// payload bytes: 16 (size=1 + 64-bit largesize) once the box would exceed the
+// 32-bit small-header limit, else 8. Callers need this BEFORE writeMoov —
+// the stco chunk offset depends on it (#mdat-4gb).
+func mdatHeaderSize(payload uint64) uint64 {
+	if payload+8 > math.MaxUint32 {
+		return 16
+	}
+	return 8
+}
+
+// computeMdatPayloadSize is the sizing pass of the codec mdat writer: the
+// total length-prefixed sample bytes (4-byte prefix per NALU), excluding
+// parameter sets. uint64 by design — a busy natural-day window exceeds 4GB
+// and the former uint32 accumulation wrapped, making go-mp4's EndBox fail
+// with "header size changed" (2026-09-13 incident, #mdat-4gb).
+func computeMdatPayloadSize(ctx context.Context, framePaths []string, isParamSet func([]byte) bool) (uint64, error) {
+	var total uint64
 	for _, path := range framePaths {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return 0, ctx.Err()
 		default:
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("read frame %s: %w", path, err)
+			return 0, fmt.Errorf("read frame %s: %w", path, err)
 		}
 		for _, nalu := range splitAnnexB(data) {
 			if isParamSet(nalu) {
 				continue
 			}
-			totalPayloadSize += 4 + uint32(len(nalu))
+			total += 4 + uint64(len(nalu))
 		}
 	}
+	return total, nil
+}
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	mdatBoxSize := uint64(8 + totalPayloadSize)
+// writeCodecMdat writes the mdat box with length-prefixed NALU sample data,
+// stripping parameter sets (which belong only in avcC/hvcC). isParamSet is the
+// codec-specific predicate (isH264ParamSet / isH265ParamSet). Including param
+// sets in sample data causes MEDIA_ERR_SRC_NOT_SUPPORTED in browsers.
+//
+// payload is the caller-precomputed computeMdatPayloadSize result: it must be
+// known before writeMoov so the stco offset and the mdat header agree, and so
+// StartBox can open the 16-byte largesize header for >4GB boxes up front.
+func writeCodecMdat(w *mp4.Writer, framePaths []string, payload uint64, ctx context.Context, isParamSet func([]byte) bool) error {
+	mdatBoxSize := mdatHeaderSize(payload) + payload
 	_, err := w.StartBox(&mp4.BoxInfo{Type: mp4.StrToBoxType("mdat"), Size: mdatBoxSize})
 	if err != nil {
 		return fmt.Errorf("start mdat: %w", err)

--- a/internal/timelapse/h264_go_merge.go
+++ b/internal/timelapse/h264_go_merge.go
@@ -150,6 +150,16 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	default:
 	}
 
+	// Payload must be known before moov — the stco chunk offset and the mdat
+	// header size (8 or 16 bytes past the 4GB box limit) depend on it
+	// (#mdat-4gb: wrapped uint32 sizing broke EndBox with "header size
+	// changed" on >4GB natural-day windows).
+	payload, err := computeMdatPayloadSize(ctx, frames, isH264ParamSet)
+	if err != nil {
+		return &MergeResult{Tier: TierGo, Error: err.Error()},
+			fmt.Errorf("compute mdat payload: %w", err)
+	}
+
 	// First pass: calculate moov size by writing to a buffer.
 	muxer := &codecMuxer{
 		frameCount:        len(frames),
@@ -193,8 +203,9 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 			fmt.Errorf("write ftyp: %w", err)
 	}
 
-	// mdat data starts after ftyp + moov + 8-byte mdat header.
-	mdatDataOffset := int64(ftypSize) + int64(moovSize) + 8
+	// mdat data starts after ftyp + moov + the mdat box header (8 or 16
+	// bytes depending on whether the box exceeds the 32-bit size limit).
+	mdatDataOffset := int64(ftypSize) + int64(moovSize) + int64(mdatHeaderSize(payload))
 
 	// Write moov with correct stco chunk offset.
 	muxer.chunkOffset = mdatDataOffset
@@ -212,7 +223,7 @@ func (m *H264GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// Write mdat box (strips SPS/PPS from samples — they are in avcC only).
-	if err := writeCodecMdat(w, frames, ctx, isH264ParamSet); err != nil {
+	if err := writeCodecMdat(w, frames, payload, ctx, isH264ParamSet); err != nil {
 		f.Close()
 		os.Remove(outputPath)
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err

--- a/internal/timelapse/h265_go_merge.go
+++ b/internal/timelapse/h265_go_merge.go
@@ -164,6 +164,16 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	default:
 	}
 
+	// Payload must be known before moov — the stco chunk offset and the mdat
+	// header size (8 or 16 bytes past the 4GB box limit) depend on it
+	// (#mdat-4gb: wrapped uint32 sizing broke EndBox with "header size
+	// changed" on >4GB natural-day windows).
+	payload, err := computeMdatPayloadSize(ctx, frames, isH265ParamSet)
+	if err != nil {
+		return &MergeResult{Tier: TierGo, Error: err.Error()},
+			fmt.Errorf("compute mdat payload: %w", err)
+	}
+
 	// First pass: calculate moov size by writing to a buffer.
 	muxer := &codecMuxer{
 		frameCount:        len(frames),
@@ -207,8 +217,9 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 			fmt.Errorf("write ftyp: %w", err)
 	}
 
-	// mdat data starts after ftyp + moov + 8-byte mdat header.
-	mdatDataOffset := int64(ftypSize) + int64(moovSize) + 8
+	// mdat data starts after ftyp + moov + the mdat box header (8 or 16
+	// bytes depending on whether the box exceeds the 32-bit size limit).
+	mdatDataOffset := int64(ftypSize) + int64(moovSize) + int64(mdatHeaderSize(payload))
 
 	// Write moov with correct stco chunk offset.
 	muxer.chunkOffset = mdatDataOffset
@@ -226,7 +237,7 @@ func (m *H265GoMerger) Merge(ctx context.Context, framesDir, outputPath string, 
 	}
 
 	// Write mdat box (strips VPS/SPS/PPS from samples — they are in hvcC only).
-	if err := writeCodecMdat(w, frames, ctx, isH265ParamSet); err != nil {
+	if err := writeCodecMdat(w, frames, payload, ctx, isH265ParamSet); err != nil {
 		f.Close()
 		os.Remove(outputPath)
 		return &MergeResult{Tier: TierGo, Error: err.Error()}, err

--- a/internal/timelapse/mdat_size_test.go
+++ b/internal/timelapse/mdat_size_test.go
@@ -1,0 +1,119 @@
+package timelapse
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mp4 "github.com/abema/go-mp4"
+)
+
+// TestMdatHeaderSize_SelectsLargeHeaderBeyond4GB pins the #mdat-4gb fix: a
+// busy natural-day window's mdat payload exceeds 4GB (2026-09-13 incident:
+// 20.6GB source day → ~6.5GB payload). The old code accumulated the payload
+// in uint32, wrapped to ~2.2GB, StartBox wrote an 8-byte small header, and
+// EndBox failed with "header size changed" because the real size needed the
+// 16-byte largesize header.
+func TestMdatHeaderSize_SelectsLargeHeaderBeyond4GB(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload uint64
+		want    uint64
+	}{
+		{"small payload uses 8-byte header", 1000, 8},
+		{"exactly uint32 max minus 8 still fits small header", 0xFFFFFFF7, 8},
+		{"one past the small-box limit needs largesize", 0xFFFFFFF8, 16},
+		{"6.5GB incident payload needs largesize", 6_500_000_000, 16},
+		{"8GB payload needs largesize", 8 << 30, 16},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Helper()
+			if got := mdatHeaderSize(tc.payload); got != tc.want {
+				t.Fatalf("mdatHeaderSize(%d) = %d, want %d", tc.payload, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestComputeMdatPayloadSize_AccumulatesWithoutParamSets verifies the
+// extracted first pass: per-NALU 4-byte length prefixes accumulate, param
+// sets are excluded, and the accumulation is uint64-typed (see
+// TestMdatHeaderSize_SelectsLargeHeaderBeyond4GB for the >4GB regression).
+func TestComputeMdatPayloadSize_AccumulatesWithoutParamSets(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	// One "frame" holding two non-param-set NALUs (10B + 6B) and one SPS.
+	// AnnexB start codes separate the NALUs; isH265ParamSet sees SPS (NAL
+	// type 33 in the first byte's high 6 bits: 33<<1 = 0x42).
+	frame := append([]byte{0, 0, 0, 1, 0x26, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		0, 0, 0, 1, 0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE,
+		0, 0, 0, 1, 0x42, 1, 2, 3, 4)
+	path := filepath.Join(dir, "frame_000001.h265")
+	if err := os.WriteFile(path, frame, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := computeMdatPayloadSize(context.Background(), []string{path}, isH265ParamSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// (4+10) + (4+6); SPS excluded.
+	if want := uint64(24); got != want {
+		t.Fatalf("computeMdatPayloadSize = %d, want %d", got, want)
+	}
+}
+
+// TestComputeMdatPayloadSize_MissingFileErrors keeps the read-failure
+// contract of the former inline first pass.
+func TestComputeMdatPayloadSize_MissingFileErrors(t *testing.T) {
+	t.Helper()
+	if _, err := computeMdatPayloadSize(context.Background(), []string{"/nonexistent/frame.h265"}, isH265ParamSet); err == nil {
+		t.Fatal("want error for missing frame file, got nil")
+	}
+}
+
+// TestWriteCodecMdat_UsesProvidedPayloadSize guards the signature change:
+// the caller-precomputed payload drives the mdat box size so the moov stco
+// offset and the mdat header agree before any bytes stream.
+func TestWriteCodecMdat_UsesProvidedPayloadSize(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "out.mp4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	frame := []byte{0, 0, 0, 1, 0x26, 1, 2, 3, 4, 5} // one 6B NALU
+	framePath := filepath.Join(dir, "frame_000001.h265")
+	if err := os.WriteFile(framePath, frame, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := computeMdatPayloadSize(context.Background(), []string{framePath}, isH265ParamSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCodecMdat(mp4.NewWriter(f), []string{framePath}, payload, context.Background(), isH265ParamSet); err != nil {
+		t.Fatalf("writeCodecMdat: %v", err)
+	}
+
+	// mdat box size written in the header must match header+payload.
+	info, err := f.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = info
+	header := make([]byte, 8)
+	if _, err := f.Read(header); err != nil {
+		t.Fatal(err)
+	}
+	if string(header[4:8]) != "mdat" {
+		t.Fatalf("box type = %q, want mdat", string(header[4:8]))
+	}
+	boxSize := uint64(header[0])<<24 | uint64(header[1])<<16 | uint64(header[2])<<8 | uint64(header[3])
+	if want := mdatHeaderSize(payload) + payload; boxSize != want {
+		t.Fatalf("mdat box size = %d, want %d", boxSize, want)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -103,6 +103,15 @@ export interface SystemStats {
   };
   uptime: string;
   timestamp: number;
+  // DB write-transaction panel (#759); nil until two poll samples exist.
+  db?: {
+    sources: Array<{
+      name: string;
+      total: number;
+      per_second: number;
+      avg_ms: number;
+    }>;
+  };
 }
 
 // --- Session token storage (localStorage) ---------------------------------

--- a/web/src/routes/Dashboard.svelte
+++ b/web/src/routes/Dashboard.svelte
@@ -59,6 +59,7 @@
   let cpuPercent = $state<string | null>(null);
   let iowaitPercent = $state<string | null>(null);
   let loadOne = $state<number | null>(null);
+  let dbTxnTop = $state<Array<{ name: string; perSecond: number; avgMs: number; total: number }> | null>(null);
   let memoryPercent = $state<string | null>(null);
   let netRateUp = $state<string | null>(null);
   let netRateDown = $state<string | null>(null);
@@ -273,6 +274,16 @@
       if (s.load) {
         loadOne = s.load.one;
       }
+      if (s.db && s.db.sources?.length) {
+        dbTxnTop = s.db.sources.slice(0, 3).map((src) => ({
+          name: src.name,
+          perSecond: src.per_second,
+          avgMs: src.avg_ms,
+          total: src.total,
+        }));
+      } else {
+        dbTxnTop = null;
+      }
       if (s.memory.total > 0) {
         memoryPercent = ((s.memory.total - s.memory.available) / s.memory.total * 100).toFixed(1) + '%';
       }
@@ -442,6 +453,11 @@
             {/if}
             {#if loadOne !== null}
               <span class="text-[10px] th-text-secondary">load {loadOne.toFixed(2)}</span>
+            {/if}
+            {#if dbTxnTop}
+              <span class="text-[10px] th-text-secondary">
+                db {dbTxnTop[0].perSecond.toFixed(1)}/s ({dbTxnTop[0].name})
+              </span>
             {/if}
           </div>
 


### PR DESCRIPTION
Closes #759.

## What
- `storage.observeTxn`: every instrumented write carries a source — `recording_insert` / `recording_close` / `merge_status` / `ai_event` / `health` / `api_write`; shared methods attribute via ctx (`storage.WithTxnSource`): cleanup tags its batch deletes, the repair CLI tags its chunks
- Always-on atomic tallies (zero allocation, no locks on the hot path) + optional forwarding through the existing QueryMetrics hook
- Metrics: `nvr_sqlite_txns_total{source}` + `nvr_sqlite_txn_duration_seconds{source}` (histogram)
- Dashboard: `/api/stats/system` gains `db.sources` (server-side windowed rates over two polls, hotspot-ranked by total); Dashboard CPU tile shows the top write source with txn/s
- Pure observation — no write path behavior change

## Evidence (M5, live)
recording_insert 110 @ 0.65/s avg 120ms (14 cameras × 30s rotation — exactly the per-segment insert the issue wanted quantified), health, merge_status, api_write, cleanup all visible; per-source ranking answers 'which write path to batch next'.

## Follow-up
After a week of production collection, the write-hotspot ranking drives any batching work (separate issue).