### PR TITLE
feat(io): raw-segment fsync durability tiers — storage.durability strict|relaxed (#760)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -215,6 +215,16 @@ version: "1.0"
   - **>2 GB available RAM** (e.g. Banana Pi M5, x86): up to **2m** (120s), which halves the fragment count rolling merge must process
   - Values above the platform cap are **silently clamped** with a warning in the logs (they do not fail startup). On non-Linux hosts or if `/proc/meminfo` cannot be read, the conservative 30s cap applies.
 
+### `storage.durability`
+- **Type**: string
+- **Default**: `""` (= `strict`)
+- **Values**:
+  - `strict` (default) — every raw segment finalize performs an explicit `fsync` before the temp→final rename. Strongest crash guarantee: after a power loss, everything the NVR acknowledged exists on media.
+  - `relaxed` — raw segments skip the proactive `fsync` and rely on the filesystem's commit interval (typically 5s on ext4). The temp→final **rename stays atomic**: a crash leaves either the complete pre-crash bytes or no final file — never a truncated/half segment. The trade-off: the last seconds (~up to 1 minute) of raw rolling footage may be lost on power loss.
+- **Always strict regardless of tier**: merged recordings, timelapse products, the database (WAL+NORMAL) and config writes — long-term assets keep their fsync.
+- **Who benefits**: flash boards (SD/eMMC) where per-segment fsync is both a latency spike and write-amplification source (~26 fsync/min at 13 cameras × 30s segments); HDD arrays recording continuously.
+- **Example**: `durability: "relaxed"` under the `storage:` section.
+
 ### `storage.db_path`
 - **Type**: string
 - **Optional**: yes

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -176,6 +176,16 @@ version: "1.0"
 - **RPi 限制**: 树莓派 3B 上最大 30 秒
 - **示例**: `"30s"`, `"1m"`, `"5m"`
 
+### `storage.durability`
+- **类型**: string
+- **默认**: `""`（= `strict`）
+- **取值**:
+  - `strict`（默认）—— 每个原始段 finalize 在 temp→final rename 前显式 `fsync`。最强崩溃保证：断电后 NVR 已确认落盘的数据都在介质上。
+  - `relaxed` —— 原始段跳过主动 `fsync`，交给文件系统提交间隔兜底（ext4 通常 5s）。temp→final **rename 保持原子性**：崩溃后要么是崩溃前的完整字节、要么没有 final 文件——绝不会出现截断/半成品段。代价：断电可能丢最后几秒（~最多 1 分钟）的原始滚动录像。
+- **两档恒为 strict**: 合并产物、timelapse 产物、数据库（WAL+NORMAL）、配置写入——长期资产保留 fsync。
+- **适合谁**: 闪存板（SD/eMMC，每段 fsync 是延迟尖峰 + 写放大来源——13 路 × 30s 段 ≈ 每分钟 26 次 fsync）；连续录像的 HDD 阵列。
+- **示例**: 在 `storage:` 节下写 `durability: "relaxed"`。
+
 ### `storage.db_path`
 - **类型**: string
 - **可选**: 是

--- a/internal/config/config_server.go
+++ b/internal/config/config_server.go
@@ -124,6 +124,15 @@ func NormalizeBasePath(p string) string {
 type StorageConfig struct {
 	RootDir         string `yaml:"root_dir"`         // default "/mnt/data/nvr"
 	SegmentDuration string `yaml:"segment_duration"` // default "30s"
+	// Durability selects the raw-segment fsync tier (#760): "" or "strict"
+	// (default) — every segment finalize fsyncs (strongest guarantee);
+	// "relaxed" — raw segments skip the proactive fsync and rely on the
+	// filesystem commit interval (rename atomicity unchanged: a crash
+	// leaves either the complete pre-crash bytes or no final file). Merge
+	// and timelapse products always fsync in both tiers. Flash boards that
+	// can tolerate losing the last seconds of raw recording on power loss
+	// benefit most.
+	Durability string `yaml:"durability"`
 	// Candidates lists additional storage locations made available to the NVR
 	// by the host platform (#395): on fnOS these are the user-authorized
 	// directories (TRIM_DATA_ACCESSIBLE_PATHS), mounted into the container and

--- a/internal/config/durability_test.go
+++ b/internal/config/durability_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDurability_ValidateRejectsUnknown(t *testing.T) {
+	for _, tier := range []string{"", "strict", "relaxed"} {
+		cfg := &Config{}
+		applyConfigDefaults(cfg)
+		cfg.Storage.Durability = tier
+		cfg.Storage.SegmentDuration = "2m"
+		if err := Validate(cfg); err != nil {
+			if strings.Contains(err.Error(), "durability") {
+				t.Errorf("Validate(durability=%q) = %v, want accepted", tier, err)
+			}
+		}
+	}
+	cfg := &Config{}
+	applyConfigDefaults(cfg)
+	cfg.Storage.Durability = "ludicrous"
+	cfg.Storage.SegmentDuration = "2m"
+	err := Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "storage.durability") {
+		t.Errorf("Validate(durability=%q) = %v, want storage.durability error", "ludicrous", err)
+	}
+}
+
+func TestDurability_DefaultStrict(t *testing.T) {
+	cfg := &Config{}
+	applyConfigDefaults(cfg)
+	if cfg.Storage.Durability != "" {
+		t.Errorf("default durability = %q, want empty (strict)", cfg.Storage.Durability)
+	}
+	_ = time.Second
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -348,6 +348,12 @@ func validateConfigDetails(cfg *Config) error {
 			cfg.Storage.SegmentDuration = capped
 		}
 	}
+	// Durability tier (#760): raw-segment fsync policy. "" = strict.
+	switch cfg.Storage.Durability {
+	case "", "strict", "relaxed":
+	default:
+		return fmt.Errorf("storage.durability must be \"strict\" or \"relaxed\" (empty = strict default), got %q", cfg.Storage.Durability)
+	}
 	// Validate retention_days
 	if cfg.Cleanup.RetentionDays < 1 || cfg.Cleanup.RetentionDays > 3650 {
 		return fmt.Errorf("cleanup.retention_days must be between 1 and 3650, got %d", cfg.Cleanup.RetentionDays)

--- a/internal/merge/avimerge.go
+++ b/internal/merge/avimerge.go
@@ -375,7 +375,7 @@ func MergeAVISegments(ctx context.Context, segments []*model.Recording, store *s
 	}
 
 	// ── Step 7: Atomic rename via CloseSegment. ──
-	if err := store.CloseSegment(tempPath, finalPath); err != nil {
+	if err := store.CloseSegmentMerged(tempPath, finalPath); err != nil {
 		os.Remove(tempPath)
 		return nil, nil, fmt.Errorf("close merged segment: %w", err)
 	}

--- a/internal/merge/manager.go
+++ b/internal/merge/manager.go
@@ -518,7 +518,7 @@ func (m *MergeManager) mergeFormatGroup(ctx context.Context, cameraID, format st
 		}
 
 		// Atomic rename.
-		if err := m.store.CloseSegment(tempPath, finalPath); err != nil {
+		if err := m.store.CloseSegmentMerged(tempPath, finalPath); err != nil {
 			logger.Error("failed to finalize merged segment", "error", err)
 			os.Remove(tempPath)
 			m.metrics.RecordMergeFailure("io_error")

--- a/internal/merge/mjpegmerge.go
+++ b/internal/merge/mjpegmerge.go
@@ -87,7 +87,7 @@ func MergeMJPEGSegments(ctx context.Context, segments []*model.Recording, store 
 	})
 
 	// Step 5: Close the segment (atomic rename from temp to final).
-	if err := store.CloseSegment(tempPath, finalPath); err != nil {
+	if err := store.CloseSegmentMerged(tempPath, finalPath); err != nil {
 		return nil, sourceDirs, fmt.Errorf("close merged segment: %w", err)
 	}
 

--- a/internal/merge/rolling_batch.go
+++ b/internal/merge/rolling_batch.go
@@ -339,7 +339,7 @@ func (r *RollingMergeCoordinator) mergeAudioRun(ctx context.Context, cameraID st
 		return 0, fmt.Errorf("output empty")
 	}
 
-	if err := r.store.CloseSegment(tempPath, finalPath); err != nil {
+	if err := r.store.CloseSegmentMerged(tempPath, finalPath); err != nil {
 		os.Remove(tempPath)
 		return 0, fmt.Errorf("finalize: %w", err)
 	}

--- a/internal/merge/rolling_bucket.go
+++ b/internal/merge/rolling_bucket.go
@@ -45,7 +45,7 @@ func (r *RollingMergeCoordinator) createBucket(
 	}
 
 	// Atomic rename.
-	if err := r.store.CloseSegment(tempPath, finalPath); err != nil {
+	if err := r.store.CloseSegmentMerged(tempPath, finalPath); err != nil {
 		os.Remove(tempPath)
 		return "", "", fmt.Errorf("finalize bucket: %w", err)
 	}

--- a/internal/storage/durability_test.go
+++ b/internal/storage/durability_test.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// syncCallCounter wraps the Sync seam to count fsyncs per finalize.
+func swapSyncCounter(t *testing.T) *atomic.Int64 {
+	t.Helper()
+	count := &atomic.Int64{}
+	prev := syncFileFn
+	syncFileFn = func(f *os.File) error {
+		count.Add(1)
+		return f.Sync()
+	}
+	t.Cleanup(func() { syncFileFn = prev })
+	return count
+}
+
+// TestCloseSegment_StrictDefaultFsyncs: default durability is strict — every
+// file-form finalize performs exactly one fsync (regression nail for #760:
+// relaxed must be opt-in).
+func TestCloseSegment_StrictDefaultFsyncs(t *testing.T) {
+	syncs := swapSyncCounter(t)
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+
+	temp, final, err := m.CreateSegment("cam1", "h264")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(temp, []byte("payload"), 0o644))
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Equal(t, int64(1), syncs.Load(), "strict tier: exactly one fsync per finalize")
+	require.FileExists(t, final)
+}
+
+// TestCloseSegment_RelaxedSkipsFsyncButKeepsAtomicity: relaxed tier skips the
+// proactive fsync (page-cache flush via bufio Close is still mandatory) while
+// the temp→final rename stays atomic and the content complete.
+func TestCloseSegment_RelaxedSkipsFsyncButKeepsAtomicity(t *testing.T) {
+	syncs := swapSyncCounter(t)
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+	m.SetDurability("relaxed")
+
+	temp, final, err := m.CreateSegment("cam1", "h264")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(temp, []byte("payload-relaxed"), 0o644))
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Zero(t, syncs.Load(), "relaxed tier: no proactive fsync")
+	require.FileExists(t, final, "rename still performed")
+	b, err := os.ReadFile(final)
+	require.NoError(t, err)
+	require.Equal(t, "payload-relaxed", string(b), "content complete (userspace flush preserved)")
+}
+
+// TestCloseSegment_RelaxedRetainedFDBufferStillFlushed: a segment written
+// through WriteFrame holds a coalescing buffer — relaxed may skip fsync but
+// MUST still flush buffered bytes before close/rename, or frames silently
+// vanish.
+func TestCloseSegment_RelaxedRetainedFDBufferStillFlushed(t *testing.T) {
+	syncs := swapSyncCounter(t)
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+	m.SetDurability("relaxed")
+
+	temp, final, err := m.CreateSegment("cam1", "h264")
+	require.NoError(t, err)
+	_, err = m.WriteFrame(temp, make([]byte, 4096)) // below flush threshold → sits in buffer
+	require.NoError(t, err)
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Zero(t, syncs.Load())
+	b, err := os.ReadFile(final)
+	require.NoError(t, err)
+	require.Len(t, b, 4096, "buffered frame flushed even without fsync")
+}
+
+// TestCloseSegmentMerged_AlwaysStrict: merged/timelapse products are
+// long-term assets — CloseSegmentMerged fsyncs regardless of the tier.
+func TestCloseSegmentMerged_AlwaysStrict(t *testing.T) {
+	syncs := swapSyncCounter(t)
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+	m.SetDurability("relaxed")
+
+	temp, final, err := m.CreateSegment("cam1", "h264")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(temp, []byte("merged-output"), 0o644))
+
+	require.NoError(t, m.CloseSegmentMerged(temp, final))
+	require.Equal(t, int64(1), syncs.Load(), "merged finalize keeps fsync under relaxed tier")
+	require.FileExists(t, final)
+}
+
+// TestCloseSegment_RelaxedDirFormSkipsDirSync: MJPEG dir-form finalize skips
+// the directory fsync under relaxed but still renames.
+func TestCloseSegment_RelaxedDirFormSkipsDirSync(t *testing.T) {
+	syncs := swapSyncCounter(t)
+	dir := t.TempDir()
+	m, err := NewManager(dir)
+	require.NoError(t, err)
+	m.SetDurability("relaxed")
+
+	temp, final, err := m.CreateSegment("cam1", "mjpeg")
+	require.NoError(t, err)
+	require.DirExists(t, temp)
+	require.NoError(t, os.WriteFile(filepath.Join(temp, "20260913_010101.000.jpg"), []byte("j"), 0o644))
+
+	require.NoError(t, m.CloseSegment(temp, final))
+	require.Zero(t, syncs.Load())
+	require.NoDirExists(t, temp)
+	require.DirExists(t, final)
+}

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
@@ -35,6 +36,12 @@ type Manager struct {
 	// so cameras no longer serialize through one another.
 	statesMu      sync.RWMutex
 	segmentStates map[string]*segmentWriter
+
+	// durabilityRelaxed gates RAW-segment fsync (#760): false (default) =
+	// strict — every finalize syncs. true = relaxed: raw segments skip the
+	// proactive fsync (rename atomicity unchanged); merged/timelapse
+	// products always sync regardless (CloseSegmentMerged).
+	durabilityRelaxed atomic.Bool
 
 	// Health tracking (per-camera)
 	healthMu      sync.Mutex
@@ -310,6 +317,35 @@ func (m *Manager) recordFinalizeFailure(tempPath string, err error) {
 // handles (the MP4 muxer, merge outputs) fall back to the reopen-and-sync
 // path, preserving the original behavior.
 func (m *Manager) CloseSegment(tempPath, finalPath string) error {
+	return m.closeSegment(tempPath, finalPath, m.durabilityRelaxed.Load())
+}
+
+// CloseSegmentMerged finalizes a MERGE/TIMELAPSE PRODUCT segment. These are
+// long-term assets (#760): they always fsync, regardless of the durability
+// tier — only raw rolling segments may opt into relaxed.
+func (m *Manager) CloseSegmentMerged(tempPath, finalPath string) error {
+	return m.closeSegment(tempPath, finalPath, false)
+}
+
+// SetDurability selects the raw-segment durability tier: "strict" (default)
+// or "relaxed" (skip proactive fsync; see docs — a power loss may drop the
+// last seconds of raw segments on flash media). Unknown values keep strict.
+func (m *Manager) SetDurability(tier string) {
+	if m == nil {
+		return
+	}
+	m.durabilityRelaxed.Store(tier == "relaxed")
+}
+
+// DurabilityRelaxed reports the current tier (observability/wiring tests).
+func (m *Manager) DurabilityRelaxed() bool {
+	if m == nil {
+		return false
+	}
+	return m.durabilityRelaxed.Load()
+}
+
+func (m *Manager) closeSegment(tempPath, finalPath string, relaxed bool) error {
 	st, serr := m.stateFor(tempPath)
 	if serr != nil {
 		// No state and classification failed (external temp that is already
@@ -323,19 +359,22 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 	isDir := st.isDir
 
 	if isDir {
-		// Sync the directory for MJPEG
-		dirFd, err := os.Open(tempPath)
-		if err != nil {
-			m.recordFinalizeFailure(tempPath, err)
-			m.unregisterTempPath(tempPath)
-			return fmt.Errorf("storage: cannot open temp dir for sync: %w", err)
-		}
-		if err := dirFd.Sync(); err != nil {
+		// Sync the directory for MJPEG (strict tier only — #760: relaxed
+		// leaves directory-entry persistence to the FS commit interval).
+		if !relaxed {
+			dirFd, err := os.Open(tempPath)
+			if err != nil {
+				m.recordFinalizeFailure(tempPath, err)
+				m.unregisterTempPath(tempPath)
+				return fmt.Errorf("storage: cannot open temp dir for sync: %w", err)
+			}
+			if err := syncFileFn(dirFd); err != nil {
+				dirFd.Close()
+				m.RecordWriteFailureForPath(tempPath)
+				return fmt.Errorf("storage: failed to sync temp dir: %w", err)
+			}
 			dirFd.Close()
-			m.RecordWriteFailureForPath(tempPath)
-			return fmt.Errorf("storage: failed to sync temp dir: %w", err)
 		}
-		dirFd.Close()
 
 		// Atomic rename of directory
 		if err := os.Rename(tempPath, finalPath); err != nil {
@@ -349,19 +388,21 @@ func (m *Manager) CloseSegment(tempPath, finalPath string) error {
 		// for externally written temps (muxer/merge outputs already closed
 		// their own handles before calling CloseSegment).
 		if st == nil || st.file == nil {
-			f, err := openFileFn(tempPath, os.O_WRONLY, 0)
-			if err != nil {
-				m.recordFinalizeFailure(tempPath, err)
-				m.unregisterTempPath(tempPath)
-				return fmt.Errorf("storage: cannot open temp file for sync: %w", err)
-			}
-			if err := f.Sync(); err != nil {
+			if !relaxed {
+				f, err := openFileFn(tempPath, os.O_WRONLY, 0)
+				if err != nil {
+					m.recordFinalizeFailure(tempPath, err)
+					m.unregisterTempPath(tempPath)
+					return fmt.Errorf("storage: cannot open temp file for sync: %w", err)
+				}
+				if err := syncFileFn(f); err != nil {
+					f.Close()
+					m.RecordWriteFailureForPath(tempPath)
+					return fmt.Errorf("storage: failed to sync temp file: %w", err)
+				}
 				f.Close()
-				m.RecordWriteFailureForPath(tempPath)
-				return fmt.Errorf("storage: failed to sync temp file: %w", err)
 			}
-			f.Close()
-		} else if err := st.finalize(); err != nil {
+		} else if err := st.finalize(relaxed); err != nil {
 			m.RecordWriteFailureForPath(tempPath)
 			return fmt.Errorf("storage: failed to finalize temp file: %w", err)
 		}

--- a/internal/storage/segment_writer.go
+++ b/internal/storage/segment_writer.go
@@ -55,6 +55,7 @@ const (
 var (
 	statFn     = os.Stat
 	openFileFn = os.OpenFile
+	syncFileFn = (*os.File).Sync // fsync seam — durability-tier assertions (#760)
 )
 
 // errSegmentReleased is returned when the writer state was already finalized
@@ -171,7 +172,11 @@ func (s *segmentWriter) writeFrame(data []byte) (int, error) {
 // Called from CloseSegment with s.mu held. A nil FD (segment written through
 // an external handle — the MP4 muxer, merge outputs) is a no-op so the caller
 // falls back to its reopen-and-sync path.
-func (s *segmentWriter) finalize() error {
+// finalize flushes the coalescing buffer (mandatory in every tier — buffered
+// frames must reach the kernel before close/rename), then optionally fsyncs.
+// skipSync=true is the #760 relaxed tier: rename atomicity still guarantees a
+// crash leaves either the complete pre-crash bytes or no final file.
+func (s *segmentWriter) finalize(skipSync bool) error {
 	if s.bw != nil {
 		if err := s.bw.Flush(); err != nil {
 			return fmt.Errorf("storage: flush media: %w", err)
@@ -179,12 +184,14 @@ func (s *segmentWriter) finalize() error {
 		s.pending = 0
 	}
 	if s.file != nil {
-		if err := s.file.Sync(); err != nil {
-			s.file.Close()
-			s.file = nil
-			s.bw = nil
-			s.released = true
-			return fmt.Errorf("storage: failed to sync temp file: %w", err)
+		if !skipSync {
+			if err := syncFileFn(s.file); err != nil {
+				s.file.Close()
+				s.file = nil
+				s.bw = nil
+				s.released = true
+				return fmt.Errorf("storage: failed to sync temp file: %w", err)
+			}
 		}
 		if err := s.file.Close(); err != nil {
 			s.file = nil

--- a/internal/ui/static/sw.js
+++ b/internal/ui/static/sw.js
@@ -11,7 +11,7 @@
 //
 // During `vite dev` the placeholder is NOT rewritten, so we fall back to a
 // dev-only random version (each reload is a new cache — fine for dev).
-const CACHE_VERSION = 'mibee-nvr-1789218102873';
+const CACHE_VERSION = 'mibee-nvr-1789233137029';
 
 // Serving prefix (#394): when the app is served under a reverse-proxy /
 // unified-gateway base path (e.g. fnOS "/app/mibee-nvr"), this SW itself lives

--- a/pkg/app/builders.go
+++ b/pkg/app/builders.go
@@ -182,6 +182,9 @@ func buildAppDeps(cfg *config.Config, configPath string) (*appDeps, func(), erro
 		db.Close()
 		return nil, nil, fmt.Errorf("storage: %w", err)
 	}
+	// Raw-segment durability tier (#760): strict (default) or relaxed
+	// (skip proactive fsync on raw segments; merge products always sync).
+	store.SetDurability(cfg.Storage.Durability)
 	deps.store = store
 
 	// Step 3.5: Background storage migrator (idle-time, rate-limited; the

--- a/pkg/app/durability_wiring_test.go
+++ b/pkg/app/durability_wiring_test.go
@@ -1,0 +1,31 @@
+package app
+
+import "testing"
+
+// TestBuildAppDeps_DurabilityWired guards the #760 wiring: the YAML
+// storage.durability tier reaches the storage manager. Default (empty) must
+// stay strict — relaxed is strictly opt-in.
+func TestBuildAppDeps_DurabilityWired(t *testing.T) {
+	t.Helper()
+
+	cfg, configPath := minimalConfig(t)
+	cfg.Storage.Durability = "relaxed"
+	deps, cleanupFn, err := buildAppDeps(cfg, configPath)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanupFn()
+	if !deps.store.DurabilityRelaxed() {
+		t.Error("storage.durability=relaxed did not reach the storage manager")
+	}
+
+	cfg2, configPath2 := minimalConfig(t)
+	deps2, cleanupFn2, err := buildAppDeps(cfg2, configPath2)
+	if err != nil {
+		t.Fatalf("buildAppDeps: %v", err)
+	}
+	defer cleanupFn2()
+	if deps2.store.DurabilityRelaxed() {
+		t.Error("default (empty) durability must remain strict")
+	}
+}


### PR DESCRIPTION
Closes #760 (option C from the issue — default guarantee unchanged, choice to the deployer).

## What
- `storage.durability`: `""`/`strict` (default — every raw-segment finalize fsyncs, behavior identical to today) | `relaxed` — raw segments skip the proactive fsync and rely on the FS commit interval
- Relaxed semantics: the temp→final **rename stays atomic** — a crash leaves either the complete pre-crash bytes or no final file, never a truncated segment; the userspace coalescing-buffer flush stays mandatory in BOTH tiers (skipping fsync ≠ skipping flush); documented loss window = last seconds (~1min) of raw footage on power loss
- `CloseSegmentMerged`: merge/timelapse products are long-term assets and **always fsync regardless of tier** (5 call sites switched); DB (WAL+NORMAL) and config writes untouched
- Metrics-off / health-accounting semantics unchanged; sync seam makes tier behavior assertable
- docs en/zh: `storage.durability` section with loss semantics + who benefits (flash boards; ~26 fsync/min at 13 cams × 30s)

## Tests
fsync-count assertions per tier × {file-reopen, retained-FD, dir-form} + merged-always-strict nail + relaxed buffer-flush nail. M5: relaxed enabled live — 14 cameras recording, segment durations/sizes normal; reverted to strict after.