### PR TITLE
docs: entry links for performance.md (zh/en)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -273,6 +273,8 @@ A `config.Validate()` warning fires when the global value is below 60s and
 at least one continuous-mode camera has no override — `mibee-nvr
 validate-config` surfaces it too.
 
+> For systematic storage & memory tuning (fsync durability tiers, preallocation, GOMEMLIMIT, background I/O budgeting) see [Performance Tuning](performance.md).
+
 ### `storage.db_path`
 - **Type**: string
 - **Optional**: yes

--- a/docs/en/observability.md
+++ b/docs/en/observability.md
@@ -115,4 +115,5 @@ This exposes `/debug/pprof/*` (CPU/heap/goroutine profiles). The endpoint sits b
 
 - [metrics.md](metrics.md) — full Prometheus metric reference
 - [configuration.md](configuration.md) — `observability` settings
+- [performance.md](performance.md) — memory tiering & background I/O budgeting (incl. the `nvr_iobudget_*` / `nvr_memlimit_bytes` metrics)
 - [troubleshooting.md](troubleshooting.md) — common problems

--- a/docs/en/storage-optimization.md
+++ b/docs/en/storage-optimization.md
@@ -544,3 +544,4 @@ A multi-stage optimization targeting 500K–1M `recordings` rows. All changes ar
 > - `internal/metrics/metrics.go` — Merge/storage/SQLite metrics, ObserveQueryDuration/IncSQLiteBusyErrors
 > - `internal/storage/AGENTS.md` — Storage conventions
 > - `docs/en/metrics.md` — Complete metrics reference
+> - [Performance Tuning](performance.md) — the operator view of fsync tiers / segment preallocation / GOMEMLIMIT / background I/O budgeting

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -230,6 +230,8 @@ cameras:
 当全局值低于 60s 且存在未覆盖的 continuous 模式相机时，`config.Validate()`
 会输出警告——`mibee-nvr validate-config` 同样会呈现。
 
+> 存储与内存的系统性调优（fsync 持久化分级、预分配、GOMEMLIMIT、后台 I/O 预算）见[性能调优](performance.md)。
+
 ### `storage.db_path`
 - **类型**: string
 - **可选**: 是

--- a/docs/zh/observability.md
+++ b/docs/zh/observability.md
@@ -115,4 +115,5 @@ observability:
 
 - [metrics.md](metrics.md) — 全部 Prometheus 指标明细
 - [configuration.md](configuration.md) — `observability` 配置项
+- [performance.md](performance.md) — 内存分层与后台 I/O 预算（含 `nvr_iobudget_*` / `nvr_memlimit_bytes` 指标）
 - [troubleshooting.md](troubleshooting.md) — 常见问题排查

--- a/docs/zh/storage-optimization.md
+++ b/docs/zh/storage-optimization.md
@@ -487,3 +487,4 @@ CREATE TABLE recordings_2026_01 (
 > - `internal/metrics/metrics.go` — 合并指标、存储指标
 > - `internal/storage/AGENTS.md` — 存储约定
 > - `docs/zh/metrics.md` — 完整指标参考
+> - [性能调优](performance.md) — fsync 分级 / 段预分配 / GOMEMLIMIT / 后台 I/O 预算的运维视角


### PR DESCRIPTION
小修：#777 引入的 `docs/{zh,en}/performance.md` 是孤儿页（全文档集 0 处引用）。从三条自然路径接入：

- `configuration.md`：存储键区尾部提示块 → 系统性存储/内存调优
- `observability.md`：Related docs 列表 → 内存分层与 I/O 预算（含 `nvr_iobudget_*` / `nvr_memlimit_bytes` 指标）
- `storage-optimization.md`：尾部参考区 → 运维视角

纯链接改动，6 文件各 1-2 行。