### PR TITLE
perf(merge): rolling-merge SPS/PPS bucket retention (#764)

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -65,6 +65,8 @@ merge:
   batch_limit: 200
   min_segment_age: "10m"
   min_segments_to_merge: 3
+  rolling_bucket_retain: 2       # buckets kept per camera, keyed by parameter set (#764)
+  rolling_bucket_idle_ttl: "10m" # finalize a bucket with no append for this long; "0" disables
 ftp:
   enabled: true
   port: 2121
@@ -775,6 +777,19 @@ lower-level cascade role) and `config.example.yaml` in the repo root for example
 - **Default**: 3
 - **Description**: Minimum number of segments required to trigger a merge
 - **Example**: `2`, `3`, `5`
+
+### `merge.rolling_bucket_retain`
+- **Type**: integer
+- **Default**: 2
+- **Range**: 0-8 (0 = default)
+- **Description**: How many rolling-merge buckets a camera keeps alive, keyed by parameter set. Cameras oscillating between quality tiers (e.g. Xiaomi HD/SD flapping during reconnect storms) alternate two SPS/PPS keys; retention makes flipping back **append** to the existing bucket instead of finalizing + re-creating it — eliminating the micro-merge storm of tiny output files. `2` covers exactly the HD/SD pair; `1` restores the legacy single-bucket behavior
+- **Example**: `1`, `2`, `3`
+
+### `merge.rolling_bucket_idle_ttl`
+- **Type**: string (duration)
+- **Default**: `"10m"`
+- **Description**: Finalizes a retained bucket that received no append for this long — the camera settled on one quality tier or stopped recording, so the bucket will not be resumed. `"0"` disables idle eviction (capacity-based eviction only)
+- **Example**: `"10m"`, `"30m"`, `"0"`
 
 ## FTP Configuration
 

--- a/docs/zh/configuration.md
+++ b/docs/zh/configuration.md
@@ -54,6 +54,8 @@ merge:
   rolling_debounce: "5s"
   rolling_window: "1h"
   rolling_min_duration: "5m"
+  rolling_bucket_retain: 2           # 每相机保留的桶数（按参数集分键，#764）；1 = 旧单桶行为
+  rolling_bucket_idle_ttl: "10m"     # 桶空闲超过该时长即 finalize；"0" 关闭空闲淘汰
   rolling_backfill_max_segments: 500 # 启动回填上限（防 RPi IO 风暴）
   rolling_backfill_max_age: "72h"    # 只回填最近 N 小时的段
 ftp:
@@ -675,6 +677,19 @@ cameras:
 - **默认**: 3
 - **描述**: 触发合并所需的最小片段数
 - **示例**: `2`, `3`, `5`
+
+### `merge.rolling_bucket_retain`
+- **类型**: integer
+- **默认**: 2
+- **范围**: 0-8（0 = 默认值）
+- **描述**: 每相机保留的滚动合并桶数（按参数集分键，#764）。在质量档位间振荡的相机（如小米 HD/SD 重连风暴）会交替两个 SPS/PPS key；桶保留让切回原档位时直接**续用旧桶追加**，而不是 finalize + 重建 —— 消除微型合并输出风暴。`2` 恰好覆盖 HD/SD 两档；`1` 恢复旧单桶行为
+- **示例**: `1`, `2`, `3`
+
+### `merge.rolling_bucket_idle_ttl`
+- **类型**: string（时长）
+- **默认**: `"10m"`
+- **描述**: 保留桶超过该时长未收到追加即 finalize —— 相机已稳定在某一档位或停止录像，该桶不会再被续用。`"0"` 关闭空闲淘汰（仅按容量淘汰）
+- **示例**: `"10m"`, `"30m"`, `"0"`
 
 ## FTP 配置
 

--- a/internal/config/apply_defaults.go
+++ b/internal/config/apply_defaults.go
@@ -332,6 +332,16 @@ func applyConfigDefaults(cfg *Config) {
 		t := true
 		cfg.Merge.RollingEnabled = &t
 	}
+	// Bucket retention (#764): 2 covers the HD/SD quality pair of an
+	// oscillating camera; idle buckets are finalized after 10m without an
+	// append. Explicit rolling_bucket_retain: 1 is preserved (legacy
+	// single-bucket behavior).
+	if cfg.Merge.RollingBucketRetain <= 0 {
+		cfg.Merge.RollingBucketRetain = 2
+	}
+	if cfg.Merge.RollingBucketIdleTTL == "" {
+		cfg.Merge.RollingBucketIdleTTL = "10m"
+	}
 	// Backfill throttling — protects RPi 3B from an IO storm on the first boot
 	// after upgrading to a default-on rolling merge. MaxSegments caps the total
 	// rows loaded/merged at startup; MaxAge bounds it to recent segments so

--- a/internal/config/config_merge.go
+++ b/internal/config/config_merge.go
@@ -30,6 +30,21 @@ type MergeConfig struct {
 	// further consolidated via POST /api/merge/consolidate. Default "5m".
 	RollingMinDuration string `yaml:"rolling_min_duration" json:"rolling_min_duration"`
 
+	// RollingBucketRetain is how many rolling buckets a camera keeps alive,
+	// keyed by parameter set (#764). Cameras oscillating between quality tiers
+	// (xiaomi HD/SD reconnect storms) alternate two SPS/PPS keys; with a single
+	// bucket every flip finalized and re-created the bucket — a micro-merge
+	// storm of tiny outputs and constant metadata churn. 2 retains exactly the
+	// HD/SD pair so flipping back appends to the existing bucket; 1 restores
+	// the legacy single-bucket behavior. Default 2.
+	RollingBucketRetain int `yaml:"rolling_bucket_retain" json:"rolling_bucket_retain"`
+
+	// RollingBucketIdleTTL finalizes a retained bucket that received no append
+	// for this long — the camera settled on one quality tier or stopped
+	// recording, so the other buckets will not be resumed. Default "10m";
+	// "0" disables idle eviction (capacity-based eviction only).
+	RollingBucketIdleTTL string `yaml:"rolling_bucket_idle_ttl" json:"rolling_bucket_idle_ttl"`
+
 	// RollingBackfill caps the startup backfill so a first boot after enabling
 	// rolling merge cannot trigger an IO storm on resource-constrained hosts
 	// (RPi 3B). MaxSegments=0 means unlimited (not recommended on RPi).
@@ -113,6 +128,12 @@ func ResolveMergeConfig(global MergeConfig, perCamera *MergeConfig) MergeConfig 
 	}
 	if perCamera.RollingMinDuration != "" {
 		result.RollingMinDuration = perCamera.RollingMinDuration
+	}
+	if perCamera.RollingBucketRetain > 0 {
+		result.RollingBucketRetain = perCamera.RollingBucketRetain
+	}
+	if perCamera.RollingBucketIdleTTL != "" {
+		result.RollingBucketIdleTTL = perCamera.RollingBucketIdleTTL
 	}
 	if perCamera.RollingBackfillMaxSegments > 0 {
 		result.RollingBackfillMaxSegments = perCamera.RollingBackfillMaxSegments

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -354,6 +354,43 @@ func TestValidate_RollingEnabledByDefault(t *testing.T) {
 		cfg.ApplyDefaults()
 		require.NoError(t, Validate(cfg))
 	})
+
+	t.Run("invalid_bucket_retain_rejected", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.ApplyDefaults()
+		cfg.Merge.RollingBucketRetain = 9
+		err := Validate(cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rolling_bucket_retain")
+	})
+
+	t.Run("invalid_bucket_idle_ttl_rejected", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.ApplyDefaults()
+		cfg.Merge.RollingBucketIdleTTL = "not-a-duration"
+		err := Validate(cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "rolling_bucket_idle_ttl")
+	})
+
+	t.Run("zero_bucket_idle_ttl_allowed", func(t *testing.T) {
+		// "0" is the documented "disable idle eviction" sentinel.
+		cfg := &Config{}
+		cfg.ApplyDefaults()
+		cfg.Merge.RollingBucketIdleTTL = "0"
+		require.NoError(t, Validate(cfg))
+	})
+
+	t.Run("bucket_retention_defaults_materialized", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.ApplyDefaults()
+		require.Equal(t, 2, cfg.Merge.RollingBucketRetain)
+		require.Equal(t, "10m", cfg.Merge.RollingBucketIdleTTL)
+		// Explicit retain of 1 (legacy single-bucket) survives defaults.
+		cfg.Merge.RollingBucketRetain = 1
+		cfg.ApplyDefaults()
+		require.Equal(t, 1, cfg.Merge.RollingBucketRetain)
+	})
 }
 
 func TestHLSSegmentCountDefault(t *testing.T) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -513,6 +513,16 @@ func validateConfigDetails(cfg *Config) error {
 		if cfg.Merge.RollingBackfillConcurrency < 0 || cfg.Merge.RollingBackfillConcurrency > 16 {
 			return fmt.Errorf("merge.rolling_backfill_concurrency must be between 0 (auto) and 16, got %d", cfg.Merge.RollingBackfillConcurrency)
 		}
+		// Bucket retention (#764): retain is a small per-camera bucket count
+		// (each retains an open merge state); TTL "0" disables idle eviction.
+		if cfg.Merge.RollingBucketRetain < 0 || cfg.Merge.RollingBucketRetain > 8 {
+			return fmt.Errorf("merge.rolling_bucket_retain must be between 0 (default) and 8, got %d", cfg.Merge.RollingBucketRetain)
+		}
+		if cfg.Merge.RollingBucketIdleTTL != "" && cfg.Merge.RollingBucketIdleTTL != "0" {
+			if d, err := time.ParseDuration(cfg.Merge.RollingBucketIdleTTL); err != nil || d <= 0 {
+				return fmt.Errorf("invalid merge.rolling_bucket_idle_ttl %q: must be a positive duration or \"0\" to disable", cfg.Merge.RollingBucketIdleTTL)
+			}
+		}
 	}
 	// Validate transcoding configuration
 	if cfg.Transcoding.MaxWorkers < 1 || cfg.Transcoding.MaxWorkers > 4 {

--- a/internal/merge/AGENTS.md
+++ b/internal/merge/AGENTS.md
@@ -11,6 +11,7 @@ manager.go       # MergeManager — periodic merge loop, camera grouping, disk s
 mp4merge.go      # MergeMP4Segments() — placeholder moov, limitedWriter, in-place header patching
 parser.go        # ParseSegment() — extracts sample tables, codec params, keyframe flags from MP4
 mjpegmerge.go    # MergeMJPEGSegments() — directory-based JPEG file moves
+rolling*.go      # Rolling merge coordinator — per-camera window buckets, retention (#764)
 *_test.go        # Tests for each component
 ```
 
@@ -57,6 +58,8 @@ mjpegmerge.go    # MergeMJPEGSegments() — directory-based JPEG file moves
 | nvr_merge_duration_seconds | Histogram | — | Merge operation duration |
 | nvr_merge_size_bytes | Histogram | — | Merged file size |
 | nvr_merge_pending_segments | GaugeVec | camera_id | Pending segments per camera |
+| nvr_rolling_merge_bucket_finalized_total | CounterVec | reason | Buckets leaving the retained set (idle_ttl/capacity_lru/size_limit) — #764 retention |
+| nvr_rolling_merge_bucket_lifetime_seconds | HistogramVec | reason | Wall time from bucket creation to finalize (#764) |
 
 
 - **DO NOT** use null-byte string concatenation for SPS/PPS grouping — use SHA-256 hash (embedded null bytes cause false matches)

--- a/internal/merge/rolling.go
+++ b/internal/merge/rolling.go
@@ -128,13 +128,20 @@ func checkDiskSpaceForMerge(store *storage.Manager, required int64) bool {
 }
 
 // RollingMergeConfig holds the effective rolling merge configuration for a camera.
-
-// RollingMergeConfig holds the effective rolling merge configuration for a camera.
 type RollingMergeConfig struct {
 	Enabled     bool
 	Debounce    time.Duration // delay after segment close before merging (batches rapid segments)
 	Window      time.Duration // bucket size (default 1h = natural-hour alignment)
 	MinDuration time.Duration // target minimum merged duration (default 5m); shorter → merge_quality='short'
+
+	// Bucket retention (#764): how many parameter-set-keyed buckets a camera
+	// keeps live (BucketRetain, default 2 = the HD/SD quality pair) and how
+	// long an append-less bucket survives (BucketIdleTTL, default 10m; 0 =
+	// capacity eviction only). Cameras oscillating between quality tiers flip
+	// SPS/PPS every reconnect; retention makes flipping back APPEND to the
+	// old bucket instead of finalizing + re-creating it (micro-merge storm).
+	BucketRetain  int
+	BucketIdleTTL time.Duration
 }
 
 // RollingMergeCoordinator is an event-driven rolling merge manager.
@@ -193,9 +200,15 @@ type RollingMergeCoordinator struct {
 
 	mergeLocks sync.Map // map[string]*mergeLock — per-camera non-blocking mutex
 
-	// bucketState tracks the current open bucket per camera for the active window.
-	// Key = cameraID, Value = *bucketInfo. Cleared on window rollover or SPS/PPS change.
-	buckets sync.Map // map[string]*bucketInfo
+	// bucketState tracks the retained buckets per camera for the active
+	// window(s). Key = cameraID, Value = *cameraBucketSet (#764: buckets are
+	// keyed by parameter set so quality-oscillating cameras resume their HD/SD
+	// buckets instead of finalizing + re-creating on every flip).
+	buckets sync.Map // map[string]*cameraBucketSet
+
+	// nowFn is the coordinator clock seam — retention TTL tests advance it
+	// deterministically. nil = time.Now.
+	nowFn func() time.Time
 
 	eventBus  *event.EventBus
 	eventCh   chan event.Event
@@ -251,6 +264,12 @@ type bucketInfo struct {
 	// (#698: a swapped merge order produced ended_at < started_at rows).
 	// Zero only for in-flight buckets created before this field existed.
 	rowStart time.Time
+
+	// createdAt / lastAppend drive the retention policy (#764): lifetime
+	// observability and idle-TTL eviction. Set at bucket creation and after
+	// every successful append; read under the set lock during selection.
+	createdAt  time.Time
+	lastAppend time.Time
 }
 
 // segmentAudioKey derives the audio compatibility key for a parsed segment.
@@ -388,6 +407,20 @@ func (r *RollingMergeCoordinator) resolveRollingConfig(cameraID string) RollingM
 	if effective.RollingMinDuration != "" {
 		if d, err := time.ParseDuration(effective.RollingMinDuration); err == nil && d > 0 {
 			cfg.MinDuration = d
+		}
+	}
+	// Bucket retention (#764). ApplyDefaults materializes 2/"10m"; resolve
+	// inline for configs that skipped it (tests, hand-built values). An
+	// explicit retain of 1 preserves the legacy single-bucket behavior; TTL
+	// "0" or unparseable disables idle eviction (capacity only).
+	if effective.RollingBucketRetain > 0 {
+		cfg.BucketRetain = effective.RollingBucketRetain
+	} else {
+		cfg.BucketRetain = 2
+	}
+	if s := effective.RollingBucketIdleTTL; s != "" && s != "0" {
+		if d, err := time.ParseDuration(s); err == nil && d > 0 {
+			cfg.BucketIdleTTL = d
 		}
 	}
 	return cfg

--- a/internal/merge/rolling_backfill.go
+++ b/internal/merge/rolling_backfill.go
@@ -174,18 +174,24 @@ func (r *RollingMergeCoordinator) BackfillCamera(ctx context.Context, cameraID s
 			}); err != nil {
 				return 0, fmt.Errorf("reset failed status: %w", err)
 			}
-			// Clear the in-memory bucket state for this camera. The bucket may
+			// Clear the in-memory bucket state for this camera. The buckets may
 			// reference recordings that were just reset (failed→pending), and
 			// appending to a stale bucket would UPDATE a row that no longer
 			// represents the current merged file. Starting fresh forces
-			// createBucket, which is always safe.
+			// createBucket, which is always safe. All retained buckets (#764)
+			// are dropped — any of them may hold stale references.
 			if old, ok := r.buckets.LoadAndDelete(cameraID); ok {
-				bi := old.(*bucketInfo)
-				bi.mu.Lock()
-				bi.mergedFilePath = ""
-				bi.mergedRecID = ""
-				bi.segmentCount = 0
-				bi.mu.Unlock()
+				if set, ok := old.(*cameraBucketSet); ok {
+					set.mu.Lock()
+					for _, bi := range set.buckets {
+						bi.mu.Lock()
+						bi.mergedFilePath = ""
+						bi.mergedRecID = ""
+						bi.segmentCount = 0
+						bi.mu.Unlock()
+					}
+					set.mu.Unlock()
+				}
 			}
 		}
 	}

--- a/internal/merge/rolling_bucket_retention_test.go
+++ b/internal/merge/rolling_bucket_retention_test.go
@@ -1,0 +1,301 @@
+package merge
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/config"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/event"
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// Bucket-retention suite (#764): cameras oscillating between two parameter
+// sets (xiaomi HD/SD quality flapping during reconnect storms) flip SPS/PPS
+// every reconnect. With a single live bucket, every flip finalized the old
+// bucket and created a new one — a micro-merge storm of tiny output files
+// and constant metadata churn. Retention keeps the last N buckets keyed by
+// parameter set so flipping BACK appends to the existing bucket.
+
+// Variant parameter sets: the PPS stays raw in the compatibility key (no
+// semantic parser), so a one-byte PPS difference is enough to make the two
+// keys alternate deterministically.
+var (
+	retentionSPS  = []byte{0x67, 0x42, 0x00, 0x0a, 0xe2, 0x40, 0x40, 0x04, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xc8, 0x40}
+	retentionPPSA = []byte{0x68, 0xce, 0x38, 0x80}
+	retentionPPSB = []byte{0x68, 0xce, 0x38, 0x81}
+)
+
+// createAndInsertSegmentWithParams is createAndInsertSegment with explicit
+// SPS/PPS bytes so tests can alternate parameter-set keys.
+func createAndInsertSegmentWithParams(t *testing.T, env *mergeTestEnv, recordingID, cameraID string, startedAt time.Time, sps, pps []byte) string {
+	t.Helper()
+
+	tempPath, finalPath, err := env.store.CreateSegment(cameraID, "h264")
+	require.NoError(t, err)
+
+	segDir := filepath.Dir(tempPath)
+	segFile := createTestH264SegmentWithParams(t, segDir, sps, pps)
+	data, err := os.ReadFile(segFile)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tempPath, data, 0o644))
+	os.Remove(segFile)
+	require.NoError(t, env.store.CloseSegment(tempPath, finalPath))
+
+	fi, err := os.Stat(finalPath)
+	require.NoError(t, err)
+
+	rec := &model.Recording{
+		ID:         recordingID,
+		CameraID:   cameraID,
+		FilePath:   finalPath,
+		Format:     model.FormatH264,
+		StartedAt:  startedAt,
+		EndedAt:    startedAt.Add(30 * time.Second),
+		Duration:   30.0,
+		FileSize:   fi.Size(),
+		FrameCount: 2,
+	}
+	require.NoError(t, env.db.InsertRecording(context.Background(), rec))
+	return finalPath
+}
+
+// waitForRecordingGone polls until the source segment row disappears from the
+// DB — the precise per-segment merge-completion signal (rolling replace
+// deletes the source row in the same transaction that writes the bucket row).
+// Appends only UPDATE the bucket row, so the row count alone cannot signal
+// append completion.
+func waitForRecordingGone(t *testing.T, env *mergeTestEnv, cameraID, recordingID string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+		require.NoError(t, err)
+		found := false
+		for _, rec := range recs {
+			if rec.ID == recordingID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for recording %s to be merged away", recordingID)
+}
+
+// fakeClock is a mutex-guarded controllable clock — the coordinator's merge
+// goroutines read r.nowFn concurrently, so the fixture must not mutate shared
+// state unsynchronized (test-own races are bugs too, #764 suite).
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// waitForBucketAppend polls until the newest bucket has absorbed n segments
+// AND recorded its last append. This is the true completion point of a
+// mergeOneSegment run: the source DB row disappears EARLIER (inside
+// appendToBucket), but bucket state — including lastAppend, the retention
+// clock read — is written after it. TTL tests must not advance the fake clock
+// while a straggler merge goroutine can still read it.
+func waitForBucketAppend(t *testing.T, r *RollingMergeCoordinator, cameraID string, n int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if b := r.newestBucket(cameraID); b != nil {
+			b.mu.Lock()
+			done := b.segmentCount == n && !b.lastAppend.IsZero()
+			b.mu.Unlock()
+			if done {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for bucket append (segments=%d) for camera %s", n, cameraID)
+}
+
+// retentionTestEnv wires a coordinator with retention-friendly defaults. nowFn,
+// when non-nil, is installed BEFORE Start — the merge goroutines read the
+// clock, so a post-Start write would race them.
+func retentionTestEnv(t *testing.T, cfg config.MergeConfig, nowFn func() time.Time) (*RollingMergeCoordinator, *mergeTestEnv, *event.EventBus) {
+	t.Helper()
+	env := newMergeTestEnv(t)
+	t.Cleanup(func() { env.close(t) })
+
+	bus := event.NewEventBus(16)
+	r := newTestRollingCoordinator(env, cfg, bus)
+	r.nowFn = nowFn
+	require.NoError(t, r.Start(context.Background()))
+	t.Cleanup(r.Stop)
+	return r, env, bus
+}
+
+// ---------------------------------------------------------------------------
+// TestRollingMerge_SPSBucketRetention — alternating keys A→B→A→B keep exactly
+// two buckets (one per key): flipping back to a retained key appends instead
+// of finalizing + re-creating.
+// ---------------------------------------------------------------------------
+
+func TestRollingMerge_SPSBucketRetention(t *testing.T) {
+	cfg := config.MergeConfig{
+		RollingEnabled:       boolPtr(true),
+		RollingDebounce:      "50ms",
+		RollingWindow:        "1h",
+		RollingBucketRetain:  2,
+		RollingBucketIdleTTL: "1h", // long TTL — capacity policy only in this test
+	}
+	_, env, bus := retentionTestEnv(t, cfg, nil)
+
+	cameraID := "cam-oscillating"
+	base := time.Now().UTC().Truncate(time.Hour).Add(5 * time.Minute)
+
+	type step struct {
+		recID string
+		pps   []byte
+		at    time.Time
+	}
+	steps := []step{
+		{"rec-a1", retentionPPSA, base},
+		{"rec-b1", retentionPPSB, base.Add(1 * time.Minute)},
+		{"rec-a2", retentionPPSA, base.Add(2 * time.Minute)},
+		{"rec-b2", retentionPPSB, base.Add(3 * time.Minute)},
+	}
+	for _, s := range steps {
+		path := createAndInsertSegmentWithParams(t, env, s.recID, cameraID, s.at, retentionSPS, s.pps)
+		publishSegmentCompleted(t, bus, cameraID, s.recID, path, "h264", s.at)
+		waitForRecordingGone(t, env, cameraID, s.recID)
+	}
+
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "A→B→A→B must produce exactly 2 buckets (one per param key), not one per flip")
+
+	// Resume (not re-create): each bucket absorbed two segments, so each row
+	// carries 4 samples (2 per segment) instead of a fresh bucket's 2.
+	totalFrames := 0
+	for _, rec := range recs {
+		require.Equal(t, 4, rec.FrameCount, "each bucket must have been appended to twice")
+		require.Equal(t, model.MergeStatusMerged, rec.MergeStatus)
+		totalFrames += rec.FrameCount
+	}
+	require.Equal(t, 8, totalFrames)
+}
+
+// ---------------------------------------------------------------------------
+// TestRollingMerge_SPSBucketRetentionIdleTTL — a retained bucket idle beyond
+// the TTL is finalized; the next segment with the same key starts a new
+// bucket instead of resuming across the gap.
+// ---------------------------------------------------------------------------
+
+func TestRollingMerge_SPSBucketRetentionIdleTTL(t *testing.T) {
+	cfg := config.MergeConfig{
+		RollingEnabled:       boolPtr(true),
+		RollingDebounce:      "50ms",
+		RollingWindow:        "1h",
+		RollingBucketRetain:  2,
+		RollingBucketIdleTTL: "10m",
+	}
+	// Controllable clock: TTL decisions read r.nowFn, so the test advances
+	// time deterministically instead of sleeping.
+	clk := &fakeClock{t: time.Now().UTC().Truncate(time.Hour).Add(5 * time.Minute)}
+	r, env, bus := retentionTestEnv(t, cfg, clk.Now)
+
+	cameraID := "cam-idle"
+	base := clk.Now()
+
+	path := createAndInsertSegmentWithParams(t, env, "rec-a1", cameraID, base, retentionSPS, retentionPPSA)
+	publishSegmentCompleted(t, bus, cameraID, "rec-a1", path, "h264", base)
+	waitForBucketAppend(t, r, cameraID, 1)
+
+	// Advance past the 10m TTL, staying inside the same window. Only after
+	// the merge goroutine fully finished (lastAppend observed) — a straggler
+	// would otherwise read the advanced clock and stamp a fresh lastAppend,
+	// silently un-expiring the bucket.
+	clk.Advance(11 * time.Minute)
+	at := base.Add(11 * time.Minute)
+
+	path = createAndInsertSegmentWithParams(t, env, "rec-a2", cameraID, at, retentionSPS, retentionPPSA)
+	publishSegmentCompleted(t, bus, cameraID, "rec-a2", path, "h264", at)
+	waitForRecordingGone(t, env, cameraID, "rec-a2")
+
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "an idle-expired bucket must NOT be resumed — a new bucket starts")
+	require.Equal(t, 2, recs[0].FrameCount)
+	require.Equal(t, 2, recs[1].FrameCount)
+}
+
+// ---------------------------------------------------------------------------
+// TestRollingMerge_SPSBucketRetentionLRUCapacity — three distinct keys with
+// retain=2: the least-recently-used bucket is evicted on admission, the set
+// never exceeds the retention cap, and an evicted key re-creates its bucket.
+// ---------------------------------------------------------------------------
+
+func TestRollingMerge_SPSBucketRetentionLRUCapacity(t *testing.T) {
+	cfg := config.MergeConfig{
+		RollingEnabled:       boolPtr(true),
+		RollingDebounce:      "50ms",
+		RollingWindow:        "1h",
+		RollingBucketRetain:  2,
+		RollingBucketIdleTTL: "1h",
+	}
+	r, env, bus := retentionTestEnv(t, cfg, nil)
+
+	cameraID := "cam-lru"
+	base := time.Now().UTC().Truncate(time.Hour).Add(5 * time.Minute)
+
+	// Third key: second PPS variant again is not enough — use a distinct SPS
+	// level byte so all three keys differ.
+	spsC := append([]byte{}, retentionSPS...)
+	spsC[3] = 0x0b
+
+	type step struct {
+		recID string
+		sps   []byte
+		pps   []byte
+	}
+	steps := []step{
+		{"rec-a1", retentionSPS, retentionPPSA},
+		{"rec-b1", retentionSPS, retentionPPSB},
+		{"rec-c1", spsC, retentionPPSA},
+		{"rec-a2", retentionSPS, retentionPPSA}, // A was evicted at C's admission → new bucket
+	}
+	for i, s := range steps {
+		at := base.Add(time.Duration(i) * time.Minute)
+		path := createAndInsertSegmentWithParams(t, env, s.recID, cameraID, at, s.sps, s.pps)
+		publishSegmentCompleted(t, bus, cameraID, s.recID, path, "h264", at)
+		waitForRecordingGone(t, env, cameraID, s.recID)
+	}
+
+	recs, _, err := env.db.ListRecordingsWithTotal(context.Background(), model.RecordingFilter{CameraID: cameraID, Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, recs, 4, "C evicts LRU-A, then A re-creates a bucket (evicting LRU-B) — 4 buckets total")
+
+	// The retained set never exceeds the cap.
+	setAny, ok := r.buckets.Load(cameraID)
+	require.True(t, ok)
+	set := setAny.(*cameraBucketSet)
+	set.mu.Lock()
+	size := len(set.buckets)
+	set.mu.Unlock()
+	require.LessOrEqual(t, size, 2, "retained bucket set must be capped at rolling_bucket_retain")
+}

--- a/internal/merge/rolling_bucket_set.go
+++ b/internal/merge/rolling_bucket_set.go
@@ -1,0 +1,177 @@
+package merge
+
+import (
+	"sync"
+	"time"
+)
+
+// cameraBucketSet holds the retained rolling buckets for one camera (#764).
+//
+// Before retention there was exactly one live bucket per camera: a camera
+// oscillating between two parameter sets (xiaomi HD/SD quality flapping in a
+// reconnect storm) finalized and re-created its bucket on every flip, ~every
+// 30s-2min — a micro-merge storm of tiny output files and constant DB/rename
+// churn that also burned the shared IO budget (#751). The set keeps the most
+// recently used buckets keyed by parameter set so flipping BACK appends to
+// the existing bucket instead of spawning a new one.
+//
+// Eviction policy (applied on each segment admission):
+//   - idle TTL: a bucket with no append for cfg.BucketIdleTTL is finalized;
+//   - capacity: at cfg.BucketRetain buckets, the least recently used one is
+//     finalized to admit the new key;
+//   - size limit: a matched bucket approaching the MP4 mdat cap (3 GiB) is
+//     finalized and a fresh bucket starts within the same window.
+//
+// "Finalize" is in-memory only — every append already commits the row, so
+// the DB/file state is final the moment the last append returned. Finalizing
+// just drops the bucket from the retained set and accounts the event.
+type cameraBucketSet struct {
+	mu      sync.Mutex
+	buckets []*bucketInfo // LRU order: least recently used first
+}
+
+// bucketSetFor loads or creates the retained-bucket set for a camera.
+func (r *RollingMergeCoordinator) bucketSetFor(cameraID string) *cameraBucketSet {
+	setAny, _ := r.buckets.LoadOrStore(cameraID, &cameraBucketSet{})
+	return setAny.(*cameraBucketSet)
+}
+
+// now returns the coordinator's clock — a seam so retention TTL tests advance
+// time deterministically instead of sleeping.
+func (r *RollingMergeCoordinator) now() time.Time {
+	if r.nowFn != nil {
+		return r.nowFn()
+	}
+	return time.Now()
+}
+
+// selectBucket returns the bucket an incoming segment should append to,
+// applying the retention policy. Callers must NOT hold set.mu or any
+// bucket.mu; the returned bucket is still unlocked (the caller locks it for
+// the merge itself).
+//
+// A bucket matches when parameter key, audio key AND window all agree — the
+// same conditions the old single-bucket path checked before finalizing, now
+// expressed as a lookup. A matched bucket at the size limit is finalized
+// (reason "size_limit") and replaced by a fresh bucket in the same window,
+// mirroring the pre-retention behavior.
+func (r *RollingMergeCoordinator) selectBucket(
+	cameraID string,
+	spsKey, audioKey string,
+	windowStart, windowEnd time.Time,
+	newSegmentBytes int64,
+	cfg RollingMergeConfig,
+) *bucketInfo {
+	now := r.now()
+	set := r.bucketSetFor(cameraID)
+	set.mu.Lock()
+	defer set.mu.Unlock()
+
+	// Match pass: resume the retained bucket with this exact key — unless it
+	// has been idle past the TTL (the camera moved on and came back much
+	// later; resuming across the gap would re-open an ancient bucket).
+	if ttl := cfg.BucketIdleTTL; ttl > 0 {
+		kept := set.buckets[:0]
+		for _, b := range set.buckets {
+			if now.Sub(b.lastAppend) > ttl {
+				r.finalizeBucketLocked(cameraID, b, "idle_ttl", now)
+				continue
+			}
+			kept = append(kept, b)
+		}
+		set.buckets = kept
+	}
+	for i, b := range set.buckets {
+		if b.spsKey != spsKey || b.audioKey != audioKey || !b.windowStart.Equal(windowStart) {
+			continue
+		}
+		// Size-roll a matched bucket that would cross the mdat cap: finalize
+		// it and fall through to fresh-bucket creation below.
+		if b.mergedFilePath != "" && b.mergedFileSize > 0 && b.mergedFileSize+newSegmentBytes > bucketSizeLimit {
+			r.finalizeBucketLocked(cameraID, b, "size_limit", now)
+			set.buckets = append(set.buckets[:i], set.buckets[i+1:]...)
+			break
+		}
+		// Move to MRU position.
+		set.buckets = append(set.buckets[:i], set.buckets[i+1:]...)
+		set.buckets = append(set.buckets, b)
+		return b
+	}
+
+	// Idle-TTL sweep already ran before the match pass (it applies to matched
+	// and unmatched buckets alike) — capacity is the remaining constraint.
+	retain := cfg.BucketRetain
+	if retain < 1 {
+		retain = 1
+	}
+	for len(set.buckets) >= retain {
+		oldest := set.buckets[0]
+		set.buckets = set.buckets[1:]
+		r.finalizeBucketLocked(cameraID, oldest, "capacity_lru", now)
+	}
+
+	fresh := &bucketInfo{
+		windowStart: windowStart,
+		windowEnd:   windowEnd,
+		createdAt:   now,
+		lastAppend:  now,
+	}
+	set.buckets = append(set.buckets, fresh)
+	return fresh
+}
+
+// finalizeBucketLocked accounts a bucket leaving the retained set. The row
+// and file are already final (every append commits); this exists for the
+// observability added in #764 — finalize frequency and bucket lifetime are
+// the signals that verify retention is working on quality-oscillating cameras.
+// Caller holds set.mu.
+func (r *RollingMergeCoordinator) finalizeBucketLocked(cameraID string, b *bucketInfo, reason string, now time.Time) {
+	lifetime := now.Sub(b.createdAt)
+	if r.metrics != nil {
+		r.metrics.RecordRollingBucketFinalized(reason, lifetime)
+	}
+	rollingLogger.Debug("rolling bucket finalized",
+		"camera_id", cameraID,
+		"reason", reason,
+		"segments", b.segmentCount,
+		"lifetime_s", lifetime.Seconds())
+}
+
+// dropBucketIfEmpty removes a bucket from its camera's set when a failed
+// merge left it in the never-created state (no file, no row). Keeping it
+// would waste a retention slot on a phantom bucket that can never match a
+// real segment (empty keys).
+func (r *RollingMergeCoordinator) dropBucketIfEmpty(cameraID string, b *bucketInfo) {
+	setAny, ok := r.buckets.Load(cameraID)
+	if !ok {
+		return
+	}
+	set := setAny.(*cameraBucketSet)
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	if b.mergedFilePath != "" || b.mergedRecID != "" || b.segmentCount != 0 {
+		return
+	}
+	for i, cand := range set.buckets {
+		if cand == b {
+			set.buckets = append(set.buckets[:i], set.buckets[i+1:]...)
+			return
+		}
+	}
+}
+
+// newestBucket returns the camera's most recently used bucket, or nil when
+// the camera has no set yet (disabled camera, non-MP4 format).
+func (r *RollingMergeCoordinator) newestBucket(cameraID string) *bucketInfo {
+	setAny, ok := r.buckets.Load(cameraID)
+	if !ok {
+		return nil
+	}
+	set := setAny.(*cameraBucketSet)
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	if len(set.buckets) == 0 {
+		return nil
+	}
+	return set.buckets[len(set.buckets)-1]
+}

--- a/internal/merge/rolling_live.go
+++ b/internal/merge/rolling_live.go
@@ -381,77 +381,16 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	cfg := r.resolveRollingConfig(seg.cameraID)
 	windowStart, windowEnd := computeWindow(seg.startedAt, cfg.Window)
 
-	// Get or create the bucket for this camera.
-	bucketAny, _ := r.buckets.LoadOrStore(seg.cameraID, &bucketInfo{
-		windowStart: windowStart,
-		windowEnd:   windowEnd,
-	})
-	bucket := bucketAny.(*bucketInfo)
+	// Select the bucket with the retention policy (#764): a retained bucket
+	// with this exact key (params + audio + window) is resumed — flipping
+	// back to a previous quality tier APPENDS instead of finalizing + re-
+	// creating. Window rollover, SPS/PPS change, audio change and the size
+	// limit are all selection mismatches now; the matched-at-size-limit case
+	// size-rolls inside selectBucket.
+	bucket := r.selectBucket(seg.cameraID, spsKey, audioKey, windowStart, windowEnd, newInfo.MdatSize, cfg)
 
 	bucket.mu.Lock()
 	defer bucket.mu.Unlock()
-
-	// Check for window rollover, SPS/PPS change, or size limit → close old
-	// bucket, start new.
-	needNewBucket := false
-	if bucket.mergedFilePath != "" {
-		if !seg.startedAt.Before(bucket.windowEnd) && !seg.startedAt.Equal(bucket.windowStart) {
-			// Segment is in a new window — the old bucket is complete.
-			rollingLogger.Debug("window rollover, finalizing bucket",
-				"camera_id", seg.cameraID,
-				"old_window_end", bucket.windowEnd,
-				"new_window_start", windowStart)
-			needNewBucket = true
-		} else if bucket.spsKey != spsKey {
-			// Codec params changed (camera reconnect) — incompatible merge.
-			rollingLogger.Info("SPS/PPS changed, starting new bucket",
-				"camera_id", seg.cameraID,
-				"old_key", bucket.spsKey[:8],
-				"new_key", spsKey[:8])
-			needNewBucket = true
-		} else if bucket.audioKey != audioKey {
-			// Audio presence/config changed (audio_enabled toggled, G.711 ↔ AAC
-			// renegotiated). Merging across the boundary would trip the
-			// mixed-audio policy in MergeMP4Segments and drop audio — and the
-			// degraded bucket would poison every later append. Start a new
-			// bucket at the boundary instead: each side keeps its own intact
-			// audio state.
-			rollingLogger.Info("audio config changed, starting new bucket",
-				"camera_id", seg.cameraID,
-				"old_key", bucket.audioKey,
-				"new_key", audioKey)
-			needNewBucket = true
-		} else if bucket.mergedFileSize > 0 && bucket.mergedFileSize+newInfo.MdatSize > bucketSizeLimit {
-			// Bucket approaching the 4 GiB MP4 mdat hard limit. Finalize it
-			// and start a fresh bucket within the same window. Without this,
-			// high-bitrate cameras (2K云台 ~1.7MB/s → 6GB/hour) accumulate
-			// until MergeMP4Segments returns "mdat box size exceeds MaxUint32"
-			// and the segment is lost from the merge queue.
-			rollingLogger.Info("bucket size limit reached, starting new bucket",
-				"camera_id", seg.cameraID,
-				"bucket_size_mb", bucket.mergedFileSize>>20,
-				"new_segment_mb", newInfo.MdatSize>>20,
-				"limit_mb", bucketSizeLimit>>20,
-				"segment_count", bucket.segmentCount)
-			needNewBucket = true
-		}
-	}
-
-	if needNewBucket {
-		// The old bucket file is already finalized in the DB (each append updates it).
-		// Just reset the in-memory state to start fresh.
-		bucket.mergedFilePath = ""
-		bucket.mergedRecID = ""
-		bucket.spsKey = ""
-		bucket.audioKey = ""
-		bucket.segmentCount = 0
-		bucket.mergedFileSize = 0
-		bucket.wallDurSec = 0
-		bucket.fileDurSec = 0
-		bucket.wallFile = nil
-		bucket.windowStart = windowStart
-		bucket.windowEnd = windowEnd
-	}
 
 	// Perform the merge.
 	var outputPath string
@@ -485,6 +424,12 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	}
 
 	if err != nil {
+		// A failed create left a never-created bucket in the retained set —
+		// drop it so it doesn't waste a retention slot (it can never match a
+		// real segment: its keys are empty).
+		if bucket.mergedFilePath == "" && bucket.segmentCount == 0 {
+			r.dropBucketIfEmpty(seg.cameraID, bucket)
+		}
 		return err
 	}
 
@@ -494,6 +439,7 @@ func (r *RollingMergeCoordinator) mergeOneSegment(ctx context.Context, seg pendi
 	bucket.spsKey = spsKey
 	bucket.audioKey = audioKey
 	bucket.segmentCount++
+	bucket.lastAppend = r.now() // retention LRU/TTL clock (#764)
 	// Track merged file size for the bucketSizeLimit check on the next append.
 	// One stat per merged segment is cheap (the file was just written and its
 	// inode is hot in cache), and avoids the need to thread size through every

--- a/internal/merge/rolling_test.go
+++ b/internal/merge/rolling_test.go
@@ -99,14 +99,14 @@ func createAndInsertSegment(t *testing.T, env *mergeTestEnv, recordingID, camera
 }
 
 // waitForBucketStable polls until the coordinator's bucket for a camera has the
-// expected segment count, or times out (merge is async).
+// expected segment count, or times out (merge is async). With retention (#764)
+// a camera holds a set of buckets; single-key cameras (all existing callers)
+// have exactly one, so the newest bucket's count is the observable.
 func waitForBucketStable(t *testing.T, r *RollingMergeCoordinator, cameraID string, expectedCount int, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		bucketAny, ok := r.buckets.Load(cameraID)
-		if ok {
-			bi := bucketAny.(*bucketInfo)
+		if bi := r.newestBucket(cameraID); bi != nil {
 			bi.mu.Lock()
 			count := bi.segmentCount
 			bi.mu.Unlock()
@@ -217,9 +217,7 @@ func waitForBucketAudio(t *testing.T, r *RollingMergeCoordinator, cameraID strin
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		bucketAny, ok := r.buckets.Load(cameraID)
-		if ok {
-			bi := bucketAny.(*bucketInfo)
+		if bi := r.newestBucket(cameraID); bi != nil {
 			bi.mu.Lock()
 			count, key := bi.segmentCount, bi.audioKey
 			bi.mu.Unlock()
@@ -1199,10 +1197,10 @@ func TestRollingMerge_BucketSizeLimit(t *testing.T) {
 
 	// Simulate the bucket having grown near the 3 GiB limit. We can't actually
 	// write 3 GiB in a test, so directly set the tracked size on the bucket
-	// state — this is the same field mergeOneSegment checks.
-	bucketAny, ok := r.buckets.Load(cameraID)
-	require.True(t, ok, "bucket should exist after first segment")
-	bucket := bucketAny.(*bucketInfo)
+	// state — this is the same field selectBucket checks (#764 moved the size
+	// roll into bucket selection).
+	bucket := r.newestBucket(cameraID)
+	require.NotNil(t, bucket, "bucket should exist after first segment")
 	bucket.mu.Lock()
 	bucket.mergedFileSize = bucketSizeLimit + 1 // over the limit
 	bucket.mu.Unlock()
@@ -1215,24 +1213,25 @@ func TestRollingMerge_BucketSizeLimit(t *testing.T) {
 	publishSegmentCompleted(t, bus, cameraID, "seg-2", filePath2, "h264", seg2Time)
 
 	// Wait for the second segment to be processed. With the size-limit fix,
-	// the bucket rolls and segmentCount ends at 1. Without the fix, the bucket
-	// appends and segmentCount ends at 2. Poll until stable (count stops
-	// changing) — we can't use waitForBucketStable(count=1) because count=1
-	// is also the state BEFORE seg-2 is processed.
+	// the bucket rolls and the newest bucket is a DIFFERENT object (the
+	// oversized one was evicted from the retained set) with segmentCount=1;
+	// without the fix, the same bucket appends and reaches count=2. Poll
+	// until stable — count=1 alone is ambiguous (it's also the state BEFORE
+	// seg-2 is processed), so also require the pointer to have changed.
 	deadline := time.Now().Add(5 * time.Second)
 	var finalCount, finalSize int64
 	for time.Now().Before(deadline) {
-		bucket.mu.Lock()
-		c := bucket.segmentCount
-		s := bucket.mergedFileSize
-		bucket.mu.Unlock()
-		// seg-2 processed → either count=1 (rolled) or count=2 (appended).
-		// Also wait for size to be updated from the fake 3GiB value (stat
-		// after merge resets it to the real small file size).
-		if (c == 1 || c == 2) && s != bucketSizeLimit+1 {
-			finalCount = int64(c)
-			finalSize = s
-			break
+		nb := r.newestBucket(cameraID)
+		if nb != nil && nb != bucket {
+			nb.mu.Lock()
+			c, s := nb.segmentCount, nb.mergedFileSize
+			nb.mu.Unlock()
+			// New bucket rolled by seg-2: count=1 and a real (small) size.
+			if c == 1 && s != 0 && s != bucketSizeLimit+1 {
+				finalCount = int64(c)
+				finalSize = s
+				break
+			}
 		}
 		time.Sleep(20 * time.Millisecond)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -102,6 +102,11 @@ type Metrics struct {
 	// Rolling merge metrics (quasi-real-time, event-driven)
 	RollingMergeLatencySeconds *prometheus.HistogramVec // labels: camera_id — time from segment close to merge complete
 	RollingMergeBucketSegments *prometheus.GaugeVec     // labels: camera_id — segments in current bucket
+	// Rolling bucket retention (#764): finalizes per reason (idle_ttl /
+	// capacity_lru / size_limit) and bucket lifetime at finalize — the
+	// signals that verify quality-oscillating cameras stopped micro-merging.
+	RollingBucketFinalizedTotal  *prometheus.CounterVec   // labels: reason
+	RollingBucketLifetimeSeconds *prometheus.HistogramVec // labels: reason
 
 	// Memory self-discipline (#756): the GOMEMLIMIT installed at startup
 	// (0 = not set — env var won, disabled by config, or unknown host).
@@ -517,6 +522,15 @@ func NewMetrics() *Metrics {
 		Name: "nvr_rolling_merge_bucket_segments",
 		Help: "Number of segments accumulated in the current rolling merge window bucket.",
 	}, []string{"camera_id"})
+	rollingBucketFinalizedTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "nvr_rolling_merge_bucket_finalized_total",
+		Help: "Rolling buckets leaving the retained set, partitioned by reason (idle_ttl/capacity_lru/size_limit).",
+	}, []string{"reason"})
+	rollingBucketLifetimeSeconds := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "nvr_rolling_merge_bucket_lifetime_seconds",
+		Help:    "Wall time from bucket creation to finalize, partitioned by reason (#764).",
+		Buckets: []float64{1, 5, 15, 60, 300, 900, 3600, 21600},
+	}, []string{"reason"})
 
 	// Auth metrics — track login attempts for security monitoring
 	authAttemptsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -799,6 +813,8 @@ func NewMetrics() *Metrics {
 		MemorySoftLimitBytes:           memorySoftLimitBytes,
 		RollingMergeLatencySeconds:     rollingMergeLatencySeconds,
 		RollingMergeBucketSegments:     rollingMergeBucketSegments,
+		RollingBucketFinalizedTotal:    rollingBucketFinalizedTotal,
+		RollingBucketLifetimeSeconds:   rollingBucketLifetimeSeconds,
 		AuthAttemptsTotal:              authAttemptsTotal,
 		AuthRateLimitedTotal:           authRateLimitedTotal,
 		AIEventsReceivedTotal:          aiEventsReceivedTotal,
@@ -896,6 +912,19 @@ func (m *Metrics) UpdateRollingMergeBucketSegments(cameraID string, count int) {
 		return
 	}
 	m.RollingMergeBucketSegments.WithLabelValues(cameraID).Set(float64(count))
+}
+
+// RecordRollingBucketFinalized records a rolling bucket leaving the retained
+// set (#764) — reason is a bounded enum (idle_ttl/capacity_lru/size_limit),
+// lifetime is the wall time from bucket creation to finalize.
+func (m *Metrics) RecordRollingBucketFinalized(reason string, lifetime time.Duration) {
+	if m == nil || m.RollingBucketFinalizedTotal == nil {
+		return
+	}
+	m.RollingBucketFinalizedTotal.WithLabelValues(reason).Inc()
+	if m.RollingBucketLifetimeSeconds != nil {
+		m.RollingBucketLifetimeSeconds.WithLabelValues(reason).Observe(lifetime.Seconds())
+	}
 }
 
 // IncStorageWriteErrors increments the storage write errors counter.


### PR DESCRIPTION
Closes #764.

## 问题

处于重连风暴的相机（典型：xiaomi 质量降级循环 HD→SD 反复切换）在两个 SPS/PPS 参数集之间来回振荡，生产日志实据：

```
SPS/PPS changed, starting new bucket  old_key=c89f4287 new_key=1b82c086
SPS/PPS changed, starting new bucket  old_key=1b82c086 new_key=c89f4287   ← 切回来了
```

单桶设计下每次翻转都 finalize + 开新桶：微型合并输出风暴（大量小 .mp4）、元数据 churn 持续不断、桶永远凑不大、finalize 占用 IO 预算（与 #751 调度目标冲突）。

## 方案：桶保留（bucket retention）

- 每相机的桶从单个变为**保留集合**（`cameraBucketSet`，LRU 序），按 参数集 key + audio key + 窗口 三元组匹配：切回保留桶 = **续用追加**，不再 finalize。
- 淘汰策略集中在 `selectBucket` 一个选择点：
  - **空闲 TTL**：`merge.rolling_bucket_idle_ttl`（默认 `10m`，`"0"` 关闭）——命中与未命中路径都先过 TTL 清扫；
  - **容量 LRU**：`merge.rolling_bucket_retain`（默认 `2`，恰好覆盖 HD/SD 两档；`1` = 旧单桶行为，范围 0-8）；
  - **尺寸上限**：命中桶逼近 3 GiB mdat 上限时 size-roll（原逻辑保留，迁入选择点）。
- 原 `needNewBucket` 四路检查（窗口翻转 / SPS / audio / size）全部收敛为选择失配——语义等价、代码减 60 行。
- 兼容性护栏：跨段追加沿用现有 `appendToBucket` 全部校验（codec/SPS/PPS/audio 防御检查、#496 墙轴累计、#698 乱序保护）不变。

## 观测（#764 验收要求）

- `nvr_rolling_merge_bucket_finalized_total{reason=idle_ttl|capacity_lru|size_limit}`
- `nvr_rolling_merge_bucket_lifetime_seconds{reason}`（桶存活时长 histogram）

## TDD

- 红①（断言）：A→B→A→B 交替 key 序列当前产生 4 桶/4 行（已运行确认）；
- 红②（编译）：新符号未定义（已运行确认）；
- 绿：同序列 2 桶、每桶 FrameCount=4（续用证据）；TTL 过期后不复活旧桶；三 key 容量淘汰 + 集合上限 ≤retain；
- 测试自身竞态修复：伪时钟互斥保护 + 以 `lastAppend` 为合并完成观测点（DB 行消失早于 goroutine 收尾）；
- 回归：`go test -race -count=3` 关键路径 + 全仓 5798 测试通过，golangci-lint 0 issues。

## 生产预期

重连风暴相机的桶 finalize 频率（新指标）与单相机合并输出文件数/小时显著下降；单 key 相机（绝大多数）行为与现状完全一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>