### PR TITLE
fix(db): sub-layer segments born terminal — retire layer=1 pending zombie rows (#763)

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -546,6 +546,11 @@ Live merge states (`pending`/`merged`/`merging`) are never matched by `--status`
    curl -u admin:password http://localhost:9090/api/merge/pending
    ```
 
+   When reading pending counts (API or raw SQL), note that `merge_status='pending'`
+   on `layer=1` rows would NOT be merge backlog: sub-stream archive segments
+   (tiered recording) never enter the merge pipeline and carry the terminal
+   status `sublayer` since v39 — only `layer=0` `pending` rows are real backlog.
+
 ### High Memory Usage
 
 #### Camera Consumes Too Much RAM

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -556,6 +556,10 @@ sudo systemctl restart mibee-nvr
    curl -u admin:password http://localhost:9090/api/merge/pending
    ```
 
+   读 pending 口径时（API 或直接 SQL）注意：`layer=1` 行的 pending 不是合并积压——
+   分层录像的子流存档段从不进合并管线，v39 起写入即终态 `sublayer`；
+   只有 `layer=0` 的 `pending` 行是真实积压。
+
 ### 内存使用过高
 
 #### 摄像头消耗太多 RAM

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -355,6 +355,12 @@ const (
 	// folded into a periodic-merge output (a "daily" / 8h / 24h / 7d / 30d
 	// window). Such segments are excluded from re-merge in subsequent windows.
 	MergeStatusDailyMerged = "daily_merged"
+	// MergeStatusSublayer marks a tierrec layer=1 sub-stream archive (#637).
+	// Sub-layer segments are standalone 60s recordings that never enter the
+	// merge pipeline — they are BORN terminal. Inserting them as 'pending'
+	// produced permanently-pending zombie rows that polluted every
+	// pending-based diagnostic (#763).
+	MergeStatusSublayer = "sublayer"
 )
 
 // TimelapseMergeStatus constants for the timelapse_merges table.

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -256,8 +256,14 @@ func (d *DB) ReadPoolStats() (sql.DBStats, bool) {
 // management page sends the full named-group order). Also ensured via
 // idempotent ALTER.
 //
+// v39: one-shot DATA migration (#763) — layer=1 tierrec rows inserted before
+// the terminal-status fix carried merge_status='pending' forever (98% of all
+// pending rows in production, polluting pending-based diagnostics and
+// crowding the ghost-row sweep). Init rewrites them to the terminal
+// 'sublayer' status; the UPDATE is idempotent (second boot touches 0 rows).
+//
 // The schema_meta table tracks the schema version for future migrations.
-const currentSchemaVersion = "38"
+const currentSchemaVersion = "39"
 
 func (d *DB) Init(ctx context.Context) error {
 	// ── Tables (full baseline — new installs get the final schema in one step) ──
@@ -534,6 +540,16 @@ func (d *DB) Init(ctx context.Context) error {
 	// ── Column backfill for pre-v38 databases: camera_groups.position ──
 	if err := d.ensureCameraGroupsPositionColumn(ctx); err != nil {
 		return err
+	}
+
+	// ── v39 data migration (#763): retire permanently-pending layer=1 rows ──
+	// Sub-layer segments never enter the merge pipeline, so 'pending' was a
+	// wrong lifecycle from birth. Idempotent: after the first run no
+	// layer!=0 'pending' rows remain (the writer now inserts terminal).
+	if _, err := d.db.ExecContext(ctx,
+		`UPDATE recordings SET merge_status='sublayer' WHERE COALESCE(layer,0)!=0 AND merge_status='pending'`,
+	); err != nil {
+		return fmt.Errorf("v39 sublayer status migration: %w", err)
 	}
 
 	_, _ = d.db.ExecContext(ctx, "UPDATE schema_meta SET value=? WHERE key='schema_version'", currentSchemaVersion)

--- a/internal/storage/db_recording.go
+++ b/internal/storage/db_recording.go
@@ -1018,18 +1018,24 @@ func (d *DB) PathIsRecordingFile(ctx context.Context, cameraID, fullpath string)
 	return true, nil
 }
 
-// ListStalePendingRecordings returns up to limit pending recordings (any
-// format, any camera) whose started_at is older than the cutoff, excluding
-// archived rows and rows with an active AI status (protected from cleanup
-// like retention). The caller stats each row's file and deletes the ones
-// that never existed — the ghost-row sweep for the 2026-09-08 incident
-// class (pending row + missing file = permanent 404 entry).
+// ListStalePendingRecordings returns up to limit sweep-candidate recordings
+// (any format, any camera) whose started_at is older than the cutoff,
+// excluding archived rows and rows with an active AI status (protected from
+// cleanup like retention). The caller stats each row's file and deletes the
+// ones that never existed — the ghost-row sweep for the 2026-09-08 incident
+// class (candidate row + missing file = permanent 404 entry).
+//
+// Candidates are layer=0 'pending' rows PLUS terminal 'sublayer' rows
+// (#763): a sub-layer archive whose file vanished is just as much a ghost.
+// Pre-migration layer=1 'pending' zombies are NOT candidates — they are
+// healthy archives pending the v39 rewrite, and each one returned would
+// starve a real ghost of the sweep's LIMIT slot.
 func (d *DB) ListStalePendingRecordings(ctx context.Context, cutoff time.Time, limit int) ([]model.Recording, error) {
 	defer d.observeQuery("ListStalePendingRecordings", time.Now())
 	if limit <= 0 {
 		limit = 500
 	}
-	sqlstr := selectRecordingColumns + ` WHERE merge_status = 'pending' AND archived = 0
+	sqlstr := selectRecordingColumns + ` WHERE ((merge_status = 'pending' AND COALESCE(layer,0)=0) OR merge_status = 'sublayer') AND archived = 0
 		AND (ai_status IS NULL OR ai_status = '')
 		AND started_at < ? ORDER BY started_at LIMIT ?;`
 	rows, err := d.readConn().QueryContext(ctx, sqlstr, timeToDB(cutoff), limit)

--- a/internal/storage/db_sublayer_status_test.go
+++ b/internal/storage/db_sublayer_status_test.go
@@ -1,0 +1,107 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mi-Bee-Studio/MiBeeNvr/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// Sub-layer terminal-status suite (#763): tierrec layer=1 rows are standalone
+// 60s archives that never enter the merge pipeline, yet they were inserted
+// with merge_status='pending' and never reached a terminal state — 98% of all
+// pending rows on the production box, polluting every pending-based
+// diagnostic and crowding the ghost-row sweep's LIMIT.
+
+func seedSubRow(t *testing.T, db *DB, id string, layer int, mergeStatus string, started time.Time) {
+	t.Helper()
+	require.NoError(t, db.InsertRecording(context.Background(), &model.Recording{
+		ID: id, CameraID: "cam-tier", Format: model.FormatH264, FilePath: "/p/" + id,
+		StartedAt: started, EndedAt: started.Add(60 * time.Second),
+		FileSize: 2048, MergeStatus: mergeStatus, Layer: layer,
+	}))
+}
+
+// TestSublayerRowsMigratedToTerminalStatus: Init's idempotent data migration
+// flips layer=1 'pending' rows to the 'sublayer' terminal status; layer=0
+// rows are untouched; re-running Init is a no-op.
+func TestSublayerRowsMigratedToTerminalStatus(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	seedSubRow(t, db, "sub-pending", 1, "pending", base)
+	seedSubRow(t, db, "sub-already-terminal", 1, "merged", base.Add(time.Minute))
+	seedSubRow(t, db, "main-pending", 0, "pending", base.Add(2*time.Minute))
+
+	// Re-run Init — the migration lives there (idempotent, every boot).
+	require.NoError(t, db.Init(ctx))
+
+	sub, err := db.GetRecording(ctx, "sub-pending")
+	require.NoError(t, err)
+	require.Equal(t, model.MergeStatusSublayer, sub.MergeStatus, "layer=1 pending rows must migrate to the terminal 'sublayer' status")
+	require.Equal(t, 1, sub.Layer)
+
+	untouchedTerminal, err := db.GetRecording(ctx, "sub-already-terminal")
+	require.NoError(t, err)
+	require.Equal(t, "merged", untouchedTerminal.MergeStatus, "migration must only touch 'pending' rows")
+
+	mainRow, err := db.GetRecording(ctx, "main-pending")
+	require.NoError(t, err)
+	require.Equal(t, "pending", mainRow.MergeStatus, "layer=0 pending rows are real merge backlog — untouched")
+
+	// Idempotent: second Init changes nothing.
+	require.NoError(t, db.Init(ctx))
+	subAgain, err := db.GetRecording(ctx, "sub-pending")
+	require.NoError(t, err)
+	require.Equal(t, model.MergeStatusSublayer, subAgain.MergeStatus)
+}
+
+// TestStalePendingSweepSkipsSublayerZombies: layer=1 'pending' zombies must
+// not crowd the ghost-row sweep's LIMIT — they are healthy archives, and
+// each one returned starves a real (layer=0) ghost of its sweep slot.
+func TestStalePendingSweepSkipsSublayerZombies(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	cutoff := base.Add(24 * time.Hour)
+
+	// Zombies: older than the ghost so ORDER BY started_at returns them first.
+	for i := range 5 {
+		seedSubRow(t, db, fmt.Sprintf("zombie-%d", i), 1, "pending", base.Add(time.Duration(i)*time.Second))
+	}
+	seedSubRow(t, db, "real-ghost", 0, "pending", base.Add(time.Minute))
+
+	rows, err := db.ListStalePendingRecordings(ctx, cutoff, 3)
+	require.NoError(t, err)
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	require.Equal(t, []string{"real-ghost"}, ids,
+		"layer=1 rows must not consume the sweep budget; the layer=0 ghost must be visible even with a tiny LIMIT")
+}
+
+// TestStalePendingSweepCoversTerminalSublayer: 'sublayer'-status rows whose
+// file vanished are still ghost rows — the sweep must cover the terminal
+// class too (otherwise terminal+missing becomes the next zombie class).
+func TestStalePendingSweepCoversTerminalSublayer(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+	base := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	cutoff := base.Add(24 * time.Hour)
+
+	seedSubRow(t, db, "sub-ghost", 1, "sublayer", base)
+	seedSubRow(t, db, "sub-fresh", 1, "sublayer", base.Add(48*time.Hour))
+
+	rows, err := db.ListStalePendingRecordings(ctx, cutoff, 100)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "sub-ghost", rows[0].ID)
+}

--- a/internal/tierrec/tierrec.go
+++ b/internal/tierrec/tierrec.go
@@ -454,7 +454,7 @@ func (r *subRecorder) closeSegmentLocked() {
 		Duration:    ended.Sub(r.startedAt).Seconds(),
 		FileSize:    r.bytes,
 		FrameCount:  r.frames,
-		MergeStatus: model.MergeStatusPending,
+		MergeStatus: model.MergeStatusSublayer, // born terminal — never a merge input (#763)
 		Layer:       model.LayerSub,
 	}
 	if err := r.mgr.cfg.Store.InsertRecording(context.Background(), rec); err != nil {

--- a/internal/tierrec/tierrec_test.go
+++ b/internal/tierrec/tierrec_test.go
@@ -98,6 +98,12 @@ func TestSubRecorder_WritesLayerOneSegments(t *testing.T) {
 	if r.Layer != model.LayerSub {
 		t.Fatalf("row layer = %d, want %d", r.Layer, model.LayerSub)
 	}
+	// #763: sub-layer rows never enter the merge pipeline — they are born
+	// terminal. A 'pending' insert is the zombie-row bug (98% of production
+	// pending pollution).
+	if r.MergeStatus != model.MergeStatusSublayer {
+		t.Fatalf("row merge_status = %q, want terminal %q", r.MergeStatus, model.MergeStatusSublayer)
+	}
 	if r.FrameCount == 0 || r.CameraID != "cam-sub" {
 		t.Fatalf("bad row: frames=%d cam=%s", r.FrameCount, r.CameraID)
 	}

--- a/web/src/lib/api/recordings.ts
+++ b/web/src/lib/api/recordings.ts
@@ -16,7 +16,7 @@ export interface Recording {
   duration: number;
   file_size: number;
   frame_count: number;
-  merge_status: 'pending' | 'merged' | 'failed' | 'incompatible' | 'dark' | 'daily_merged' | 'merging';
+  merge_status: 'pending' | 'merged' | 'failed' | 'incompatible' | 'dark' | 'daily_merged' | 'merging' | 'sublayer';
   merge_progress?: number; // 0-100, persisted to DB
   merge_path?: string;
   archived?: boolean;


### PR DESCRIPTION
Closes #763.

## 问题

tierrec 子层段（layer=1，tiered 录像模式的连续子流存档）设计上不进合并管线，但插入时写 `merge_status='pending'` 且**永远没有终态**——生产机全库 pending 9088 条中 8913 条（98%）是这类行，每小时净增数百条：

- 所有 pending 口径被污染：排障时把 layer=1 噪音读成"合并积压竞赛正在输"，实际 layer=0 可合并积压仅 ~250 条、合并引擎消化正常；
- **真实功能危害**：幽灵行清扫（`ListStalePendingRecordings`，LIMIT 500）无 layer 过滤——僵尸行是健康存档但吃掉清扫限额，挤掉真正的 pending+文件缺失幽灵行。

## 方案

1. **写入即终态**：新终态 `merge_status='sublayer'`（`model.MergeStatusSublayer`），tierrec 插入直接写——它们生来就不进合并管线，pending 是错误生命周期；
2. **存量迁移（v39，幂等）**：`UPDATE recordings SET merge_status='sublayer' WHERE COALESCE(layer,0)!=0 AND merge_status='pending'`，随 `Init()` 每次启动执行（二跑 0 行）；
3. **口径统一**：幽灵清扫候选 = `layer=0 pending` ∪ `终态 sublayer`（子层文件消失仍是幽灵，继续扫）；迁移前的 layer=1 pending 僵尸不再是候选；其余 pending 查询（rolling/backfill/PendingCounts）本就带 `COALESCE(layer,0)=0` 过滤，无需改；
4. **cleanup 对齐**：retention 按年龄删（状态无关），终态子层行照常过期清理——不受合并保护语义影响（已验证 `listExpiredRecordings` 无状态过滤）。

## TDD

- 红（4 个，全部运行确认失败）：tierrec 插入终态断言；迁移后 pending→sublayer；僵尸不挤占清扫限额（5 僵尸 + limit 3 下真幽灵可见）；终态 sublayer 幽灵仍在清扫范围；
- 绿：全部通过 + `go test -race`（storage/tierrec/model）+ 前端 vitest 631 全过 + 全仓 5832 测试 + golangci-lint 0 issues；
- 前端仅拓宽 TS 联合类型（UI 对未知状态走默认分支，子层行本就不进默认列表/时间线）。

## 生产预期

迁移后 pending 总数从 ~9088 回落到 ~250 量级（真实 layer=0 积压），增长斜率回归与 layer=0 段产出一致；下次排障不再被误导。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>